### PR TITLE
Terminal: one device drives a session, with a deliberate handover

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -14,7 +14,7 @@ import * as store from './sessions.js';
 import * as groups from './groups.js';
 import * as order from './order.js';
 import * as demo from './demo.js';
-import { attach, agentInfo, deriveState, stop, ensureRunning, sendInput, copySelection, paneModes } from './runner.js';
+import { attach, agentInfo, deriveState, stop, ensureRunning, sendInput, copySelection, paneModes, isRunning } from './runner.js';
 import { buildUsage } from './usage.js';
 import { buildTraces, traceDigests, digestFor } from './traces.js';
 import { initPush, publicKey, deviceCount, addSubscription, removeSubscription, sendToAll } from './push.js';
@@ -1034,9 +1034,17 @@ wss.on('connection', (ws, req) => {
   });
   handle.onExit(() => {
     if (ws.readyState === ws.OPEN) {
-      // 4000 = real process exit. The client uses this to NOT auto-reconnect
-      // (which would respawn the agent in a loop); it offers a Restart instead.
-      try { ws.close(4000, 'exited'); } catch { ws.close(); }
+      // Our tmux client can die for two very different reasons, and the browser
+      // must react differently to each:
+      //   4001 = another device attached and tmux's -D detached us. The session
+      //          is alive and now belongs to that device, so this client goes
+      //          quiet instead of reconnecting (that would be a tug-of-war).
+      //   4000 = the agent process itself exited. Do NOT auto-reconnect (it
+      //          would respawn the agent in a loop); offer a Restart instead.
+      const handedOff = USE_TMUX && isRunning(session.id);
+      try {
+        ws.close(handedOff ? 4001 : 4000, handedOff ? 'handedoff' : 'exited');
+      } catch { ws.close(); }
     }
   });
 

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -345,12 +345,16 @@ export function attach(session, cols, rows) {
     const args = [];
     if (fs.existsSync(TMUX_CONF)) args.push('-f', TMUX_CONF);
     args.push(
-      // -A: attach if it exists, else create. We deliberately do NOT pass -D
-      // (detach others): the same session may be open in two browser windows,
-      // and -D + auto-reconnect would make them fight. Instead each client
-      // re-syncs its size on focus (see TerminalPane), and window-size=latest
-      // makes the focused window fit exactly.
-      'new-session', '-A', '-s', tmuxName(session.id), '-c', workdir,
+      // -A: attach if it exists, else create. -D: detach any other client, so
+      // exactly ONE device drives the session at a time. Sharing it was worse:
+      // window-size=latest resized the shared window to whoever spoke last, and
+      // agent TUIs (which paint into the normal buffer, not the alt screen)
+      // re-emit their frame with erase math computed at the OLD width — so every
+      // phone/desktop flip left another copy of the same text in the scrollback,
+      // wrapped at the other device's width. The handover is sequential instead:
+      // the detached client is told the session lives on (close code 4001) and
+      // waits for a deliberate return before taking it back (see TerminalPane).
+      'new-session', '-A', '-D', '-s', tmuxName(session.id), '-c', workdir,
       '-e', `AM_SESSION=${folder}`,
       '-e', `AM_NAME=${session.name}`,
       '-e', `AM_ID=${session.id}`,

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -31,12 +31,18 @@ const THEMES: Record<'light' | 'dark', ITheme> = {
   },
 };
 
-type ConnState = 'connecting' | 'connected' | 'closed' | 'exited';
+type ConnState = 'connecting' | 'connected' | 'closed' | 'exited' | 'handedoff';
 
 // Close code the server uses when the session's process exited for real (vs a
 // transient drop). The client must NOT auto-reconnect on this, or it would
 // respawn the agent in a loop and trample an in-progress login flow.
 const EXIT_CODE = 4000;
+
+// Close code for "another device took this session over" (tmux attaches with
+// -D, so only one client drives a session at a time). The session is still
+// running: we must not reconnect on a timer, or this pane and the phone would
+// pull the session back and forth. We wait for the user to come back here.
+const HANDOFF_CODE = 4001;
 
 function workspaceLabel(p: string | null) {
   const rel = (p || '').replace(/^\.\/?/, '').replace(/^\/+|\/+$/g, '');
@@ -161,6 +167,8 @@ export default function TerminalPane({
   const termRef = useRef<Terminal | null>(null);
   const resyncRef = useRef<() => void>(() => {});
   const reconnectRef = useRef<() => void>(() => {});
+  // Take a handed-off session back (bound inside the connection effect).
+  const resumeRef = useRef<() => void>(() => {});
   // Send a raw byte string to the PTY (for the mobile key-bar: arrows, Esc…).
   const sendKeyRef = useRef<(d: string) => void>(() => {});
   const [conn, setConn] = useState<ConnState>('connecting');
@@ -243,6 +251,7 @@ export default function TerminalPane({
     let mouseDragStart: { x: number; y: number } | null = null;
     let mouseDragged = false;
     const onPointerDown = (e: PointerEvent) => {
+      takeBack(); // clicking into a handed-off pane means "I'm working here now"
       if (e.pointerType !== 'mouse' || e.button !== 0) return;
       mouseDragStart = { x: e.clientX, y: e.clientY };
       mouseDragged = false;
@@ -315,6 +324,7 @@ export default function TerminalPane({
     document.fonts?.ready.then(() => { try { fit.fit(); } catch { /* ignore */ } });
 
     let closedByUs = false;
+    let handedOff = false;
     let retry: ReturnType<typeof setTimeout> | null = null;
     // Reconnect with backoff: a sleeping/unreachable Space shouldn't be hammered
     // every second by every open pane. Reset once a connection succeeds.
@@ -383,6 +393,9 @@ export default function TerminalPane({
         // reattach to the still-running tmux session.
         endBoot();
         if (e.code === EXIT_CODE) { setConn('exited'); return; }
+        // Another device took over: stay detached (no retry timer) until the
+        // user deliberately comes back to this pane — see takeBack().
+        if (e.code === HANDOFF_CODE) { handedOff = true; setConn('handedoff'); return; }
         setConn('closed');
         if (!closedByUs) {
           retry = setTimeout(connect, retryDelay);
@@ -395,13 +408,33 @@ export default function TerminalPane({
     // the NEW process paint, not leftovers (tmux repaints the live screen).
     reconnectRef.current = () => { if (retry) clearTimeout(retry); retryDelay = 1200; try { term.reset(); } catch { /* ignore */ } connect(); };
 
-    // Re-fit and tell the server our size. With tmux window-size=latest this
-    // makes the focused window own the size, so a duplicate window open at a
-    // different size doesn't leave us with tmux's "dots" filler.
+    // Take the session back from whichever device holds it now. Called ONLY for
+    // a deliberate return to this pane — the tab regaining focus/visibility, or
+    // a tap/click in the terminal — never on a timer, so the phone we just put
+    // down keeps the session while it sits in the background. Reattaching sizes
+    // tmux to this device, which is the point: each device gets a window that
+    // fits it, at the cost of one reflow per handover instead of per glance.
+    const takeBack = () => {
+      if (!handedOff || document.hidden) return false;
+      handedOff = false;
+      connect();
+      return true;
+    };
+    resumeRef.current = () => { takeBack(); };
+
+    // Re-fit and tell the server our size. The attached client owns the tmux
+    // window, so this keeps it fitting this device exactly instead of leaving
+    // tmux's "dots" filler. Never reconnects: a layout change (another pane
+    // opening, the sidebar toggling) is not a reason to pull a session off the
+    // device the user is actually holding.
     const resync = () => {
+      if (handedOff) return;
       try { fit.fit(); send({ t: 'r', cols: term.cols, rows: term.rows }); } catch { /* ignore */ }
     };
-    const onVisible = () => { if (!document.hidden) resync(); };
+    // Returning to this tab IS deliberate — take the session back, or just
+    // re-sync the size if we still hold it.
+    const onReturn = () => { if (!takeBack()) resync(); };
+    const onVisible = () => { if (!document.hidden) onReturn(); };
     resyncRef.current = resync; // so the zoom control can refit
 
     // Typing means the user sees enough to interact — drop the boot cover.
@@ -412,7 +445,7 @@ export default function TerminalPane({
     const dataSub = term.onData((d) => send({ t: 'i', d }));
     const ro = new ResizeObserver(resync);
     ro.observe(hostRef.current!);
-    window.addEventListener('focus', resync);
+    window.addEventListener('focus', onReturn);
     document.addEventListener('visibilitychange', onVisible);
 
     // Touch scrolling: xterm doesn't translate touch gestures for applications
@@ -421,7 +454,7 @@ export default function TerminalPane({
     // the app tracks the mouse (tmux scrolls its history), local scrollLines
     // otherwise.
     let touchY: number | null = null;
-    const onTouchStart = (e: TouchEvent) => { touchY = e.touches[0].clientY; };
+    const onTouchStart = (e: TouchEvent) => { takeBack(); touchY = e.touches[0].clientY; };
     const onTouchMove = (e: TouchEvent) => {
       if (touchY == null) return;
       const y = e.touches[0].clientY;
@@ -461,7 +494,7 @@ export default function TerminalPane({
       host.removeEventListener('touchstart', onTouchStart);
       host.removeEventListener('touchmove', onTouchMove);
       host.removeEventListener('touchend', onTouchEnd);
-      window.removeEventListener('focus', resync);
+      window.removeEventListener('focus', onReturn);
       document.removeEventListener('visibilitychange', onVisible);
       dataSub.dispose();
       keySub.dispose();
@@ -555,7 +588,21 @@ export default function TerminalPane({
           ))}
         </div>
       )}
-      {booting && conn !== 'exited' && (
+      {conn === 'handedoff' && (
+        // The session is running elsewhere, not stopped — say so, and make the
+        // way back obvious (clicking the terminal works too).
+        <div className="term-exit mono">
+          <div className="tx-row">
+            <span>open on another device · still running</span>
+            <button
+              className="tx-btn"
+              onMouseDown={(e) => e.stopPropagation()}
+              onClick={(e) => { e.stopPropagation(); resumeRef.current(); }}
+            ><RefreshGlyph /> resume here</button>
+          </div>
+        </div>
+      )}
+      {booting && conn !== 'exited' && conn !== 'handedoff' && (
         <div className="term-boot mono">
           {conn === 'connecting' ? 'connecting' : `starting ${cli?.label || session.cli}`}<span className="et-cursor" />
         </div>


### PR DESCRIPTION
## The problem

Opening the same session on a phone and a desktop shared one tmux client. With `window-size=latest` the shared window resized to whoever spoke last — and agent TUIs paint into the **normal buffer, not the alt screen**, so on each resize they re-emit their frame with erase math computed at the *old* width. The old frame never gets erased. Every device flip left another copy of the same text in the scrollback, wrapped at the other device's width.

## The change

Attach with `-D`, so exactly one client drives a session at a time, and make the handover explicit rather than a tug-of-war:

- **`runner.js`** — `new-session -A -D`.
- **`index.js`** — on client exit, distinguish the two cases. tmux session still alive (someone else attached) → close **4001**; the agent process actually exited → **4000**, which the client already treats as "offer Restart, don't reconnect".
- **`TerminalPane.tsx`** — 4001 sets a `handedoff` state with **no retry timer**, plus an overlay saying the session is still running with a *resume here* button. The pane takes the session back only on a **deliberate return** — tab focus/visibility, or a tap/click in the terminal — never on a timer, so the phone you just put down keeps the session while it sits in the background. `resync()` no longer reconnects, so an unrelated layout change (another pane opening, the sidebar toggling) can't yank the session off the device you're actually holding.

Each device now gets a window that fits it exactly, at the cost of one reflow per handover instead of per glance.

## Verification

Ran a local server (`USE_TMUX=1`) with two live WebSocket clients:

```
PASS  A stays connected while alone
PASS  A sees its own command output
PASS  A is closed once B attaches
PASS  A close code is 4001 (handoff), got 4001
PASS  A close reason is "handedoff", got "handedoff"
PASS  B stays connected
PASS  B can type and sees output
PASS  B gets 4001 when A returns, got 4001
PASS  A2 holds the session after taking it back
PASS  A2 can type after taking over
PASS  real exit closes with 4000, got 4000
```

tmux window follows the attached client: `desktop 200x50 → phone 60x24 → desktop 200x50`.

`tsc --noEmit` and `vite build` both pass.

Not exercised: the browser-side `takeBack()` triggers themselves (visibilitychange / focus / touchstart) — those were verified by reading, not by driving a real phone and desktop against one Space. Worth a manual pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)