### PR TITLE
Files pane: create folders, rename, move and delete entries

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1137,6 +1137,35 @@ app.post('/api/files/:id/rename', (req, res) => {
   res.json({ ok: true });
 });
 
+// Move an entry into another folder under the same root, keeping its name —
+// the drag-and-drop half of rename. `to` is the destination FOLDER ('' = root).
+app.post('/api/files/:id/move', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const { root, target: from } = browsePath(s, String(req.query.path || ''));
+  if (!from || from === root || !fs.existsSync(from)) return res.status(400).json({ error: 'bad path' });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  const destDir = resolveSafe(root, String(req.query.to || ''));
+  if (!destDir || !fs.existsSync(destDir)) return res.status(400).json({ error: 'bad path' });
+  try { if (!fs.statSync(destDir).isDirectory()) return res.status(400).json({ error: 'not a folder' }); }
+  catch { return res.status(400).json({ error: 'bad path' }); }
+  // A folder can't land inside itself — compared on real paths, so a symlink in
+  // the destination chain can't smuggle the subtree past the check.
+  try {
+    const realFrom = fs.realpathSync(from);
+    const realDest = fs.realpathSync(destDir);
+    if (realDest === realFrom || realDest.startsWith(realFrom + path.sep)) {
+      return res.status(400).json({ error: "can't move a folder into itself" });
+    }
+  } catch { return res.status(400).json({ error: 'bad path' }); }
+  const to = path.join(destDir, path.basename(from));
+  if (to === from) return res.json({ ok: true }); // already where it was dropped
+  if (fs.existsSync(to)) return res.status(409).json({ error: 'already exists' });
+  try { fs.renameSync(from, to); } catch (e) { return res.status(500).json({ error: e.message }); }
+  res.json({ ok: true });
+});
+
 // Recursive: deleting a folder takes what's inside it with it. The UI asks
 // twice before calling this.
 app.delete('/api/files/:id/entry', (req, res) => {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1080,6 +1080,76 @@ app.post('/api/files/:id/upload', (req, res) => {
   req.pipe(out);
 });
 
+// One path segment, no traversal and no separator smuggling.
+const badSegment = (n) =>
+  !n || n === '.' || n === '..' || n.includes('/') || n.includes('\\') || n.includes('\0');
+
+// Folders something else depends on: an agent's own workspace and the shared
+// skills dir. Moving or deleting those out from under a running agent breaks
+// its cwd, so the browser refuses. Returns a label, or null if it's fair game.
+function dependedOnDir(abs) {
+  const real = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
+  const target = real(abs);
+  if (target === real(SKILLS_DIR)) return 'the shared skills folder';
+  for (const s of store.list()) {
+    if (s.path && real(workspacePath(s.path)) === target) return `${s.name}'s workspace`;
+  }
+  return null;
+}
+
+// Resolve a browser request against one session's root: `rel` (the entry, or
+// its parent for mkdir) plus an optional new single-segment `name`.
+function browsePath(session, rel, name) {
+  const root = folderPathOf(session);
+  const target = resolveSafe(root, name ? path.join(rel || '.', name) : rel);
+  return { root, target };
+}
+
+app.post('/api/files/:id/mkdir', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const name = String(req.query.name || '').trim();
+  if (badSegment(name)) return res.status(400).json({ error: 'bad name' });
+  const rel = String(req.query.path || '');
+  const { root, target } = browsePath(s, rel, name);
+  const parent = resolveSafe(root, rel);
+  // One folder, in a parent that already exists — not a whole missing chain.
+  if (!target || !parent || !fs.existsSync(parent)) return res.status(400).json({ error: 'bad path' });
+  if (fs.existsSync(target)) return res.status(409).json({ error: 'already exists' });
+  try { fs.mkdirSync(target); } catch (e) { return res.status(500).json({ error: e.message }); }
+  res.json({ ok: true });
+});
+
+app.post('/api/files/:id/rename', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const name = String(req.query.name || '').trim();
+  if (badSegment(name)) return res.status(400).json({ error: 'bad name' });
+  const rel = String(req.query.path || '');
+  const { root, target: from } = browsePath(s, rel);
+  if (!from || from === root || !fs.existsSync(from)) return res.status(400).json({ error: 'bad path' });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  const { target: to } = browsePath(s, path.dirname(rel), name);
+  if (!to) return res.status(400).json({ error: 'bad path' });
+  if (to !== from && fs.existsSync(to)) return res.status(409).json({ error: 'already exists' });
+  try { fs.renameSync(from, to); } catch (e) { return res.status(500).json({ error: e.message }); }
+  res.json({ ok: true });
+});
+
+// Recursive: deleting a folder takes what's inside it with it. The UI asks
+// twice before calling this.
+app.delete('/api/files/:id/entry', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const { root, target } = browsePath(s, String(req.query.path || ''));
+  if (!target || target === root || !fs.existsSync(target)) return res.status(400).json({ error: 'bad path' });
+  const dep = dependedOnDir(target);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  try { fs.rmSync(target, { recursive: true, force: true }); } catch (e) { return res.status(500).json({ error: e.message }); }
+  res.json({ ok: true });
+});
+
 // Sanitize a client-supplied workspace-relative path: no '..', no absolute
 // paths, must resolve under WORKSPACES_DIR. Returns the normalized relative
 // path ('' = the workspaces root), or null if invalid.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -144,7 +144,7 @@ export const uploadFile = (id: string, p: string, file: File) =>
 export const downloadUrl = (id: string, p: string) =>
   `/api/files/${id}/download?path=${encodeURIComponent(p)}`;
 
-// Folder edits carry a reason when they fail ("already exists", "that folder is
+// Entry edits carry a reason when they fail ("already exists", "that folder is
 // …"), and the file browser shows it inline — so these use fileErr, not json.
 const fileErr = async (r: Response) => {
   const body = await r.json().catch(() => null);
@@ -158,6 +158,11 @@ export const createFolder = (id: string, parent: string, name: string) =>
 
 export const renameEntry = (id: string, p: string, name: string) =>
   fetch(`/api/files/${id}/rename?path=${encodeURIComponent(p)}&name=${encodeURIComponent(name)}`,
+    { method: 'POST' }).then(fileErr);
+
+// `toDir` is the destination folder ('' = the browser's root); the name rides along.
+export const moveEntry = (id: string, p: string, toDir: string) =>
+  fetch(`/api/files/${id}/move?path=${encodeURIComponent(p)}&to=${encodeURIComponent(toDir)}`,
     { method: 'POST' }).then(fileErr);
 
 export const deleteEntry = (id: string, p: string) =>

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -144,6 +144,25 @@ export const uploadFile = (id: string, p: string, file: File) =>
 export const downloadUrl = (id: string, p: string) =>
   `/api/files/${id}/download?path=${encodeURIComponent(p)}`;
 
+// Folder edits carry a reason when they fail ("already exists", "that folder is
+// …"), and the file browser shows it inline — so these use fileErr, not json.
+const fileErr = async (r: Response) => {
+  const body = await r.json().catch(() => null);
+  if (!r.ok) throw new Error((body && body.error) || `${r.status}`);
+  return body;
+};
+
+export const createFolder = (id: string, parent: string, name: string) =>
+  fetch(`/api/files/${id}/mkdir?path=${encodeURIComponent(parent)}&name=${encodeURIComponent(name)}`,
+    { method: 'POST' }).then(fileErr);
+
+export const renameEntry = (id: string, p: string, name: string) =>
+  fetch(`/api/files/${id}/rename?path=${encodeURIComponent(p)}&name=${encodeURIComponent(name)}`,
+    { method: 'POST' }).then(fileErr);
+
+export const deleteEntry = (id: string, p: string) =>
+  fetch(`/api/files/${id}/entry?path=${encodeURIComponent(p)}`, { method: 'DELETE' }).then(fileErr);
+
 // ---- session sharing (docs/session-sharing.md) ----
 export interface ShareInfo {
   namespace: string | null;

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
 import type { Session } from '../types';
 import * as api from '../api';
 import type { FileEntry } from '../api';
 import Logo from './Logo';
-import { FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, PlusGlyph, PencilGlyph, TrashGlyph } from './icons';
+import { FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, PlusGlyph, PencilGlyph, TrashGlyph, MoveGlyph } from './icons';
 
 const fmtSize = (n: number) => {
   if (n < 1024) return `${n} B`;
@@ -12,6 +12,7 @@ const fmtSize = (n: number) => {
 };
 
 const join = (a: string, b: string) => (a ? `${a}/${b}` : b);
+const parentOf = (p: string) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '');
 const sortEntries = (es: FileEntry[]) =>
   [...es].sort((a, b) => (a.dir === b.dir ? a.name.localeCompare(b.name) : a.dir ? -1 : 1));
 
@@ -20,6 +21,43 @@ const triggerDownload = (url: string, name: string) => {
   a.href = url; a.download = name;
   document.body.appendChild(a); a.click(); a.remove();
 };
+
+// An entry on its way somewhere else — dragged, or picked with the move button
+// (touch has no drag). Both routes end in the same move() with the same rules.
+interface Moving { path: string; name: string; dir: boolean }
+
+// Our own drag flavour, so a folder can tell an entry coming from this tree from
+// an OS file drop and treat them differently (move vs upload).
+const ENTRY_MIME = 'application/x-agent-manager-entry';
+
+// Where an entry may land: not back where it already is, and — for a folder —
+// not inside itself, which would take the folder with it.
+const canDrop = (m: Moving, destDir: string) =>
+  parentOf(m.path) !== destDir && !(m.dir && (destDir === m.path || destDir.startsWith(`${m.path}/`)));
+
+// The whole tree talks to the pane through this: rows are recursive and every
+// one of them can rename, delete, and accept a drop, so threading callbacks
+// through each level would mean passing eight props down N levels.
+interface TreeApi {
+  sessionId: string;
+  open: (p: string) => void;               // re-root the tree here
+  fail: (msg: string) => void;             // into the hint bar
+  // Re-read one directory listing wherever it sits in the tree. A move touches
+  // two of them (source parent, destination), which is why refreshes travel on
+  // a bus instead of a callback to the immediate parent.
+  refresh: (dir: string) => void;
+  subscribe: (dir: string, fn: () => void) => () => void;
+  upload: (dir: string, files: FileList | File[]) => void;
+  drag: Moving | null;                     // HTML5 drag in flight
+  setDrag: (m: Moving | null) => void;
+  dropDir: string | null;                  // the folder the drag is hovering
+  setDropDir: (p: string | null) => void;
+  picked: Moving | null;                   // move-by-button, awaiting a target
+  pick: (m: Moving | null) => void;
+  move: (m: Moving, destDir: string) => void;
+}
+const TreeCtx = createContext<TreeApi | null>(null);
+const useTree = () => useContext(TreeCtx)!;
 
 // ASCII-tree rails: one cell per ancestor (vertical line if that ancestor has
 // more siblings below) plus the elbow cell for this row (├ normally, └ if last).
@@ -34,11 +72,11 @@ function Rails({ prefix, isLast }: { prefix: boolean[]; isLast: boolean }) {
 }
 const padFor = (prefix: boolean[]) => ({ paddingLeft: `${(prefix.length + 1) * 1.1}em` });
 
-// Inline field for naming a new folder or renaming one. Enter commits, Escape
-// cancels, blur commits — and `done` keeps the blur that follows a keypress
-// from committing (or cancelling) a second time.
-function NameInput({ init, onCommit, onCancel }: {
-  init: string; onCommit: (name: string) => void; onCancel: () => void;
+// Inline field for naming a new folder or renaming an entry. Enter commits,
+// Escape cancels, blur commits — and `done` keeps the blur that follows a
+// keypress from committing (or cancelling) a second time.
+function NameInput({ init, placeholder = 'folder name', onCommit, onCancel }: {
+  init: string; placeholder?: string; onCommit: (name: string) => void; onCancel: () => void;
 }) {
   const [value, setValue] = useState(init);
   const done = useRef(false);
@@ -50,7 +88,7 @@ function NameInput({ init, onCommit, onCancel }: {
   };
   return (
     <input
-      autoFocus className="tw-input" value={value} spellCheck={false} placeholder="folder name"
+      autoFocus className="tw-input" value={value} spellCheck={false} placeholder={placeholder}
       onChange={(e) => setValue(e.target.value)}
       onBlur={() => finish(true)}
       onKeyDown={(e) => {
@@ -62,15 +100,14 @@ function NameInput({ init, onCommit, onCancel }: {
   );
 }
 
-// Lazily-loaded contents of one directory; recurses through FolderNode.
-// `nonce` re-lists after one of its folders is renamed or deleted.
-function DirContents({ sessionId, path, prefix, onOpen, onError }: {
-  sessionId: string; path: string; prefix: boolean[];
-  onOpen: (p: string) => void; onError: (msg: string) => void;
-}) {
+// Lazily-loaded contents of one directory; recurses through EntryRow. Re-reads
+// when the pane's refresh bus names this path.
+function DirContents({ path, prefix }: { path: string; prefix: boolean[] }) {
+  const { sessionId, subscribe } = useTree();
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [err, setErr] = useState(false);
   const [nonce, setNonce] = useState(0);
+  useEffect(() => subscribe(path, () => setNonce((n) => n + 1)), [subscribe, path]);
   useEffect(() => {
     let alive = true;
     api.listFiles(sessionId, path)
@@ -86,92 +123,130 @@ function DirContents({ sessionId, path, prefix, onOpen, onError }: {
   const arr = sortEntries(entries);
   return (
     <>
-      {arr.map((e, i) => {
-        const isLast = i === arr.length - 1;
-        const p = join(path, e.name);
-        return e.dir ? (
-          <FolderNode
-            key={e.name} sessionId={sessionId} path={p} name={e.name} prefix={prefix} isLast={isLast}
-            onOpen={onOpen} onError={onError} onChanged={() => setNonce((n) => n + 1)}
-          />
-        ) : (
-          <div
-            key={e.name}
-            className="tree-row file"
-            style={padFor(prefix)}
-            onDoubleClick={() => triggerDownload(api.downloadUrl(sessionId, p), e.name)}
-            title="Double-click to download"
-          >
-            <Rails prefix={prefix} isLast={isLast} />
-            <FileGlyph className="tw-ico" />
-            <span className="tw-name">{e.name}</span>
-            <span className="tw-size">{fmtSize(e.size)}</span>
-          </div>
-        );
-      })}
+      {arr.map((e, i) => (
+        <EntryRow
+          key={e.name} entry={e} path={join(path, e.name)} prefix={prefix} isLast={i === arr.length - 1}
+        />
+      ))}
     </>
   );
 }
 
-// A folder row: single click toggles inline expand, double click opens it as the
-// new tree root. A short timer disambiguates the two. Rename and delete ride the
-// row on hover; delete asks once, because it takes the contents with it.
-function FolderNode({ sessionId, path, name, prefix, isLast, onOpen, onError, onChanged }: {
-  sessionId: string; path: string; name: string; prefix: boolean[]; isLast: boolean;
-  onOpen: (p: string) => void; onError: (msg: string) => void; onChanged: () => void;
+// One row, file or folder. A folder single-clicks to expand inline and
+// double-clicks to become the new tree root (a short timer disambiguates the
+// two); a file double-clicks to download. Rename, move, and delete ride the row
+// on hover; delete asks first, since nothing here is undoable.
+function EntryRow({ entry, path, prefix, isLast }: {
+  entry: FileEntry; path: string; prefix: boolean[]; isLast: boolean;
 }) {
+  const t = useTree();
+  const dir = entry.dir;
+  const kind = dir ? 'folder' : 'file';
   const [open, setOpen] = useState(false);
   const [editing, setEditing] = useState(false);
   const [confirmDel, setConfirmDel] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // While a row is being renamed or is asking about a delete, its gestures are
+  // off — a click near the buttons must not also expand or re-root the tree.
+  const held = editing || confirmDel;
   const onClick = () => {
-    if (editing || confirmDel || timer.current) return;
+    if (held || !dir || timer.current) return;
     timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
   };
   const onDoubleClick = () => {
-    if (editing || confirmDel) return;
+    if (held) return;
     if (timer.current) { clearTimeout(timer.current); timer.current = null; }
-    onOpen(path);
+    if (dir) t.open(path);
+    else triggerDownload(api.downloadUrl(t.sessionId, path), entry.name);
   };
+
   // The parent listing owns this row, so it's the one that has to re-read.
   const settle = (p: Promise<unknown>) =>
-    p.then(() => { onError(''); onChanged(); }).catch((e) => onError(e.message));
-  const rename = (next: string) => { setEditing(false); settle(api.renameEntry(sessionId, path, next)); };
-  const remove = () => { setConfirmDel(false); settle(api.deleteEntry(sessionId, path)); };
+    p.then(() => { t.fail(''); t.refresh(parentOf(path)); }).catch((e) => t.fail(e.message));
+  const rename = (next: string) => { setEditing(false); settle(api.renameEntry(t.sessionId, path, next)); };
+  const remove = () => { setConfirmDel(false); settle(api.deleteEntry(t.sessionId, path)); };
+
+  // Folders take drops: an entry from this tree moves into them, OS files
+  // upload into them. A file row is not a container, so it lets the drag fall
+  // through to the body, which stands for the folder the tree is rooted at.
+  const onDragOver = (e: React.DragEvent) => {
+    const inside = !!t.drag;
+    if (!dir || !(inside || e.dataTransfer.types.includes('Files'))) return;
+    e.stopPropagation();                        // a folder owns the hover, even to refuse it
+    if (inside && !canDrop(t.drag!, path)) { t.setDropDir(null); return; }
+    e.preventDefault();                         // only now is it a drop target
+    e.dataTransfer.dropEffect = inside ? 'move' : 'copy';
+    t.setDropDir(path);
+  };
+  const onDrop = (e: React.DragEvent) => {
+    if (!dir) return;
+    e.preventDefault();
+    e.stopPropagation();
+    t.setDropDir(null);
+    if (t.drag) t.move(t.drag, path);           // move() re-checks where it may land
+    else if (e.dataTransfer.files.length) t.upload(path, e.dataTransfer.files);
+  };
+
+  // A picked entry turns every eligible folder into a one-click destination —
+  // the touch route to the same move, where no drag is possible.
+  const target = t.picked && dir && canDrop(t.picked, path) ? t.picked : null;
+  const mine = t.picked?.path === path || t.drag?.path === path;
 
   return (
     <>
-      <div className="tree-row folder" style={padFor(prefix)} onClick={onClick} onDoubleClick={onDoubleClick} title="Click to expand · double-click to open">
+      <div
+        className={`tree-row ${kind}${t.dropDir === path ? ' drop' : ''}${mine ? ' lifted' : ''}`}
+        style={padFor(prefix)}
+        draggable={!held}
+        onDragStart={(e) => {
+          if (held) return;
+          e.stopPropagation();                  // not the pane's own header drag
+          e.dataTransfer.setData(ENTRY_MIME, path);
+          e.dataTransfer.effectAllowed = 'move';
+          t.setDrag({ path, name: entry.name, dir });
+        }}
+        onDragEnd={() => { t.setDrag(null); t.setDropDir(null); }}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+        onClick={onClick}
+        onDoubleClick={onDoubleClick}
+        title={dir ? 'Click to expand · double-click to open · drag to move' : 'Double-click to download · drag to move'}
+      >
         <Rails prefix={prefix} isLast={isLast} />
-        <FolderGlyph className="tw-ico" open={open} />
+        {dir ? <FolderGlyph className="tw-ico" open={open} /> : <FileGlyph className="tw-ico" />}
         {editing ? (
-          <NameInput init={name} onCommit={rename} onCancel={() => setEditing(false)} />
+          <NameInput init={entry.name} placeholder={`${kind} name`} onCommit={rename} onCancel={() => setEditing(false)} />
         ) : (
           <>
-            <span className="tw-name">{name}</span>
+            <span className="tw-name">{entry.name}</span>
+            {!dir && <span className="tw-size">{fmtSize(entry.size)}</span>}
             {/* the row's expand/open gestures must not fire from these buttons */}
             <span
-              className={`tw-actions${confirmDel ? ' open' : ''}`}
+              className={`tw-actions${confirmDel || target ? ' open' : ''}`}
               onClick={(e) => e.stopPropagation()}
               onDoubleClick={(e) => e.stopPropagation()}
             >
               {confirmDel ? (
                 <>
-                  <span className="tw-warn">Delete folder and everything in it?</span>
+                  <span className="tw-warn">{dir ? 'Delete folder and everything in it?' : 'Delete file?'}</span>
                   <button className="mini-btn danger" onClick={remove}>Delete</button>
                   <button className="mini-btn" onClick={() => setConfirmDel(false)}>Cancel</button>
                 </>
-              ) : (
+              ) : target ? (
+                <button className="mini-btn accent" onClick={() => t.move(target, path)}>Move here</button>
+              ) : !t.picked && (
                 <>
-                  <button className="mini-btn" title="Rename folder" onClick={() => setEditing(true)}><PencilGlyph /></button>
-                  <button className="mini-btn" title="Delete folder" onClick={() => setConfirmDel(true)}><TrashGlyph /></button>
+                  <button className="mini-btn" title={`Rename ${kind}`} onClick={() => setEditing(true)}><PencilGlyph /></button>
+                  <button className="mini-btn" title={`Move ${kind}`} onClick={() => t.pick({ path, name: entry.name, dir })}><MoveGlyph /></button>
+                  <button className="mini-btn" title={`Delete ${kind}`} onClick={() => setConfirmDel(true)}><TrashGlyph /></button>
                 </>
               )}
             </span>
           </>
         )}
       </div>
-      {open && <DirContents sessionId={sessionId} path={path} prefix={[...prefix, !isLast]} onOpen={onOpen} onError={onError} />}
+      {dir && open && <DirContents path={path} prefix={[...prefix, !isLast]} />}
     </>
   );
 }
@@ -190,27 +265,47 @@ export default function FilesPane({
   const [root, setRoot] = useState('');
   const [rootLabel, setRootLabel] = useState('workspace');
   const [busy, setBusy] = useState(false);
-  const [dragOver, setDragOver] = useState(false);
-  const [reloadKey, setReloadKey] = useState(0);
   const [creating, setCreating] = useState(false);
   const [err, setErr] = useState('');
+  const [drag, setDrag] = useState<Moving | null>(null);
+  const [dropDir, setDropDir] = useState<string | null>(null);
+  const [picked, setPicked] = useState<Moving | null>(null);
 
   useEffect(() => { api.listFiles(session.id, '').then((r) => setRootLabel(r.root)).catch(() => {}); }, [session.id]);
 
-  const upload = async (files: FileList | File[]) => {
+  // Directory listings subscribe by path so an edit can re-read exactly the
+  // ones it touched, leaving the rest of the expanded tree where it was.
+  const subs = useRef(new Map<string, Set<() => void>>());
+  const subscribe = useCallback((dir: string, fn: () => void) => {
+    const at = subs.current.get(dir) ?? new Set<() => void>();
+    subs.current.set(dir, at);
+    at.add(fn);
+    return () => { at.delete(fn); if (!at.size) subs.current.delete(dir); };
+  }, []);
+  const refresh = useCallback((dir: string) => { subs.current.get(dir)?.forEach((fn) => fn()); }, []);
+
+  const upload = useCallback(async (dir: string, files: FileList | File[]) => {
     setBusy(true);
     for (const f of Array.from(files)) {
-      try { await api.uploadFile(session.id, root, f); } catch { /* skip */ }
+      try { await api.uploadFile(session.id, dir, f); } catch { /* skip */ }
     }
     setBusy(false);
-    setReloadKey((k) => k + 1);
-  };
+    refresh(dir);
+  }, [session.id, refresh]);
+
+  const move = useCallback((m: Moving, destDir: string) => {
+    setDrag(null); setDropDir(null); setPicked(null);
+    if (!canDrop(m, destDir)) return;
+    api.moveEntry(session.id, m.path, destDir)
+      .then(() => { setErr(''); refresh(parentOf(m.path)); refresh(destDir); })
+      .catch((e) => setErr(e.message));
+  }, [session.id, refresh]);
 
   // A new folder lands in whichever folder the tree is currently rooted at.
   const createFolder = (name: string) => {
     setCreating(false);
     api.createFolder(session.id, root, name)
-      .then(() => { setErr(''); setReloadKey((k) => k + 1); })
+      .then(() => { setErr(''); refresh(root); })
       .catch((e) => setErr(e.message));
   };
 
@@ -219,6 +314,23 @@ export default function FilesPane({
   const up = () => goto(root.includes('/') ? root.slice(0, root.lastIndexOf('/')) : '');
   const crumbs = ['', ...root.split('/').filter(Boolean).map((_, i, arr) => arr.slice(0, i + 1).join('/'))];
   const here = root ? root.split('/').pop() : rootLabel;
+
+  // Crumbs are drop targets too: rooted deep in the tree, they're the only way
+  // to send something back up without navigating there first.
+  const crumbDnd = (c: string) => ({
+    onDragOver: (e: React.DragEvent) => {
+      if (!drag || !canDrop(drag, c)) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+      setDropDir(c);
+    },
+    onDrop: (e: React.DragEvent) => { if (drag) { e.preventDefault(); move(drag, c); } },
+  });
+
+  const tree: TreeApi = {
+    sessionId: session.id, open: goto, fail: setErr, refresh, subscribe, upload,
+    drag, setDrag, dropDir, setDropDir, picked, pick: setPicked, move,
+  };
 
   return (
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
@@ -235,41 +347,73 @@ export default function FilesPane({
           {crumbs.map((c, i) => (
             <span key={c || 'root'}>
               {i > 0 && <span className="sep">/</span>}
-              <button className="crumb" onClick={() => goto(c)}>{i === 0 ? rootLabel : c.split('/').pop()}</button>
+              <button
+                /* the current root is the body's target, not the crumb's */
+                className={`crumb${drag && dropDir === c && c !== root ? ' drop' : ''}`}
+                onClick={() => goto(c)}
+                {...crumbDnd(c)}
+              >
+                {i === 0 ? rootLabel : c.split('/').pop()}
+              </button>
             </span>
           ))}
         </div>
         <span className="spacer" />
+        {picked && canDrop(picked, root) && (
+          <button className="mini-btn accent" title={`Move ${picked.name} into ${here}`} onClick={(e) => { e.stopPropagation(); move(picked, root); }}>
+            <MoveGlyph /> Move here
+          </button>
+        )}
         <button className="mini-btn" title={`New folder in ${here}`} onClick={(e) => { e.stopPropagation(); setCreating(true); }}>
           <PlusGlyph /> Folder
         </button>
-        <label className="mini-btn upload-btn" title="Upload files">
+        <label className="mini-btn upload-btn" title={`Upload into ${here}`}>
           <UploadGlyph /> Upload
-          <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(e.target.files); e.target.value = ''; }} />
+          <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(root, e.target.files); e.target.value = ''; }} />
         </label>
         <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
       </div>
 
-      <div
-        className={`files-body tree${dragOver ? ' drag' : ''}`}
-        style={{ fontSize: `${(13 * zoom) / 100}px` }}
-        onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
-        onDragLeave={() => setDragOver(false)}
-        onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) upload(e.dataTransfer.files); }}
-      >
-        {creating && (
-          <div className="tree-row folder" style={padFor([])}>
-            <FolderGlyph className="tw-ico" />
-            <NameInput init="" onCommit={createFolder} onCancel={() => setCreating(false)} />
-          </div>
-        )}
-        <DirContents key={`${root}:${reloadKey}`} sessionId={session.id} path={root} prefix={[]} onOpen={goto} onError={setErr} />
-        {busy && <div className="tree-msg">Uploading…</div>}
-      </div>
+      <TreeCtx.Provider value={tree}>
+        {/* Anything dropped on the background — an OS file, or an entry from
+            deeper in the tree — belongs to the folder the tree is rooted at. */}
+        <div
+          className={`files-body tree${dropDir === root ? ' drag' : ''}`}
+          style={{ fontSize: `${(13 * zoom) / 100}px` }}
+          onDragOver={(e) => {
+            if (drag && !canDrop(drag, root)) { setDropDir(null); return; }
+            e.preventDefault();
+            e.dataTransfer.dropEffect = drag ? 'move' : 'copy';
+            setDropDir(root);
+          }}
+          onDragLeave={(e) => { if (!e.currentTarget.contains(e.relatedTarget as Node | null)) setDropDir(null); }}
+          onDrop={(e) => {
+            e.preventDefault();
+            setDropDir(null);
+            if (drag) move(drag, root);
+            else if (e.dataTransfer.files.length) upload(root, e.dataTransfer.files);
+          }}
+        >
+          {creating && (
+            <div className="tree-row folder" style={padFor([])}>
+              <FolderGlyph className="tw-ico" />
+              <NameInput init="" onCommit={createFolder} onCancel={() => setCreating(false)} />
+            </div>
+          )}
+          <DirContents key={root} path={root} prefix={[]} />
+          {busy && <div className="tree-msg">Uploading…</div>}
+        </div>
+      </TreeCtx.Provider>
 
-      {err
-        ? <div className="files-hint err">{err}</div>
-        : <div className="files-hint">Click a folder to expand · double-click to open it · double-click a file to download</div>}
+      {err ? <div className="files-hint err">{err}</div>
+        : picked ? (
+          <div className="files-hint moving">
+            <span>Moving <b>{picked.name}</b> — pick a destination folder</span>
+            <button className="mini-btn" onClick={() => setPicked(null)}>Cancel</button>
+          </div>
+        ) : (
+          <div className="files-hint">Click to expand · double-click to open or download · drag into a folder to move</div>
+        )}
     </div>
   );
 }

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -3,7 +3,7 @@ import type { Session } from '../types';
 import * as api from '../api';
 import type { FileEntry } from '../api';
 import Logo from './Logo';
-import { FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph } from './icons';
+import { FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, PlusGlyph, PencilGlyph, TrashGlyph } from './icons';
 
 const fmtSize = (n: number) => {
   if (n < 1024) return `${n} B`;
@@ -34,19 +34,50 @@ function Rails({ prefix, isLast }: { prefix: boolean[]; isLast: boolean }) {
 }
 const padFor = (prefix: boolean[]) => ({ paddingLeft: `${(prefix.length + 1) * 1.1}em` });
 
+// Inline field for naming a new folder or renaming one. Enter commits, Escape
+// cancels, blur commits — and `done` keeps the blur that follows a keypress
+// from committing (or cancelling) a second time.
+function NameInput({ init, onCommit, onCancel }: {
+  init: string; onCommit: (name: string) => void; onCancel: () => void;
+}) {
+  const [value, setValue] = useState(init);
+  const done = useRef(false);
+  const finish = (commit: boolean) => {
+    if (done.current) return;
+    done.current = true;
+    const name = value.trim();
+    if (commit && name && name !== init) onCommit(name); else onCancel();
+  };
+  return (
+    <input
+      autoFocus className="tw-input" value={value} spellCheck={false} placeholder="folder name"
+      onChange={(e) => setValue(e.target.value)}
+      onBlur={() => finish(true)}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter') finish(true);
+        if (e.key === 'Escape') finish(false);
+      }}
+    />
+  );
+}
+
 // Lazily-loaded contents of one directory; recurses through FolderNode.
-function DirContents({ sessionId, path, prefix, onOpen }: {
-  sessionId: string; path: string; prefix: boolean[]; onOpen: (p: string) => void;
+// `nonce` re-lists after one of its folders is renamed or deleted.
+function DirContents({ sessionId, path, prefix, onOpen, onError }: {
+  sessionId: string; path: string; prefix: boolean[];
+  onOpen: (p: string) => void; onError: (msg: string) => void;
 }) {
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [err, setErr] = useState(false);
+  const [nonce, setNonce] = useState(0);
   useEffect(() => {
     let alive = true;
     api.listFiles(sessionId, path)
       .then((r) => { if (alive) { setEntries(r.entries); setErr(false); } })
       .catch(() => { if (alive) setErr(true); });
     return () => { alive = false; };
-  }, [sessionId, path]);
+  }, [sessionId, path, nonce]);
 
   if (err) return <div className="tree-msg" style={padFor(prefix)}>can't read folder</div>;
   if (!entries) return <div className="tree-msg" style={padFor(prefix)}>…</div>;
@@ -59,7 +90,10 @@ function DirContents({ sessionId, path, prefix, onOpen }: {
         const isLast = i === arr.length - 1;
         const p = join(path, e.name);
         return e.dir ? (
-          <FolderNode key={e.name} sessionId={sessionId} path={p} name={e.name} prefix={prefix} isLast={isLast} onOpen={onOpen} />
+          <FolderNode
+            key={e.name} sessionId={sessionId} path={p} name={e.name} prefix={prefix} isLast={isLast}
+            onOpen={onOpen} onError={onError} onChanged={() => setNonce((n) => n + 1)}
+          />
         ) : (
           <div
             key={e.name}
@@ -80,28 +114,64 @@ function DirContents({ sessionId, path, prefix, onOpen }: {
 }
 
 // A folder row: single click toggles inline expand, double click opens it as the
-// new tree root. A short timer disambiguates the two.
-function FolderNode({ sessionId, path, name, prefix, isLast, onOpen }: {
-  sessionId: string; path: string; name: string; prefix: boolean[]; isLast: boolean; onOpen: (p: string) => void;
+// new tree root. A short timer disambiguates the two. Rename and delete ride the
+// row on hover; delete asks once, because it takes the contents with it.
+function FolderNode({ sessionId, path, name, prefix, isLast, onOpen, onError, onChanged }: {
+  sessionId: string; path: string; name: string; prefix: boolean[]; isLast: boolean;
+  onOpen: (p: string) => void; onError: (msg: string) => void; onChanged: () => void;
 }) {
   const [open, setOpen] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [confirmDel, setConfirmDel] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onClick = () => {
-    if (timer.current) return;
+    if (editing || confirmDel || timer.current) return;
     timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
   };
   const onDoubleClick = () => {
+    if (editing || confirmDel) return;
     if (timer.current) { clearTimeout(timer.current); timer.current = null; }
     onOpen(path);
   };
+  // The parent listing owns this row, so it's the one that has to re-read.
+  const settle = (p: Promise<unknown>) =>
+    p.then(() => { onError(''); onChanged(); }).catch((e) => onError(e.message));
+  const rename = (next: string) => { setEditing(false); settle(api.renameEntry(sessionId, path, next)); };
+  const remove = () => { setConfirmDel(false); settle(api.deleteEntry(sessionId, path)); };
+
   return (
     <>
       <div className="tree-row folder" style={padFor(prefix)} onClick={onClick} onDoubleClick={onDoubleClick} title="Click to expand · double-click to open">
         <Rails prefix={prefix} isLast={isLast} />
         <FolderGlyph className="tw-ico" open={open} />
-        <span className="tw-name">{name}</span>
+        {editing ? (
+          <NameInput init={name} onCommit={rename} onCancel={() => setEditing(false)} />
+        ) : (
+          <>
+            <span className="tw-name">{name}</span>
+            {/* the row's expand/open gestures must not fire from these buttons */}
+            <span
+              className={`tw-actions${confirmDel ? ' open' : ''}`}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+            >
+              {confirmDel ? (
+                <>
+                  <span className="tw-warn">Delete folder and everything in it?</span>
+                  <button className="mini-btn danger" onClick={remove}>Delete</button>
+                  <button className="mini-btn" onClick={() => setConfirmDel(false)}>Cancel</button>
+                </>
+              ) : (
+                <>
+                  <button className="mini-btn" title="Rename folder" onClick={() => setEditing(true)}><PencilGlyph /></button>
+                  <button className="mini-btn" title="Delete folder" onClick={() => setConfirmDel(true)}><TrashGlyph /></button>
+                </>
+              )}
+            </span>
+          </>
+        )}
       </div>
-      {open && <DirContents sessionId={sessionId} path={path} prefix={[...prefix, !isLast]} onOpen={onOpen} />}
+      {open && <DirContents sessionId={sessionId} path={path} prefix={[...prefix, !isLast]} onOpen={onOpen} onError={onError} />}
     </>
   );
 }
@@ -122,6 +192,8 @@ export default function FilesPane({
   const [busy, setBusy] = useState(false);
   const [dragOver, setDragOver] = useState(false);
   const [reloadKey, setReloadKey] = useState(0);
+  const [creating, setCreating] = useState(false);
+  const [err, setErr] = useState('');
 
   useEffect(() => { api.listFiles(session.id, '').then((r) => setRootLabel(r.root)).catch(() => {}); }, [session.id]);
 
@@ -134,12 +206,23 @@ export default function FilesPane({
     setReloadKey((k) => k + 1);
   };
 
-  const up = () => setRoot(root.includes('/') ? root.slice(0, root.lastIndexOf('/')) : '');
+  // A new folder lands in whichever folder the tree is currently rooted at.
+  const createFolder = (name: string) => {
+    setCreating(false);
+    api.createFolder(session.id, root, name)
+      .then(() => { setErr(''); setReloadKey((k) => k + 1); })
+      .catch((e) => setErr(e.message));
+  };
+
+  // Navigating away drops a stale "already exists" / "that folder is …" notice.
+  const goto = (p: string) => { setErr(''); setCreating(false); setRoot(p); };
+  const up = () => goto(root.includes('/') ? root.slice(0, root.lastIndexOf('/')) : '');
   const crumbs = ['', ...root.split('/').filter(Boolean).map((_, i, arr) => arr.slice(0, i + 1).join('/'))];
+  const here = root ? root.split('/').pop() : rootLabel;
 
   return (
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
-      {/* One compact bar: logo, navigation, upload, close — no title. */}
+      {/* One compact bar: logo, navigation, new folder, upload, close — no title. */}
       <div
         className={`pane-head files-head${dragId ? ' draggable' : ''}`}
         draggable={!!dragId}
@@ -152,11 +235,14 @@ export default function FilesPane({
           {crumbs.map((c, i) => (
             <span key={c || 'root'}>
               {i > 0 && <span className="sep">/</span>}
-              <button className="crumb" onClick={() => setRoot(c)}>{i === 0 ? rootLabel : c.split('/').pop()}</button>
+              <button className="crumb" onClick={() => goto(c)}>{i === 0 ? rootLabel : c.split('/').pop()}</button>
             </span>
           ))}
         </div>
         <span className="spacer" />
+        <button className="mini-btn" title={`New folder in ${here}`} onClick={(e) => { e.stopPropagation(); setCreating(true); }}>
+          <PlusGlyph /> Folder
+        </button>
         <label className="mini-btn upload-btn" title="Upload files">
           <UploadGlyph /> Upload
           <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(e.target.files); e.target.value = ''; }} />
@@ -171,11 +257,19 @@ export default function FilesPane({
         onDragLeave={() => setDragOver(false)}
         onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) upload(e.dataTransfer.files); }}
       >
-        <DirContents key={`${root}:${reloadKey}`} sessionId={session.id} path={root} prefix={[]} onOpen={setRoot} />
+        {creating && (
+          <div className="tree-row folder" style={padFor([])}>
+            <FolderGlyph className="tw-ico" />
+            <NameInput init="" onCommit={createFolder} onCancel={() => setCreating(false)} />
+          </div>
+        )}
+        <DirContents key={`${root}:${reloadKey}`} sessionId={session.id} path={root} prefix={[]} onOpen={goto} onError={setErr} />
         {busy && <div className="tree-msg">Uploading…</div>}
       </div>
 
-      <div className="files-hint">Click a folder to expand · double-click to open it · double-click a file to download</div>
+      {err
+        ? <div className="files-hint err">{err}</div>
+        : <div className="files-hint">Click a folder to expand · double-click to open it · double-click a file to download</div>}
     </div>
   );
 }

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -55,6 +55,16 @@ interface TreeApi {
   picked: Moving | null;                   // move-by-button, awaiting a target
   pick: (m: Moving | null) => void;
   move: (m: Moving, destDir: string) => void;
+  // The folder the header bar works on. Clicking a folder makes it the
+  // destination for "+ Folder" and "Upload"; with nothing selected both fall
+  // back to the folder the tree is rooted at.
+  selected: string | null;
+  select: (p: string | null) => void;
+  // Which listing is currently showing the name field for a new folder, so the
+  // field appears *in* the folder it will create into rather than at the root.
+  creatingIn: string | null;
+  createFolder: (dir: string, name: string) => void;
+  cancelCreate: () => void;
 }
 const TreeCtx = createContext<TreeApi | null>(null);
 const useTree = () => useContext(TreeCtx)!;
@@ -103,7 +113,7 @@ function NameInput({ init, placeholder = 'folder name', onCommit, onCancel }: {
 // Lazily-loaded contents of one directory; recurses through EntryRow. Re-reads
 // when the pane's refresh bus names this path.
 function DirContents({ path, prefix }: { path: string; prefix: boolean[] }) {
-  const { sessionId, subscribe } = useTree();
+  const { sessionId, subscribe, creatingIn, createFolder, cancelCreate } = useTree();
   const [entries, setEntries] = useState<FileEntry[] | null>(null);
   const [err, setErr] = useState(false);
   const [nonce, setNonce] = useState(0);
@@ -116,13 +126,26 @@ function DirContents({ path, prefix }: { path: string; prefix: boolean[] }) {
     return () => { alive = false; };
   }, [sessionId, path, nonce]);
 
+  // Sits at the top of this listing, indented like the entries it joins — the
+  // folder is created here, so this is where its name is typed. A click inside
+  // must not reach the background, which would clear the destination.
+  const naming = creatingIn === path ? (
+    <div className="tree-row folder" style={padFor(prefix)} onClick={(e) => e.stopPropagation()}>
+      <Rails prefix={prefix} isLast={false} />
+      <FolderGlyph className="tw-ico" />
+      <NameInput init="" onCommit={(name) => createFolder(path, name)} onCancel={cancelCreate} />
+    </div>
+  ) : null;
+
   if (err) return <div className="tree-msg" style={padFor(prefix)}>can't read folder</div>;
-  if (!entries) return <div className="tree-msg" style={padFor(prefix)}>…</div>;
-  if (entries.length === 0) return <div className="tree-msg" style={padFor(prefix)}>empty</div>;
+  if (!entries) return <>{naming}<div className="tree-msg" style={padFor(prefix)}>…</div></>;
+  // An empty folder still says so, unless the thing about to fill it is on screen.
+  if (entries.length === 0) return naming ?? <div className="tree-msg" style={padFor(prefix)}>empty</div>;
 
   const arr = sortEntries(entries);
   return (
     <>
+      {naming}
       {arr.map((e, i) => (
         <EntryRow
           key={e.name} entry={e} path={join(path, e.name)} prefix={prefix} isLast={i === arr.length - 1}
@@ -147,12 +170,32 @@ function EntryRow({ entry, path, prefix, isLast }: {
   const [confirmDel, setConfirmDel] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  // Naming a new folder in here opens the listing it will appear in, so the
+  // field is on screen even if the folder was picked while collapsed. A click
+  // may have left a toggle pending — it would close the listing back up a
+  // moment after the field appeared, so it is dropped here.
+  useEffect(() => {
+    if (t.creatingIn !== path) return;
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+    setOpen(true);
+  }, [t.creatingIn, path]);
+
   // While a row is being renamed or is asking about a delete, its gestures are
   // off — a click near the buttons must not also expand or re-root the tree.
   const held = editing || confirmDel;
-  const onClick = () => {
+  // Clicking a folder also makes it the destination the header bar works on.
+  // Every row swallows its click: the background behind them clears that.
+  // Reaching for a folder opens it; only clicking the one already chosen
+  // folds it back up, so picking a destination never closes what you picked.
+  const onClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
     if (held || !dir || timer.current) return;
-    timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
+    const reselecting = t.selected === path;
+    t.select(path);
+    timer.current = setTimeout(() => {
+      timer.current = null;
+      setOpen((o) => (reselecting ? !o : true));
+    }, 200);
   };
   const onDoubleClick = () => {
     if (held) return;
@@ -164,8 +207,13 @@ function EntryRow({ entry, path, prefix, isLast }: {
   // The parent listing owns this row, so it's the one that has to re-read.
   const settle = (p: Promise<unknown>) =>
     p.then(() => { t.fail(''); t.refresh(parentOf(path)); }).catch((e) => t.fail(e.message));
-  const rename = (next: string) => { setEditing(false); settle(api.renameEntry(t.sessionId, path, next)); };
-  const remove = () => { setConfirmDel(false); settle(api.deleteEntry(t.sessionId, path)); };
+  // Renaming or deleting the destination leaves the header pointing at a path
+  // that no longer exists, so it falls back to the root.
+  const dropSelection = () => {
+    if (t.selected === path || t.selected?.startsWith(`${path}/`)) t.select(null);
+  };
+  const rename = (next: string) => { setEditing(false); dropSelection(); settle(api.renameEntry(t.sessionId, path, next)); };
+  const remove = () => { setConfirmDel(false); dropSelection(); settle(api.deleteEntry(t.sessionId, path)); };
 
   // Folders take drops: an entry from this tree moves into them, OS files
   // upload into them. A file row is not a container, so it lets the drag fall
@@ -196,7 +244,7 @@ function EntryRow({ entry, path, prefix, isLast }: {
   return (
     <>
       <div
-        className={`tree-row ${kind}${t.dropDir === path ? ' drop' : ''}${mine ? ' lifted' : ''}`}
+        className={`tree-row ${kind}${t.selected === path ? ' selected' : ''}${t.dropDir === path ? ' drop' : ''}${mine ? ' lifted' : ''}`}
         style={padFor(prefix)}
         draggable={!held}
         onDragStart={(e) => {
@@ -265,7 +313,8 @@ export default function FilesPane({
   const [root, setRoot] = useState('');
   const [rootLabel, setRootLabel] = useState('workspace');
   const [busy, setBusy] = useState(false);
-  const [creating, setCreating] = useState(false);
+  const [creatingIn, setCreatingIn] = useState<string | null>(null);
+  const [selected, setSelected] = useState<string | null>(null);
   const [err, setErr] = useState('');
   const [drag, setDrag] = useState<Moving | null>(null);
   const [dropDir, setDropDir] = useState<string | null>(null);
@@ -296,21 +345,26 @@ export default function FilesPane({
   const move = useCallback((m: Moving, destDir: string) => {
     setDrag(null); setDropDir(null); setPicked(null);
     if (!canDrop(m, destDir)) return;
+    // The destination travels with the folder, so following it would mean
+    // tracking a path that just changed; simpler to fall back to the root.
+    setSelected((s) => (s === m.path || s?.startsWith(`${m.path}/`) ? null : s));
     api.moveEntry(session.id, m.path, destDir)
       .then(() => { setErr(''); refresh(parentOf(m.path)); refresh(destDir); })
       .catch((e) => setErr(e.message));
   }, [session.id, refresh]);
 
-  // A new folder lands in whichever folder the tree is currently rooted at.
-  const createFolder = (name: string) => {
-    setCreating(false);
-    api.createFolder(session.id, root, name)
-      .then(() => { setErr(''); refresh(root); })
+  // A new folder lands in the selected folder, or — with nothing selected — in
+  // whichever folder the tree is currently rooted at.
+  const createFolder = useCallback((dir: string, name: string) => {
+    setCreatingIn(null);
+    api.createFolder(session.id, dir, name)
+      .then(() => { setErr(''); refresh(dir); })
       .catch((e) => setErr(e.message));
-  };
+  }, [session.id, refresh]);
 
-  // Navigating away drops a stale "already exists" / "that folder is …" notice.
-  const goto = (p: string) => { setErr(''); setCreating(false); setRoot(p); };
+  // Navigating away drops a stale "already exists" / "that folder is …" notice,
+  // and a selection that is no longer in view.
+  const goto = (p: string) => { setErr(''); setCreatingIn(null); setSelected(null); setRoot(p); };
   const up = () => goto(root.includes('/') ? root.slice(0, root.lastIndexOf('/')) : '');
   const crumbs = ['', ...root.split('/').filter(Boolean).map((_, i, arr) => arr.slice(0, i + 1).join('/'))];
   const here = root ? root.split('/').pop() : rootLabel;
@@ -327,9 +381,15 @@ export default function FilesPane({
     onDrop: (e: React.DragEvent) => { if (drag) { e.preventDefault(); move(drag, c); } },
   });
 
+  // What "+ Folder" and "Upload" act on: the folder you last clicked, else the
+  // folder the tree is rooted at.
+  const dest = selected ?? root;
+  const destLabel = selected ? selected.split('/').pop()! : here;
+
   const tree: TreeApi = {
     sessionId: session.id, open: goto, fail: setErr, refresh, subscribe, upload,
     drag, setDrag, dropDir, setDropDir, picked, pick: setPicked, move,
+    selected, select: setSelected, creatingIn, createFolder, cancelCreate: () => setCreatingIn(null),
   };
 
   return (
@@ -364,12 +424,12 @@ export default function FilesPane({
             <MoveGlyph /> Move here
           </button>
         )}
-        <button className="mini-btn" title={`New folder in ${here}`} onClick={(e) => { e.stopPropagation(); setCreating(true); }}>
+        <button className="mini-btn" title={`New folder in ${destLabel}`} onClick={(e) => { e.stopPropagation(); setCreatingIn(dest); }}>
           <PlusGlyph /> Folder
         </button>
-        <label className="mini-btn upload-btn" title={`Upload into ${here}`}>
+        <label className="mini-btn upload-btn" title={`Upload into ${destLabel}`}>
           <UploadGlyph /> Upload
-          <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(root, e.target.files); e.target.value = ''; }} />
+          <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(dest, e.target.files); e.target.value = ''; }} />
         </label>
         <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
       </div>
@@ -393,13 +453,9 @@ export default function FilesPane({
             if (drag) move(drag, root);
             else if (e.dataTransfer.files.length) upload(root, e.dataTransfer.files);
           }}
+          /* the background is the root: clicking it hands the header back */
+          onClick={() => setSelected(null)}
         >
-          {creating && (
-            <div className="tree-row folder" style={padFor([])}>
-              <FolderGlyph className="tw-ico" />
-              <NameInput init="" onCommit={createFolder} onCancel={() => setCreating(false)} />
-            </div>
-          )}
           <DirContents key={root} path={root} prefix={[]} />
           {busy && <div className="tree-msg">Uploading…</div>}
         </div>
@@ -410,6 +466,11 @@ export default function FilesPane({
           <div className="files-hint moving">
             <span>Moving <b>{picked.name}</b> — pick a destination folder</span>
             <button className="mini-btn" onClick={() => setPicked(null)}>Cancel</button>
+          </div>
+        ) : selected ? (
+          <div className="files-hint selected">
+            <span>New folders and uploads go into <b>{destLabel}</b></span>
+            <button className="mini-btn" onClick={() => setSelected(null)}>Clear</button>
           </div>
         ) : (
           <div className="files-hint">Click to expand · double-click to open or download · drag into a folder to move</div>

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -100,6 +100,14 @@ export const UploadGlyph = ({ className }: { className?: string }) => (
   </G>
 );
 
+// Move: an arrow crossing into a folder mouth — the button form of a drag.
+export const MoveGlyph = ({ className }: { className?: string }) => (
+  <G className={className}>
+    <path d="M1.5 4.75a1 1 0 0 1 1-1h2.6a1 1 0 0 1 .7.3l.9.9h5.8a1 1 0 0 1 1 1v5.3a1 1 0 0 1-1 1H2.5a1 1 0 0 1-1-1z" />
+    <path d="M5.4 8.9h4.4M8.1 7.2l1.9 1.7-1.9 1.7" />
+  </G>
+);
+
 export const UpGlyph = ({ className }: { className?: string }) => (
   <G className={className}>
     <path d="M8 12.8V3.4M4.4 7L8 3.4 11.6 7" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -628,7 +628,18 @@ body {
 .tw-name { flex: 1; overflow: hidden; text-overflow: ellipsis; }
 .tw-size { color: var(--muted); font-size: 0.8em; flex: none; padding-left: 0.6em; font-variant-numeric: tabular-nums; }
 .tree-msg { color: var(--muted); font-size: 0.85em; padding: 0.15em 0; }
+
+/* folder edits: rename/delete ride the row on hover, name field replaces it */
+.tw-actions { display: flex; align-items: center; gap: 2px; flex: none; opacity: 0; pointer-events: none; transition: opacity 0.12s ease-out; }
+.tree-row:hover .tw-actions, .tree-row:focus-within .tw-actions, .tw-actions.open { opacity: 1; pointer-events: auto; }
+.tw-actions .mini-btn { font-size: 0.8em; padding: 2px 5px; }
+.tw-actions .mini-btn svg { width: 1em; height: 1em; }
+.tw-actions .mini-btn.danger { color: var(--danger); }
+.tw-warn { color: var(--muted); font-size: 0.8em; padding-right: 0.2em; }
+.tw-input { flex: 1; min-width: 4em; background: var(--panel-2); border: 1px solid var(--accent); border-radius: var(--r-sm); color: var(--text); font: inherit; font-size: 1em; padding: 0 0.25em; outline: none; }
+
 .files-hint { flex: none; padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel); color: var(--muted); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.files-hint.err { color: var(--danger); }
 
 /* settings */
 .settings-nav { padding: 10px; display: flex; flex-direction: column; gap: 4px; }
@@ -829,6 +840,7 @@ a.btn-ghost { text-decoration: none; }
   .tree { padding-top: 6px; }
   .group { margin: 13px 0 5px; }
   .row .row-actions { opacity: 1; pointer-events: auto; position: static; transform: none; margin-left: 4px; background: transparent; }
+  .tw-actions { opacity: 1; pointer-events: auto; } /* no hover on touch */
   .row .cli-logo, .row .count { opacity: 1 !important; }
   .row .age { display: none; } /* actions are always visible on touch — no room */
   .g-add { opacity: 1; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -636,6 +636,10 @@ body {
 .tw-actions .mini-btn svg { width: 1em; height: 1em; }
 .tw-actions .mini-btn.danger { color: var(--danger); }
 
+/* the folder the header bar acts on — marked down its edge, so a drop landing
+   on the same row still reads as the stronger, filled highlight */
+.tree-row.selected { background: color-mix(in srgb, var(--accent) 9%, transparent); box-shadow: inset 2px 0 0 var(--accent); }
+
 /* moving: the row being carried dims, the folder under the drag lights up */
 .tree-row.lifted { opacity: 0.5; }
 .tree-row.drop { background: color-mix(in srgb, var(--accent) 16%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent); }
@@ -651,6 +655,12 @@ body {
 .files-hint.moving { display: flex; align-items: center; gap: 8px; color: var(--accent); }
 .files-hint.moving span { overflow: hidden; text-overflow: ellipsis; }
 .files-hint.moving .mini-btn { flex: none; font-size: 10px; padding: 1px 5px; }
+/* same shape for the destination, in the quieter text — it is a standing state,
+   not something the pane is waiting on */
+.files-hint.selected { display: flex; align-items: center; gap: 8px; }
+.files-hint.selected span { overflow: hidden; text-overflow: ellipsis; }
+.files-hint.selected b { color: var(--text); font-weight: 600; }
+.files-hint.selected .mini-btn { flex: none; font-size: 10px; padding: 1px 5px; }
 
 /* settings */
 .settings-nav { padding: 10px; display: flex; flex-direction: column; gap: 4px; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -629,17 +629,28 @@ body {
 .tw-size { color: var(--muted); font-size: 0.8em; flex: none; padding-left: 0.6em; font-variant-numeric: tabular-nums; }
 .tree-msg { color: var(--muted); font-size: 0.85em; padding: 0.15em 0; }
 
-/* folder edits: rename/delete ride the row on hover, name field replaces it */
+/* entry edits: rename/move/delete ride the row on hover, name field replaces it */
 .tw-actions { display: flex; align-items: center; gap: 2px; flex: none; opacity: 0; pointer-events: none; transition: opacity 0.12s ease-out; }
 .tree-row:hover .tw-actions, .tree-row:focus-within .tw-actions, .tw-actions.open { opacity: 1; pointer-events: auto; }
 .tw-actions .mini-btn { font-size: 0.8em; padding: 2px 5px; }
 .tw-actions .mini-btn svg { width: 1em; height: 1em; }
 .tw-actions .mini-btn.danger { color: var(--danger); }
+
+/* moving: the row being carried dims, the folder under the drag lights up */
+.tree-row.lifted { opacity: 0.5; }
+.tree-row.drop { background: color-mix(in srgb, var(--accent) 16%, transparent); box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 55%, transparent); }
+.crumb.drop { color: var(--accent); background: color-mix(in srgb, var(--accent) 16%, transparent); }
+.mini-btn.accent { color: var(--accent); }
+.mini-btn.accent:hover { background: color-mix(in srgb, var(--accent) 16%, transparent); }
 .tw-warn { color: var(--muted); font-size: 0.8em; padding-right: 0.2em; }
 .tw-input { flex: 1; min-width: 4em; background: var(--panel-2); border: 1px solid var(--accent); border-radius: var(--r-sm); color: var(--text); font: inherit; font-size: 1em; padding: 0 0.25em; outline: none; }
 
 .files-hint { flex: none; padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel); color: var(--muted); font-size: 11px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .files-hint.err { color: var(--danger); }
+/* while an entry is picked up the hint bar is the place to put it back down */
+.files-hint.moving { display: flex; align-items: center; gap: 8px; color: var(--accent); }
+.files-hint.moving span { overflow: hidden; text-overflow: ellipsis; }
+.files-hint.moving .mini-btn { flex: none; font-size: 10px; padding: 1px 5px; }
 
 /* settings */
 .settings-nav { padding: 10px; display: flex; flex-direction: column; gap: 4px; }


### PR DESCRIPTION
The file browser could only read and receive files: you could walk the tree and upload into it, but making somewhere to upload *to*, renaming anything, or moving anything meant asking an agent to run `mkdir`/`mv`. This adds folder creation, and rename, move and delete for both files and folders.

Rebased onto current `main`.

## Server

Four endpoints beside the existing upload/download, all routed through the same symlink-aware `resolveSafe`:

- `POST /api/files/:id/mkdir?path=&name=`
- `POST /api/files/:id/rename?path=&name=`
- `POST /api/files/:id/move?path=&to=`
- `DELETE /api/files/:id/entry?path=`

Names must be a single path segment (no `/`, `\`, `..`, or NUL), the root itself can't be renamed, moved or deleted, and `mkdir` requires a parent that already exists — one folder, not a whole missing chain. Delete is recursive, which is why the UI asks first.

`move` keeps the entry's name and only changes where it lives. On top of rename's guards it wants a destination that is a folder, and refuses to put a folder inside itself — compared on **real** paths, so a symlink in the destination chain can't smuggle the subtree past the check.

Rename, move and delete refuse on a folder something else depends on — an agent's own workspace, or the shared skills dir — and say which: `that folder is worker's workspace`. From a Files pane at the workspaces root those folders sit right there in the listing, and moving one out from under a running agent breaks its cwd. Deleting the agent first frees its folder.

## Web

Files and folders now share one `EntryRow`, so the row actions are the same for both:

- **Click a folder to make it the destination.** `+ Folder` and `Upload` act on the folder you last clicked — marked with a rule down its edge, and named both in the two buttons' tooltips and in the hint bar. With nothing chosen they act on the folder the tree is rooted at, which the crumbs name. The header hands itself back to the root when you click the tree background, navigate, or rename, move or delete the chosen folder out from under it.
- **`+ Folder`** opens an inline name row inside the folder it will create into — at the top of that listing, opening it if it was collapsed; Enter creates, Escape cancels.
- Reaching for a folder opens it, and only clicking the one already chosen folds it up. The two gestures share the click that already disambiguates expand from open-as-root, so picking a destination can't close what was just picked.
- **Per-row hover actions**: the pencil renames in place with an inline field; the trash swaps the row into `Delete folder and everything in it?` / `Delete file?` with Delete/Cancel. While a row is editing or confirming, its click-to-expand and double-click-to-open gestures are suppressed.
- **Drag to move**: every row is draggable and every folder row is a drop target, as are the crumbs (rooted deep in the tree, they're the only way to send something back up without navigating there first) and the tree background, which stands for the folder the tree is rooted at. The folder under the drag lights up; the row being carried dims. Illegal targets — the entry's own parent, a folder's own subtree — never light up and never accept.
- **An OS file dropped on a folder row** now uploads into *that* folder; the background still uploads into the root, whatever is chosen — a drop names its own target, so it does not consult the selection.
- **Move on touch**, where there is no drag: each row's third action picks the entry up, the hint bar says what's in hand with a way to put it down, and every eligible folder offers `Move here` — the header offers it for the current root.
- After an edit only the affected listings re-read (a move re-reads two: the source parent and the destination), so the rest of the expanded tree stays where it was. Failures show in the hint bar with the server's reason.
- On touch, where there is no hover, the row actions stay visible — same as the sidebar already does.

Listings re-read through a small path-keyed subscription instead of a callback to the immediate parent, because a move changes two directories that aren't in a parent/child relationship, and only those two should re-read.

## Testing

`tsc --noEmit` clean, `vite build` clean. Every endpoint exercised against a throwaway server on a spare port — 47 checks, all passing:

| case | result |
| --- | --- |
| create → rename → delete round-trip, nested folder, non-empty recursive delete | ok |
| move a file up, down and sideways; move a non-empty folder; move to the root | ok |
| move into the folder it's already in (no-op) | ok, nothing changed |
| rename and delete a **file** | ok |
| duplicate name (mkdir, rename, move) | 409 `already exists` |
| `..` in the name, in the path, or in the move destination; blank name | 400 `bad name` / `bad path` |
| missing parent, missing entry, missing destination, the root itself | 400 `bad path` |
| a folder into itself, and into its own subfolder | 400 `can't move a folder into itself` |
| move destination that is a file | 400 `not a folder` |
| an agent's workspace, the shared skills dir | 409 with the naming message |
| a symlink planted in the workspace pointing outside it — mkdir, rename, move and delete through it | all 400, nothing outside the root created, moved or deleted |
| a symlink pointing back into the folder being moved | 400, subtree intact |

The destination behaviour was then driven through real Chromium against a throwaway server, asserting against the filesystem rather than against the UI's own account of itself — 9 checks, all passing:

| case | result |
| --- | --- |
| nothing chosen → both header actions target the root | ok |
| clicking a folder retargets both, marks the row, names it in the hint bar | ok |
| `+ Folder` created `alpha/made-in-alpha` | ok, and nothing at the root |
| the new folder appears inside the parent, which opened for it | ok |
| `Upload` wrote `alpha/uploaded.txt` | ok, and nothing at the root |
| a nested folder as the destination → `alpha/nested/deep` | ok |
| first click opens a folder, a second folds it up, selection survives | ok |
| clicking the tree background hands the header back to the root | ok |
| deleting the chosen folder falls the header back to the root | ok |

That last group caught a real bug, now fixed: the 200ms timer that tells click-to-expand from double-click-to-open stayed pending across a quick `+ Folder`, and fired afterwards to collapse the folder out from under the naming field. It only reproduces under fast interaction — pausing between the two clicks hides it.

Still not driven by hand: drag-and-drop and the touch move path.

Worth noting, and not something this PR changes: a newly created empty folder may not survive a Space restart, since the bucket doesn't persist empty directories (the repo notes this, and re-creates recorded workspace paths on boot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

