### PR TITLE
Trace: add share and handover actions

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1304,6 +1304,31 @@ app.get('/api/trace/bundles', async (_req, res) => {
   catch (e) { res.status(500).json({ error: (e && e.message) || 'failed' }); }
 });
 
+// Resolve the concrete local source behind a trace pane. Handover uses this to
+// seed the next agent with a path it can inspect directly, whether the pane
+// points at one of this Manager's sessions or at an imported Hub bundle.
+app.get('/api/trace/:id/location', async (req, res) => {
+  const pane = store.get(req.params.id);
+  if (!pane || pane.cli !== 'trace') return res.status(404).json({ error: 'not a trace pane' });
+  const source = pane.traceSource || { kind: 'session', ref: pane.id };
+  try {
+    if (source.kind === 'bundle') {
+      if (!/^[\w.-]+$/.test(String(source.ref))) return res.status(400).json({ error: 'bad bundle ref' });
+      const dir = path.join(DATA_DIR, 'traces', source.ref);
+      const names = (await fs.promises.readdir(dir)).filter((n) => n.endsWith('.jsonl'));
+      if (!names.length) return res.status(404).json({ error: 'bundle has no trace file', code: 'no-trace' });
+      return res.json({ path: path.join(dir, names[0]), source });
+    }
+    const target = store.get(source.ref);
+    if (!target) return res.status(404).json({ error: 'source session is gone', code: 'no-trace' });
+    const hit = await findTrace(target, store.list());
+    if (!hit) return res.status(404).json({ error: 'no trace found for this session', code: 'no-trace' });
+    return res.json({ path: hit.src, sessionId: hit.sessionId || null, source });
+  } catch (e) {
+    res.status(500).json({ error: (e && e.message) || 'could not resolve trace path' });
+  }
+});
+
 // Paginated on purpose: a single session here is 6.15 MB and the panel only ever
 // shows a window of it. `limit` is clamped in readTrace().
 app.get('/api/trace/:id', async (req, res) => {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -62,6 +62,9 @@ export default function App() {
   const [toast, setToast] = useState<string | null>(null);
   // Session id whose share dialog is open (null = closed).
   const [shareId, setShareId] = useState<string | null>(null);
+  // Imported traces already live on the Hub; sharing them means handing on
+  // their original dataset link, not publishing a duplicate dataset.
+  const [traceShare, setTraceShare] = useState<{ title: string; url: string } | null>(null);
   const showErr = (msg: string) => (e: unknown) => { console.error(msg, e); setToast(msg); window.setTimeout(() => setToast(null), 4000); };
   // Overview presentation: tiles (default) or the classic list.
   const [ovView, setOvViewRaw] = useState<'tiles' | 'list'>(() =>
@@ -310,6 +313,27 @@ export default function App() {
   const deleteGroup = (id: string) => api.deleteGroup(id).then(() => { if (activeRef === `g:${id}`) setActiveRef(null); refresh(); }).catch(showErr('Couldn’t delete the group'));
   const stopSession = (id: string) => api.stopSession(id).then(refresh).catch(showErr('Couldn’t stop the agent'));
   const deleteSession = (id: string) => api.deleteSession(id).then(() => { if (activeRef === `s:${id}`) setActiveRef(null); refresh(); }).catch(showErr('Couldn’t delete the agent'));
+  const shareTrace = async (id: string) => {
+    const pane = sessById[id];
+    if (!pane || pane.cli !== 'trace') return;
+    const source = pane.traceSource;
+    // A local trace is only a view over its source session. Publish that source
+    // through the normal redaction/access dialog instead of duplicating it.
+    if (source?.kind === 'session' && sessById[source.ref]) {
+      setShareId(source.ref);
+      return;
+    }
+    try {
+      // An imported trace is already a shared Hub dataset. Re-share its
+      // provenance URL instead of creating a second, disconnected copy.
+      const trace = await api.getTracePage(id, 0, 1);
+      const url = trace.source?.url;
+      if (!url) throw new Error('this trace has no shareable source link');
+      setTraceShare({ title: pane.name, url });
+    } catch (e) {
+      showErr('Couldn’t share the trace')(e);
+    }
+  };
   // Clicking a session: nested → open its group with that pane focused; loose → solo view.
   const openSession = (sid: string, groupId?: string) => {
     if (groupId) {
@@ -541,6 +565,31 @@ export default function App() {
           onClose={() => { setShareId(null); refresh(); }}
         />
       )}
+      {traceShare && (
+        <div className="welcome-backdrop" onClick={() => setTraceShare(null)}>
+          <div className="welcome-card share-card" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
+            <div className="welcome-head">
+              <div>
+                <h2 style={{ margin: 0, fontSize: 16 }}>Share “{traceShare.title}”</h2>
+                <p className="share-sub">This imported trace already has a Hub dataset. Share its original link.</p>
+              </div>
+            </div>
+            <div className="share-linkrow">
+              <input readOnly value={traceShare.url} onFocus={(e) => e.currentTarget.select()} />
+              <button className="btn-ghost" onClick={() => {
+                navigator.clipboard?.writeText(traceShare.url).then(() => {
+                  setToast('Trace link copied');
+                  window.setTimeout(() => setToast(null), 2400);
+                }).catch(() => {});
+              }}>Copy</button>
+            </div>
+            <div className="share-actions">
+              <button className="btn-ghost" onClick={() => setTraceShare(null)}>Close</button>
+              <a className="btn-primary" href={traceShare.url} target="_blank" rel="noreferrer">Open dataset</a>
+            </div>
+          </div>
+        </div>
+      )}
       <Sidebar
         clis={clis}
         tree={tree}
@@ -552,6 +601,8 @@ export default function App() {
         onOpenSession={openSession}
         onNewSession={newSession}
         onShareSession={setShareId}
+        onShareTrace={shareTrace}
+        onTraceHandover={api.getTraceLocation}
         onOpenTrace={openTrace}
         onOpenSharedTrace={openSharedTrace}
         onNewGroup={newGroup}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -263,6 +263,17 @@ export const getTracePage = async (id: string, offset = 0, limit = 200): Promise
   return r.json();
 };
 
+export interface TraceLocation {
+  path: string;
+  sessionId?: string | null;
+  source: { kind: 'session' | 'bundle'; ref: string };
+}
+export const getTraceLocation = async (id: string): Promise<TraceLocation> => {
+  const r = await fetch(`/api/trace/${id}/location`);
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
+  return r.json();
+};
+
 // Receiving: pull a shared trace off the Hub so a pane can render it. Accepts a
 // bare dataset id or a pasted dataset URL (the server normalizes).
 export interface ImportedBundle {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -4,7 +4,7 @@ import { STATE_LABEL, isPassive } from '../types';
 import Logo from './Logo';
 import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
-import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, ListGlyph } from './icons';
+import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph } from './icons';
 
 type Zone = 'before' | 'after' | 'on';
 
@@ -25,7 +25,7 @@ const fmtAgo = (ts?: number) => {
 export default function Sidebar({
   clis, tree, activeRef, focusedId, defaultPath, ages,
   onActivate, onOpenSession, onNewSession, onNewGroup, onRenameGroup, onRenameSession, onDeleteGroup,
-  onStopSession, onDeleteSession, onShareSession, onOpenTrace, onOpenSharedTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
+  onStopSession, onDeleteSession, onShareSession, onShareTrace, onTraceHandover, onOpenTrace, onOpenSharedTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
   archived, showArchived, onToggleArchived,
 }: {
   clis: Cli[];
@@ -45,6 +45,8 @@ export default function Sidebar({
   onStopSession: (id: string) => void;
   onDeleteSession: (id: string) => void;
   onShareSession: (id: string) => void;
+  onShareTrace: (id: string) => void;
+  onTraceHandover: (id: string) => Promise<{ path: string; sessionId?: string | null }>;
   onOpenTrace: (id: string) => void;
   onOpenSharedTrace: (repo: string) => Promise<void>;
   onMove: (ref: string, to: MoveTarget) => void;
@@ -63,6 +65,7 @@ export default function Sidebar({
   const [quickMore, setQuickMore] = useState(false); // reveals name + folder
   const [quickName, setQuickName] = useState('');
   const [quickLoc, setQuickLoc] = useState('.');
+  const [quickError, setQuickError] = useState<string | null>(null);
   // When creation was launched from a group's + the new agent lands there.
   const [createTarget, setCreateTarget] = useState<string | null>(null);
   const [groupName, setGroupName] = useState('');
@@ -114,11 +117,31 @@ export default function Sidebar({
   // "More options" adds a name + folder; the group tile flips to group creation.
   const quickable = clis.filter((c) => c.id !== 'shell' && !isPassive(c.id));
   const openQuick = () => {
+    setQuickError(null);
     setQuickCli((q) => q ?? (quickable.find((c) => c.available && c.ready)?.id || quickable.find((c) => c.available)?.id || null));
     setQuickMode('agent');
     setQuickLoc(defaultPath || '.');
     setGroupLoc(defaultPath || '.');
     setPanel('quick');
+  };
+  const openHandover = async (s: Session) => {
+    try {
+      setQuickError(null);
+      const loc = await onTraceHandover(s.id);
+      const selected = quickable.find((c) => c.available && c.ready)
+        || quickable.find((c) => c.available);
+      setQuickCli(selected?.id || null);
+      setQuickMode('agent');
+      setQuickMore(false);
+      setQuickName('');
+      setQuickLoc(defaultPath || '.');
+      setQuickPrompt(`In this session we will continue from the session traces at ${loc.path}${loc.sessionId ? ` (session ${loc.sessionId})` : ''}`);
+      setPanel('quick');
+    } catch (e) {
+      setQuickError(e instanceof Error ? e.message : 'could not resolve that trace');
+      setQuickMode('agent');
+      setPanel('quick');
+    }
   };
   const submitQuick = () => {
     const p = quickPrompt.trim();
@@ -209,7 +232,12 @@ export default function Sidebar({
         )}
         <span className="age">{fmtAgo(ages?.[s.id])}</span>
         <span className="row-actions">
-          {s.running
+          {s.cli === 'trace' ? (
+            <>
+              <button className="mini-btn" title="Share this trace" onClick={(e) => { e.stopPropagation(); onShareTrace(s.id); }}><ShareGlyph /></button>
+              <button className="mini-btn" title="Continue from this trace in a new agent" onClick={(e) => { e.stopPropagation(); openHandover(s); }}><HandoverGlyph /></button>
+            </>
+          ) : s.running
             ? <button className="mini-btn" title="Stop" onClick={(e) => { e.stopPropagation(); onStopSession(s.id); }}><StopGlyph /></button>
             : <button className="mini-btn" title="Start" onClick={(e) => { e.stopPropagation(); onOpenSession(s.id, groupId); }}><PlayGlyph /></button>}
           {SHAREABLE_CLIS.includes(s.cli) && (
@@ -315,6 +343,7 @@ export default function Sidebar({
 
             {quickMode === 'agent' ? (
               <>
+                {quickError && <div className="open-trace-err">{quickError}</div>}
                 <textarea
                   autoFocus
                   rows={1}

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -177,3 +177,11 @@ export const ShareGlyph = ({ className }: { className?: string }) => (
     <line x1="8.6" y1="10.5" x2="15.4" y2="6.5" /><line x1="8.6" y1="13.5" x2="15.4" y2="17.5" />
   </svg>
 );
+
+// A conversation branching into its next agent: used for trace handover.
+export const HandoverGlyph = ({ className }: { className?: string }) => (
+  <G className={className}>
+    <path d="M3 3.2v3.1A2.7 2.7 0 0 0 5.7 9h6.4" />
+    <path d="M8.9 5.8 12.1 9l-3.2 3.2" />
+  </G>
+);


### PR DESCRIPTION
## What changed

- replace the inert Stop action on Trace rows with a Share action
- add a handover action that opens the existing agent launcher
- prefill the next agent with the concrete local trace path while preserving the prompt across harness selection
- reuse the original session publishing flow for local traces and the original Hub dataset link for imported traces
- add a read-only endpoint that resolves the local source behind a Trace pane

## Why

Trace panes are passive views, so stopping them is not meaningful. The useful next actions are sharing the trace or continuing the work in another harness with explicit trace context.

## Validation

- `tsc --noEmit`
- production Vite build
- `node --check server/src/index.js`
- `git diff --check`
