### PR TITLE
entrypoint: don't leak state-sync loops across restarts

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,15 @@ export AM_LOCAL="/home/node/local"
 if ! mkdir -p "$AM_LOCAL/bin" 2>/dev/null; then AM_LOCAL="$DATA_DIR/.local-cache"; mkdir -p "$AM_LOCAL/bin"; fi
 export UV_CACHE_DIR="$AM_LOCAL/uv-cache"
 
+# Liveness handle for the state-sync loops below: this script ends with
+# `exec node …`, so $$ IS the app's pid. Each loop checks it and gives up once
+# its own app instance is gone, because a dev-mode app restart re-runs this
+# script inside the SAME container: the old loops survive (reparented to PID 1)
+# and the new run adds three more. Measured after three restart attempts: ten
+# loops alive, all waking every 60s to rsync the same bucket paths over each
+# other. Not exported — nothing downstream needs it (see NON_SECRET note above).
+AM_MAIN_PID=$$
+
 # Codex keeps a growing family of SQLite databases (logs_2, goals_1, memories_1
 # plus mmap'd -shm siblings) that corrupt on the FUSE bucket: SQLite needs real
 # locking/mmap. Same cure as OpenClaw — codex's HOME lives on LOCAL disk. The
@@ -54,6 +63,7 @@ rsync -a --exclude 'sessions' --exclude '*.sqlite*' --exclude 'db-backups' \
 ln -sfn "$CODEX_DURABLE/sessions" "$CODEX_HOME/sessions"
 ( while :; do
     sleep 60
+    kill -0 "$AM_MAIN_PID" 2>/dev/null || exit
     rsync -a --exclude 'sessions' --exclude '*.sqlite*' --exclude 'db-backups' \
       --exclude 'cache' --exclude '.tmp' --exclude 'mcp-oauth-locks' \
       "$CODEX_HOME/" "$CODEX_DURABLE/" 2>/dev/null || true
@@ -92,6 +102,7 @@ done
 cp "$HOME/.gitconfig" "$OPENCLAW_HOME/.gitconfig" 2>/dev/null || true
 ( while :; do
     sleep 60
+    kill -0 "$AM_MAIN_PID" 2>/dev/null || exit
     rsync -a --delete "$OPENCLAW_STATE_DIR/" "$OC_BACKUP/" 2>/dev/null || true
   done ) &
 
@@ -124,6 +135,7 @@ ln -sfn "$OC_LIVE" "$OC_LINK"
 ln -sfn "$HERMES_LIVE" "$HERMES_LINK"
 ( while :; do
     sleep 60
+    kill -0 "$AM_MAIN_PID" 2>/dev/null || exit
     rsync -a "$OC_LIVE/" "$OC_DURABLE/" 2>/dev/null || true
     rsync -a "$HERMES_LIVE/" "$HERMES_DURABLE/" 2>/dev/null || true
   done ) &


### PR DESCRIPTION
## Symptom

`entrypoint.sh` spawns three background state-sync loops (codex, openclaw, opencode+hermes), each an unconditional `while :; do sleep 60; rsync …; done` with nothing to stop them.

That is invisible in normal operation, because a Space restart replaces the whole container. But an HF Spaces **dev-mode app restart re-runs `entrypoint.sh` inside the SAME container**: the previous run's loops keep going, reparented to PID 1, and the new run adds three more. They multiply with every restart and race each other writing the same destinations on a FUSE-mounted bucket.

## Measured evidence

`ps` on a live Space after three restart attempts (PPID 1 = orphaned):

```
   13     1  node /app/server/src/index.js      <- the live app
   39    13  sh /app/entrypoint.sh              <- its 3 loops (legitimate)
   44    13  sh /app/entrypoint.sh
   56    13  sh /app/entrypoint.sh
 8913     1  sh /app/entrypoint.sh              <- orphaned from a failed restart
 8918     1  sh /app/entrypoint.sh
 8930     1  sh /app/entrypoint.sh
10058     1  sh /app/entrypoint.sh              <- and another
10063     1  sh /app/entrypoint.sh
10076     1  sh /app/entrypoint.sh
```

Ten loops alive, each waking every 60s to rsync to the bucket.

## Fix

The script ends with `exec node /app/server/src/index.js`, so the shell that spawns the loops *becomes* the node process — same pid. That makes its pid a free liveness handle, with no pidfile and no `pgrep` pattern matching:

- capture it as `AM_MAIN_PID=$$` before any loop is backgrounded;
- each iteration does `kill -0 "$AM_MAIN_PID" 2>/dev/null || exit` **after the sleep, before the rsync**, so a loop whose app instance is gone exits without writing to the bucket again.

Same one-line guard in all three loops. When node dies the loops end on their own, so a re-run cannot accumulate them — and it self-heals after a crash, not only after a restart. What gets synced, the 60s interval, and everything else in the entrypoint are unchanged.

## Verification

- `sh -n entrypoint.sh` and `dash -n entrypoint.sh` pass (POSIX sh, no bashisms).
- The mechanism was proven in isolation with a throwaway script: a parent that sets `AM_MAIN_PID=$$`, backgrounds a `kill -0`-guarded loop, then `exec sleep 300`. Killing the exec'd process stopped the loop within one iteration and it disappeared from `ps`. The same script without the guard left an orphan at PPID 1 still ticking — reproducing the bug exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)