### PR TITLE
Terminal: stop the fit from counting a row that doesn't fit

### DIFF
--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -566,7 +566,9 @@ export default function TerminalPane({
           <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
         </div>
       </div>
-      <div className="term-host" ref={hostRef} />
+      <div className="term-host">
+        <div className="term-fill" ref={hostRef} />
+      </div>
       {copyMode && (
         <div className="term-copy-hint mono">copy mode · scroll to read, press Esc or type to return</div>
       )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -562,6 +562,14 @@ body {
 .slot.focused .pane-head { background: color-mix(in srgb, var(--accent) 8%, var(--panel)); }
 
 .term-host { flex: 1; min-height: 0; padding: 10px 8px 8px 12px; background: var(--term-bg); }
+/* The terminal's own parent must carry NO padding. FitAddon sizes the grid from
+   getComputedStyle(parent).height, which under border-box INCLUDES padding — so
+   padding on the direct parent made it count one row (and one column) more than
+   fits, and the grid overflowed its clipped viewport: the bottom line rendered
+   sliced in half. Most visible with Codex, which paints its status line on the
+   very last row, where Claude leaves it blank. The frame keeps the padding; this
+   filler is the exact box the grid is measured against. */
+.term-fill { height: 100%; min-height: 0; }
 /* mobile control-key bar: the keys a phone keyboard lacks, pinned below the
    terminal so it rides just above the on-screen keyboard */
 .term-keybar { flex: none; display: flex; gap: 5px; padding: 5px 6px; background: var(--panel); border-top: 1px solid var(--border); overflow-x: auto; }


### PR DESCRIPTION
The bottom line of a Codex pane renders sliced in half.

## Cause

`FitAddon` derives the grid from `getComputedStyle(xterm.parentElement).height`. Under `box-sizing: border-box` — which this app sets globally — that value **includes padding**, and the terminal's parent `.term-host` carried `padding: 10px 8px 8px 12px`. The fit therefore believed it had 18px more height (and 20px more width) than the visible box, asked for one row too many, and the grid overflowed its clipped viewport.

Measured against a live pane in a headless Chromium, 1440px wide, 17px rows:

| window height | grid overflow before | after |
|---|---|---|
| 900 | 3px | fits (14px slack) |
| 907 | 13px | fits |
| 913 | 7px | fits |
| 920 | 17px — the whole row is gone | fits exactly |

The cut is always 1–18px depending on window height, so usually about half a line. The right-most column was shaved 3px for the same reason.

It shows up on **Codex** because Codex paints its status line (`gpt-5.6-sol medium · /path`) on the very last row; Claude leaves that row blank, so the same defect is invisible there.

## Fix

The frame keeps its padding; a padding-free `.term-fill` inside it is now the terminal's direct parent — the exact box the grid is measured against.

## Verification

A ruler of `row N ____gjpq|` lines printed into a live pane, before and after, at four window heights. Before, the last row sits flush on the pane border with its lower half chopped; after, it renders in full with room beneath. Run against a real Vite build of the modified source proxied to the live backend, not just a DOM patch. `tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)