### PR TITLE
server: exit non-zero when listen fails

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -977,8 +977,21 @@ const server = http.createServer(app);
 const wss = new WebSocketServer({ server, path: '/ws' });
 // Without these listeners a transport error (client reset, listen failure)
 // throws out of the EventEmitter and crashes the process.
-wss.on('error', (e) => console.error('[wss error]', e.message));
-server.on('error', (e) => console.error('[server error]', e.message));
+// A bind failure surfaces on both emitters; the server handler below owns it, so
+// skip it here to keep one report and one exit.
+wss.on('error', (e) => { if (e && e.syscall !== 'listen') console.error('[wss error]', e.message); });
+server.on('error', (e) => {
+  console.error('[server error]', e.message);
+  // A failed listen leaves no handle, so the loop drains and node returns 0 —
+  // the supervisor reads that as a clean stop and stays quiet, and the operator
+  // reads "exit code: 0" as the Space crashing on its own. Fail loudly instead.
+  // (Seen on Spaces dev mode: it restarts the app in the same container while
+  // the previous, healthy node still holds the port.)
+  if (e && e.syscall === 'listen') {
+    console.error(`[fatal] cannot listen on :${PORT} — something else is probably already bound to it. Exiting 1.`);
+    process.exit(1);
+  }
+});
 
 // Only accept WebSockets from our own page. WS handshakes skip CORS entirely
 // and the browser attaches cookies, so without this check any website could try


### PR DESCRIPTION
## Symptom

A live Space logged this and then reported a clean stop:

```
[wss error] listen EADDRINUSE: address already in use :::7860
[server error] listen EADDRINUSE: address already in use :::7860
=== Application stopped (exit code: 0) at 2026-07-27 17:05:54 UTC ===
```

The operator read `exit code: 0` as "the Space keeps crashing on its own". It wasn't: the long-running instance was healthy and still serving on :7860 — only the *restart attempt* (Spaces dev mode restarts the app inside the same container while the previous node still owns the port) failed. A supervisor can't tell this apart from a successful stop either, so nothing gets flagged.

## Cause

`server/src/index.js` logged listen errors and returned:

```js
wss.on('error', (e) => console.error('[wss error]', e.message));
server.on('error', (e) => console.error('[server error]', e.message));
```

When `listen()` fails there is no listening handle, so the event loop drains and node exits **0** — indistinguishable from a clean shutdown.

## Fix

The `server` `error` handler now prints an actionable diagnostic naming the port and `process.exit(1)` — but only for listen-time failures (`e.syscall === 'listen'`, i.e. EADDRINUSE/EACCES), which are fatal because the server can never serve. Post-listen socket errors keep the old log-and-survive behaviour; this process pumps every terminal and must not die on a dropped socket.

The same bind failure also surfaces on the `wss` emitter (both lines appear in the log above), so that handler skips `syscall === 'listen'` and leaves it to the `server` handler — one report, one exit. The listener stays attached, so nothing throws out of the EventEmitter.

`unhandledRejection` / `uncaughtException` backstops are untouched.

## Verification

`node --check server/src/index.js` passes. `error.syscall === 'listen'` on bind failure confirmed against Node directly (a second `http.Server` bound to a taken port emits `code: 'EADDRINUSE', syscall: 'listen'`); the app itself was not started (needs tmux + a writable data dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
