### PR TITLE
Files pane: rename, move, create where you clicked, and save on purpose

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1489,6 +1489,45 @@ app.post('/api/files/:id/rename', (req, res) => {
   res.json({ ok: true, name, path: path.relative(root, to) });
 });
 
+// Move an entry into another folder under the same root, keeping its name — the
+// drag-and-drop half of rename. `to` is the destination FOLDER ('' = the root).
+// Adapted from PR #9, including the realpath check below.
+app.post('/api/files/:id/move', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const root = folderPathOf(s);
+  const b = req.body || {};
+  const from = resolveSafe(root, b.path);
+  if (!from || !fs.existsSync(from)) return res.status(404).json({ error: 'not found' });
+  if (path.resolve(from) === path.resolve(root)) return res.status(400).json({ error: 'cannot move the workspace root' });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+
+  const destDir = resolveSafe(root, b.to || '');
+  if (!destDir || !fs.existsSync(destDir)) return res.status(404).json({ error: 'no such folder' });
+  if (!fs.statSync(destDir).isDirectory()) return res.status(400).json({ error: 'not a folder' });
+
+  // A folder can't land inside itself — compared on REAL paths, so a symlink in
+  // the destination chain can't smuggle the subtree past the check.
+  try {
+    const realFrom = fs.realpathSync(from);
+    const realDest = fs.realpathSync(destDir);
+    if (realDest === realFrom || realDest.startsWith(realFrom + path.sep)) {
+      return res.status(400).json({ error: "can't move a folder into itself" });
+    }
+  } catch { return res.status(400).json({ error: 'bad path' }); }
+
+  const to = path.join(destDir, path.basename(from));
+  if (path.resolve(to) === path.resolve(from)) return res.json({ ok: true, path: path.relative(root, to) });
+  if (fs.existsSync(to)) return res.status(409).json({ error: `"${path.basename(from)}" already exists there` });
+  try {
+    fs.renameSync(from, to);
+  } catch (e) {
+    return res.status(500).json({ error: String((e && e.message) || e) });
+  }
+  res.json({ ok: true, path: path.relative(root, to) });
+});
+
 // Delete one entry. Folders go recursively — the pane says so before asking.
 app.delete('/api/files/:id/entry', (req, res) => {
   const s = store.get(req.params.id);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1414,6 +1414,20 @@ app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (re
   res.json({ ok: true, size: after.size, mtime: after.mtimeMs });
 });
 
+// Folders something else depends on: an agent's own workspace and the shared
+// skills dir. Renaming or deleting those out from under a running agent breaks
+// its cwd, so the pane refuses. Returns a label to say WHY, or null if it's fair
+// game. (Carried over from #9, which had this before we did.)
+function dependedOnDir(abs) {
+  const real = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
+  const target = real(abs);
+  if (target === real(SKILLS_DIR)) return 'the shared skills folder';
+  for (const s of store.list()) {
+    if (s.path && real(workspacePath(s.path)) === target) return `${s.name}'s workspace`;
+  }
+  return null;
+}
+
 // ---------- create and delete ----------
 // A workspace-relative NAME (not a path): one segment, nothing that could climb
 // out of the folder it is being created in.
@@ -1451,6 +1465,30 @@ for (const [verb, make] of [
   });
 }
 
+// Rename one entry in place. The new name is a NAME, so a rename can never also
+// move something — that is the /move route's job (still to come from #9).
+app.post('/api/files/:id/rename', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  const root = folderPathOf(s);
+  const from = resolveSafe(root, (req.body || {}).path);
+  const name = cleanName((req.body || {}).name);
+  if (!from || !name) return res.status(400).json({ error: 'bad name' });
+  if (!fs.existsSync(from)) return res.status(404).json({ error: 'not found' });
+  if (path.resolve(from) === path.resolve(root)) return res.status(400).json({ error: 'cannot rename the workspace root' });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  const to = path.join(path.dirname(from), name);
+  if (path.resolve(to) === path.resolve(from)) return res.json({ ok: true, name }); // no-op
+  if (fs.existsSync(to)) return res.status(409).json({ error: `"${name}" already exists here` });
+  try {
+    fs.renameSync(from, to);
+  } catch (e) {
+    return res.status(500).json({ error: String((e && e.message) || e) });
+  }
+  res.json({ ok: true, name, path: path.relative(root, to) });
+});
+
 // Delete one entry. Folders go recursively — the pane says so before asking.
 app.delete('/api/files/:id/entry', (req, res) => {
   const s = store.get(req.params.id);
@@ -1461,6 +1499,10 @@ app.delete('/api/files/:id/entry', (req, res) => {
   // resolveSafe keeps this inside the workspace; this keeps it off the workspace
   // itself, which would take every session's folder with it.
   if (path.resolve(target) === path.resolve(root)) return res.status(400).json({ error: 'cannot delete the workspace root' });
+  // A folder an agent is living in, or the shared skills dir, is not the
+  // browser's to remove: the agent's cwd would vanish under a running process.
+  const dep = dependedOnDir(target);
+  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
   try {
     fs.rmSync(target, { recursive: true, force: true });
   } catch (e) {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -205,6 +205,11 @@ export const createFile = (id: string, parent: string, name: string) =>
   fetch(`/api/files/${id}/touch`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: parent, name }) })
     .then(jsonOrError);
 
+// Rename in place. The server takes a NAME, so this can never also move it.
+export const renameEntry = (id: string, p: string, name: string): Promise<{ path: string }> =>
+  fetch(`/api/files/${id}/rename`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: p, name }) })
+    .then(jsonOrError);
+
 // Delete a file, or a folder and everything under it.
 export const deleteEntry = (id: string, p: string) =>
   fetch(`/api/files/${id}/entry?path=${encodeURIComponent(p)}`, { method: 'DELETE' }).then(jsonOrError);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -210,6 +210,12 @@ export const renameEntry = (id: string, p: string, name: string): Promise<{ path
   fetch(`/api/files/${id}/rename`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: p, name }) })
     .then(jsonOrError);
 
+// Move an entry into another folder, keeping its name. `to` is the destination
+// folder ('' = the pane's root).
+export const moveEntry = (id: string, p: string, to: string): Promise<{ path: string }> =>
+  fetch(`/api/files/${id}/move`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ path: p, to }) })
+    .then(jsonOrError);
+
 // Delete a file, or a folder and everything under it.
 export const deleteEntry = (id: string, p: string) =>
   fetch(`/api/files/${id}/entry?path=${encodeURIComponent(p)}`, { method: 'DELETE' }).then(jsonOrError);

--- a/web/src/components/CodeView.tsx
+++ b/web/src/components/CodeView.tsx
@@ -84,11 +84,11 @@ export default function CodeView({ text, name, editable, onChange, onSave, theme
   }, [name]);
 
   // Adopt text that changed from the outside (file reloaded, edits discarded)
-  // while leaving the user's own typing alone.
+  // while leaving the user's own typing alone. setDoc marks the dispatch as ours
+  // so it doesn't come back through onChange as a fresh edit.
   useEffect(() => {
     const v = view.current;
-    if (!v || v.state.doc.toString() === text) return;
-    v.dispatch({ changes: { from: 0, to: v.state.doc.length, insert: text } });
+    if (v) core.current?.setDoc(v, text);
   }, [text]);
 
   useEffect(() => { if (view.current) core.current?.setEditable(view.current, editable); }, [editable]);

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -10,7 +10,7 @@ import { TraceView, type TraceSource } from './TracePane';
 import {
   FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, BackGlyph, DownloadGlyph,
   RefreshGlyph, ImageGlyph, CodeGlyph, DocGlyph, GlobeGlyph,
-  FolderPlusGlyph, FilePlusGlyph, TrashGlyph,
+  FolderPlusGlyph, FilePlusGlyph, TrashGlyph, PencilGlyph,
 } from './icons';
 
 const fmtSize = (n: number) => {
@@ -125,7 +125,44 @@ type RowProps = {
   sessionId: string; prefix: boolean[]; sort: Sort; reloadKey: number;
   onOpen: (p: string) => void; onPreview: (p: string) => void; selected: string | null;
   onDelete: (path: string, name: string, dir: boolean) => void;
+  onRename: (path: string, name: string) => void;
+  renaming: string | null;
+  setRenaming: (path: string | null) => void;
 };
+
+// Renaming happens in the row, on the name itself: the thing being renamed stays
+// where it is, under the cursor, instead of jumping to a dialog. Enter commits,
+// Esc abandons, and a blur commits too — leaving the field is an answer.
+function RenameInput({ init, onCommit, onCancel }: {
+  init: string; onCommit: (name: string) => void; onCancel: () => void;
+}) {
+  const [v, setV] = useState(init);
+  const done = useRef(false);
+  const finish = (commit: boolean) => {
+    if (done.current) return;            // blur fires again after Enter
+    done.current = true;
+    const name = v.trim();
+    if (commit && name && name !== init) onCommit(name); else onCancel();
+  };
+  return (
+    <input
+      className="tw-rename" autoFocus value={v}
+      onClick={(e) => e.stopPropagation()}
+      onFocus={(e) => {
+        // Select the stem, not the extension: renaming rarely means retyping .txt.
+        const dot = init.lastIndexOf('.');
+        e.currentTarget.setSelectionRange(0, dot > 0 ? dot : init.length);
+      }}
+      onChange={(e) => setV(e.target.value)}
+      onKeyDown={(e) => {
+        e.stopPropagation();
+        if (e.key === 'Enter') { e.preventDefault(); finish(true); }
+        if (e.key === 'Escape') { e.preventDefault(); done.current = true; onCancel(); }
+      }}
+      onBlur={() => finish(true)}
+    />
+  );
+}
 
 // Deleting asks in the row itself rather than in a browser dialog: the question
 // names what is about to go, and for a folder it says that its contents go with
@@ -145,7 +182,7 @@ function ConfirmDelete({ name, dir, busy, onYes, onNo }: {
 }
 
 // Rows for one already-loaded listing; folders recurse through FolderNode.
-function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete }: RowProps & {
+function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming }: RowProps & {
   entries: FileEntry[]; path: string;
 }) {
   const arr = sortEntries(entries, sort);
@@ -160,6 +197,7 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
               key={e.name} sessionId={sessionId} path={p} name={e.name} mtime={e.mtime}
               prefix={prefix} isLast={isLast} sort={sort} reloadKey={reloadKey}
               onOpen={onOpen} onPreview={onPreview} selected={selected} onDelete={onDelete}
+              onRename={onRename} renaming={renaming} setRenaming={setRenaming}
             />
           );
         }
@@ -174,10 +212,22 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
           >
             <Rails prefix={prefix} isLast={isLast} />
             <KindGlyph name={e.name} kind={e.kind} className="tw-ico" />
-            <span className="tw-name">{e.name}</span>
+            {renaming === p ? (
+              <RenameInput
+                init={e.name}
+                onCommit={(name) => onRename(p, name)}
+                onCancel={() => setRenaming(null)}
+              />
+            ) : <span className="tw-name">{e.name}</span>}
             <span className="tw-size">{fmtSize(e.size)}</span>
             <span className="tw-time">{fmtWhen(e.mtime)}</span>
             <span className="tw-acts">
+              <button
+                className="tw-act" title={`Rename ${e.name}`}
+                onClick={(ev) => { ev.stopPropagation(); setRenaming(p); }}
+              >
+                <PencilGlyph />
+              </button>
               <button
                 className="tw-act" title="Download"
                 onClick={(ev) => { ev.stopPropagation(); triggerDownload(api.downloadUrl(sessionId, p), e.name); }}
@@ -212,11 +262,12 @@ function DirContents({ path, sessionId, prefix, ...rest }: RowProps & { path: st
 function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
   path: string; name: string; mtime: number; isLast: boolean;
 }) {
-  const { prefix, onOpen, onDelete } = rest;
+  const { prefix, onOpen, onDelete, onRename, renaming, setRenaming } = rest;
   const [open, setOpen] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
   const onClick = () => {
+    if (renaming === path) return;   // the row is an input right now
     if (timer.current) return;
     timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
   };
@@ -232,10 +283,22 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
       >
         <Rails prefix={prefix} isLast={isLast} />
         <FolderGlyph className="tw-ico dir" open={open} />
-        <span className="tw-name">{name}</span>
+        {renaming === path ? (
+          <RenameInput
+            init={name}
+            onCommit={(next) => onRename(path, next)}
+            onCancel={() => setRenaming(null)}
+          />
+        ) : <span className="tw-name">{name}</span>}
         <span className="tw-size" />
         <span className="tw-time">{fmtWhen(mtime)}</span>
         <span className="tw-acts">
+          <button
+            className="tw-act" title={`Rename ${name}`}
+            onClick={(ev) => { ev.stopPropagation(); setRenaming(path); }}
+          >
+            <PencilGlyph />
+          </button>
           <button
             className="tw-act danger" title={`Delete ${name}`}
             onClick={(ev) => { ev.stopPropagation(); onDelete(path, name, true); }}
@@ -635,6 +698,7 @@ export default function FilesPane({
   const [creating, setCreating] = useState<null | 'folder' | 'file'>(null);
   const [newName, setNewName] = useState('');
   const [pendingDel, setPendingDel] = useState<null | { path: string; name: string; dir: boolean }>(null);
+  const [renaming, setRenaming] = useState<string | null>(null);
   const [acting, setActing] = useState(false);
   const [actErr, setActErr] = useState<string | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
@@ -687,6 +751,20 @@ export default function FilesPane({
       setActErr(String(e?.message || e));
     } finally {
       setActing(false);
+    }
+  };
+
+  const doRename = async (p: string, name: string) => {
+    setRenaming(null); setActErr(null);
+    try {
+      const { path: next } = await api.renameEntry(session.id, p, name);
+      // Keep the viewer pointed at the same bytes: renaming the open file, or a
+      // folder above it, should not close what you were reading.
+      if (viewing === p) setViewing(next);
+      else if (viewing && viewing.startsWith(`${p}/`)) setViewing(`${next}${viewing.slice(p.length)}`);
+      setReloadKey((k) => k + 1);
+    } catch (e: any) {
+      setActErr(String(e?.message || e));
     }
   };
 
@@ -923,6 +1001,7 @@ export default function FilesPane({
               entries={dir.entries} path={root} sessionId={session.id} prefix={[]} sort={sort}
               reloadKey={reloadKey} onOpen={openDir} onPreview={setViewing} selected={viewing}
               onDelete={(p, name, isDir) => { setCreating(null); setActErr(null); setPendingDel({ path: p, name, dir: isDir }); }}
+              onRename={doRename} renaming={renaming} setRenaming={(p) => { setActErr(null); setRenaming(p); }}
             />
           )}
           {busy && <div className="tree-msg">Uploading…</div>}

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -175,6 +175,45 @@ function RenameInput({ init, onCommit, onCancel }: {
   );
 }
 
+// Leaving a file with an unsaved buffer is the one moment that deserves to
+// interrupt: a hint at the foot of the pane is not a warning, and the cost of
+// missing it is the work you just did. Small, centred on the pane, and every
+// answer is one click — including doing nothing.
+function UnsavedDialog({ name, conflict, busy, onSave, onDiscard, onCancel }: {
+  name: string; conflict: boolean; busy: boolean;
+  onSave: () => void; onDiscard: () => void; onCancel: () => void;
+}) {
+  return (
+    <div
+      className="fv-modal-back"
+      onMouseDown={(e) => { if (e.target === e.currentTarget) onCancel(); }}
+    >
+      <div
+        className="fv-modal" role="dialog" aria-modal="true" aria-label="Unsaved changes"
+        onKeyDown={(e) => {
+          e.stopPropagation();
+          if (e.key === 'Escape') { e.preventDefault(); onCancel(); }   // Esc backs out, never discards
+          if (e.key === 'Enter') { e.preventDefault(); onSave(); }
+        }}
+      >
+        <div className="fv-modal-title">Unsaved changes in {name}</div>
+        <div className="fv-modal-body">
+          {conflict
+            ? 'This file also changed on disk since you opened it. Saving replaces what is there now.'
+            : 'Your edits have not been written to the file.'}
+        </div>
+        <div className="fv-modal-acts">
+          <button className="mini-btn" onClick={onCancel}>Keep editing</button>
+          <button className="mini-btn danger" onClick={onDiscard} disabled={busy}>Discard</button>
+          <button className="mini-btn primary" autoFocus onClick={onSave} disabled={busy}>
+            {busy ? 'Saving…' : conflict ? 'Overwrite and close' : 'Save and close'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // Deleting asks in the row itself rather than in a browser dialog: the question
 // names what is about to go, and for a folder it says that its contents go with
 // it, because none of this is undoable.
@@ -452,6 +491,8 @@ export type SaveState = {
   status: 'clean' | 'dirty' | 'saving' | 'saved' | 'error';
   /** Write the buffer. Enabled only while there is something to write. */
   save: () => void;
+  /** Write it and report whether it landed — for "save and close". */
+  saveNow: (force?: boolean) => Promise<boolean>;
   /** Throw the buffer away and go back to what is on disk. */
   discard: () => void;
   error: string | null;
@@ -553,9 +594,12 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
   // One writer for every save — the debounce, the flush on close, and ⌘S all
   // come through here. `force` drops the mtime precondition, which is what
   // "overwrite" means after a conflict.
-  const flush = useCallback(async (force = false) => {
+  // Resolves true when the file on disk matches the buffer — which "save and
+  // close" needs, so a failed write keeps the dialog up instead of closing over
+  // the error.
+  const flush = useCallback(async (force = false): Promise<boolean> => {
     const job = pending.current;
-    if (!job) return;
+    if (!job) return true;               // nothing outstanding
     pending.current = null;
     setStatus('saving'); setSaveErr(null);
     try {
@@ -565,6 +609,7 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
       if (kindRef.current === 'html') setSource(job.text);
       setStatus('saved');
       onSaved?.();
+      return true;
     } catch (e: any) {
       const msg = String(e?.message || e);
       // A refused save must NOT drop the text — put it back so the next attempt
@@ -573,6 +618,7 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
       setConflict(/changed on disk/.test(msg));
       setSaveErr(msg);
       setStatus('error');
+      return false;
     }
   }, [sessionId, path, onSaved]);
 
@@ -599,6 +645,7 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
   const edit = useMemo<SaveState>(() => ({
     can: canEdit,
     save: () => flush(),
+    saveNow: (force = false) => flush(force),
     discard: () => {
       pending.current = null;
       setDraft(null); setSaveErr(null); setStatus('clean');
@@ -791,15 +838,33 @@ export default function FilesPane({
   };
 
   // Nothing is written without being asked for, so leaving a file with an unsaved
-  // buffer would drop it silently. Ask once; a second Esc (or Back) goes through.
+  // buffer would drop it silently. Ask in a dialog — the answer is the work.
   const edit = info.edit;
   const unsaved = edit?.status === 'dirty' || edit?.status === 'error' || !!edit?.conflict;
   const leaveView = () => {
-    if (unsaved && !confirmClose) { setConfirmClose(true); return; }
+    if (unsaved) { setConfirmClose(true); return; }
     setConfirmClose(false);
     setViewing(null);
   };
   useEffect(() => { if (!unsaved) setConfirmClose(false); }, [unsaved]);
+
+  // "Save and close" has to wait for the write to land before leaving, so the
+  // dialog stays up (disabled) rather than closing on a save that then fails.
+  // Dismissing the dialog has to hand focus back, or the keyboard is left on
+  // <body> and the next Esc goes nowhere — which reads as the guard being broken.
+  const backToEditing = () => {
+    setConfirmClose(false);
+    requestAnimationFrame(() => {
+      const cm = paneRef.current?.querySelector<HTMLElement>('.fv-cm .cm-content');
+      (cm || paneRef.current)?.focus({ preventScroll: true });
+    });
+  };
+
+  const saveAndClose = async () => {
+    if (!edit) return;
+    const ok = await edit.saveNow(!!edit.conflict);
+    if (ok) { setConfirmClose(false); setViewing(null); }
+  };
 
   // Create lands in the folder you are looking at, which is the one the
   // breadcrumb names.
@@ -1114,6 +1179,17 @@ export default function FilesPane({
         </div>
       </div>
 
+      {viewing && confirmClose && edit && (
+        <UnsavedDialog
+          name={viewing.split('/').pop()!}
+          conflict={!!edit.conflict}
+          busy={edit.status === 'saving'}
+          onSave={saveAndClose}
+          onDiscard={() => { edit.discard(); setConfirmClose(false); setViewing(null); }}
+          onCancel={backToEditing}
+        />
+      )}
+
       {viewing && (
         <div className="files-view">
           <FileView
@@ -1126,11 +1202,7 @@ export default function FilesPane({
       <div className="files-hint">
         {!viewing
           ? 'Click a file to preview · click a folder to expand · double-click a folder to open it'
-          : confirmClose
-            ? (edit?.conflict
-              ? 'This file changed on disk — Reload or Overwrite, or Esc again to leave your edits behind'
-              : 'Unsaved changes — ⌘S to save, or Esc again to discard them')
-            : edit?.status === 'dirty'
+          : edit?.status === 'dirty'
               ? 'Unsaved changes — ⌘S or Save'
               : edit?.can
                 ? 'Type to edit · ⌘S saves · Esc goes back'

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -10,7 +10,7 @@ import { TraceView, type TraceSource } from './TracePane';
 import {
   FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, BackGlyph, DownloadGlyph,
   RefreshGlyph, ImageGlyph, CodeGlyph, DocGlyph, GlobeGlyph,
-  FolderPlusGlyph, FilePlusGlyph, TrashGlyph, PencilGlyph,
+  FolderPlusGlyph, FilePlusGlyph, TrashGlyph, PencilGlyph, MoveGlyph,
 } from './icons';
 
 const fmtSize = (n: number) => {
@@ -74,9 +74,6 @@ const triggerDownload = (url: string, name: string) => {
   document.body.appendChild(a); a.click(); a.remove();
 };
 
-// How long typing has to pause before the file is written back.
-const AUTOSAVE_MS = 800;
-
 const CODE_RE = /\.(js|mjs|cjs|jsx|ts|tsx|py|rb|go|rs|java|kt|swift|c|h|cc|cpp|cs|php|pl|lua|r|jl|sh|bash|zsh|fish|ps1|css|scss|less|json|jsonl|ya?ml|toml|ini|sql|graphql|vue|svelte|tf)$/i;
 
 // Kind glyphs, one pen: a listing should read as one set, not a sticker album.
@@ -128,7 +125,21 @@ type RowProps = {
   onRename: (path: string, name: string) => void;
   renaming: string | null;
   setRenaming: (path: string | null) => void;
+  /** Drag-and-drop, and the tap-friendly version of the same move. */
+  onMove: (from: string, toDir: string) => void;
+  moving: Moving | null;
+  setMoving: (m: Moving | null) => void;
+  /** The folder new entries and uploads land in. */
+  target: string;
+  setTarget: (dir: string) => void;
 };
+
+export interface Moving { path: string; name: string; dir: boolean }
+
+// A move that would change nothing, or eat itself: back into the folder it is
+// already in, or a folder into its own subtree.
+const canMoveTo = (m: Moving, destDir: string) =>
+  dirOf(m.path) !== destDir && destDir !== m.path && !destDir.startsWith(`${m.path}/`);
 
 // Renaming happens in the row, on the name itself: the thing being renamed stays
 // where it is, under the cursor, instead of jumping to a dialog. Enter commits,
@@ -182,7 +193,7 @@ function ConfirmDelete({ name, dir, busy, onYes, onNo }: {
 }
 
 // Rows for one already-loaded listing; folders recurse through FolderNode.
-function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming }: RowProps & {
+function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving, target, setTarget }: RowProps & {
   entries: FileEntry[]; path: string;
 }) {
   const arr = sortEntries(entries, sort);
@@ -198,6 +209,7 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
               prefix={prefix} isLast={isLast} sort={sort} reloadKey={reloadKey}
               onOpen={onOpen} onPreview={onPreview} selected={selected} onDelete={onDelete}
               onRename={onRename} renaming={renaming} setRenaming={setRenaming}
+              onMove={onMove} moving={moving} setMoving={setMoving} target={target} setTarget={setTarget}
             />
           );
         }
@@ -205,8 +217,15 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
         return (
           <div
             key={e.name}
-            className={`tree-row file${selected === p ? ' selected' : ''}`}
+            className={`tree-row file${selected === p ? ' selected' : ''}${moving?.path === p ? ' moving' : ''}`}
             style={padFor(prefix)}
+            draggable={renaming !== p}
+            onDragStart={(ev) => {
+              ev.dataTransfer.setData('text/plain', p);
+              ev.dataTransfer.effectAllowed = 'move';
+              setMoving({ path: p, name: e.name, dir: false });
+            }}
+            onDragEnd={() => setMoving(null)}
             onClick={() => onPreview(p)}
             title={`${e.name} — ${kindNote}${fmtSize(e.size)} · ${fmtStamp(e.mtime)}`}
           >
@@ -227,6 +246,12 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
                 onClick={(ev) => { ev.stopPropagation(); setRenaming(p); }}
               >
                 <PencilGlyph />
+              </button>
+              <button
+                className="tw-act" title={`Move ${e.name} — then pick a folder`}
+                onClick={(ev) => { ev.stopPropagation(); setMoving({ path: p, name: e.name, dir: false }); }}
+              >
+                <MoveGlyph />
               </button>
               <button
                 className="tw-act" title="Download"
@@ -262,12 +287,20 @@ function DirContents({ path, sessionId, prefix, ...rest }: RowProps & { path: st
 function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
   path: string; name: string; mtime: number; isLast: boolean;
 }) {
-  const { prefix, onOpen, onDelete, onRename, renaming, setRenaming } = rest;
+  const { prefix, onOpen, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving, target, setTarget } = rest;
   const [open, setOpen] = useState(false);
+  const [over, setOver] = useState(false);
+  const takes = !!moving && canMoveTo(moving, path);   // would a drop here do anything?
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
   const onClick = () => {
     if (renaming === path) return;   // the row is an input right now
+    if (moving) {                    // a move is armed: this row is the answer
+      if (canMoveTo(moving, path)) onMove(moving.path, path);
+      else setMoving(null);
+      return;
+    }
+    setTarget(path);                 // new folders, new files and uploads land here
     if (timer.current) return;
     timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
   };
@@ -278,7 +311,24 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
   return (
     <>
       <div
-        className="tree-row folder" style={padFor(prefix)} onClick={onClick} onDoubleClick={onDoubleClick}
+        className={`tree-row folder${target === path ? ' target' : ''}${over && takes ? ' drop' : ''}${moving?.path === path ? ' moving' : ''}`}
+        style={padFor(prefix)}
+        draggable={renaming !== path}
+        onDragStart={(ev) => {
+          ev.dataTransfer.setData('text/plain', path);
+          ev.dataTransfer.effectAllowed = 'move';
+          setMoving({ path, name, dir: true });
+        }}
+        onDragEnd={() => { setMoving(null); setOver(false); }}
+        onDragOver={(ev) => { if (takes) { ev.preventDefault(); ev.dataTransfer.dropEffect = 'move'; setOver(true); } }}
+        onDragLeave={() => setOver(false)}
+        onDrop={(ev) => {
+          setOver(false);
+          if (!takes || !moving) return;
+          ev.preventDefault(); ev.stopPropagation();
+          onMove(moving.path, path);
+        }}
+        onClick={onClick} onDoubleClick={onDoubleClick}
         title={`${name} — folder · ${fmtStamp(mtime)}\nClick to expand · double-click to open`}
       >
         <Rails prefix={prefix} isLast={isLast} />
@@ -298,6 +348,12 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
             onClick={(ev) => { ev.stopPropagation(); setRenaming(path); }}
           >
             <PencilGlyph />
+          </button>
+          <button
+            className="tw-act" title={`Move ${name} — then pick a folder`}
+            onClick={(ev) => { ev.stopPropagation(); setMoving({ path, name, dir: true }); }}
+          >
+            <MoveGlyph />
           </button>
           <button
             className="tw-act danger" title={`Delete ${name}`}
@@ -390,7 +446,11 @@ export type SaveState = {
   /** Editable at all: a text kind we hold WHOLE (not a truncated head). */
   can: boolean;
   why?: string;                                   // why not, when it can't
-  status: 'clean' | 'typing' | 'saving' | 'saved' | 'error';
+  status: 'clean' | 'dirty' | 'saving' | 'saved' | 'error';
+  /** Write the buffer. Enabled only while there is something to write. */
+  save: () => void;
+  /** Throw the buffer away and go back to what is on disk. */
+  discard: () => void;
   error: string | null;
   /** A concurrent writer won the race; the two ways out. */
   conflict: boolean;
@@ -422,9 +482,9 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
   const [status, setStatus] = useState<SaveState['status']>('clean');
   const [saveErr, setSaveErr] = useState<string | null>(null);
   const [conflict, setConflict] = useState(false);
-  // The autosave timer, and the values it must read at fire time rather than at
-  // schedule time (mtime moves with every save).
-  const timer = useRef<number | null>(null);
+  // The buffer waiting to be written, if any. There is no timer: these files
+  // have no undo and no git behind them, so nothing reaches disk until it is
+  // asked for.
   const pending = useRef<{ text: string; mtime: number } | null>(null);
 
   useEffect(() => {
@@ -494,7 +554,6 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
     const job = pending.current;
     if (!job) return;
     pending.current = null;
-    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
     setStatus('saving'); setSaveErr(null);
     try {
       const after = await api.writeFile(sessionId, path, job.text, force ? 0 : job.mtime);
@@ -514,25 +573,19 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
     }
   }, [sessionId, path, onSaved]);
 
-  // Every keystroke restarts a short timer: agents read these files, and this
-  // one writes to a FUSE-mounted bucket, so a save per character is out.
+  // Typing only fills the buffer. Writing it is a decision, taken with the Save
+  // button or ⌘S — an autosave here would be one stray keystroke away from
+  // silently rewriting a file with no undo behind it.
   const onEdit = useCallback((next: string) => {
     setDraft(next);
     if (!canEdit || !meta) return;
     pending.current = { text: next, mtime: meta.mtime };
-    setStatus('typing');
-    if (timer.current) clearTimeout(timer.current);
-    timer.current = window.setTimeout(() => flush(), AUTOSAVE_MS);
-  }, [canEdit, meta, flush]);
+    setStatus((st) => (st === 'error' ? st : 'dirty'));   // keep a failure visible
+  }, [canEdit, meta]);
 
-  // Closing the file, or switching to another, must not lose the last keystroke:
-  // fetch outlives the component, so firing it from cleanup is enough.
-  const flushRef = useRef(flush);
-  flushRef.current = flush;
-  useEffect(() => () => {
-    if (timer.current) clearTimeout(timer.current);
-    if (pending.current) flushRef.current();
-  }, [path]);
+  // Switching files abandons an unsaved buffer, so the pane asks before it lets
+  // that happen (see leaveView).
+  useEffect(() => () => { pending.current = null; }, [path]);
 
   useEffect(() => {
     if (status !== 'saved') return;
@@ -542,6 +595,11 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
 
   const edit = useMemo<SaveState>(() => ({
     can: canEdit,
+    save: () => flush(),
+    discard: () => {
+      pending.current = null;
+      setDraft(null); setSaveErr(null); setStatus('clean');
+    },
     // Only worth saying when editing was plausible and isn't: nobody expects to
     // type into a PDF, so an image or a binary says nothing at all.
     why: editKind && meta?.truncated ? 'too big to edit — only the first part is loaded' : undefined,
@@ -550,9 +608,8 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
     conflict,
     reload: () => {
       pending.current = null;
-      if (timer.current) { clearTimeout(timer.current); timer.current = null; }
       setDraft(null); setSaveErr(null); setConflict(false); setStatus('clean');
-    setTraceHead(null); setTraceQuery('');
+      setTraceHead(null); setTraceQuery('');
       setMeta(null);
       api.previewFile(sessionId, path).then(setMeta).catch(() => {});
       if (kindRef.current === 'html') {
@@ -699,6 +756,10 @@ export default function FilesPane({
   const [newName, setNewName] = useState('');
   const [pendingDel, setPendingDel] = useState<null | { path: string; name: string; dir: boolean }>(null);
   const [renaming, setRenaming] = useState<string | null>(null);
+  const [moving, setMoving] = useState<Moving | null>(null);
+  // Where new folders, new files and uploads land: the folder you last clicked,
+  // falling back to the one the breadcrumb names.
+  const [target, setTarget] = useState<string | null>(null);
   const [acting, setActing] = useState(false);
   const [actErr, setActErr] = useState<string | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
@@ -720,22 +781,22 @@ export default function FilesPane({
   const upload = async (files: FileList | File[]) => {
     setBusy(true);
     for (const f of Array.from(files)) {
-      try { await api.uploadFile(session.id, root, f); } catch { /* skip */ }
+      try { await api.uploadFile(session.id, dest, f); } catch { /* skip */ }
     }
     setBusy(false);
     setReloadKey((k) => k + 1);
   };
 
-  // Leaving is unconditional now — the last keystroke is flushed on the way out
-  // (see FileView). The exception is an unresolved conflict, where leaving WOULD
-  // drop work: that asks once.
+  // Nothing is written without being asked for, so leaving a file with an unsaved
+  // buffer would drop it silently. Ask once; a second Esc (or Back) goes through.
   const edit = info.edit;
+  const unsaved = edit?.status === 'dirty' || edit?.status === 'error' || !!edit?.conflict;
   const leaveView = () => {
-    if (edit?.conflict && !confirmClose) { setConfirmClose(true); return; }
+    if (unsaved && !confirmClose) { setConfirmClose(true); return; }
     setConfirmClose(false);
     setViewing(null);
   };
-  useEffect(() => { if (!edit?.conflict) setConfirmClose(false); }, [edit?.conflict]);
+  useEffect(() => { if (!unsaved) setConfirmClose(false); }, [unsaved]);
 
   // Create lands in the folder you are looking at, which is the one the
   // breadcrumb names.
@@ -744,13 +805,28 @@ export default function FilesPane({
     if (!name || !creating) return;
     setActing(true); setActErr(null);
     try {
-      await (creating === 'folder' ? api.createFolder : api.createFile)(session.id, root, name);
+      await (creating === 'folder' ? api.createFolder : api.createFile)(session.id, dest, name);
       setCreating(null); setNewName('');
       setReloadKey((k) => k + 1);
     } catch (e: any) {
       setActErr(String(e?.message || e));
     } finally {
       setActing(false);
+    }
+  };
+
+  const dest = target && (target === root || target.startsWith(root ? `${root}/` : '')) ? target : root;
+  useEffect(() => { setTarget(null); setMoving(null); }, [root]);
+
+  const doMove = async (from: string, toDir: string) => {
+    setMoving(null); setActErr(null);
+    try {
+      const { path: next } = await api.moveEntry(session.id, from, toDir);
+      if (viewing === from) setViewing(next);
+      else if (viewing && viewing.startsWith(`${from}/`)) setViewing(`${next}${viewing.slice(from.length)}`);
+      setReloadKey((k) => k + 1);
+    } catch (e: any) {
+      setActErr(String(e?.message || e));
     }
   };
 
@@ -814,10 +890,9 @@ export default function FilesPane({
       onKeyDown={viewing ? (e) => {
         if (e.key === 'Escape') { e.preventDefault(); leaveView(); }
         // Cmd/Ctrl-S works from anywhere in the pane, not just inside the editor.
-        // ⌘S is a no-op that people press anyway: swallow it so the browser's
-        // save dialog never appears over an editor that already saved.
         else if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 's' && edit?.can) {
           e.preventDefault();
+          if (edit.status === 'dirty' || edit.status === 'error') edit.save();
         }
       } : undefined}
     >
@@ -835,8 +910,8 @@ export default function FilesPane({
             <span className="fv-title" title={viewing}>
               <KindGlyph name={name} kind={meta?.kind} className="tw-ico" />
               <span className="fv-name">{name}</span>
-              {(edit?.status === 'typing' || edit?.status === 'saving') && (
-                <span className="fv-dirty" title="Saving…">•</span>
+              {(edit?.status === 'dirty' || edit?.status === 'saving') && (
+                <span className="fv-dirty" title="Unsaved changes">•</span>
               )}
             </span>
             <span className="spacer" />
@@ -894,8 +969,18 @@ export default function FilesPane({
             ) : edit?.error ? (
               <span className="fi-err" title={edit.error}>{edit.error}</span>
             ) : edit?.can && edit.status !== 'clean' ? (
-              <span className={`fv-save ${edit.status}`}>
-                {edit.status === 'saving' ? 'saving…' : edit.status === 'saved' ? 'saved' : 'editing…'}
+              <span className="fv-edit">
+                {edit.status === 'saved' ? <span className="fv-save saved">saved</span> : (
+                  <>
+                    <button className="mini-btn" onClick={edit.discard} disabled={edit.status === 'saving'}>Discard</button>
+                    <button
+                      className="mini-btn primary" onClick={edit.save}
+                      disabled={edit.status === 'saving'} title="Save (⌘S)"
+                    >
+                      {edit.status === 'saving' ? 'Saving…' : 'Save'}
+                    </button>
+                  </>
+                )}
               </span>
             ) : null}
             {edit && !edit.can && edit.why && (
@@ -962,6 +1047,7 @@ export default function FilesPane({
             <input
               autoFocus className="files-new-input"
               placeholder={creating === 'folder' ? 'New folder name' : 'New file name'}
+              title={`Will be created in ${dest || rootLabel}`}
               value={newName}
               onChange={(e) => { setNewName(e.target.value); setActErr(null); }}
               onKeyDown={(e) => {
@@ -969,8 +1055,23 @@ export default function FilesPane({
                 if (e.key === 'Escape') { e.preventDefault(); setCreating(null); setActErr(null); }
               }}
             />
+            <span className="files-new-where" title="Click a folder to change where new entries land">
+              in {dest ? dest.split('/').pop() : rootLabel}
+            </span>
             <button className="mini-btn primary" disabled={!newName.trim() || acting} onClick={create}>Create</button>
             <button className="mini-btn" disabled={acting} onClick={() => { setCreating(null); setActErr(null); }}>Cancel</button>
+          </div>
+        )}
+        {moving && (
+          <div className="files-new">
+            <MoveGlyph className="tw-ico" />
+            <span className="tw-warn">Moving <strong>{moving.name}</strong> — click a folder, or drop it on one</span>
+            {canMoveTo(moving, root) && (
+              <button className="mini-btn" onClick={() => doMove(moving.path, root)}>
+                Move here ({root ? root.split('/').pop() : rootLabel})
+              </button>
+            )}
+            <button className="mini-btn" onClick={() => setMoving(null)}>Cancel</button>
           </div>
         )}
         {pendingDel && (
@@ -1002,6 +1103,8 @@ export default function FilesPane({
               reloadKey={reloadKey} onOpen={openDir} onPreview={setViewing} selected={viewing}
               onDelete={(p, name, isDir) => { setCreating(null); setActErr(null); setPendingDel({ path: p, name, dir: isDir }); }}
               onRename={doRename} renaming={renaming} setRenaming={(p) => { setActErr(null); setRenaming(p); }}
+              onMove={doMove} moving={moving} setMoving={(m) => { setActErr(null); setMoving(m); }}
+              target={dest} setTarget={setTarget}
             />
           )}
           {busy && <div className="tree-msg">Uploading…</div>}
@@ -1021,10 +1124,14 @@ export default function FilesPane({
         {!viewing
           ? 'Click a file to preview · click a folder to expand · double-click a folder to open it'
           : confirmClose
-            ? 'This file changed on disk — Reload or Overwrite, or Esc again to leave your edits behind'
-            : edit?.can
-              ? 'Type to edit — saved automatically · Esc goes back'
-              : 'Esc goes back to the files'}
+            ? (edit?.conflict
+              ? 'This file changed on disk — Reload or Overwrite, or Esc again to leave your edits behind'
+              : 'Unsaved changes — ⌘S to save, or Esc again to discard them')
+            : edit?.status === 'dirty'
+              ? 'Unsaved changes — ⌘S or Save'
+              : edit?.can
+                ? 'Type to edit · ⌘S saves · Esc goes back'
+                : 'Esc goes back to the files'}
       </div>
     </div>
   );

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -242,6 +242,12 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
             <span className="tw-time">{fmtWhen(e.mtime)}</span>
             <span className="tw-acts">
               <button
+                className="tw-act" title="Download"
+                onClick={(ev) => { ev.stopPropagation(); triggerDownload(api.downloadUrl(sessionId, p), e.name); }}
+              >
+                <DownloadGlyph />
+              </button>
+              <button
                 className="tw-act" title={`Rename ${e.name}`}
                 onClick={(ev) => { ev.stopPropagation(); setRenaming(p); }}
               >
@@ -252,12 +258,6 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
                 onClick={(ev) => { ev.stopPropagation(); setMoving({ path: p, name: e.name, dir: false }); }}
               >
                 <MoveGlyph />
-              </button>
-              <button
-                className="tw-act" title="Download"
-                onClick={(ev) => { ev.stopPropagation(); triggerDownload(api.downloadUrl(sessionId, p), e.name); }}
-              >
-                <DownloadGlyph />
               </button>
               <button
                 className="tw-act danger" title={`Delete ${e.name}`}
@@ -343,6 +343,9 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
         <span className="tw-size" />
         <span className="tw-time">{fmtWhen(mtime)}</span>
         <span className="tw-acts">
+          {/* no download for a folder — hold its slot so Rename, Move and Delete
+              sit in the same place on every row */}
+          <span className="tw-act ghost" aria-hidden />
           <button
             className="tw-act" title={`Rename ${name}`}
             onClick={(ev) => { ev.stopPropagation(); setRenaming(path); }}

--- a/web/src/components/cm-core.ts
+++ b/web/src/components/cm-core.ts
@@ -170,7 +170,9 @@ export function createEditor(opts: {
       langComp.of([]),
       themeComp.of(baseTheme(opts.theme === 'dark')),
       editComp.of([EditorView.editable.of(opts.editable), EditorState.readOnly.of(!opts.editable)]),
-      EditorView.updateListener.of((u) => { if (u.docChanged) opts.onChange(u.state.doc.toString()); }),
+      EditorView.updateListener.of((u) => {
+        if (u.docChanged && !applying.has(u.view)) opts.onChange(u.state.doc.toString());
+      }),
     ],
   });
 
@@ -181,6 +183,21 @@ export function createEditor(opts: {
     if (lang) view.dispatch({ effects: langComp.reconfigure(lang) });
   }).catch(() => {});
   return view;
+}
+
+// Replacing the document from the outside (a discard, a reload, a rename) is not
+// an edit. Without this flag the update listener fires on our own dispatch and
+// marks the file dirty again the instant it was made clean.
+const applying = new WeakSet<EditorView>();
+
+export function setDoc(view: EditorView, text: string) {
+  if (view.state.doc.toString() === text) return;
+  applying.add(view);
+  try {
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: text } });
+  } finally {
+    applying.delete(view);
+  }
 }
 
 export function setEditable(view: EditorView, editable: boolean) {

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -89,6 +89,16 @@ export const MoonGlyph = ({ className }: { className?: string }) => (
   </G>
 );
 
+// Move: an arrow leaving one container for another.
+export const MoveGlyph = ({ className }: { className?: string }) => (
+  <G className={className}>
+    <path d="M2.4 3.9a1 1 0 0 1 1-1h2.2a1 1 0 0 1 .7.3l.6.6h1.9" />
+    <path d="M2.4 3.9v7.3a1 1 0 0 0 1 1h3.1" />
+    <path d="M9.1 6.2h4.5M11.5 4.1l2.1 2.1-2.1 2.1" />
+    <path d="M13.6 8.9v2.3a1 1 0 0 1-1 1H9.4" />
+  </G>
+);
+
 export const TrashGlyph = ({ className }: { className?: string }) => (
   <G className={className}>
     <path d="M3 4.5h10M6.4 4.4v-1a1 1 0 0 1 1-1h1.2a1 1 0 0 1 1 1v1" />

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -721,6 +721,9 @@ body {
 .tw-warn { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mini-btn.danger { background: var(--danger); color: #fff; border-color: transparent; }
 .mini-btn.danger:disabled { opacity: .5; }
+/* the one obvious action in a group — Create, Save and close */
+.mini-btn.primary { background: var(--accent); color: var(--accent-fg); border-color: transparent; }
+.mini-btn.primary:disabled { opacity: .45; }
 .tree-row.selected { background: color-mix(in srgb, var(--accent) 14%, transparent); }
 .tree-row.selected .tw-name { color: var(--accent); font-weight: 600; }
 .tree-msg { color: var(--muted); font-size: 0.85em; padding: 0.15em 0; }
@@ -804,6 +807,17 @@ body {
 .fv-trace-tools .tv-search { height: 20px; font-size: 11px; max-width: 12em; }
 .fv-trace-tools .tv-nav .mini-btn { padding: 0 4px; }
 .files-view .trace-body { flex: 1; min-height: 0; }
+
+/* Unsaved-changes dialog: over the PANE, not the window — it belongs to the file
+   you were editing, and other panes stay usable. */
+.fv-modal-back { position: absolute; inset: 0; z-index: 30; display: grid; place-items: center;
+  background: color-mix(in srgb, var(--bg) 62%, transparent); backdrop-filter: blur(1.5px); }
+.fv-modal { width: min(23rem, calc(100% - 2rem)); background: var(--panel); color: var(--text);
+  border: 1px solid var(--border-strong); border-radius: var(--r-lg);
+  box-shadow: 0 8px 28px #0000002e; padding: 14px 16px 12px; }
+.fv-modal-title { font-weight: 600; font-size: 13px; margin-bottom: 5px; }
+.fv-modal-body { font-size: 12px; color: var(--muted); line-height: 1.45; }
+.fv-modal-acts { display: flex; justify-content: flex-end; gap: 6px; margin-top: 13px; }
 
 /* pdf: our own pages, stacked on the same neutral stage as images */
 .fv-pdf { flex: 1; min-height: 0; overflow: auto; background: var(--bg); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -690,11 +690,19 @@ body {
    carry download+delete, folders only delete, and the header carries neither.
    Sized to two buttons and right-aligned, so Size and Modified land on the same
    x in every row and under their own headings. */
+/* the folder new entries land in, and the one a drag is currently over */
+.tree-row.target > .tw-name { text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 3px; }
+.tree-row.drop { background: color-mix(in srgb, var(--accent) 20%, transparent);
+  outline: 1px solid var(--accent); outline-offset: -1px; }
+.tree-row.moving { opacity: 0.5; }
+.files-new-where { flex: none; color: var(--muted); font-size: 11px; }
+.files-new strong { font-weight: 600; }
+
 .tw-rename { flex: 1; min-width: 0; font: inherit; color: var(--text); background: var(--term-bg);
   border: 1px solid var(--accent); border-radius: var(--r-sm); padding: 0 4px; margin: -1px 0; outline: none; }
 
 /* room for three buttons on a file row (rename, download, delete) */
-.tw-acts { flex: none; width: 4.9em; display: inline-flex; align-items: center;
+.tw-acts { flex: none; width: 6.5em; display: inline-flex; align-items: center;
   justify-content: flex-end; gap: 1px; }
 
 /* Create prompt and delete confirm: one row above the listing, where the thing

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -686,6 +686,7 @@ body {
 .tree-row:hover .tw-act { opacity: 1; }
 .tw-act:hover { color: var(--accent); }
 .tw-act.danger:hover { color: var(--danger); }
+.tw-act.ghost { pointer-events: none; }
 /* One fixed column for the row actions, whatever a row happens to hold: files
    carry download+delete, folders only delete, and the header carries neither.
    Sized to two buttons and right-aligned, so Size and Modified land on the same

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -690,7 +690,11 @@ body {
    carry download+delete, folders only delete, and the header carries neither.
    Sized to two buttons and right-aligned, so Size and Modified land on the same
    x in every row and under their own headings. */
-.tw-acts { flex: none; width: 3.3em; display: inline-flex; align-items: center;
+.tw-rename { flex: 1; min-width: 0; font: inherit; color: var(--text); background: var(--term-bg);
+  border: 1px solid var(--accent); border-radius: var(--r-sm); padding: 0 4px; margin: -1px 0; outline: none; }
+
+/* room for three buttons on a file row (rename, download, delete) */
+.tw-acts { flex: none; width: 4.9em; display: inline-flex; align-items: center;
   justify-content: flex-end; gap: 1px; }
 
 /* Create prompt and delete confirm: one row above the listing, where the thing


### PR DESCRIPTION
Everything left from PR #9, plus one default reversed. Absorbs #20 (closed), so this is the single follow-up to the merged Files pane work.

## Rename

A pencil on row hover turns the name into an input, in place — the thing being renamed stays where it is instead of jumping to a dialog. Enter commits, Esc abandons, blur commits, and the stem is preselected so renaming `draft.txt` doesn't mean retyping `.txt`. Folders the same. The server takes a **name**, not a path, so a rename can never quietly move something.

## The guard #9 had and #15 didn't

`dependedOnDir()` refuses any folder something else is standing on: an agent's own workspace, or the shared skills dir. Renaming one breaks a running agent's cwd — and **delete would have removed it outright**, since the delete merged in #15 only refused the workspace root. Both now refuse, with a reason worth reading:

```
that folder is worker's workspace
that folder is the shared skills folder
```

Credit to #9 — this is its function, carried across.

## Move

Drag a row onto a folder, or press **Move** and click one — the second path exists because there's no dragging on a phone. Adapted from #9, including its realpath containment check, so a symlink in the destination chain can't smuggle a folder into its own subtree.

Refused: a folder into itself or its own subfolder, a destination that isn't a folder, a name already taken there, and anything `dependedOnDir()` protects.

## New entries land where you clicked

Clicking a folder makes it the target for New folder, New file and uploads. The create prompt says which folder that is (`in archive`), and it resets when you navigate. Before this, everything landed in the breadcrumb folder however deep in the tree you were working.

## Nothing is written until you ask for it

Autosave was the wrong default here: these files have no undo and no git behind them, and an agent may be reading them. One stray keystroke in the wrong buffer and the old contents are gone.

The editor still opens writable — no edit mode to enter — but typing only fills a buffer. **Save** (or ⌘S) writes it, **Discard** throws it away, a dot beside the filename marks unsaved work.

Leaving with a buffer outstanding asks in a **dialog over the pane**, not a hint at the foot of it:

> **Unsaved changes in edit-me.txt**
> Your edits have not been written to the file.
> `Keep editing`  `Discard`  `Save and close`

Save and close waits for the write to land before leaving, so a refused save keeps the dialog up instead of closing over the error; after a conflict it says so and offers *Overwrite and close*. Esc inside the dialog means Keep editing — never discard.

The mtime precondition, the truncated-head refusal and the read-only trace all stand as they were.

## Bugs found on the way

- Replacing the document from the outside — a discard, a reload, a rename — came back through CodeMirror's update listener as a fresh edit, so **Discard re-dirtied the file the instant it cleaned it**. `setDoc()` marks those dispatches as ours.
- Dismissing the dialog left focus on `<body>`, so the **next Esc went nowhere** and the guard looked broken.
- `.mini-btn.primary` had been dropped in the autosave revert, so every primary action (Create, Save and close) rendered as a plain button.
- A file row ended in download while a folder row didn't, so rename/move/delete sat a slot apart between the two. Download leads now and folders hold that slot open.

## Checks

Endpoints: rename 200 · slash in a name 400 · onto an existing name 409 · an agent's workspace 409 · skills 409 · workspace root 400. Move a file in and back out 200 · folder into itself 400 · into its own subfolder 400 · into a file 400 · onto an existing name 409 · skills 409. Delete of an agent's workspace and of skills now 409, where both previously succeeded.

Browser: drag highlights the target and moves the file; the Move button arms a banner and clicking a folder completes it; a file created after clicking `archive` lands there and not at the root; typing sits 2.5 s with the disk unchanged; the dialog names the file and covers only its own pane; Keep editing returns to a still-dirty buffer; Esc twice leaves the file open and the disk untouched; Save and close writes then closes; Discard closes with the disk clean; a clean file closes without a dialog; row-action icons measured at identical x on folder and file rows.

Deployed to the private dev Space and re-checked there after each change.

One gap worth naming: `dragTo` hangs on HTML5 drag in headless Chromium, so the drag tests dispatch `dragstart`/`dragover`/`drop` directly. That exercises the handlers and the server but not the browser's native drag gesture — worth one manual drag before merging.

## #9

Fully covered now, across #15 and this. It can be closed once this lands.
