### PR TITLE
visibility: don't let a stale HF_TOKEN wedge a private Space forever

### DIFF
--- a/server/src/visibility.js
+++ b/server/src/visibility.js
@@ -24,6 +24,13 @@ const hfToken = () => process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN
 // private — but we surface a warning so the operator can verify or add a token.
 let state = { spaceId: SPACE_ID, public: false, known: false, checkedAt: 0, reason: null, bucket: null, buckets: [], bucketUnverified: false };
 let volumes = null; // bucket ids mounted on this Space; discovered once (fixed until restart)
+// Failure counter for the authed volumes call. A transient network blip
+// should retry; a permanently bad token (e.g. a stale HF_TOKEN carried over
+// when a Space was duplicated) must NOT wedge the Space forever. After this
+// many consecutive failures we give up, treat the bucket as undiscoverable,
+// and unlock with a `bucketUnverified` warning instead of staying closed.
+let bucketDiscoverFails = 0;
+const BUCKET_DISCOVER_MAX_FAILS = 3;
 
 const HEADERS = { 'user-agent': 'agent-manager' };
 // Every HF API call is bounded: a hung request must never wedge the boot
@@ -31,6 +38,11 @@ const HEADERS = { 'user-agent': 'agent-manager' };
 const HF_TIMEOUT_MS = 8000;
 const hfFetch = (url, opts = {}) => fetch(url, { ...opts, signal: AbortSignal.timeout(HF_TIMEOUT_MS) });
 
+// Returns:
+//   - an array of bucket ids (may be empty) once discovery has succeeded OR
+//     has been given up on (so the Space can unlock with a warning).
+//   - null only for a TRULY transient failure (first/short retry window) so
+//     the caller keeps the last verdict and tries again next cycle.
 async function discoverBuckets() {
   if (volumes !== null) return volumes;
   const token = hfToken();
@@ -39,12 +51,24 @@ async function discoverBuckets() {
     const r = await hfFetch(`https://huggingface.co/api/spaces/${SPACE_ID}`, {
       headers: { ...HEADERS, authorization: `Bearer ${token}` },
     });
-    if (!r.ok) return null; // transient — retry next cycle
+    if (!r.ok) {
+      // 401/403 → the token is bad/expired. A network blip would have thrown.
+      // Retry a couple of times in case HF is having a moment, then give up
+      // so we don't wedge a confirmed-private Space forever.
+      if (++bucketDiscoverFails >= BUCKET_DISCOVER_MAX_FAILS) {
+        console.warn(`[visibility] authed /api/spaces returned ${r.status} ${bucketDiscoverFails}x — giving up on bucket discovery; unlocking with bucketUnverified (check the Space's HF_TOKEN secret)`);
+        volumes = []; return volumes;
+      }
+      return null; // transient — retry next cycle
+    }
     const j = await r.json();
     volumes = ((j.runtime && j.runtime.volumes) || [])
       .filter((v) => v && v.type === 'bucket' && v.source)
       .map((v) => v.source);
-  } catch { return null; }
+  } catch {
+    // Thrown (DNS/timeout/network) → genuinely transient, don't burn the counter.
+    return null;
+  }
   return volumes;
 }
 
@@ -66,8 +90,12 @@ async function check() {
     // Not publicly visible (401/404) → the Space is private. Now the bucket(s).
     const buckets = await discoverBuckets();
     if (buckets === null) { state = { ...state, checkedAt: Date.now() }; return state; } // keep last verdict
-    // No token → buckets couldn't be discovered → we can't verify the bucket.
-    if (!hfToken()) {
+    // Treat the give-up path the same as having no token: the bucket is
+    // unverifiable, NOT public. Unlock the Space with a warning rather than
+    // wedging it closed forever (a bad/stale HF_TOKEN must never brick a
+    // confirmed-private Space).
+    const bucketUnverified = !hfToken() || bucketDiscoverFails >= BUCKET_DISCOVER_MAX_FAILS;
+    if (bucketUnverified) {
       state = { spaceId: SPACE_ID, public: false, known: true, checkedAt: Date.now(), reason: null, bucket: null, buckets: [], bucketUnverified: true };
       return state;
     }


### PR DESCRIPTION
## Problem

A duplicated Space can end up with a stale or invalid `HF_TOKEN` secret (carried over from the template at dup time, before the operator's own push). The current visibility watcher then wedges the Space **closed forever** — including for the owner — even though the Space itself is verified private.

## Repro

1. Duplicate this Space (HF_TOKEN secret is set to a template value at dup time)
2. Push a fresh commit over the top — your build of `d55326d` boots in the new Space
3. Visit the Space → stuck on the **"Set up the Agent Manager in two steps — public instance"** lock screen, despite `private: true` and `stage: RUNNING` on `/api/spaces/<id>`.

## Root cause

`server/src/visibility.js` does three things on each `check()` cycle:

1. Unauthed `GET /api/spaces/<id>` → on a private Space, returns 401 → "private, ✓"
2. If `HF_TOKEN` is set, `discoverBuckets()` calls **authed** `GET /api/spaces/<id>` to read `runtime.volumes` and resolve the mounted bucket ids.
3. If that authed call returns non-OK, `discoverBuckets()` returns `null` with the comment "transient — retry next cycle". `check()` then early-returns with `known:false` and "keep last verdict".

`isPublic()` (`visibility.js:98`) **fails closed while unknown**: `state.public || (!!SPACE_ID && !state.known)`. So `isPublic()` stays `true` forever — the Space is bricked closed for its owner, with no path to recover short of manually editing secrets out-of-band.

This happened to me on `thomwolf/agent-manager` today (dup at 11:27:48Z with a stale `HF_TOKEN`, confirmed via the runtime logs and `/api/visibility`:

```json
{"public":false,"known":false,"reason":null,"buckets":[],"bucketUnverified":false}
```

`canRelaunch:true` reported an `HF_TOKEN` was present, but the authed volumes call consistently failed → `known` never flipped.)

## Fix

Differentiate **transient** failures (DNS/timeout/network — thrown `fetch`) from **persistent** auth failures (non-OK HTTP response, e.g. 401/403 from a bad token). After `BUCKET_DISCOVER_MAX_FAILS = 3` consecutive non-OK responses, give up on bucket discovery, set `volumes = []`, and let the Space unlock with `bucketUnverified: true` — exactly the existing code path for "no token at all". Network blips don't burn the counter; only consistent auth failures do.

The Space's privacy was already confirmed by the unauthed 401 on step 1. A bad `HF_TOKEN` only blocks **bucket** discovery, which is a warning-grade condition, not a lock-grade one. The existing `bucketUnverified` warning flow (UI surfaces it, operator verifies or rotates the token) is the right UX for this state — not "brick the Space".

## Changes

- `server/src/visibility.js`:
  - Add `bucketDiscoverFails` counter + `BUCKET_DISCOVER_MAX_FAILS = 3` constant.
  - `discoverBuckets()`: on non-OK authed response, increment counter; if it crosses the threshold, log a warning and return `[]` (give up) instead of `null` (retry forever). Thrown fetches still return `null` and don't increment — they're genuinely transient.
  - `check()`: unify the "bucket unverifiable" path — both "no token" and "gave up after repeated auth failures" unlock with `bucketUnverified: true`. The `if (!hfToken())` branch is replaced by a computed `bucketUnverified` flag.

## Verification

Applied the secret-side fix (rotated the `HF_TOKEN` secret on the live Space to a valid token) — Space unlocked within ~2 min, `/api/info` returned `locked:false, bucketUnverified:false, buckets:["thomwolf/agent-manager-data"]`. The code-side patch here prevents the next operator from hitting the same wedge.

`node --check server/src/visibility.js` passes.