### PR TITLE
runner: keep tmux's own stderr out of the Space log

### DIFF
--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -101,7 +101,13 @@ export function agentInfo() {
   if (!USE_TMUX) return map;
   let list;
   try {
-    list = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'], { encoding: 'utf8' });
+    // stderr is dropped on every tmux call that already handles its own
+    // failure: with no server running (fresh container, or after the last
+    // session ends) tmux prints "error connecting to /tmp/tmux-1000/default"
+    // and the catch below treats that as "no sessions" — so the message is
+    // pure noise that made a healthy Space look broken in the log.
+    list = execFileSync('tmux', ['list-sessions', '-F', '#{session_name}'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
   } catch {
     paneSig.clear();
     return map; // no server / no sessions
@@ -113,7 +119,10 @@ export function agentInfo() {
     const id = name.slice(3);
     live.add(id);
     let text = '';
-    try { text = execFileSync('tmux', ['capture-pane', '-p', '-t', name], { encoding: 'utf8' }); } catch {}
+    try {
+      text = execFileSync('tmux', ['capture-pane', '-p', '-t', name],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch {}
     const sig = djb2(text);
     const prev = paneSig.get(id);
     const changedAt = !prev || prev.sig !== sig ? now : prev.changedAt;
@@ -474,10 +483,12 @@ export function copySelection(id) {
   const bufferName = `am-copy-${tmuxName(id)}`;
   let text = '';
   try {
-    text = execFileSync('tmux', ['save-buffer', '-b', bufferName, '-'], { encoding: 'utf8', env: TERM_ENV });
+    text = execFileSync('tmux', ['save-buffer', '-b', bufferName, '-'],
+      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], env: TERM_ENV });
   } catch {
     try {
-      text = execFileSync('tmux', ['save-buffer', '-'], { encoding: 'utf8', env: TERM_ENV });
+      text = execFileSync('tmux', ['save-buffer', '-'],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], env: TERM_ENV });
     } catch {
       return null;
     }


### PR DESCRIPTION
## Symptom

A perfectly healthy Space logs lines like:

```
error connecting to /tmp/tmux-1000/default (No such file or directory)
```

It shows up on a fresh container before the first session exists, and again on every poll after the last session ends — which makes a working Space look broken.

## Cause

`execFileSync` passes the child's stderr straight through to the parent's stderr unless `stdio` says otherwise, so tmux's own complaint lands in the Space log. tmux prints that message whenever a command runs with no server up. The call sites already `catch` the failure and treat it as "no sessions", so nothing is actually wrong — the text is pure noise. Some tmux calls in `server/src/runner.js` already suppressed stderr (`paneModes`) and some did not.

## Fix

Make stderr handling consistent: on the tmux calls whose failure is already handled locally, drop the child's stderr the same way `paneModes` does — `stdio: ['ignore', 'pipe', 'ignore']` with `encoding: 'utf8'`, so stdout still comes back as a string.

- `agentInfo`'s `list-sessions` (the reported leak) — plus a comment explaining why stderr is dropped
- `agentInfo`'s `capture-pane`
- both `save-buffer` attempts in `copySelection` (these also fire routinely when a session has no copy buffer yet)

Left alone on purpose: `has-session`, `new-session`, `send-keys` and `kill-session` already use `stdio: 'ignore'` (nothing to leak, no stdout read), and `new-session` in `ensureRunning` is the one call whose failure is *not* swallowed — it throws to the caller, so its diagnostics stay useful. There are no async `execFile` calls in the file; `pty.spawn` is untouched.

Cosmetic only: no change to control flow, error handling, or any return value.

## Verification

- `node --check server/src/runner.js` passes.
- Reproduced the leak and its absence against a throwaway tmux socket with no server:
  - without `stdio`: parent stderr receives `error connecting to /tmp/tmux-1000/amdemo-nosuchsock (No such file or directory)` (81 bytes)
  - with `stdio: ['ignore','pipe','ignore']`: parent stderr receives 0 bytes
- Confirmed `stdio: ['ignore','pipe','ignore']` + `encoding: 'utf8'` still returns stdout as a string (`typeof === 'string'`, real `list-sessions` output intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)