### PR TITLE
Files pane: rename entries, and refuse to touch a folder an agent lives in

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1414,6 +1414,20 @@ app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (re
   res.json({ ok: true, size: after.size, mtime: after.mtimeMs });
 });
 
+// Folders something else depends on: an agent's own workspace and the shared
+// skills dir. Renaming or deleting those out from under a running agent breaks
+// its cwd, so the pane refuses. Returns a label to say WHY, or null if it's fair
+// game. (Carried over from #9, which had this before we did.)
+function dependedOnDir(abs) {
+  const real = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
+  const target = real(abs);
+  if (target === real(SKILLS_DIR)) return 'the shared skills folder';
+  for (const s of store.list()) {
+    if (s.path && real(workspacePath(s.path)) === target) return `${s.name}'s workspace`;
+  }
+  return null;
+}
+
 // ---------- create and delete ----------
 // A workspace-relative NAME (not a path): one segment, nothing that could climb
 // out of the folder it is being created in.
@@ -1451,6 +1465,30 @@ for (const [verb, make] of [
   });
 }
 
+// Rename one entry in place. The new name is a NAME, so a rename can never also
+// move something — that is the /move route's job (still to come from #9).
+app.post('/api/files/:id/rename', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const root = folderPathOf(s);
+  const from = resolveSafe(root, (req.body || {}).path);
+  const name = cleanName((req.body || {}).name);
+  if (!from || !name) return res.status(400).json({ error: 'bad name' });
+  if (!fs.existsSync(from)) return res.status(404).json({ error: 'not found' });
+  if (path.resolve(from) === path.resolve(root)) return res.status(400).json({ error: 'cannot rename the workspace root' });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  const to = path.join(path.dirname(from), name);
+  if (path.resolve(to) === path.resolve(from)) return res.json({ ok: true, name }); // no-op
+  if (fs.existsSync(to)) return res.status(409).json({ error: `"${name}" already exists here` });
+  try {
+    fs.renameSync(from, to);
+  } catch (e) {
+    return res.status(500).json({ error: String((e && e.message) || e) });
+  }
+  res.json({ ok: true, name, path: path.relative(root, to) });
+});
+
 // Delete one entry. Folders go recursively — the pane says so before asking.
 app.delete('/api/files/:id/entry', (req, res) => {
   const s = store.get(req.params.id);
@@ -1461,6 +1499,10 @@ app.delete('/api/files/:id/entry', (req, res) => {
   // resolveSafe keeps this inside the workspace; this keeps it off the workspace
   // itself, which would take every session's folder with it.
   if (path.resolve(target) === path.resolve(root)) return res.status(400).json({ error: 'cannot delete the workspace root' });
+  // A folder an agent is living in, or the shared skills dir, is not the
+  // browser's to remove: the agent's cwd would vanish under a running process.
+  const dep = dependedOnDir(target);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
   try {
     fs.rmSync(target, { recursive: true, force: true });
   } catch (e) {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -205,6 +205,11 @@ export const createFile = (id: string, parent: string, name: string) =>
   fetch(`/api/files/${id}/touch`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: parent, name }) })
     .then(jsonOrError);
 
+// Rename in place. The server takes a NAME, so this can never also move it.
+export const renameEntry = (id: string, p: string, name: string): Promise<{ path: string }> =>
+  fetch(`/api/files/${id}/rename`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: p, name }) })
+    .then(jsonOrError);
+
 // Delete a file, or a folder and everything under it.
 export const deleteEntry = (id: string, p: string) =>
   fetch(`/api/files/${id}/entry?path=${encodeURIComponent(p)}`, { method: 'DELETE' }).then(jsonOrError);

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -10,7 +10,7 @@ import { TraceView, type TraceSource } from './TracePane';
 import {
   FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, BackGlyph, DownloadGlyph,
   RefreshGlyph, ImageGlyph, CodeGlyph, DocGlyph, GlobeGlyph,
-  FolderPlusGlyph, FilePlusGlyph, TrashGlyph,
+  FolderPlusGlyph, FilePlusGlyph, TrashGlyph, PencilGlyph,
 } from './icons';
 
 const fmtSize = (n: number) => {
@@ -125,7 +125,44 @@ type RowProps = {
   sessionId: string; prefix: boolean[]; sort: Sort; reloadKey: number;
   onOpen: (p: string) => void; onPreview: (p: string) => void; selected: string | null;
   onDelete: (path: string, name: string, dir: boolean) => void;
+  onRename: (path: string, name: string) => void;
+  renaming: string | null;
+  setRenaming: (path: string | null) => void;
 };
+
+// Renaming happens in the row, on the name itself: the thing being renamed stays
+// where it is, under the cursor, instead of jumping to a dialog. Enter commits,
+// Esc abandons, and a blur commits too — leaving the field is an answer.
+function RenameInput({ init, onCommit, onCancel }: {
+  init: string; onCommit: (name: string) => void; onCancel: () => void;
+}) {
+  const [v, setV] = useState(init);
+  const done = useRef(false);
+  const finish = (commit: boolean) => {
+    if (done.current) return;            // blur fires again after Enter
+    done.current = true;
+    const name = v.trim();
+    if (commit && name && name !== init) onCommit(name); else onCancel();
+  };
+  return (
+    <input
+      className="tw-rename" autoFocus value={v}
+      onClick={(e) => e.stopPropagation()}
+      onFocus={(e) => {
+        // Select the stem, not the extension: renaming rarely means retyping .txt.
+        const dot = init.lastIndexOf('.');
+        e.currentTarget.setSelectionRange(0, dot > 0 ? dot : init.length);
+      }}
+      onChange={(e) => setV(e.target.value)}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+        if (e.key === 'Escape') { e.preventDefault(); done.current = true; onCancel(); }
+      }}
+      onBlur={() => finish(true)}
+    />
+  );
+}
 
 // Deleting asks in the row itself rather than in a browser dialog: the question
 // names what is about to go, and for a folder it says that its contents go with
@@ -145,7 +182,7 @@ function ConfirmDelete({ name, dir, busy, onYes, onNo }: {
 }
 
 // Rows for one already-loaded listing; folders recurse through FolderNode.
-function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete }: RowProps & {
+function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming }: RowProps & {
   entries: FileEntry[]; path: string;
 }) {
   const arr = sortEntries(entries, sort);
@@ -160,6 +197,7 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
               key={e.name} sessionId={sessionId} path={p} name={e.name} mtime={e.mtime}
               prefix={prefix} isLast={isLast} sort={sort} reloadKey={reloadKey}
               onOpen={onOpen} onPreview={onPreview} selected={selected} onDelete={onDelete}
+              onRename={onRename} renaming={renaming} setRenaming={setRenaming}
             />
           );
         }
@@ -174,10 +212,22 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
           >
             <Rails prefix={prefix} isLast={isLast} />
             <KindGlyph name={e.name} kind={e.kind} className="tw-ico" />
-            <span className="tw-name">{e.name}</span>
+            {renaming === p ? (
+              <RenameInput
+                init={e.name}
+                onCommit={(name) => onRename(p, name)}
+                onCancel={() => setRenaming(null)}
+              />
+            ) : <span className="tw-name">{e.name}</span>}
             <span className="tw-size">{fmtSize(e.size)}</span>
             <span className="tw-time">{fmtWhen(e.mtime)}</span>
             <span className="tw-acts">
+              <button
+                className="tw-act" title={`Rename ${e.name}`}
+                onClick={(ev) => { ev.stopPropagation(); setRenaming(p); }}
+              >
+                <PencilGlyph />
+              </button>
               <button
                 className="tw-act" title="Download"
                 onClick={(ev) => { ev.stopPropagation(); triggerDownload(api.downloadUrl(sessionId, p), e.name); }}
@@ -212,11 +262,12 @@ function DirContents({ path, sessionId, prefix, ...rest }: RowProps & { path: st
 function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
   path: string; name: string; mtime: number; isLast: boolean;
 }) {
-  const { prefix, onOpen, onDelete } = rest;
+  const { prefix, onOpen, onDelete, onRename, renaming, setRenaming } = rest;
   const [open, setOpen] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
   const onClick = () => {
+    if (renaming === path) return;   // the row is an input right now
     if (timer.current) return;
     timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
   };
@@ -232,10 +283,22 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
       >
         <Rails prefix={prefix} isLast={isLast} />
         <FolderGlyph className="tw-ico dir" open={open} />
-        <span className="tw-name">{name}</span>
+        {renaming === path ? (
+          <RenameInput
+            init={name}
+            onCommit={(next) => onRename(path, next)}
+            onCancel={() => setRenaming(null)}
+          />
+        ) : <span className="tw-name">{name}</span>}
         <span className="tw-size" />
         <span className="tw-time">{fmtWhen(mtime)}</span>
         <span className="tw-acts">
+          <button
+            className="tw-act" title={`Rename ${name}`}
+            onClick={(ev) => { ev.stopPropagation(); setRenaming(path); }}
+          >
+            <PencilGlyph />
+          </button>
           <button
             className="tw-act danger" title={`Delete ${name}`}
             onClick={(ev) => { ev.stopPropagation(); onDelete(path, name, true); }}
@@ -635,6 +698,7 @@ export default function FilesPane({
   const [creating, setCreating] = useState<null | 'folder' | 'file'>(null);
   const [newName, setNewName] = useState('');
   const [pendingDel, setPendingDel] = useState<null | { path: string; name: string; dir: boolean }>(null);
+  const [renaming, setRenaming] = useState<string | null>(null);
   const [acting, setActing] = useState(false);
   const [actErr, setActErr] = useState<string | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
@@ -687,6 +751,20 @@ export default function FilesPane({
       setActErr(String(e?.message || e));
     } finally {
       setActing(false);
+    }
+  };
+
+  const doRename = async (p: string, name: string) => {
+    setRenaming(null); setActErr(null);
+    try {
+      const { path: next } = await api.renameEntry(session.id, p, name);
+      // Keep the viewer pointed at the same bytes: renaming the open file, or a
+      // folder above it, should not close what you were reading.
+      if (viewing === p) setViewing(next);
+      else if (viewing && viewing.startsWith(`${p}/`)) setViewing(`${next}${viewing.slice(p.length)}`);
+      setReloadKey((k) => k + 1);
+    } catch (e: any) {
+      setActErr(String(e?.message || e));
     }
   };
 
@@ -923,6 +1001,7 @@ export default function FilesPane({
               entries={dir.entries} path={root} sessionId={session.id} prefix={[]} sort={sort}
               reloadKey={reloadKey} onOpen={openDir} onPreview={setViewing} selected={viewing}
               onDelete={(p, name, isDir) => { setCreating(null); setActErr(null); setPendingDel({ path: p, name, dir: isDir }); }}
+              onRename={doRename} renaming={renaming} setRenaming={(p) => { setActErr(null); setRenaming(p); }}
             />
           )}
           {busy && <div className="tree-msg">Uploading…</div>}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -690,7 +690,11 @@ body {
    carry download+delete, folders only delete, and the header carries neither.
    Sized to two buttons and right-aligned, so Size and Modified land on the same
    x in every row and under their own headings. */
-.tw-acts { flex: none; width: 3.3em; display: inline-flex; align-items: center;
+.tw-rename { flex: 1; min-width: 0; font: inherit; color: var(--text); background: var(--term-bg);
+  border: 1px solid var(--accent); border-radius: var(--r-sm); padding: 0 4px; margin: -1px 0; outline: none; }
+
+/* room for three buttons on a file row (rename, download, delete) */
+.tw-acts { flex: none; width: 4.9em; display: inline-flex; align-items: center;
   justify-content: flex-end; gap: 1px; }
 
 /* Create prompt and delete confirm: one row above the listing, where the thing


### PR DESCRIPTION
Two pieces of PR #9 that #15 didn't carry over. Straight follow-up to the merged Files pane work.

## Rename

A pencil on row hover turns the name into an input, in place — the thing being renamed stays where it is instead of jumping to a dialog. Enter commits, Esc abandons, blur commits (leaving the field is an answer), and the stem is preselected, so renaming `draft.txt` doesn't mean retyping `.txt`. Works the same on folders.

The server takes a **name**, not a path, so a rename can never quietly move something. That stays `/move`'s job — still to come from #9.

## The guard #9 had and we didn't

`dependedOnDir()` refuses any folder something else is standing on: an agent's own workspace, or the shared skills dir. Renaming one breaks a running agent's cwd — and **DELETE would have removed it outright**, since the delete we merged in #15 only refused the workspace root. Both now refuse, with a reason worth reading:

```
that folder is worker's workspace
that folder is the shared skills folder
```

Credit to #9 — this is its function, carried across.

## Checks

Endpoints: rename a file 200 · slash in the name 400 · onto an existing name 409 · an agent's workspace 409 · the skills folder 409 · the workspace root 400. Delete of an agent's workspace and of the skills folder now 409, where both previously succeeded.

Browser: the editor opens with the stem selected, Enter renames on disk, Esc leaves it alone, a folder renames the same way, and a protected folder reports why it won't.

## Still open from #9

- **Move** (drag-and-drop into a folder, plus the `/move` route)
- **"The folder you click is where new folders and uploads land"** — create and upload currently target the breadcrumb folder, not the expanded one

Both are worth having; neither is in this PR.