### PR TITLE
Terminal: a paste button for the mobile key-bar

### DIFF
--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -180,10 +180,40 @@ export default function TerminalPane({
   const [copyMode, setCopyMode] = useState(false); // tmux copy/scrollback mode
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(session.name);
+  // Fallback paste sheet: shown only when we can't read the clipboard directly.
+  const [pasteOpen, setPasteOpen] = useState(false);
   const commitName = () => {
     const v = draft.trim();
     if (v && v !== session.name) onRename?.(v);
     setEditing(false);
+  };
+
+  // Hand text to xterm rather than the socket: paste() applies bracketed-paste
+  // framing and normalises newlines, so a multi-line paste arrives as one blob
+  // instead of a burst of Enters that submit half-typed prompts.
+  const commitPaste = (text: string) => {
+    if (!text) return;
+    setPasteOpen(false);
+    termRef.current?.paste(text);
+    termRef.current?.focus();
+  };
+
+  // Phones have no Ctrl+V, so the key-bar needs an explicit paste. Two paths,
+  // because the direct read is unavailable exactly where this app usually runs:
+  //   1. navigator.clipboard.readText() — works top-level (iOS shows its own
+  //      "Paste" confirmation). BLOCKED in Hugging Face's cross-origin iframe,
+  //      and absent on older mobile browsers.
+  //   2. a focused textarea the user pastes into with the OS long-press menu.
+  //      A `paste` event's clipboardData is always readable — it's user-driven,
+  //      not permissioned — so this works even when (1) is denied.
+  // execCommand('paste') is not an option: unlike 'copy' it's disabled for web
+  // content in every browser, so there is no synchronous legacy path.
+  const requestPaste = () => {
+    let p: Promise<string> | undefined;
+    try { p = navigator.clipboard?.readText?.(); } catch { p = undefined; }
+    if (!p) { setPasteOpen(true); return; }
+    p.then((text) => { if (text) commitPaste(text); else setPasteOpen(true); })
+      .catch(() => setPasteOpen(true));
   };
 
   useEffect(() => {
@@ -588,6 +618,44 @@ export default function TerminalPane({
               onPointerDown={(e) => { e.preventDefault(); e.stopPropagation(); sendKeyRef.current(seq); termRef.current?.focus(); }}
             >{label}</button>
           ))}
+          {/* Unlike the key buttons this must NOT preventDefault: the clipboard
+              read needs a real click gesture. stopPropagation keeps the bar's
+              own preventDefault (which preserves terminal focus) off this one. */}
+          <button
+            className="tk-btn tk-paste"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => { e.stopPropagation(); requestPaste(); }}
+          >paste</button>
+        </div>
+      )}
+      {pasteOpen && (
+        // Reached when the clipboard read was blocked (cross-origin iframe) or
+        // came back empty. The textarea is the whole point: long-press inside it
+        // and the OS offers Paste, which fires a `paste` event we can read.
+        <div className="term-paste" onPointerDown={(e) => e.stopPropagation()}>
+          <div className="tp-row">
+            <span className="tp-hint mono">long-press below → Paste</span>
+            <button className="tp-x" onClick={() => { setPasteOpen(false); termRef.current?.focus(); }}>cancel</button>
+          </div>
+          <textarea
+            className="tp-input mono"
+            autoFocus
+            rows={2}
+            placeholder="paste here…"
+            onPaste={(e) => {
+              const text = e.clipboardData.getData('text/plain');
+              if (text) { e.preventDefault(); commitPaste(text); }
+            }}
+            // Typed text (or a paste some browsers deliver as plain input) still
+            // needs a way out; Enter sends, Shift+Enter keeps the newline.
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') { setPasteOpen(false); termRef.current?.focus(); }
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                commitPaste((e.target as HTMLTextAreaElement).value);
+              }
+            }}
+          />
         </div>
       )}
       {conn === 'handedoff' && (

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -633,15 +633,16 @@ export default function TerminalPane({
         // came back empty. The textarea is the whole point: long-press inside it
         // and the OS offers Paste, which fires a `paste` event we can read.
         <div className="term-paste" onPointerDown={(e) => e.stopPropagation()}>
-          <div className="tp-row">
-            <span className="tp-hint mono">long-press below → Paste</span>
-            <button className="tp-x" onClick={() => { setPasteOpen(false); termRef.current?.focus(); }}>cancel</button>
-          </div>
           <textarea
             className="tp-input mono"
             autoFocus
-            rows={2}
-            placeholder="paste here…"
+            rows={1}
+            // The instruction lives IN the field, because the field IS the
+            // target and a separate hint line only raised the question "below
+            // what?". Focusing it makes iOS/Android offer Paste on their own
+            // (that callout is what usually gets tapped); long-press is the
+            // manual backup when they don't.
+            placeholder="tap Paste — or long-press here"
             onPaste={(e) => {
               const text = e.clipboardData.getData('text/plain');
               if (text) { e.preventDefault(); commitPaste(text); }
@@ -656,6 +657,7 @@ export default function TerminalPane({
               }
             }}
           />
+          <button className="tp-x" onClick={() => { setPasteOpen(false); termRef.current?.focus(); }}>cancel</button>
         </div>
       )}
       {conn === 'handedoff' && (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -588,10 +588,8 @@ body {
 .tk-paste { flex: 0 0 auto; padding: 0 10px; font-size: 12px; }
 /* fallback paste sheet — sits directly above the key-bar, i.e. right on top of
    the on-screen keyboard, so the field is visible while the OS menu is open */
-.term-paste { flex: none; position: relative; z-index: 6; display: flex; flex-direction: column; gap: 4px; padding: 6px; background: var(--panel); border-top: 1px solid var(--border); }
-.term-paste .tp-row { display: flex; align-items: center; justify-content: space-between; }
-.term-paste .tp-hint { font-size: 11px; color: var(--muted); }
-.term-paste .tp-x { background: none; border: none; padding: 0 2px; color: var(--accent); font: inherit; font-size: 11px; cursor: pointer; }
+.term-paste { flex: none; position: relative; z-index: 6; display: flex; align-items: center; gap: 8px; padding: 6px; background: var(--panel); border-top: 1px solid var(--border); }
+.term-paste .tp-x { flex: none; background: none; border: none; padding: 0 2px; color: var(--accent); font: inherit; font-size: 11px; cursor: pointer; }
 .term-paste .tp-input { width: 100%; box-sizing: border-box; resize: none; padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: var(--r-md);
   background: var(--panel-2); color: var(--text); font-size: 13px; line-height: 1.35; }
 .term-paste .tp-input:focus { outline: none; border-color: var(--accent); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -572,9 +572,29 @@ body {
 .term-fill { height: 100%; min-height: 0; }
 /* mobile control-key bar: the keys a phone keyboard lacks, pinned below the
    terminal so it rides just above the on-screen keyboard */
-.term-keybar { flex: none; display: flex; gap: 5px; padding: 5px 6px; background: var(--panel); border-top: 1px solid var(--border); overflow-x: auto; }
+/* position+z-index, or the bar stops responding to taps: .xterm-screen is
+   position:relative, so whenever the grid is taller than its box it paints AND
+   hit-tests over a statically-positioned sibling. Measured at 390px wide: at
+   844px tall (iPhone 12/13/14) the screen reaches 69px past the bar's top and
+   swallows every tap on it; at 851/860/873/880/896 it doesn't overlap at all.
+   Height-dependent, so it looks intermittent rather than broken. Separate from
+   the FitAddon padding fix — that one stopped the bottom row rendering sliced,
+   it does not stop the grid from covering what sits below it. */
+.term-keybar { flex: none; position: relative; z-index: 6; display: flex; gap: 5px; padding: 5px 6px; background: var(--panel); border-top: 1px solid var(--border); overflow-x: auto; }
 .tk-btn { flex: 1 0 auto; min-width: 34px; height: 30px; border: 1px solid var(--border-strong); border-radius: var(--r-md); background: var(--panel-2); color: var(--text); font-size: 13px; line-height: 1; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; user-select: none; -webkit-user-select: none; touch-action: manipulation; }
 .tk-btn:active { background: color-mix(in srgb, var(--accent) 22%, var(--panel-2)); border-color: var(--accent); }
+/* wider than the key glyphs (word label) and last in the row, so keep it from
+   being squeezed by flex:1 on its siblings */
+.tk-paste { flex: 0 0 auto; padding: 0 10px; font-size: 12px; }
+/* fallback paste sheet — sits directly above the key-bar, i.e. right on top of
+   the on-screen keyboard, so the field is visible while the OS menu is open */
+.term-paste { flex: none; position: relative; z-index: 6; display: flex; flex-direction: column; gap: 4px; padding: 6px; background: var(--panel); border-top: 1px solid var(--border); }
+.term-paste .tp-row { display: flex; align-items: center; justify-content: space-between; }
+.term-paste .tp-hint { font-size: 11px; color: var(--muted); }
+.term-paste .tp-x { background: none; border: none; padding: 0 2px; color: var(--accent); font: inherit; font-size: 11px; cursor: pointer; }
+.term-paste .tp-input { width: 100%; box-sizing: border-box; resize: none; padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: var(--r-md);
+  background: var(--panel-2); color: var(--text); font-size: 13px; line-height: 1.35; }
+.term-paste .tp-input:focus { outline: none; border-color: var(--accent); }
 .term-host .xterm { height: 100%; }
 .xterm .xterm-viewport { scrollbar-width: none; }
 .xterm .xterm-viewport::-webkit-scrollbar { width: 0; height: 0; display: none; }


### PR DESCRIPTION
Phones have no Ctrl+V and the key-bar had no paste, so text simply could not get into a session from a phone.

## Why a plain button isn't enough

`TerminalPane.tsx` already documents that this app usually runs inside Hugging Face's **cross-origin iframe, which blocks the async Clipboard API outright**. And unlike copy there's no legacy escape hatch — `execCommand('paste')` is disabled for web content in every browser, so the existing `legacyCopy` trick has no paste equivalent. A naive button would silently no-op exactly where you need it.

So it layers:

1. `navigator.clipboard.readText()` — works top-level; iOS shows its own Paste confirmation.
2. When that's blocked, denied, or empty: a sheet above the bar with a focused textarea. Long-press it, tap the OS's **Paste**, and the resulting `paste` event's `clipboardData` is readable regardless of what the Clipboard API permits — it's user-driven, not permissioned. Enter sends typed text, Escape/cancel dismisses.

Text goes through `term.paste()` rather than the socket so bracketed-paste framing survives: a multi-line paste lands as one blob instead of a burst of Enters that submit half-typed prompts.

## It also fixes the bar being untappable

This is why the change needs a `z-index` and not just a button. `.xterm-screen` is `position: relative`, so whenever the grid is taller than its box it paints **and hit-tests** over the statically-positioned key-bar.

Measured in headless Chromium at 390px wide:

| viewport height | screen past bar top | paste button tappable |
|---|---|---|
| **844** (iPhone 12/13/14) | **+69px** | **no** |
| 851 | −23px | yes |
| 860 | −15px | yes |
| 873 | −11px | yes |
| 880 | −18px | yes |
| 896 | −17px | yes |

Height-dependent, so it reads as intermittent rather than broken. **This affected the existing esc/tab/arrow keys too**, not just the new button.

Distinct from 574d679 (#13): that stopped the bottom row rendering *sliced*; it does not stop the grid from covering what sits below it. I verified the overlap still reproduces on top of that commit, then confirmed the stacking fix clears it at all six heights (including later runs where the overlap was present at 69–84px and the button stayed tappable).

## Verification

Driven with real Chromium against a live server and tmux session at 390×844 — 12 checks, all passing:

- button renders in the bar; bar visible at 390px
- direct clipboard read pastes into the terminal; no sheet shown when it works
- blocked read falls back to the sheet; sheet exposes a focused textarea
- `paste` event reaches the terminal through the sheet; sheet closes after
- multi-line paste delivers both lines and does **not** execute line 1 (bracketed paste held)
- cancel dismisses the sheet

Desktop re-checked separately: no key-bar, no sheet, terminal renders with content, grid not collapsed.
