### PR TITLE
Bucket backup: PoC — every 1h/3h/24h, launch a Job to copy the bucket to private Hub storage

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -271,23 +271,33 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   of runtime, so a few minutes per backup — plus Hub storage for both
   copies. Every 1h means 24 runs a day.
 
-  History lvwerra/am-backup — private · mirror lvwerra/am-backup
-          ^ links to the dataset            ^ links to the bucket
-  · last run 4 Aug 16:36 (completed)   ← the stage links to the Job's page
-  · backing up now — follow the job ↗  ← while one is in flight
+  Backup dataset    lvwerra/am-dev-2-backup     -> the dataset page
+  Mirror bucket     lvwerra/am-dev-2-backup     -> the bucket page
+  Backup jobs       am-backup-am-dev-2          -> every run of this Space's backup
+  Last updated      4 Aug 19:35 (completed)     -- or "backing up now..."
 
-  [ Back up now ]        ← available whenever there is a token, schedule or not;
-                           reads "Backing up…" and is disabled while one runs
+  [ Back up now ]        <- available whenever there is a token, schedule or not;
+                            reads "Backing up..." and is disabled while one runs
 ```
 
-**Both destinations are named and linked, separately.** They default to the same
-id string — one a dataset, one a bucket — so a single unlabelled name told you
-which only by luck. The dataset carries the privacy state, since that is what the
-gate checks.
+**A table, not a sentence.** Three destinations and a timestamp are things you
+scan. It reuses the `.kv` block the Space section already uses, so it looks like
+the rest of the dashboard rather than like a new invention.
 
-**While a backup runs, the row links to the Job.** The copying happens on the Hub,
-so that page is where the progress actually is; the row polls every 10s and
-follows the stage until it is terminal.
+**Both repos are named, because they default to the same id string** — one a
+dataset, one a bucket. A single unlabelled name told you which only by luck. The
+dataset row carries the privacy state, since that is what the gate checks.
+
+**The jobs link is static.** Every run is launched with `--name am-backup-<space>`,
+which the Hub keeps as a `name=` label, so
+`/settings/jobs?label=name%3Dam-backup-<space>` lists them all — past, running and
+failed. Strictly better than linking the latest job id: no state to track, and the
+page you land on shows a failure in context. A test pins the launch name and the
+filter to the same value so they cannot drift.
+
+**Links inherit the text colour**, with a dotted underline that goes solid and
+accent on hover — the same restraint as `.trace-hint a`. Default-blue anchors were
+the one thing in the row that did not look like this app.
 
 **The cost is the operator's, so the row says whose.** "It costs this Space
 nothing" was true and beside the point: the Space is not who pays. What matters

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -271,10 +271,23 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   of runtime, so a few minutes per backup — plus Hub storage for both
   copies. Every 1h means 24 runs a day.
 
-  lvwerra/agent-manager-backup — private · last run 4 Aug 16:36 (completed)
+  History lvwerra/am-backup — private · mirror lvwerra/am-backup
+          ^ links to the dataset            ^ links to the bucket
+  · last run 4 Aug 16:36 (completed)   ← the stage links to the Job's page
+  · backing up now — follow the job ↗  ← while one is in flight
+
   [ Back up now ]        ← available whenever there is a token, schedule or not;
                            reads "Backing up…" and is disabled while one runs
 ```
+
+**Both destinations are named and linked, separately.** They default to the same
+id string — one a dataset, one a bucket — so a single unlabelled name told you
+which only by luck. The dataset carries the privacy state, since that is what the
+gate checks.
+
+**While a backup runs, the row links to the Job.** The copying happens on the Hub,
+so that page is where the progress actually is; the row polls every 10s and
+follows the stage until it is terminal.
 
 **The cost is the operator's, so the row says whose.** "It costs this Space
 nothing" was true and beside the point: the Space is not who pays. What matters

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -6,85 +6,85 @@ but `/data` holds the workspaces agents have been working in, their transcripts,
 the session list, and the operator's config. A deleted Space, a detached volume,
 or an `rm -rf` in the wrong workspace takes all of it.
 
-This is a periodic mirror of the bucket into **private Hub storage**, on an
-interval the operator sets alongside `archive` (Settings → hourly by default once
-enabled). Nothing here deletes from the bucket, ever.
+Two copies, on an interval the operator sets alongside `archive`:
 
-The bucket is itself a Hub resource, so the copy happens **entirely Hub-side**:
-no walk of the FUSE mount, no download, no re-upload. §3 is the evidence, and it
-is what makes an hourly cadence cheap enough to be boring.
+- a **private bucket**, overwritten each run — server-side, no bytes moved, and a
+  restore from it is equally instant. This is the "get the Space back" copy.
+- a **private dataset repo**, committed each run — the version history a bucket
+  cannot give, because buckets are mutable and non-versioned. This is the "get
+  yesterday's file back" copy.
+
+Both run in a **scheduled HF Job**, so the work happens on the Hub: backups
+continue while this Space is asleep, cost it no I/O, and never walk the FUSE
+mount. Nothing here deletes from the bucket, ever.
 
 ## 1. Decisions (locked)
 
-1. **Destination is a private bucket, not a dataset repo.** Not a preference —
-   bucket→repo copy is refused by the Hub today (§3.1). The bucket destination is
-   also the better fit: server-side copy, and no git history to grow forever.
-   The Hub's own docs recommend buckets for rolling backups for exactly that
-   reason.
-2. **The copy is server-side, by Xet hash.** `hf cp hf://buckets/<src>/ hf://buckets/<dst>/`
-   moves hashes, not bytes: 13,482 real files in 20 s (§3.2). The app makes API
-   calls; it does not read `/data`.
-3. **Everything is copied, credentials included.** Operator's call, and the
-   mechanism agrees: server-side copy has no include/exclude, so per-prefix
-   surgery would mean giving up the fast path. A restored Space comes back
-   signed-in.
-4. **The destination must be private, and that is a hard gate.** The mirror
-   contains live OAuth tokens for every agent, the Web Push private key, and
-   `session-secret` (§4). The backup refuses to run against a non-private
-   destination — checked on every run, not just at creation. Same instinct as
-   `visibility.js`, which locks the app when the Space or bucket is public.
-5. **Off until the operator turns it on.** It copies the contents of their
-   machine into another Hub resource; that is a deliberate act. Once on, hourly.
-6. **Never prune the destination.** A file deleted in `/data` stays in the
-   mirror. That is what makes this a backup rather than a synchroniser — an
-   `rm -rf` in a workspace is precisely the accident we are insuring against, and
-   a mirror that faithfully reproduces the deletion insures against nothing.
-7. **Restore is a documented script, not a button** (§9). Restoring over a live
-   bucket is destructive and only the operator knows which side should win.
+1. **The schedule lives on the Hub, not in this app.** `hf jobs scheduled run`
+   takes a cron. The Space's only job is to make the Hub's schedule match the
+   operator's config, and to report what the Hub says about it. A backup that
+   only runs while the app is healthy is a backup that will be missing exactly
+   when it is needed.
+2. **Two destinations, because they are cheap at different things.** Bucket
+   storage is accounted in *logical* bytes — two identical snapshots measured as
+   exactly 2× (§3.5) — so dated bucket snapshots multiply cost. A git repo stores
+   each distinct blob once and skips empty commits entirely, so an hour with no
+   changes adds *nothing* (§3.4). History belongs in the dataset; instant restore
+   belongs in the bucket.
+3. **Everything is copied, credentials included.** Operator's call. A restored
+   Space comes back signed-in. The mechanism agrees: server-side copy has no
+   include/exclude, so exclusions would mean giving up the fast path.
+4. **Both destinations must be private, re-checked inside the Job on every run.**
+   The copy contains live agent OAuth tokens, the Web Push private key, and
+   `session-secret` (§4). Creation-time privacy is not enough — a repo can be
+   flipped public later — so the gate runs in the Job itself and aborts before
+   anything is written. Verified to bite (§3.6).
+5. **The source bucket is mounted read-only** (`:ro`) in the Job. A backup must
+   not be able to write to the thing it is backing up.
+6. **Off until the operator turns it on.** It copies this machine's contents into
+   other Hub resources; that is a deliberate act. Once on, hourly.
+7. **Never prune the mirror.** A file deleted in `/data` stays in the bucket
+   mirror. An `rm -rf` in a workspace is precisely the accident being insured
+   against, and a mirror that faithfully reproduces the deletion insures against
+   nothing. The dataset gets `--delete "*"` so its *newest* commit matches the
+   bucket, while every earlier commit keeps the deleted file recoverable — the
+   best of both.
+8. **Restore is a documented script, not a button** (§8).
 
 ## 2. What we already have
 
 - **The bucket id, already discovered.** `visibility.js` reads
-  `GET /api/spaces/{id}` → `runtime.volumes[]` and keeps the entries with
-  `type === 'bucket'`. Verified on two Spaces: `{source: 'lvwerra/agent-manager-data', mountPath: '/data'}`.
-  The feature needs no new discovery.
-- **`hf` CLI 1.25.1 in the image**, with `hf buckets create/cp/list/info/rm`.
-  `share.js` already shells out to `hf` with this token, so there is no new auth
-  path.
+  `GET /api/spaces/{id}` → `runtime.volumes[]`, keeping entries with
+  `type === 'bucket'`. Verified on two Spaces:
+  `{source: 'lvwerra/agent-manager-data', mountPath: '/data'}`.
+- **`hf` CLI 1.25.1 in the image**, with `buckets`, `cp`, `jobs scheduled`.
+  `share.js` already shells out to `hf` with this token — no new auth path.
 - `am-config.json` + `GET/PUT /api/config` + a whitelisted enum, rendered as a
   segmented control in `SettingsView.tsx`. `archive.after` is the precedent the
   operator asked for; `backup` is another key in the same object.
-- `share.js`'s rule that heavy work happens in a child process. Less critical
-  here — `hf cp` *is* a subprocess and the work is on the Hub — but the timer
-  still spawns rather than blocks.
 
 ## 3. Verified Hub behaviour
 
-All measured against the real Hub with `hf` 1.25.1, on this Space's own buckets.
+All measured against the real Hub, on this Space's own buckets.
 
 ### 3.1 Bucket → dataset repo is not possible today
 
 ```
 $ hf cp hf://buckets/lvwerra/am-dev-2-data/sessions.json \
-        hf://datasets/lvwerra/am-backup-probe2/sessions.json
+        hf://datasets/lvwerra/…/sessions.json
 Error: Invalid value. Bucket-to-repo copy is not supported.
 ```
 
-The client raises it (`hf_api.py`: `if destination_uri.is_repo: if source_uri.is_bucket: raise`),
-and the CLI source attributes it to a **server limitation**. The Hub docs say so
-twice, in the same words:
+The client raises it and the CLI source attributes it to a **server limitation**.
+The Hub docs say so twice: transferring from a bucket to a repository without
+reuploading is "not yet available, but is **on the roadmap**".
 
-> Note that transferring data the other way from a bucket to a repository
-> (model, dataset, Space) without reuploading is **not yet available, but is on
-> the roadmap**.
+This is why §5 step 2 goes through a Job with the bucket mounted rather than a
+server-side copy. If the roadmap item lands, step 2 collapses into one `hf cp`
+and the rest of this design is untouched.
 
-Supported directions today: local→repo, local→bucket, repo→repo, repo→bucket,
-bucket→bucket. Server-side copies also require source and destination in the
-**same storage region**.
-
-**So "back up to a dataset, Hub-side" is not available.** It is on the roadmap,
-which makes this worth re-checking later: if it lands, §11.2 becomes a two-line
-change of destination type and the design is otherwise untouched.
+Supported today: local→repo, local→bucket, repo→repo, repo→bucket, bucket→bucket.
+Server-side copies require source and destination in the **same storage region**.
 
 ### 3.2 Bucket → bucket is server-side, recursive, and fast
 
@@ -94,211 +94,221 @@ change of destination type and the design is otherwise untouched.
 | `state/` of the production bucket, cold | 13,482 | **20 s** |
 | the same copy again | 13,482 | **18 s** |
 
-- A **trailing slash on both sides copies contents recursively**, preserving
-  paths. All 49/49 files of the small bucket landed at the same relative paths.
-- ~670 files/s. The production bucket is 102,691 files, so a **full mirror
-  extrapolates to ≈2.5 minutes** — comfortably inside an hourly cadence, and it
-  costs the Space no I/O at all.
-- The repeat run is not cheaper (18 s vs 20 s): `cp` re-copies entries rather
-  than diffing. Since no bytes move, this is a per-file metadata cost, not
-  bandwidth. It also means there is no "nothing changed, do nothing" shortcut on
-  this path — unlike the dataset path (§3.4).
-- Only Xet-tracked files copy server-to-server; the docs note small non-Xet files
-  are transparently downloaded and re-uploaded by the client. At 670 files/s over
-  13k mixed small files, nothing suggests we hit that path meaningfully from a
-  bucket source.
+Trailing slashes on both sides copy contents recursively, preserving paths
+(49/49 landed). ~670 files/s, so the 102,691-file production bucket extrapolates
+to **≈2.5 minutes**. The repeat is not cheaper — `cp` re-copies entries rather
+than diffing — but no bytes move either way.
 
-### 3.3 What buckets do not give us
+### 3.3 A Job can mount the live bucket read-only, while the Space has it
 
-- **No versioning.** Buckets are "non-versioned and mutable", overwrite-in-place,
-  and deletions are "immediate and permanent". There is no history and no
-  point-in-time recovery. See §10 — this is the real cost of the fast path.
-- **No remote→remote sync**, so no `--delete` and no `--include/--exclude`
-  between two buckets: `hf sync` raises "Remote to remote sync is not supported.
-  One path must be local." Pruning, if ever wanted, is a separate
-  `hf buckets rm --recursive`. Per §1.6 we do not want it.
-- **`hf buckets info` lags.** Immediately after a verified 49-file copy it still
-  reported `size: 0, total_files: 0`. It is eventually consistent — verify a copy
-  with `hf buckets list -R`, never with `info`.
-- Destination mtimes are **copy time**, not source time, so mtime cannot be used
-  to reason about staleness of individual files.
+```
+$ hf jobs run -v hf://buckets/lvwerra/am-dev-2-data:/live:ro python:3.12 \
+    bash -c 'ls /live; find /live -type f | wc -l'
+home  install.log  install.sh  order.json  sessions.json  state  workspaces
+49
+```
 
-### 3.4 The dataset-repo path, for comparison (§11.2)
+Concurrent mount is fine, which is what makes step 2 possible at all.
 
-Measured separately, uploading a local directory with `hf upload` (152 files, one
-3 MB binary):
+### 3.4 Upload from that mount into a private dataset
 
-| case | wall | result |
-|---|---|---|
-| cold | 44 s | 1 commit |
-| nothing changed | 10 s | **no commit** — "No files have been modified since last commit. Skipping to prevent empty commit." |
-| one file changed | 10 s | 1 commit, only that file transferred |
-| `--delete "*"`, one file deleted locally | 10 s | 1 commit, mirrored the deletion |
-| `--delete "*"`, nothing changed | 10 s | no commit |
+Inside the Job: `hf upload <ds> /live . --repo-type dataset --private --delete "*"`
 
-So `hf upload` is already an incremental, hash-checking mirror that produces no
-empty commits, and files over a few MB land in LFS automatically. It is a good
-mechanism — it just requires reading the mount, and it keeps every version
-forever (§10).
+- 49 files, **8.2 s**, dataset created **private: True**.
+- Run again with nothing changed: *"No files have been modified since last commit.
+  Skipping to prevent empty commit."* — **same commit sha, no new commit.**
+
+So version history costs nothing on an idle hour, and only changed files transfer
+on a busy one. This is the property that makes hourly history affordable.
+
+### 3.5 Bucket storage is accounted in logical bytes
+
+Two *identical* 13,482-file snapshots into one bucket reported
+`size: 4,118,488,963, total_files: 26,966` — exactly double. Xet dedups the
+chunks physically, but dedup-based *billing* is documented as an Enterprise
+benefit, so dated bucket prefixes cannot be assumed free. Hence §1.2: history
+goes in the dataset, and the bucket keeps exactly one copy.
+
+Also: `hf buckets info` is **eventually consistent** — immediately after a
+verified 49-file copy it still reported `size: 0`. Verify a copy with
+`hf buckets list -R`, never with `info`.
+
+### 3.6 The privacy gate refuses a public destination
+
+Flipped the destination dataset to public and triggered the schedule:
+
+```
+refusing to back up: dataset lvwerra/… is not private
+Job failed with exit code: 1
+```
+
+The dataset received **no new commit**. This is the one control standing between
+the operator's saved logins and the public internet, so it is verified rather
+than assumed.
+
+### 3.7 Incidental
+
+`pip install "huggingface_hub[cli]"` warns on 1.26.0 — *"does not provide the
+extra 'cli'"* — which now ships the CLI in the base package. The job script
+installs the plain package.
 
 ## 4. What is in the bucket (measured)
 
-The production bucket `lvwerra/agent-manager-data`: **11.4 GB, 102,691 files.**
-Walking the mount directly:
+`lvwerra/agent-manager-data`: **11.4 GB, 102,691 files.** Walking the mount:
+89,681 files under `/data`, of which `workspaces/` 58,356, `state/` 13,447,
+`node_modules/` 18,647, `.git/` 3,410.
 
-| subtree | files |
-|---|---|
-| everything under `/data` | 89,681 |
-| `workspaces/` | 58,356 |
-| `state/` | 13,447 |
-| `node_modules/` anywhere | 18,647 |
-| `.git/` anywhere | 3,410 |
+For the record, the cost this design avoids: a cold recursive walk of the mount
+ran into minutes (`du -sh /data` did not finish in 300 s), while a warm walk of
+one 620 MB workspace took 1 s.
 
-Cost of the mount-based alternative, for the record: a cold recursive walk ran
-into minutes (`du -sh /data` did not finish in 300 s) while a warm walk of one
-620 MB workspace took 1 s. The Hub-side path skips this entirely.
-
-**Credential surface**, all of it included per §1.3 and the reason §1.4 is a hard
-gate:
+**Credential surface**, all included per §1.3 and the reason §1.4 is a hard gate:
 
 - `state/claude/.credentials.json`, `state/codex/auth.json`, `state/hermes/auth.json`
 - `state/vapid.json` — this install's private Web Push key
 - `session-secret` at the bucket root
-- `home/` — agent dotfiles and whatever else lives in the home directory
+- `home/` — agent dotfiles
 - `secret-notes.json` — the operator's descriptions of injected secrets
 
 ## 5. The pipeline
 
+One scheduled Job, `am-backup-<space>`, cron from the config:
+
 ```
-timer (interval from am-config.json, unref'd)
-  └─ skip if: disabled · already running · no HF_TOKEN
-  └─ resolve source bucket id from runtime.volumes[]        (visibility.js)
-  └─ resolve/create destination:  <ns>/<space>-backup  --private
-  └─ HARD GATE: hf buckets info <dst> → private !== true  ⇒ refuse, surface why
-  └─ spawn: hf cp hf://buckets/<src>/ hf://buckets/<dst>/latest/
-  └─ verify with `hf buckets list <dst>/latest -R | wc -l`  (never `info`, §3.3)
-  └─ persist { at, duration, files, error } to DATA_DIR/backup-state.json
+hf jobs scheduled run "0 * * * *" --name am-backup-<space> \
+  --secrets HF_TOKEN \
+  -e AM_SOURCE=<live bucket> -e AM_MIRROR=<mirror bucket> -e AM_DATASET=<dataset> \
+  -v hf://buckets/<live bucket>:/live:ro \
+  --timeout 3000s python:3.12 bash -c '<script>'
 ```
+
+The script:
+
+1. **Gate** — abort unless the dataset and mirror bucket are private (§3.6).
+2. **Mirror** — `hf cp hf://buckets/$AM_SOURCE/ hf://buckets/$AM_MIRROR/latest/`.
+   Server-side; hashes move, not bytes.
+3. **History** — `hf upload $AM_DATASET /live . --repo-type dataset --private
+   --delete "*"`, reading the read-only mount.
 
 Details that matter:
 
-- **One at a time.** A run that overruns must not overlap the next; the timer
-  checks a running flag and logs the skip.
-- **Catch-up on boot, jittered** — a few minutes after start, not at boot when
-  the CLIs are still installing.
-- **A backup is a fuzzy snapshot.** Agents write while the copy runs, so the
-  mirror is not point-in-time consistent. Acceptable here, and worth saying
-  rather than glossing: it is a backup of a running machine.
-- **Failures are logged, not retried.** The next hour is the retry; the last
-  error surfaces in the status row so a silently broken backup becomes visible.
-- **`latest/` prefix**, not a dated one — see §10 on why dated prefixes are a
-  billing question rather than a free win.
+- **Values travel as env vars, never as shell text.** A repo id arrives from
+  `PUT /api/config` and ends up in an argument list, so ids are validated against
+  `^[A-Za-z0-9][\w.-]*/[A-Za-z0-9][\w.-]*$` and refused rather than escaped.
+  There is no legitimate bucket called `; rm -rf /`. Tested.
+- **`--timeout 3000s`** (50 min) is deliberately shorter than the shortest
+  interval, so a hung run dies before the next one is due. Tested.
+- **No update verb for a scheduled Job** — only run/delete — so any change to
+  cron or destination is delete-then-create. The desired state is fingerprinted
+  and compared, because missing a change means silently backing up to the old
+  destination. Tested.
+- **Reconcile is idempotent**: with nothing changed it is one list call and no
+  writes. Runs on boot (12 s in, after bucket discovery) and after every config
+  save.
+- **A backup is a fuzzy snapshot.** Agents write while it runs, so it is not
+  point-in-time consistent. Acceptable for this purpose, and worth saying rather
+  than glossing.
 
 ## 6. Config and API
 
 ```js
 // am-config.json — validated with a whitelist, like archive.after
 backup: {
-  every: 'never' | 'hour' | '6h' | 'day',   // default 'never' (§1.5)
-  bucket: '',                                // default <ns>/<space>-backup
+  every: 'never' | 'hour' | '6h' | 'day',   // default 'never' (§1.6)
+  mirror: '',                                // default <ns>/<space>-backup
+  dataset: '',                               // default <ns>/<space>-backup
 }
 ```
 
 ```
-GET  /api/backup/status  → { every, bucket, private, running, last: {...}, error }
-POST /api/backup/run     → kick one now (same path as the timer)
+GET  /api/backup/status  → { every, source, mirror, dataset, defaults,
+                             scheduled: { cron, suspended, lastRun, nextRun },
+                             datasetPrivate, error }
+POST /api/backup/run     → trigger the schedule now (or a one-off Job if off)
 ```
 
-`GET/PUT /api/config` gains the `backup` key. No new auth surface: both routes
-sit behind the existing visibility gate.
+`status` reports the schedule as the **Hub** sees it, not as we last left it, and
+re-reads the destination's privacy on every call.
 
-## 7. Settings surface
-
-One block in `SettingsView.tsx`, matching `archive`:
+## 7. Settings surface (phase 2)
 
 ```
 Back up the bucket                            [ off | hourly | 6h | daily ]
-  Copies everything on your bucket — workspaces, history, saved logins —
-  to a second private bucket on the Hub. The copy happens on the Hub, so
-  it costs this Space nothing. Nothing is ever deleted from your bucket,
-  and files you delete stay in the backup.
+  Copies your whole bucket — workspaces, history, saved logins — to private
+  Hub storage: a bucket you can restore from instantly, and a dataset that
+  keeps version history. The copy runs on the Hub, so it costs this Space
+  nothing and continues while it sleeps.
 
-  Backup bucket  [ lvwerra/agent-manager-backup ]   ● private
+  Mirror   [ lvwerra/agent-manager-backup ]            ● private
+  History  [ lvwerra/agent-manager-backup ] (dataset)  ● private
 
-  Last backup: 12 minutes ago · 102,691 files · 2m 28s
-  [ Back up now ]                            [ Open bucket ↗ ]
+  Last run: 12 minutes ago · next 15:00 · 102,691 files
+  [ Back up now ]                          [ Open ↗ ]
 ```
 
-The privacy dot is not decoration: it is the state of the §1.4 gate, and the one
-thing an operator must be able to see at a glance about a copy of their
+The privacy dots are not decoration: they are the state of the §1.4 gate, and the
+one thing an operator must be able to see at a glance about a copy of their
 credentials.
 
 ## 8. Restore
 
-Restore is the direction the Hub *does* support Hub-side, which is a pleasant
-asymmetry: `hf cp hf://buckets/<backup>/latest/ hf://buckets/<live>/` puts the
-data back without anything being downloaded — and the same copy works into a
-*fresh* Space's bucket, which is the real disaster case.
+The direction the Hub *does* support server-side, pleasingly:
 
-`scripts/restore-bucket.mjs <backup-bucket> <target-bucket>` wraps that with the
-guards that matter: refuse when the target is non-empty unless `--force`, and
-print what would be overwritten first. Documented, not a button, per §1.7.
+```
+hf cp hf://buckets/<mirror>/latest/ hf://buckets/<live>/       # instant, whole bucket
+hf cp hf://datasets/<dataset>/      hf://buckets/<live>/       # from a version
+```
+
+repo→bucket is supported (§3.1), so restoring a specific commit's contents is
+also server-side. Both are **documented but untested** (§10.5).
+
+`scripts/restore-bucket.mjs` will wrap these with the guards that matter: refuse
+a non-empty target unless `--force`, and print what would be overwritten first.
+Not a button: restoring over a live bucket is destructive, and only the operator
+knows which side should win.
 
 ## 9. Storage growth
 
-A bucket mirror costs **the current footprint, once** — 11.4 GB today, whatever
-it is tomorrow. There is no history to accumulate, which is exactly why the Hub
-docs recommend buckets over dataset repos for rolling backups: with git, deleting
-a file frees nothing.
-
-The one growth term is §1.6: files deleted in `/data` linger in the mirror
-forever. Deliberate, and cheap — but it means the mirror is a high-water mark of
-everything the bucket has ever held, not a copy of what it holds now. If that
-ever gets expensive, prune with `hf buckets rm --recursive` against a reviewed
-list; never automatically.
-
-**Pseudo-versioning is possible but unpriced.** Copying to a dated prefix each
-run (`latest/` → `2026-08-04T13/`) would give point-in-time recovery, and Xet
-chunk dedup means unchanged content is not stored twice. But the docs say
-dedup-based *billing* is an Enterprise benefit, so on other plans dated prefixes
-may bill as full copies. Not doing it until the billing is confirmed (§11.4).
+- **Mirror**: one copy of current state, ~11.4 GB today. Plus §1.7 — files
+  deleted in `/data` linger, so it is a high-water mark rather than a copy of
+  now. Deliberate; prune manually with `hf buckets rm --recursive` against a
+  reviewed list if it ever matters.
+- **Dataset**: one blob per distinct file version. Idle hours add nothing at all
+  (§3.4). The growth term is churny large files — append-only transcripts under
+  `state/*/projects/`, and any SQLite an agent keeps — where each hour's version
+  is stored forever. If that becomes the dominant cost, the options are
+  `super_squash_history` (drops the past, keeps current) or excluding transcripts
+  from the dataset step and letting session *sharing* own that data, since it
+  already exports traces with redaction. Not decided (§10.4).
 
 ## 10. Risks and open questions
 
-1. **No point-in-time recovery is the real trade.** This design protects against
-   deletion (§1.6) and against losing the Space, but not against *corruption*: a
-   file damaged in place propagates on the next copy and the good version is gone
-   forever. The dataset path (§3.4) is the one that gives history. If corruption
-   matters more than cost, the answer is both — hourly bucket mirror plus an
-   occasional versioned dataset snapshot from the mount, which is §11.2 and is
-   deliberately not in v1.
-2. **A backup bucket is a second copy of every credential.** §1.4's gate is the
-   mitigation, and it must be re-checked every run — a bucket can be flipped to
-   public after creation. Open: should the backup also refuse when the *Space* is
-   public, as `visibility.js` does for the app?
-3. **Region.** Server-side copy requires source and destination in the same
-   storage region. Untested across regions — the destination should be created
-   without an explicit region so it lands in the default, and a region mismatch
-   should be reported as its own error rather than a generic copy failure.
-4. **Dated-prefix billing** (§9) is unconfirmed.
-5. **~2.5 min is extrapolated**, from 13,482 files in 20 s. The full 102,691-file
-   copy has not been run end to end. If it is much worse than linear, hourly on a
-   large bucket needs revisiting — hence duration in the status row.
-6. **Sustained hourly API volume** over weeks is unproven.
-7. **Restore has never been exercised.** A backup that has not been restored once
+1. **A backup is a second copy of every credential.** §1.4's gate is the
+   mitigation and it is verified (§3.6). Open: should the backup also refuse when
+   the *Space* is public, as `visibility.js` does for the app?
+2. **Region.** Server-side copy requires source and destination in the same
+   storage region. The mirror is created without an explicit region so it lands
+   in the default; a mismatch should be reported as its own error rather than a
+   generic copy failure. Untested across regions.
+3. **~2.5 min is extrapolated** from 13,482 files in 20 s; the full
+   102,691-file copy has not been run end to end. Likewise the dataset step has
+   only been measured on 49 files — 102,691 files through `hf upload` is the real
+   unknown here, and the reason phase 1 records duration.
+4. **Transcript churn in the dataset** (§9) is unbounded and undecided.
+5. **Restore has never been exercised.** A backup that has not been restored once
    is a hypothesis. Phase 3 restores into a scratch Space for real.
-8. **Bucket→repo is on the roadmap** (§3.1). Re-check before building anything
-   elaborate on the mount-based path.
+6. **Sustained hourly Job volume** over weeks is unproven, as is the interaction
+   with the Job quota on a free account.
+7. **Bucket→repo is on the roadmap** (§3.1) — re-check before elaborating step 2.
 
 ## 11. Phasing
 
-1. **Config + timer + the copy + status API.** Headless, driven by
-   `POST /api/backup/run`; run one full 102,691-file copy and record the real
-   duration (§10.5).
-2. **Settings UI** (§7) — interval, destination, the privacy dot, status line,
-   "Back up now".
+1. **Done** — config keys, Hub-side schedule reconciliation, the two-step Job,
+   `GET /api/backup/status`, `POST /api/backup/run`, tests. Verified end to end
+   against the Hub: schedule created, idempotent re-reconcile, trigger, both
+   steps run, private dataset committed, and the privacy gate refusing a public
+   destination.
+2. **Settings UI** (§7) — interval, destinations, privacy dots, status, run-now.
 3. **`scripts/restore-bucket.mjs` + docs, and one real restore** into a scratch
-   Space. Until this runs, the feature is unproven (§10.7).
-4. **Optional versioned snapshots** — the §3.4 dataset path at a slow cadence,
-   for point-in-time recovery (§10.1), or dated prefixes if §9's billing turns
-   out to be favourable.
+   Space (§10.5).
+4. **Retention** — decide §9 for transcript churn.

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -274,7 +274,7 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   Backup dataset    lvwerra/am-dev-2-backup     -> the dataset page
   Mirror bucket     lvwerra/am-dev-2-backup     -> the bucket page
   Backup jobs       am-backup-am-dev-2          -> every run of this Space's backup
-  Last updated      4 Aug 19:35 (completed)     -- or "backing up now..."
+  Last updated      4 Aug 19:35                 -- a timestamp, never a stage
 
   [ Back up now ]        <- available whenever there is a token, schedule or not;
                             reads "Backing up..." and is disabled while one runs
@@ -294,6 +294,23 @@ which the Hub keeps as a `name=` label, so
 failed. Strictly better than linking the latest job id: no state to track, and the
 page you land on shows a failure in context. A test pins the launch name and the
 filter to the same value so they cannot drift.
+
+**No stage in the table.** It read `(running)` for runs that had long finished,
+because `stage || 'RUNNING'` invented an answer whenever the Hub did not give one.
+The state a Job is in belongs on the jobs page linked above; the row reports only
+when it last ran. Two fixes behind that:
+
+- **Active stages are enumerated, not terminal ones.** `SCHEDULING`/`RUNNING` mean
+  in flight; anything else — including an unrecognised stage or no answer at all —
+  counts as finished. The old way round meant an unknown answer read as "running",
+  which both lied and would have blocked every later backup behind a job that no
+  longer exists.
+- **The Job id is parsed format-agnostically.** The image installs
+  `huggingface_hub` unpinned, so the CLI in a Space is not the one on a dev
+  machine, and a differing launch output silently left `jobId: null` — which
+  disabled overlap detection and left nothing to poll. `parseJobId` accepts
+  `id=<id>`, a bare id, or one inside a job URL, and logs the raw output when it
+  still cannot find one.
 
 **Links inherit the text colour**, with a dotted underline that goes solid and
 accent on hover — the same restraint as `.trace-hint a`. Default-blue anchors were

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -6,279 +6,299 @@ but `/data` holds the workspaces agents have been working in, their transcripts,
 the session list, and the operator's config. A deleted Space, a detached volume,
 or an `rm -rf` in the wrong workspace takes all of it.
 
-This is a periodic mirror of the bucket into a **private dataset repo**, so that
-losing the Space costs an afternoon instead of everything.
+This is a periodic mirror of the bucket into **private Hub storage**, on an
+interval the operator sets alongside `archive` (Settings → hourly by default once
+enabled). Nothing here deletes from the bucket, ever.
 
-Interval is an operator setting alongside `archive` (Settings → hourly by default
-once enabled). Nothing here deletes from the bucket, ever.
+The bucket is itself a Hub resource, so the copy happens **entirely Hub-side**:
+no walk of the FUSE mount, no download, no re-upload. §3 is the evidence, and it
+is what makes an hourly cadence cheap enough to be boring.
 
 ## 1. Decisions (locked)
 
-1. **A mirrored file tree, not a tarball.** The dataset holds the bucket's files
-   at their own paths. A tarball would be a fresh multi-gigabyte LFS blob every
-   hour, stored forever (§3, §10). A tree dedupes: only changed files transfer,
-   and an hour with no changes produces *no commit at all* (§3).
-2. **One private dataset per Space**, `<namespace>/am-bucket-<space-name>`.
-   Created `--private`, and the backup **refuses to run** if the repo is not
-   private — the same instinct as `visibility.js`, which locks the whole app when
-   the Space or bucket is public.
-3. **Agent credentials are excluded by default.** The bucket contains live OAuth
-   credentials (§4). A backup exists to save *work*, and a restore can re-login.
-   Copying live tokens into a Hub repo multiplies the blast radius of that repo
-   for no gain the operator asked for. Opt-in toggle, worded plainly.
-4. **The walk and the upload run in a child process.** Same hard rule as
-   `share.js` §1: this app has wedged once on synchronous work, and a background
-   task that fires every hour must never be the next cause.
-5. **Off until the operator turns it on.** It writes the contents of their
-   machine to their Hub account; that is a deliberate act, not a default. Once
-   on, the interval defaults to hourly.
-6. **Restore is a documented script, not a button.** Restoring over a live
-   bucket is destructive and situational (§9). v1 gives `scripts/restore-bucket.mjs`
-   and instructions; the app does not offer one-click restore.
+1. **Destination is a private bucket, not a dataset repo.** Not a preference —
+   bucket→repo copy is refused by the Hub today (§3.1). The bucket destination is
+   also the better fit: server-side copy, and no git history to grow forever.
+   The Hub's own docs recommend buckets for rolling backups for exactly that
+   reason.
+2. **The copy is server-side, by Xet hash.** `hf cp hf://buckets/<src>/ hf://buckets/<dst>/`
+   moves hashes, not bytes: 13,482 real files in 20 s (§3.2). The app makes API
+   calls; it does not read `/data`.
+3. **Everything is copied, credentials included.** Operator's call, and the
+   mechanism agrees: server-side copy has no include/exclude, so per-prefix
+   surgery would mean giving up the fast path. A restored Space comes back
+   signed-in.
+4. **The destination must be private, and that is a hard gate.** The mirror
+   contains live OAuth tokens for every agent, the Web Push private key, and
+   `session-secret` (§4). The backup refuses to run against a non-private
+   destination — checked on every run, not just at creation. Same instinct as
+   `visibility.js`, which locks the app when the Space or bucket is public.
+5. **Off until the operator turns it on.** It copies the contents of their
+   machine into another Hub resource; that is a deliberate act. Once on, hourly.
+6. **Never prune the destination.** A file deleted in `/data` stays in the
+   mirror. That is what makes this a backup rather than a synchroniser — an
+   `rm -rf` in a workspace is precisely the accident we are insuring against, and
+   a mirror that faithfully reproduces the deletion insures against nothing.
+7. **Restore is a documented script, not a button** (§9). Restoring over a live
+   bucket is destructive and only the operator knows which side should win.
 
 ## 2. What we already have
 
-- `share.js` publishes a dataset repo already: `hf repo create --type dataset`,
-  `hf upload`, then `hfApi()` for settings/access. Same CLI, same token, same
-  namespace resolution (`shareNamespace()`). The backup reuses that shape and
-  needs no new Hub plumbing.
+- **The bucket id, already discovered.** `visibility.js` reads
+  `GET /api/spaces/{id}` → `runtime.volumes[]` and keeps the entries with
+  `type === 'bucket'`. Verified on two Spaces: `{source: 'lvwerra/agent-manager-data', mountPath: '/data'}`.
+  The feature needs no new discovery.
+- **`hf` CLI 1.25.1 in the image**, with `hf buckets create/cp/list/info/rm`.
+  `share.js` already shells out to `hf` with this token, so there is no new auth
+  path.
 - `am-config.json` + `GET/PUT /api/config` + a whitelisted enum, rendered as a
-  segmented control in `SettingsView.tsx`. `archive.after` is exactly the
-  precedent the operator asked for; `backup` is another key in the same object.
-- `watchdog.js` for the "periodic work that must not wedge the loop" pattern, and
-  `tracked()`/`PHASE` if the backup ever touches the main thread.
-- `scripts/share-session.mjs` as the model for a heavy child-process worker that
-  is *also* runnable by hand — the property that makes it debuggable.
+  segmented control in `SettingsView.tsx`. `archive.after` is the precedent the
+  operator asked for; `backup` is another key in the same object.
+- `share.js`'s rule that heavy work happens in a child process. Less critical
+  here — `hf cp` *is* a subprocess and the work is on the Hub — but the timer
+  still spawns rather than blocks.
 
 ## 3. Verified Hub behaviour
 
-Measured against a throwaway private dataset (`hf` **1.25.1**, since deleted);
-152 files including one 3 MB binary.
+All measured against the real Hub with `hf` 1.25.1, on this Space's own buckets.
+
+### 3.1 Bucket → dataset repo is not possible today
+
+```
+$ hf cp hf://buckets/lvwerra/am-dev-2-data/sessions.json \
+        hf://datasets/lvwerra/am-backup-probe2/sessions.json
+Error: Invalid value. Bucket-to-repo copy is not supported.
+```
+
+The client raises it (`hf_api.py`: `if destination_uri.is_repo: if source_uri.is_bucket: raise`),
+and the CLI source attributes it to a **server limitation**. The Hub docs say so
+twice, in the same words:
+
+> Note that transferring data the other way from a bucket to a repository
+> (model, dataset, Space) without reuploading is **not yet available, but is on
+> the roadmap**.
+
+Supported directions today: local→repo, local→bucket, repo→repo, repo→bucket,
+bucket→bucket. Server-side copies also require source and destination in the
+**same storage region**.
+
+**So "back up to a dataset, Hub-side" is not available.** It is on the roadmap,
+which makes this worth re-checking later: if it lands, §11.2 becomes a two-line
+change of destination type and the design is otherwise untouched.
+
+### 3.2 Bucket → bucket is server-side, recursive, and fast
+
+| case | files | wall |
+|---|---|---|
+| whole small bucket (`am-dev-2-data`) | 49 | **1 s** |
+| `state/` of the production bucket, cold | 13,482 | **20 s** |
+| the same copy again | 13,482 | **18 s** |
+
+- A **trailing slash on both sides copies contents recursively**, preserving
+  paths. All 49/49 files of the small bucket landed at the same relative paths.
+- ~670 files/s. The production bucket is 102,691 files, so a **full mirror
+  extrapolates to ≈2.5 minutes** — comfortably inside an hourly cadence, and it
+  costs the Space no I/O at all.
+- The repeat run is not cheaper (18 s vs 20 s): `cp` re-copies entries rather
+  than diffing. Since no bytes move, this is a per-file metadata cost, not
+  bandwidth. It also means there is no "nothing changed, do nothing" shortcut on
+  this path — unlike the dataset path (§3.4).
+- Only Xet-tracked files copy server-to-server; the docs note small non-Xet files
+  are transparently downloaded and re-uploaded by the client. At 670 files/s over
+  13k mixed small files, nothing suggests we hit that path meaningfully from a
+  bucket source.
+
+### 3.3 What buckets do not give us
+
+- **No versioning.** Buckets are "non-versioned and mutable", overwrite-in-place,
+  and deletions are "immediate and permanent". There is no history and no
+  point-in-time recovery. See §10 — this is the real cost of the fast path.
+- **No remote→remote sync**, so no `--delete` and no `--include/--exclude`
+  between two buckets: `hf sync` raises "Remote to remote sync is not supported.
+  One path must be local." Pruning, if ever wanted, is a separate
+  `hf buckets rm --recursive`. Per §1.6 we do not want it.
+- **`hf buckets info` lags.** Immediately after a verified 49-file copy it still
+  reported `size: 0, total_files: 0`. It is eventually consistent — verify a copy
+  with `hf buckets list -R`, never with `info`.
+- Destination mtimes are **copy time**, not source time, so mtime cannot be used
+  to reason about staleness of individual files.
+
+### 3.4 The dataset-repo path, for comparison (§11.2)
+
+Measured separately, uploading a local directory with `hf upload` (152 files, one
+3 MB binary):
 
 | case | wall | result |
 |---|---|---|
-| cold upload (152 files, 3 MB) | 44 s | 1 commit |
-| re-run, nothing changed | 10 s | **no commit** — "No files have been modified since last commit. Skipping to prevent empty commit." |
-| re-run, one small file changed | 10 s | 1 commit, only that file transferred |
-| re-run with `--delete "*"`, one file deleted locally | 10 s | 1 commit, the file is gone from the repo |
-| re-run with `--delete "*"`, nothing changed | 10 s | **no commit** |
+| cold | 44 s | 1 commit |
+| nothing changed | 10 s | **no commit** — "No files have been modified since last commit. Skipping to prevent empty commit." |
+| one file changed | 10 s | 1 commit, only that file transferred |
+| `--delete "*"`, one file deleted locally | 10 s | 1 commit, mirrored the deletion |
+| `--delete "*"`, nothing changed | 10 s | no commit |
 
-What this buys us, and why the whole design leans on it:
+So `hf upload` is already an incremental, hash-checking mirror that produces no
+empty commits, and files over a few MB land in LFS automatically. It is a good
+mechanism — it just requires reading the mount, and it keeps every version
+forever (§10).
 
-- **`hf upload <repo> <dir> . --repo-type dataset` is already an incremental
-  mirror.** It hash-checks every file and transfers only what differs. We do not
-  need to track state, diff trees, or remember what we sent last hour.
-- **An idle hour is free and invisible.** No empty commits means hourly backups
-  do not produce 8,760 junk commits a year; the history is a list of real
-  changes. This survives `--delete "*"`, so mirroring deletions costs nothing
-  when nothing was deleted.
-- **`--delete "*"` matches nested paths**, so one flag makes the dataset a true
-  mirror rather than an append-only pile of files the operator once had.
-- Files over a few MB land in **LFS** automatically (the 3 MB binary did) — no
-  `.gitattributes` work on our side.
-- `upload-large-folder` is **deprecated** in 1.25.1 in favour of `hf upload`.
+## 4. What is in the bucket (measured)
 
-## 4. What is actually in the bucket (measured)
-
-On this Space's bucket, walked directly:
+The production bucket `lvwerra/agent-manager-data`: **11.4 GB, 102,691 files.**
+Walking the mount directly:
 
 | subtree | files |
 |---|---|
-| everything under `/data` | **89,681** |
+| everything under `/data` | 89,681 |
 | `workspaces/` | 58,356 |
 | `state/` | 13,447 |
-| — of which `state/claude/projects/` (transcripts) | 767 |
 | `node_modules/` anywhere | 18,647 |
 | `.git/` anywhere | 3,410 |
 
-Two costs that shape the design:
+Cost of the mount-based alternative, for the record: a cold recursive walk ran
+into minutes (`du -sh /data` did not finish in 300 s) while a warm walk of one
+620 MB workspace took 1 s. The Hub-side path skips this entirely.
 
-- **The FUSE walk is the expensive part, and it is cache-dependent.** A cold
-  recursive walk of the whole bucket ran into minutes — `du -sh /data` did not
-  finish inside 300 s — while a warm walk of one 620 MB workspace took 1 s. So
-  the first backup after a boot is slow and later ones are cheap, which is
-  survivable hourly but *only* off the event loop (§1.4).
-- **Live credentials are in there**, which is the single most consequential fact
-  in this document:
-  - `state/claude/.credentials.json`
-  - `state/codex/auth.json`
-  - `state/hermes/auth.json`
-  - `state/vapid.json` — this install's private Web Push key
-  - `secret-notes.json` — the operator's descriptions of injected secrets
+**Credential surface**, all of it included per §1.3 and the reason §1.4 is a hard
+gate:
 
-  A dataset holding those is a credential store with a Hub URL. Hence §1.3.
+- `state/claude/.credentials.json`, `state/codex/auth.json`, `state/hermes/auth.json`
+- `state/vapid.json` — this install's private Web Push key
+- `session-secret` at the bucket root
+- `home/` — agent dotfiles and whatever else lives in the home directory
+- `secret-notes.json` — the operator's descriptions of injected secrets
 
-## 5. What gets excluded
-
-Default exclusions, in two classes.
-
-**Regenerable bulk** — costs upload time and storage, restores by rebuilding:
+## 5. The pipeline
 
 ```
-**/node_modules/**    **/.venv/**        **/__pycache__/**   **/*.pyc
-**/dist/**            **/build/**        **/target/**        **/.next/**
-**/.cache/**          **/.pytest_cache/**
-```
-
-`node_modules` alone is 18,647 files — 21% of the bucket's file count for
-content that `npm ci` reproduces.
-
-**Credentials and keys** — excluded unless the operator opts in:
-
-```
-state/*/.credentials.json   state/*/auth.json   state/*/.env
-state/vapid.json            **/.git-credentials
-```
-
-**Deliberately kept:** `.git` directories. Git objects are immutable and
-content-addressed, which makes them the *ideal* case for a deduping mirror —
-each object uploads once, forever. And branches, stashes, and unpushed commits
-are exactly the work a backup is for. 3,410 files is cheap.
-
-Whatever is skipped gets **counted and logged** in the backup status (§7). A
-backup that silently omits things reads as "you are covered" when you are not.
-
-## 6. The pipeline
-
-```
-hourly timer (main thread, unref'd)
-  └─ skip if: disabled · already running · repo not private · no HF_TOKEN
-  └─ spawn scripts/backup-bucket.mjs          ← child process, per §1.4
-        ├─ walk DATA_DIR applying the exclusion globs
-        ├─ hf upload <repo> <staged> . --repo-type dataset --delete "*"
-        │     (hash-check → transfer only what changed → skip empty commits)
-        └─ print a JSON report on stdout
-  └─ persist the report to DATA_DIR/backup-state.json
+timer (interval from am-config.json, unref'd)
+  └─ skip if: disabled · already running · no HF_TOKEN
+  └─ resolve source bucket id from runtime.volumes[]        (visibility.js)
+  └─ resolve/create destination:  <ns>/<space>-backup  --private
+  └─ HARD GATE: hf buckets info <dst> → private !== true  ⇒ refuse, surface why
+  └─ spawn: hf cp hf://buckets/<src>/ hf://buckets/<dst>/latest/
+  └─ verify with `hf buckets list <dst>/latest -R | wc -l`  (never `info`, §3.3)
+  └─ persist { at, duration, files, error } to DATA_DIR/backup-state.json
 ```
 
 Details that matter:
 
-- **The staged tree.** `hf upload` takes a directory, and we need exclusions
-  applied — so the script builds a staging tree of **hardlinks** into a temp dir
-  (no copy, no extra bytes) and uploads that. Hardlinks across the FUSE mount
-  need verifying on the real Space; if they fail, fall back to `--exclude` globs
-  passed straight to `hf upload` (it supports them) and skip staging entirely.
-  **Open — the fallback is the safer default until measured (§12).**
-- **One at a time.** A run that overruns the hour must not overlap the next; the
-  timer checks a running flag and logs the skip.
-- **Catch-up on boot, jittered.** If the last backup is older than the interval,
-  run one a few minutes after boot — not at boot, when the CLIs are installing
-  and the walk is coldest.
-- **A backup is a fuzzy snapshot.** Agents are writing while we read. Files may
-  be captured mid-write and the tree is not a point-in-time image. That is
-  acceptable for this purpose and must be *said*, not glossed: it is a backup of
-  a running machine, not a database snapshot.
-- **Failures are logged, not retried.** The next hour is the retry. The last
-  error is surfaced in the status row so a silently broken backup becomes
-  visible.
+- **One at a time.** A run that overruns must not overlap the next; the timer
+  checks a running flag and logs the skip.
+- **Catch-up on boot, jittered** — a few minutes after start, not at boot when
+  the CLIs are still installing.
+- **A backup is a fuzzy snapshot.** Agents write while the copy runs, so the
+  mirror is not point-in-time consistent. Acceptable here, and worth saying
+  rather than glossing: it is a backup of a running machine.
+- **Failures are logged, not retried.** The next hour is the retry; the last
+  error surfaces in the status row so a silently broken backup becomes visible.
+- **`latest/` prefix**, not a dated one — see §10 on why dated prefixes are a
+  billing question rather than a free win.
 
-## 7. Settings surface
-
-One new block in `SettingsView.tsx`, matching `archive`:
-
-```
-Back up the bucket                                   [ off | hourly | 6h | daily ]
-  Mirrors your workspaces and session history to a private dataset so
-  a lost Space is recoverable. Nothing is ever deleted from the bucket.
-
-  Dataset   [ lvwerra/am-bucket-am-dev-2        ]  (private)
-  Include agent credentials                                    [ off | on ]
-    Off: the backup skips saved logins, so a restored Space asks you to
-    sign in again. On: your live agent tokens are copied to the dataset.
-
-  Last backup: 12 minutes ago · 1.2 GB · 34 files changed · skipped 18,647
-  [ Back up now ]                                    [ Open dataset ↗ ]
-```
-
-The status line is load-bearing: a backup nobody can see the state of is a
-backup nobody trusts.
-
-## 8. Config and API
+## 6. Config and API
 
 ```js
 // am-config.json — validated with a whitelist, like archive.after
 backup: {
   every: 'never' | 'hour' | '6h' | 'day',   // default 'never' (§1.5)
-  repo: '',                                  // default <ns>/am-bucket-<space>
-  includeCredentials: false,                 // §1.3
+  bucket: '',                                // default <ns>/<space>-backup
 }
 ```
 
 ```
-GET  /api/backup/status   → { every, repo, private, running, last: {...}, error }
-POST /api/backup/run      → kick one now (same path as the timer)
+GET  /api/backup/status  → { every, bucket, private, running, last: {...}, error }
+POST /api/backup/run     → kick one now (same path as the timer)
 ```
 
 `GET/PUT /api/config` gains the `backup` key. No new auth surface: both routes
-sit behind the same visibility gate as everything else.
+sit behind the existing visibility gate.
 
-## 9. Restore
+## 7. Settings surface
 
-`scripts/restore-bucket.mjs <repo> <target>`:
+One block in `SettingsView.tsx`, matching `archive`:
 
 ```
-hf download <repo> --repo-type dataset --local-dir <target>
+Back up the bucket                            [ off | hourly | 6h | daily ]
+  Copies everything on your bucket — workspaces, history, saved logins —
+  to a second private bucket on the Hub. The copy happens on the Hub, so
+  it costs this Space nothing. Nothing is ever deleted from your bucket,
+  and files you delete stay in the backup.
+
+  Backup bucket  [ lvwerra/agent-manager-backup ]   ● private
+
+  Last backup: 12 minutes ago · 102,691 files · 2m 28s
+  [ Back up now ]                            [ Open bucket ↗ ]
 ```
 
-then re-create what was excluded — `npm ci` where a `package-lock.json` came
-back, re-login for each agent. Documented, not automated, because restoring onto
-a bucket that already has content is destructive and only the operator knows
-which side should win.
+The privacy dot is not decoration: it is the state of the §1.4 gate, and the one
+thing an operator must be able to see at a glance about a copy of their
+credentials.
 
-The reason this stays a script: a "Restore" button that overwrites a live bucket
-is a footgun aimed at the one thing this feature exists to protect.
+## 8. Restore
 
-## 10. Storage growth
+Restore is the direction the Hub *does* support Hub-side, which is a pleasant
+asymmetry: `hf cp hf://buckets/<backup>/latest/ hf://buckets/<live>/` puts the
+data back without anything being downloaded — and the same copy works into a
+*fresh* Space's bucket, which is the real disaster case.
 
-The mirror's cost over time is **the sum of every distinct version of every
-file**, because git keeps history. The hazard is not the big files, it is the
-*churny* big files: anything multi-MB that changes every hour is a new LFS object
-every hour, kept forever.
+`scripts/restore-bucket.mjs <backup-bucket> <target-bucket>` wraps that with the
+guards that matter: refuse when the target is non-empty unless `--force`, and
+print what would be overwritten first. Documented, not a button, per §1.7.
 
-Known churn: agent transcripts under `state/*/projects/` (append-only JSONL, so
-every hour is a new full copy of a growing file) and any SQLite database an agent
-keeps. 767 transcript files today, but they only grow.
+## 9. Storage growth
 
-Options, in preference order — **not yet decided (§12)**:
+A bucket mirror costs **the current footprint, once** — 11.4 GB today, whatever
+it is tomorrow. There is no history to accumulate, which is exactly why the Hub
+docs recommend buckets over dataset repos for rolling backups: with git, deleting
+a file frees nothing.
 
-1. Accept it, and surface the dataset's size in the status row so growth is
-   visible before it is a problem.
-2. Squash history periodically (`super_squash_history`), keeping the mirror
-   current and dropping the past — a mirror, not an archive.
-3. Exclude transcripts from the hourly pass and let session *sharing* (which
-   already exports traces properly, with redaction) own that data.
+The one growth term is §1.6: files deleted in `/data` linger in the mirror
+forever. Deliberate, and cheap — but it means the mirror is a high-water mark of
+everything the bucket has ever held, not a copy of what it holds now. If that
+ever gets expensive, prune with `hf buckets rm --recursive` against a reviewed
+list; never automatically.
 
-Option 3 is tempting and probably right long-term: two features backing up the
-same transcripts, one of them without redaction, is a smell.
+**Pseudo-versioning is possible but unpriced.** Copying to a dated prefix each
+run (`latest/` → `2026-08-04T13/`) would give point-in-time recovery, and Xet
+chunk dedup means unchanged content is not stored twice. But the docs say
+dedup-based *billing* is an Enterprise benefit, so on other plans dated prefixes
+may bill as full copies. Not doing it until the billing is confirmed (§11.4).
 
-## 11. Risks and open questions
+## 10. Risks and open questions
 
-1. **The credential decision (§1.3) is the one to review first.** Default-off is
-   my recommendation. Note that "off" makes a restored Space need re-login for
-   every agent, which is a real cost the operator may prefer to trade away.
-2. **A backup dataset is a new blast radius.** Even excluding credentials, the
-   workspaces contain whatever agents wrote — source, data, notes. The
-   private-repo check (§1.2) is a hard gate, not a warning, for that reason.
-   Should we also refuse when the *Space* is public, as `visibility.js` does?
-3. **Hardlink staging across FUSE is unverified** (§6). Fallback is `--exclude`
-   globs, which is simpler; possibly skip staging in v1 entirely.
-4. **Cold-walk cost on a much larger bucket.** 89,681 files walks fine warm; the
-   cold case ran to minutes here. A bucket 10× this size may not fit an hourly
-   cadence, so the status row should show duration and the timer should log when
-   a run overruns its interval.
-5. **Hub rate limits / commit volume** are untested at a sustained hourly cadence
-   over weeks. Expected fine — no-op hours make no commits at all — but unproven.
-6. **Two backups of one thing.** §10 option 3; worth settling before both exist.
+1. **No point-in-time recovery is the real trade.** This design protects against
+   deletion (§1.6) and against losing the Space, but not against *corruption*: a
+   file damaged in place propagates on the next copy and the good version is gone
+   forever. The dataset path (§3.4) is the one that gives history. If corruption
+   matters more than cost, the answer is both — hourly bucket mirror plus an
+   occasional versioned dataset snapshot from the mount, which is §11.2 and is
+   deliberately not in v1.
+2. **A backup bucket is a second copy of every credential.** §1.4's gate is the
+   mitigation, and it must be re-checked every run — a bucket can be flipped to
+   public after creation. Open: should the backup also refuse when the *Space* is
+   public, as `visibility.js` does for the app?
+3. **Region.** Server-side copy requires source and destination in the same
+   storage region. Untested across regions — the destination should be created
+   without an explicit region so it lands in the default, and a region mismatch
+   should be reported as its own error rather than a generic copy failure.
+4. **Dated-prefix billing** (§9) is unconfirmed.
+5. **~2.5 min is extrapolated**, from 13,482 files in 20 s. The full 102,691-file
+   copy has not been run end to end. If it is much worse than linear, hourly on a
+   large bucket needs revisiting — hence duration in the status row.
+6. **Sustained hourly API volume** over weeks is unproven.
 7. **Restore has never been exercised.** A backup that has not been restored once
-   is a hypothesis. Phase 3 should include an actual restore into a scratch Space.
+   is a hypothesis. Phase 3 restores into a scratch Space for real.
+8. **Bucket→repo is on the roadmap** (§3.1). Re-check before building anything
+   elaborate on the mount-based path.
 
-## 12. Phasing
+## 11. Phasing
 
-1. **Config + scheduler + `scripts/backup-bucket.mjs` + status API.** Headless,
-   driven by `POST /api/backup/run`. Prove the incremental mirror on a real
-   bucket and measure the cold walk.
-2. **Settings UI** (§7) — the interval control, dataset field, credential
-   toggle, status line, "Back up now".
+1. **Config + timer + the copy + status API.** Headless, driven by
+   `POST /api/backup/run`; run one full 102,691-file copy and record the real
+   duration (§10.5).
+2. **Settings UI** (§7) — interval, destination, the privacy dot, status line,
+   "Back up now".
 3. **`scripts/restore-bucket.mjs` + docs, and one real restore** into a scratch
-   Space. Until this runs, the feature is unproven (§11.7).
-4. **Retention** — decide §10, implement squash or transcript exclusion.
+   Space. Until this runs, the feature is unproven (§10.7).
+4. **Optional versioned snapshots** — the §3.4 dataset path at a slow cadence,
+   for point-in-time recovery (§10.1), or dated prefixes if §9's billing turns
+   out to be favourable.

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -17,8 +17,10 @@ Two copies, on an interval the operator sets alongside `archive`:
 Both happen inside one **HF Job** that this app launches and forgets, so the
 copying runs on the Hub: a backup costs this Space one API call, never reads
 `/data` (whose cold walk runs to minutes), and cannot wedge the event loop that
-pumps the terminals. It needs an `HF_TOKEN` (§1.6). Nothing here deletes from the
-bucket, ever.
+pumps the terminals. It does cost the *operator* — each run bills an HF Job
+(cpu-basic) and both copies occupy Hub storage, which §7 states plainly before
+anyone switches it on. It needs an `HF_TOKEN` (§1.6). Nothing here deletes from
+the bucket, ever.
 
 ## 1. Decisions (locked)
 
@@ -193,7 +195,7 @@ hf jobs run --detach --name am-backup-<space> \
   --secrets HF_TOKEN \
   -e AM_SOURCE=<live bucket> -e AM_MIRROR=<mirror bucket> -e AM_DATASET=<dataset> \
   -v hf://buckets/<live bucket>:/live:ro \
-  --timeout 3000s python:3.12 bash -c '<script>'
+  --flavor cpu-basic --timeout 3000s python:3.12 bash -c '<script>'
 ```
 
 The script:
@@ -212,6 +214,9 @@ Details that matter:
   There is no legitimate bucket called `; rm -rf /`. Tested.
 - **`--timeout 3000s`** (50 min) is deliberately shorter than the shortest
   interval, so a hung run dies before the next one is due. Tested.
+- **`--flavor cpu-basic` is pinned, not inherited.** The operator pays for every
+  run, the work is API calls and file hashing, and a change to the Hub's default
+  flavour must not be able to quietly make hourly backups more expensive. Tested.
 - **Runs never overlap.** Before launching, the previous Job's stage is checked;
   a first backup of a large bucket can outlast an interval, and two concurrent
   uploads to one dataset would race. Skipping is logged, not silent.
@@ -248,15 +253,28 @@ privacy on every call, rather than reporting what we last remembered.
 Back up the bucket                              [ off | 1h | 3h | 24h ]
   Copies your whole bucket — workspaces, history, saved logins — to private
   Hub storage: a bucket you can restore from instantly, and a dataset that
-  keeps version history. The copy runs on the Hub, so it costs this Space
-  nothing and continues while it sleeps.
+  keeps version history. Nothing is ever deleted from your bucket.
+
+  Each run is an HF Job billed to your account — cpu-basic, $0.01 per hour
+  of runtime, so a few minutes per backup — plus Hub storage for both
+  copies. Every 1h means 24 runs a day.
 
   lvwerra/agent-manager-backup — private · last run 4 Aug 16:36 (completed)
   [ Back up now ]
 ```
 
-Without a token the intervals are disabled and the row says so, pointing at the
-`HF_TOKEN` secret (§1.6) in the same words the update/relaunch rows already use.
+**The cost is the operator's, so the row says whose.** "It costs this Space
+nothing" was true and beside the point: the Space is not who pays. What matters
+before switching this on is that each run bills an HF Job and both copies occupy
+Hub storage, so the row states the tier, the rate, and how many runs an interval
+implies.
+
+**Unavailable has to look unavailable.** With no token, only *off* is selectable
+and a warning box says why — that backing up needs a write-scoped `HF_TOKEN`
+secret (§1.6) which this Space does not have. `disabled` alone only stops the
+click: `.seg button` had no `:disabled` style, so a dead control still rendered as
+a live one. Fixed in `styles.css`, which also fixes every other segmented control
+in the app.
 
 The privacy dots are not decoration: they are the state of the §1.4 gate, and the
 one thing an operator must be able to see at a glance about a copy of their

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -1,0 +1,284 @@
+# Bucket backup — design
+
+The bucket is the only thing in this system that cannot be rebuilt. The image is
+in the Dockerfile, the app is on GitHub, the CLIs reinstall on a factory reboot —
+but `/data` holds the workspaces agents have been working in, their transcripts,
+the session list, and the operator's config. A deleted Space, a detached volume,
+or an `rm -rf` in the wrong workspace takes all of it.
+
+This is a periodic mirror of the bucket into a **private dataset repo**, so that
+losing the Space costs an afternoon instead of everything.
+
+Interval is an operator setting alongside `archive` (Settings → hourly by default
+once enabled). Nothing here deletes from the bucket, ever.
+
+## 1. Decisions (locked)
+
+1. **A mirrored file tree, not a tarball.** The dataset holds the bucket's files
+   at their own paths. A tarball would be a fresh multi-gigabyte LFS blob every
+   hour, stored forever (§3, §10). A tree dedupes: only changed files transfer,
+   and an hour with no changes produces *no commit at all* (§3).
+2. **One private dataset per Space**, `<namespace>/am-bucket-<space-name>`.
+   Created `--private`, and the backup **refuses to run** if the repo is not
+   private — the same instinct as `visibility.js`, which locks the whole app when
+   the Space or bucket is public.
+3. **Agent credentials are excluded by default.** The bucket contains live OAuth
+   credentials (§4). A backup exists to save *work*, and a restore can re-login.
+   Copying live tokens into a Hub repo multiplies the blast radius of that repo
+   for no gain the operator asked for. Opt-in toggle, worded plainly.
+4. **The walk and the upload run in a child process.** Same hard rule as
+   `share.js` §1: this app has wedged once on synchronous work, and a background
+   task that fires every hour must never be the next cause.
+5. **Off until the operator turns it on.** It writes the contents of their
+   machine to their Hub account; that is a deliberate act, not a default. Once
+   on, the interval defaults to hourly.
+6. **Restore is a documented script, not a button.** Restoring over a live
+   bucket is destructive and situational (§9). v1 gives `scripts/restore-bucket.mjs`
+   and instructions; the app does not offer one-click restore.
+
+## 2. What we already have
+
+- `share.js` publishes a dataset repo already: `hf repo create --type dataset`,
+  `hf upload`, then `hfApi()` for settings/access. Same CLI, same token, same
+  namespace resolution (`shareNamespace()`). The backup reuses that shape and
+  needs no new Hub plumbing.
+- `am-config.json` + `GET/PUT /api/config` + a whitelisted enum, rendered as a
+  segmented control in `SettingsView.tsx`. `archive.after` is exactly the
+  precedent the operator asked for; `backup` is another key in the same object.
+- `watchdog.js` for the "periodic work that must not wedge the loop" pattern, and
+  `tracked()`/`PHASE` if the backup ever touches the main thread.
+- `scripts/share-session.mjs` as the model for a heavy child-process worker that
+  is *also* runnable by hand — the property that makes it debuggable.
+
+## 3. Verified Hub behaviour
+
+Measured against a throwaway private dataset (`hf` **1.25.1**, since deleted);
+152 files including one 3 MB binary.
+
+| case | wall | result |
+|---|---|---|
+| cold upload (152 files, 3 MB) | 44 s | 1 commit |
+| re-run, nothing changed | 10 s | **no commit** — "No files have been modified since last commit. Skipping to prevent empty commit." |
+| re-run, one small file changed | 10 s | 1 commit, only that file transferred |
+| re-run with `--delete "*"`, one file deleted locally | 10 s | 1 commit, the file is gone from the repo |
+| re-run with `--delete "*"`, nothing changed | 10 s | **no commit** |
+
+What this buys us, and why the whole design leans on it:
+
+- **`hf upload <repo> <dir> . --repo-type dataset` is already an incremental
+  mirror.** It hash-checks every file and transfers only what differs. We do not
+  need to track state, diff trees, or remember what we sent last hour.
+- **An idle hour is free and invisible.** No empty commits means hourly backups
+  do not produce 8,760 junk commits a year; the history is a list of real
+  changes. This survives `--delete "*"`, so mirroring deletions costs nothing
+  when nothing was deleted.
+- **`--delete "*"` matches nested paths**, so one flag makes the dataset a true
+  mirror rather than an append-only pile of files the operator once had.
+- Files over a few MB land in **LFS** automatically (the 3 MB binary did) — no
+  `.gitattributes` work on our side.
+- `upload-large-folder` is **deprecated** in 1.25.1 in favour of `hf upload`.
+
+## 4. What is actually in the bucket (measured)
+
+On this Space's bucket, walked directly:
+
+| subtree | files |
+|---|---|
+| everything under `/data` | **89,681** |
+| `workspaces/` | 58,356 |
+| `state/` | 13,447 |
+| — of which `state/claude/projects/` (transcripts) | 767 |
+| `node_modules/` anywhere | 18,647 |
+| `.git/` anywhere | 3,410 |
+
+Two costs that shape the design:
+
+- **The FUSE walk is the expensive part, and it is cache-dependent.** A cold
+  recursive walk of the whole bucket ran into minutes — `du -sh /data` did not
+  finish inside 300 s — while a warm walk of one 620 MB workspace took 1 s. So
+  the first backup after a boot is slow and later ones are cheap, which is
+  survivable hourly but *only* off the event loop (§1.4).
+- **Live credentials are in there**, which is the single most consequential fact
+  in this document:
+  - `state/claude/.credentials.json`
+  - `state/codex/auth.json`
+  - `state/hermes/auth.json`
+  - `state/vapid.json` — this install's private Web Push key
+  - `secret-notes.json` — the operator's descriptions of injected secrets
+
+  A dataset holding those is a credential store with a Hub URL. Hence §1.3.
+
+## 5. What gets excluded
+
+Default exclusions, in two classes.
+
+**Regenerable bulk** — costs upload time and storage, restores by rebuilding:
+
+```
+**/node_modules/**    **/.venv/**        **/__pycache__/**   **/*.pyc
+**/dist/**            **/build/**        **/target/**        **/.next/**
+**/.cache/**          **/.pytest_cache/**
+```
+
+`node_modules` alone is 18,647 files — 21% of the bucket's file count for
+content that `npm ci` reproduces.
+
+**Credentials and keys** — excluded unless the operator opts in:
+
+```
+state/*/.credentials.json   state/*/auth.json   state/*/.env
+state/vapid.json            **/.git-credentials
+```
+
+**Deliberately kept:** `.git` directories. Git objects are immutable and
+content-addressed, which makes them the *ideal* case for a deduping mirror —
+each object uploads once, forever. And branches, stashes, and unpushed commits
+are exactly the work a backup is for. 3,410 files is cheap.
+
+Whatever is skipped gets **counted and logged** in the backup status (§7). A
+backup that silently omits things reads as "you are covered" when you are not.
+
+## 6. The pipeline
+
+```
+hourly timer (main thread, unref'd)
+  └─ skip if: disabled · already running · repo not private · no HF_TOKEN
+  └─ spawn scripts/backup-bucket.mjs          ← child process, per §1.4
+        ├─ walk DATA_DIR applying the exclusion globs
+        ├─ hf upload <repo> <staged> . --repo-type dataset --delete "*"
+        │     (hash-check → transfer only what changed → skip empty commits)
+        └─ print a JSON report on stdout
+  └─ persist the report to DATA_DIR/backup-state.json
+```
+
+Details that matter:
+
+- **The staged tree.** `hf upload` takes a directory, and we need exclusions
+  applied — so the script builds a staging tree of **hardlinks** into a temp dir
+  (no copy, no extra bytes) and uploads that. Hardlinks across the FUSE mount
+  need verifying on the real Space; if they fail, fall back to `--exclude` globs
+  passed straight to `hf upload` (it supports them) and skip staging entirely.
+  **Open — the fallback is the safer default until measured (§12).**
+- **One at a time.** A run that overruns the hour must not overlap the next; the
+  timer checks a running flag and logs the skip.
+- **Catch-up on boot, jittered.** If the last backup is older than the interval,
+  run one a few minutes after boot — not at boot, when the CLIs are installing
+  and the walk is coldest.
+- **A backup is a fuzzy snapshot.** Agents are writing while we read. Files may
+  be captured mid-write and the tree is not a point-in-time image. That is
+  acceptable for this purpose and must be *said*, not glossed: it is a backup of
+  a running machine, not a database snapshot.
+- **Failures are logged, not retried.** The next hour is the retry. The last
+  error is surfaced in the status row so a silently broken backup becomes
+  visible.
+
+## 7. Settings surface
+
+One new block in `SettingsView.tsx`, matching `archive`:
+
+```
+Back up the bucket                                   [ off | hourly | 6h | daily ]
+  Mirrors your workspaces and session history to a private dataset so
+  a lost Space is recoverable. Nothing is ever deleted from the bucket.
+
+  Dataset   [ lvwerra/am-bucket-am-dev-2        ]  (private)
+  Include agent credentials                                    [ off | on ]
+    Off: the backup skips saved logins, so a restored Space asks you to
+    sign in again. On: your live agent tokens are copied to the dataset.
+
+  Last backup: 12 minutes ago · 1.2 GB · 34 files changed · skipped 18,647
+  [ Back up now ]                                    [ Open dataset ↗ ]
+```
+
+The status line is load-bearing: a backup nobody can see the state of is a
+backup nobody trusts.
+
+## 8. Config and API
+
+```js
+// am-config.json — validated with a whitelist, like archive.after
+backup: {
+  every: 'never' | 'hour' | '6h' | 'day',   // default 'never' (§1.5)
+  repo: '',                                  // default <ns>/am-bucket-<space>
+  includeCredentials: false,                 // §1.3
+}
+```
+
+```
+GET  /api/backup/status   → { every, repo, private, running, last: {...}, error }
+POST /api/backup/run      → kick one now (same path as the timer)
+```
+
+`GET/PUT /api/config` gains the `backup` key. No new auth surface: both routes
+sit behind the same visibility gate as everything else.
+
+## 9. Restore
+
+`scripts/restore-bucket.mjs <repo> <target>`:
+
+```
+hf download <repo> --repo-type dataset --local-dir <target>
+```
+
+then re-create what was excluded — `npm ci` where a `package-lock.json` came
+back, re-login for each agent. Documented, not automated, because restoring onto
+a bucket that already has content is destructive and only the operator knows
+which side should win.
+
+The reason this stays a script: a "Restore" button that overwrites a live bucket
+is a footgun aimed at the one thing this feature exists to protect.
+
+## 10. Storage growth
+
+The mirror's cost over time is **the sum of every distinct version of every
+file**, because git keeps history. The hazard is not the big files, it is the
+*churny* big files: anything multi-MB that changes every hour is a new LFS object
+every hour, kept forever.
+
+Known churn: agent transcripts under `state/*/projects/` (append-only JSONL, so
+every hour is a new full copy of a growing file) and any SQLite database an agent
+keeps. 767 transcript files today, but they only grow.
+
+Options, in preference order — **not yet decided (§12)**:
+
+1. Accept it, and surface the dataset's size in the status row so growth is
+   visible before it is a problem.
+2. Squash history periodically (`super_squash_history`), keeping the mirror
+   current and dropping the past — a mirror, not an archive.
+3. Exclude transcripts from the hourly pass and let session *sharing* (which
+   already exports traces properly, with redaction) own that data.
+
+Option 3 is tempting and probably right long-term: two features backing up the
+same transcripts, one of them without redaction, is a smell.
+
+## 11. Risks and open questions
+
+1. **The credential decision (§1.3) is the one to review first.** Default-off is
+   my recommendation. Note that "off" makes a restored Space need re-login for
+   every agent, which is a real cost the operator may prefer to trade away.
+2. **A backup dataset is a new blast radius.** Even excluding credentials, the
+   workspaces contain whatever agents wrote — source, data, notes. The
+   private-repo check (§1.2) is a hard gate, not a warning, for that reason.
+   Should we also refuse when the *Space* is public, as `visibility.js` does?
+3. **Hardlink staging across FUSE is unverified** (§6). Fallback is `--exclude`
+   globs, which is simpler; possibly skip staging in v1 entirely.
+4. **Cold-walk cost on a much larger bucket.** 89,681 files walks fine warm; the
+   cold case ran to minutes here. A bucket 10× this size may not fit an hourly
+   cadence, so the status row should show duration and the timer should log when
+   a run overruns its interval.
+5. **Hub rate limits / commit volume** are untested at a sustained hourly cadence
+   over weeks. Expected fine — no-op hours make no commits at all — but unproven.
+6. **Two backups of one thing.** §10 option 3; worth settling before both exist.
+7. **Restore has never been exercised.** A backup that has not been restored once
+   is a hypothesis. Phase 3 should include an actual restore into a scratch Space.
+
+## 12. Phasing
+
+1. **Config + scheduler + `scripts/backup-bucket.mjs` + status API.** Headless,
+   driven by `POST /api/backup/run`. Prove the incremental mirror on a real
+   bucket and measure the cold walk.
+2. **Settings UI** (§7) — the interval control, dataset field, credential
+   toggle, status line, "Back up now".
+3. **`scripts/restore-bucket.mjs` + docs, and one real restore** into a scratch
+   Space. Until this runs, the feature is unproven (§11.7).
+4. **Retention** — decide §10, implement squash or transcript exclusion.

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -239,10 +239,22 @@ backup: {
 
 ```
 GET  /api/backup/status  → { every, source, mirror, dataset, defaults, hasToken,
-                             unavailable, last: { at, jobId, stage }, nextDue,
+                             canRunNow, running, unavailable,
+                             last: { at, jobId, stage }, nextDue,
                              datasetPrivate, error }
-POST /api/backup/run     → launch one Job now
+POST /api/backup/run     → launch one Job now (works with the schedule off)
 ```
+
+**On demand does not require a schedule.** `unavailable` is why the *timer* is
+quiet — it includes "switched off" — while `canRunNow` ignores the interval
+entirely, because taking one backup before a risky change is the main reason to
+want a button. Both derive from one function, so the row and the timer can never
+disagree.
+
+`POST /api/backup/run` refuses while a run is in flight ("a backup is already
+running"): two Jobs uploading to one dataset would race. The route returns the
+reason in the body and the client surfaces it, rather than swallowing it for a
+bare status code.
 
 `status` re-reads the last Job's stage from the **Hub** and the destination's
 privacy on every call, rather than reporting what we last remembered.
@@ -260,7 +272,8 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   copies. Every 1h means 24 runs a day.
 
   lvwerra/agent-manager-backup — private · last run 4 Aug 16:36 (completed)
-  [ Back up now ]
+  [ Back up now ]        ← available whenever there is a token, schedule or not;
+                           reads "Backing up…" and is disabled while one runs
 ```
 
 **The cost is the operator's, so the row says whose.** "It costs this Space

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -14,17 +14,25 @@ Two copies, on an interval the operator sets alongside `archive`:
   cannot give, because buckets are mutable and non-versioned. This is the "get
   yesterday's file back" copy.
 
-Both run in a **scheduled HF Job**, so the work happens on the Hub: backups
-continue while this Space is asleep, cost it no I/O, and never walk the FUSE
-mount. Nothing here deletes from the bucket, ever.
+Both happen inside one **HF Job** that this app launches and forgets, so the
+copying runs on the Hub: a backup costs this Space one API call, never reads
+`/data` (whose cold walk runs to minutes), and cannot wedge the event loop that
+pumps the terminals. It needs an `HF_TOKEN` (§1.6). Nothing here deletes from the
+bucket, ever.
 
 ## 1. Decisions (locked)
 
-1. **The schedule lives on the Hub, not in this app.** `hf jobs scheduled run`
-   takes a cron. The Space's only job is to make the Hub's schedule match the
-   operator's config, and to report what the Hub says about it. A backup that
-   only runs while the app is healthy is a backup that will be missing exactly
-   when it is needed.
+1. **One dumb loop: if it is on and due, launch a Job.** Every five minutes the
+   app asks whether the last run started more than an interval ago; if so it
+   launches one detached Job and forgets it. No cron, no catch-up queue, no
+   reconciliation. "Due" is derived from a timestamp on disk, so it behaves
+   correctly across restarts.
+
+   The cost is that backups only fire while the app is up. That is a smaller loss
+   than it sounds — the bucket only changes when agents are running, which means
+   when the Space is up — and `hf jobs scheduled` (a cron on the Hub, which does
+   fire while the Space sleeps) is a contained change if that stops being true.
+   It was built and verified working; it was dropped to keep the PoC simple.
 2. **Two destinations, because they are cheap at different things.** Bucket
    storage is accounted in *logical* bytes — two identical snapshots measured as
    exactly 2× (§3.5) — so dated bucket snapshots multiply cost. A git repo stores
@@ -41,15 +49,19 @@ mount. Nothing here deletes from the bucket, ever.
    anything is written. Verified to bite (§3.6).
 5. **The source bucket is mounted read-only** (`:ro`) in the Job. A backup must
    not be able to write to the thing it is backing up.
-6. **Off until the operator turns it on.** It copies this machine's contents into
-   other Hub resources; that is a deliberate act. Once on, hourly.
-7. **Never prune the mirror.** A file deleted in `/data` stays in the bucket
+6. **It requires `HF_TOKEN` in the environment.** There is no way to launch a Job
+   or write to the Hub without one, so with no token the feature reports itself
+   unavailable — one reason string, shared by the timer and the settings row —
+   rather than failing every interval into the logs.
+7. **Off until the operator turns it on.** It copies this machine's contents into
+   other Hub resources; that is a deliberate act. Once on: 1h, 3h or 24h.
+8. **Never prune the mirror.** A file deleted in `/data` stays in the bucket
    mirror. An `rm -rf` in a workspace is precisely the accident being insured
    against, and a mirror that faithfully reproduces the deletion insures against
    nothing. The dataset gets `--delete "*"` so its *newest* commit matches the
    bucket, while every earlier commit keeps the deleted file recoverable — the
    best of both.
-8. **Restore is a documented script, not a button** (§8).
+9. **Restore is a documented script, not a button** (§8).
 
 ## 2. What we already have
 
@@ -57,8 +69,10 @@ mount. Nothing here deletes from the bucket, ever.
   `GET /api/spaces/{id}` → `runtime.volumes[]`, keeping entries with
   `type === 'bucket'`. Verified on two Spaces:
   `{source: 'lvwerra/agent-manager-data', mountPath: '/data'}`.
-- **`hf` CLI 1.25.1 in the image**, with `buckets`, `cp`, `jobs scheduled`.
-  `share.js` already shells out to `hf` with this token — no new auth path.
+- **`hf` CLI 1.25.1 in the image**, with `buckets`, `cp` and `jobs run`.
+  `share.js` already shells out to `hf` with this token — no new auth path, and
+  `index.js` already treats a missing `HF_TOKEN` as a feature-disabled state
+  (`canRelaunch`), which is the pattern §1.6 follows.
 - `am-config.json` + `GET/PUT /api/config` + a whitelisted enum, rendered as a
   segmented control in `SettingsView.tsx`. `archive.after` is the precedent the
   operator asked for; `backup` is another key in the same object.
@@ -135,7 +149,7 @@ verified 49-file copy it still reported `size: 0`. Verify a copy with
 
 ### 3.6 The privacy gate refuses a public destination
 
-Flipped the destination dataset to public and triggered the schedule:
+Flipped the destination dataset to public and launched a run:
 
 ```
 refusing to back up: dataset lvwerra/… is not private
@@ -172,10 +186,10 @@ one 620 MB workspace took 1 s.
 
 ## 5. The pipeline
 
-One scheduled Job, `am-backup-<space>`, cron from the config:
+One detached Job per interval, `am-backup-<space>`:
 
 ```
-hf jobs scheduled run "0 * * * *" --name am-backup-<space> \
+hf jobs run --detach --name am-backup-<space> \
   --secrets HF_TOKEN \
   -e AM_SOURCE=<live bucket> -e AM_MIRROR=<mirror bucket> -e AM_DATASET=<dataset> \
   -v hf://buckets/<live bucket>:/live:ro \
@@ -198,13 +212,11 @@ Details that matter:
   There is no legitimate bucket called `; rm -rf /`. Tested.
 - **`--timeout 3000s`** (50 min) is deliberately shorter than the shortest
   interval, so a hung run dies before the next one is due. Tested.
-- **No update verb for a scheduled Job** — only run/delete — so any change to
-  cron or destination is delete-then-create. The desired state is fingerprinted
-  and compared, because missing a change means silently backing up to the old
-  destination. Tested.
-- **Reconcile is idempotent**: with nothing changed it is one list call and no
-  writes. Runs on boot (12 s in, after bucket discovery) and after every config
-  save.
+- **Runs never overlap.** Before launching, the previous Job's stage is checked;
+  a first backup of a large bucket can outlast an interval, and two concurrent
+  uploads to one dataset would race. Skipping is logged, not silent.
+- **The config is re-read every tick**, so changing the interval takes effect
+  without restarting anything.
 - **A backup is a fuzzy snapshot.** Agents write while it runs, so it is not
   point-in-time consistent. Acceptable for this purpose, and worth saying rather
   than glossing.
@@ -214,37 +226,37 @@ Details that matter:
 ```js
 // am-config.json — validated with a whitelist, like archive.after
 backup: {
-  every: 'never' | 'hour' | '6h' | 'day',   // default 'never' (§1.6)
-  mirror: '',                                // default <ns>/<space>-backup
-  dataset: '',                               // default <ns>/<space>-backup
+  every: 'never' | '1h' | '3h' | '24h',   // default 'never' (§1.7)
+  mirror: '',                              // default <ns>/<space>-backup
+  dataset: '',                             // default <ns>/<space>-backup
 }
 ```
 
 ```
-GET  /api/backup/status  → { every, source, mirror, dataset, defaults,
-                             scheduled: { cron, suspended, lastRun, nextRun },
+GET  /api/backup/status  → { every, source, mirror, dataset, defaults, hasToken,
+                             unavailable, last: { at, jobId, stage }, nextDue,
                              datasetPrivate, error }
-POST /api/backup/run     → trigger the schedule now (or a one-off Job if off)
+POST /api/backup/run     → launch one Job now
 ```
 
-`status` reports the schedule as the **Hub** sees it, not as we last left it, and
-re-reads the destination's privacy on every call.
+`status` re-reads the last Job's stage from the **Hub** and the destination's
+privacy on every call, rather than reporting what we last remembered.
 
-## 7. Settings surface (phase 2)
+## 7. Settings surface
 
 ```
-Back up the bucket                            [ off | hourly | 6h | daily ]
+Back up the bucket                              [ off | 1h | 3h | 24h ]
   Copies your whole bucket — workspaces, history, saved logins — to private
   Hub storage: a bucket you can restore from instantly, and a dataset that
   keeps version history. The copy runs on the Hub, so it costs this Space
   nothing and continues while it sleeps.
 
-  Mirror   [ lvwerra/agent-manager-backup ]            ● private
-  History  [ lvwerra/agent-manager-backup ] (dataset)  ● private
-
-  Last run: 12 minutes ago · next 15:00 · 102,691 files
-  [ Back up now ]                          [ Open ↗ ]
+  lvwerra/agent-manager-backup — private · last run 4 Aug 16:36 (completed)
+  [ Back up now ]
 ```
+
+Without a token the intervals are disabled and the row says so, pointing at the
+`HF_TOKEN` secret (§1.6) in the same words the update/relaunch rows already use.
 
 The privacy dots are not decoration: they are the state of the §1.4 gate, and the
 one thing an operator must be able to see at a glance about a copy of their
@@ -303,12 +315,16 @@ knows which side should win.
 
 ## 11. Phasing
 
-1. **Done** — config keys, Hub-side schedule reconciliation, the two-step Job,
-   `GET /api/backup/status`, `POST /api/backup/run`, tests. Verified end to end
-   against the Hub: schedule created, idempotent re-reconcile, trigger, both
-   steps run, private dataset committed, and the privacy gate refusing a public
-   destination.
-2. **Settings UI** (§7) — interval, destinations, privacy dots, status, run-now.
+1. **Done (this PR)** — config keys, the interval loop, the two-step Job, the
+   token gate, `GET /api/backup/status`, `POST /api/backup/run`, the settings row,
+   and tests. Verified end to end against the real Hub on a small bucket: off and
+   no-token skip with a reason, first tick launches, the next tick correctly says
+   "not due", the Job completes, and the private dataset gets its commit. The
+   privacy gate was verified by breaking it — public destination, run aborts with
+   exit 1, no commit.
+2. **A real run against the production bucket** — 11.4 GB / 102,691 files. Every
+   number for that scale is still extrapolated (§10.3); this is the next thing to
+   learn, and cheap to learn.
 3. **`scripts/restore-bucket.mjs` + docs, and one real restore** into a scratch
-   Space (§10.5).
+   Space (§10.5). Until this runs, the feature is a hypothesis.
 4. **Retention** — decide §9 for transcript churn.

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -152,14 +152,23 @@ export function jobArgs({ source, mirror, dataset }) {
 }
 
 /**
- * Why a backup cannot run right now, or null if it can. One place, so the timer
- * and the settings row always agree about it.
+ * Why an on-demand backup cannot run, or null if it can. Deliberately does NOT
+ * consider the interval: "back up now" is exactly what you want before a risky
+ * change, without committing to a schedule.
  */
-export function unavailableReason(cfg) {
+export function runNowBlockedBy() {
   if (!hasToken()) return 'needs a write-scoped HF_TOKEN secret on the Space';
   if (!sourceBucket()) return 'no bucket is mounted on this Space';
-  if ((cfg?.backup?.every || 'never') === 'never') return 'switched off';
   return null;
+}
+
+/**
+ * Why the scheduled backup is not running, or null if it is live. Same reasons
+ * as on-demand plus the interval, so the timer and the settings row can never
+ * disagree about it.
+ */
+export function unavailableReason(cfg) {
+  return runNowBlockedBy() || ((cfg?.backup?.every || 'never') === 'never' ? 'switched off' : null);
 }
 
 /** Resolve the destinations, falling back to <namespace>/<space>-backup. */
@@ -172,9 +181,13 @@ async function targets(cfg) {
 
 /** Launch one backup Job now. Returns { job } — the Hub does the rest. */
 export async function runBackupNow(cfg) {
-  if (!hasToken()) throw new Error('needs a write-scoped HF_TOKEN secret on the Space');
+  const blocked = runNowBlockedBy();
+  if (blocked) throw new Error(blocked);
+  // Two runs at once would have two Jobs uploading to the same dataset, which
+  // race. The timer skips for this reason too; on demand it is worth saying out
+  // loud rather than silently doing nothing.
+  if (await isRunning()) throw new Error('a backup is already running');
   const source = sourceBucket();
-  if (!source) throw new Error('no bucket is mounted on this Space — nothing to back up');
   const { mirror, dataset } = await targets(cfg);
   for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
     if (label === 'mirror' && !id) continue;
@@ -202,6 +215,15 @@ async function jobStage(jobId) {
 
 const DONE = new Set(['COMPLETED', 'ERROR', 'FAILED', 'CANCELED']);
 
+/** Is the last launched Job still going? Unknown stage counts as finished, so a
+ *  Hub hiccup can never wedge backups off forever. */
+async function isRunning() {
+  const { jobId } = loadState();
+  if (!jobId) return false;
+  const stage = await jobStage(jobId);
+  return !!stage && !DONE.has(stage);
+}
+
 /**
  * One tick: launch a backup if one is due. Deliberately dumb — no cron, no
  * catch-up queue. "Due" is just "the last one started more than an interval
@@ -215,9 +237,7 @@ export async function tick(cfg) {
   if (!due) return { skipped: 'not due' };
 
   // Never let two runs overlap: a big first backup can outlast an interval.
-  if (state.jobId && !DONE.has(await jobStage(state.jobId))) {
-    return { skipped: 'previous backup still running' };
-  }
+  if (await isRunning()) return { skipped: 'previous backup still running' };
   try {
     const r = await runBackupNow(cfg);
     console.log(`[backup] launched job ${r.job} (every ${cfg.backup.every})`);
@@ -254,9 +274,11 @@ export async function backupStatus(cfg) {
   const every = cfg?.backup?.every || 'never';
   const source = sourceBucket();
   const { mirror, dataset, defaults } = await targets(cfg);
+  // Not gated on the interval: an on-demand backup is a real backup, and its
+  // result has to be visible even with the schedule off.
   const [stage, priv] = await Promise.all([
-    every === 'never' ? null : jobStage(state.jobId),
-    every === 'never' || !dataset ? null : datasetPrivate(dataset),
+    state.jobId ? jobStage(state.jobId) : null,
+    dataset && hasToken() ? datasetPrivate(dataset) : null,
   ]);
   return {
     every,
@@ -265,6 +287,8 @@ export async function backupStatus(cfg) {
     dataset,
     defaults,
     hasToken: hasToken(),
+    canRunNow: !runNowBlockedBy(),
+    running: !!stage && !DONE.has(stage),
     unavailable: unavailableReason(cfg),
     last: state.startedAt
       ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || 'RUNNING' }

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -1,0 +1,295 @@
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR } from './config.js';
+import { visibility } from './visibility.js';
+import { shareNamespace } from './share.js';
+
+// Bucket backup: a periodic, Hub-side copy of this Space's bucket.
+// Design and rationale: docs/bucket-backup.md (§3 verified behaviour, §5 pipeline).
+//
+// Two steps, neither of which runs here:
+//
+//   1. bucket → bucket, server-side by Xet hash. No bytes move (13,482 files in
+//      20s, measured) and a restore from it is equally instant. Overwritten each
+//      run — it is the "get the Space back" copy.
+//   2. the same bucket, mounted READ-ONLY inside the Job, → a private dataset
+//      repo. This is the version history a bucket cannot give: buckets are
+//      mutable and non-versioned, so without this an overwritten file is simply
+//      gone (§10.1).
+//
+// Both steps run in a SCHEDULED HF JOB, which is the whole point: the work
+// happens on the Hub, so backups continue while this Space is asleep, cost it no
+// I/O at all, and never touch the FUSE mount whose cold walk runs to minutes.
+// This app has wedged once on synchronous work; a job that fires every hour
+// should not be the next cause, and the safest way to achieve that is for the
+// hour to not belong to us.
+//
+// Why a dataset for history and a bucket for the mirror, rather than one of
+// them: bucket storage is accounted in logical bytes — two identical snapshots
+// measured as exactly 2× — while a git repo stores each distinct blob once and
+// skips empty commits entirely. So history is far cheaper in the dataset, and
+// instant restore is only possible from the bucket (§9).
+
+const STATE_FILE = path.join(DATA_DIR, 'backup-state.json');
+const SPACE_ID = process.env.SPACE_ID || '';
+const spaceName = () => SPACE_ID.split('/')[1] || 'agent-manager';
+
+// 50 minutes: a run that hangs must die before the next hour fires, so a stuck
+// backup can never stack up behind itself.
+const JOB_TIMEOUT = '3000s';
+const JOB_IMAGE = 'python:3.12';
+
+export const CRON = {
+  hour: '0 * * * *',
+  '6h': '0 */6 * * *',
+  day: '0 3 * * *', // small hours, when a bucket is least likely to be mid-write
+};
+export const cronFor = (every) => CRON[every] || null;
+
+// A bucket/dataset id arrives from PUT /api/config and ends up in a Job's
+// argument list. Anything outside this charset is refused rather than escaped —
+// there is no legitimate repo called `; rm -rf /`.
+const ID_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
+export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_RE.test(s);
+
+function run(args, { timeout = 120_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    execFile('hf', args, { timeout, env: process.env, maxBuffer: 8 << 20 }, (err, stdout, stderr) => {
+      if (err) {
+        err.stderr = String(stderr || '');
+        err.stdout = String(stdout || '');
+        return reject(err);
+      }
+      resolve(String(stdout || ''));
+    });
+  });
+}
+
+export function loadState() {
+  try { return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')); } catch { return {}; }
+}
+function saveState(s) {
+  try { fs.writeFileSync(STATE_FILE, JSON.stringify(s, null, 2)); } catch {}
+}
+
+// The bucket mounted at /data, as discovered by visibility.js from
+// GET /api/spaces/{id} → runtime.volumes[]. AM_BACKUP_SOURCE overrides it for
+// local runs, where there is no Space and so no volume to discover.
+export function sourceBucket() {
+  if (process.env.AM_BACKUP_SOURCE) return process.env.AM_BACKUP_SOURCE;
+  const v = visibility();
+  return (v.buckets && v.buckets[0]) || null;
+}
+
+export async function defaultsFor() {
+  const ns = await shareNamespace().catch(() => '');
+  if (!ns) return { mirror: '', dataset: '' };
+  return { mirror: `${ns}/${spaceName()}-backup`, dataset: `${ns}/${spaceName()}-backup` };
+}
+
+// The script the Job runs. No interpolation: every value arrives as an env var
+// (`-e`), so a config string can never become shell syntax.
+export const JOB_SCRIPT = `set -euo pipefail
+# Plain package, no [cli] extra: 1.26.0 dropped it ("does not provide the extra
+# 'cli'") and ships the CLI in the base install. Asking for it only earns a
+# warning in the run logs.
+pip install -q huggingface_hub
+
+# A backup carries every saved login on the bucket — agent OAuth tokens, the Web
+# Push private key, session-secret (docs/bucket-backup.md §4). So a public
+# destination is a stop, not a warning. Re-checked HERE, on every run, because a
+# repo can be flipped public long after it was created.
+python - <<'PY'
+import os, sys
+from huggingface_hub import HfApi
+api = HfApi()
+ds, mirror = os.environ["AM_DATASET"], os.environ.get("AM_MIRROR", "")
+try:
+    if api.dataset_info(ds).private is not True:
+        sys.exit(f"refusing to back up: dataset {ds} is not private")
+except Exception as e:
+    # Not existing yet is fine — the upload below creates it private.
+    if "404" not in str(e) and "RepositoryNotFound" not in type(e).__name__:
+        raise
+if mirror and api.bucket_info(mirror).private is not True:
+    sys.exit(f"refusing to back up: bucket {mirror} is not private")
+PY
+
+# 1. Server-side mirror: hashes move, not bytes.
+if [ -n "\${AM_MIRROR:-}" ]; then
+  hf cp "hf://buckets/\$AM_SOURCE/" "hf://buckets/\$AM_MIRROR/latest/"
+fi
+
+# 2. Version history, read from the bucket mounted read-only at /live — the
+#    Hub's copy, not any Space's disk. Unchanged files transfer nothing and
+#    produce no commit; --delete mirrors removals into the new commit while the
+#    previous commit keeps them recoverable.
+hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
+  --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
+`;
+
+// Job arguments, as an array (never a shell string). Exported for the tests:
+// asserting on this is how we know a config value cannot reach a shell.
+export function jobArgs({ source, mirror, dataset, cron = null, name }) {
+  const spec = [
+    '--secrets', 'HF_TOKEN',
+    '-e', `AM_SOURCE=${source}`,
+    '-e', `AM_MIRROR=${mirror || ''}`,
+    '-e', `AM_DATASET=${dataset}`,
+    '-v', `hf://buckets/${source}:/live:ro`,
+    '--timeout', JOB_TIMEOUT,
+    JOB_IMAGE, 'bash', '-c', JOB_SCRIPT,
+  ];
+  if (name) spec.unshift('--name', name);
+  return cron
+    ? ['jobs', 'scheduled', 'run', cron, ...spec]
+    : ['jobs', 'run', '--detach', ...spec];
+}
+
+// What the config asks for, as one comparable string. If this changes, the
+// schedule is replaced — there is no "update" verb for a scheduled Job, only
+// run/delete, so a change means delete-then-create.
+export const fingerprint = ({ cron, source, mirror, dataset }) =>
+  [cron, source, mirror || '-', dataset].join('|');
+
+export function reconcile(existing, desired) {
+  if (!desired) return existing ? 'delete' : 'keep';
+  if (!existing) return 'create';
+  if (existing.fingerprint !== desired.fingerprint) return 'replace';
+  if (existing.suspend) return 'replace';
+  return 'keep';
+}
+
+async function listSchedules() {
+  try { return JSON.parse(await run(['jobs', 'scheduled', 'ls', '--json'])) || []; } catch { return []; }
+}
+
+async function findSchedule(id) {
+  if (!id) return null;
+  return (await listSchedules()).find((s) => s.id === id) || null;
+}
+
+/**
+ * Make the Hub match the operator's config: create, replace, or remove the
+ * scheduled Job. Called on boot and after PUT /api/config. Never throws — a
+ * backup that cannot be scheduled records why and leaves the app alone.
+ */
+export async function ensureSchedule(cfg) {
+  const state = loadState();
+  const every = cfg?.backup?.every || 'never';
+  const cron = cronFor(every);
+  const existing = await findSchedule(state.scheduledJobId);
+  const existingRec = existing ? { fingerprint: state.fingerprint, suspend: !!existing.suspend } : null;
+
+  if (!cron) {
+    if (existing) await run(['jobs', 'scheduled', 'delete', existing.id]).catch(() => {});
+    saveState({ ...state, scheduledJobId: null, fingerprint: null, every: 'never', error: null });
+    return { action: existing ? 'deleted' : 'none' };
+  }
+
+  const source = sourceBucket();
+  if (!source) {
+    saveState({ ...state, error: 'no bucket is mounted on this Space — nothing to back up' });
+    return { action: 'blocked', error: 'no bucket mounted' };
+  }
+  const d = await defaultsFor();
+  const mirror = (cfg.backup.mirror || d.mirror || '').trim();
+  const dataset = (cfg.backup.dataset || d.dataset || '').trim();
+  for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
+    if (label === 'mirror' && !id) continue;
+    if (!validRepoId(id)) {
+      const error = `refusing to schedule: ${label} "${id}" is not a valid repo id`;
+      saveState({ ...state, error });
+      return { action: 'blocked', error };
+    }
+  }
+
+  const desired = { fingerprint: fingerprint({ cron, source, mirror, dataset }) };
+  const action = reconcile(existingRec, desired);
+  if (action === 'keep') return { action };
+
+  // The mirror bucket has to exist and be private before anything is copied
+  // into it. The dataset is created private by the upload itself.
+  if (mirror) {
+    await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
+  }
+
+  if (action === 'replace' && existing) {
+    await run(['jobs', 'scheduled', 'delete', existing.id]).catch(() => {});
+  }
+  const name = `am-backup-${spaceName()}`.slice(0, 40);
+  const out = await run(jobArgs({ source, mirror, dataset, cron, name }), { timeout: 180_000 });
+  const id = (out.match(/id=(\S+)/) || [])[1] || null;
+  saveState({
+    ...state, scheduledJobId: id, fingerprint: desired.fingerprint,
+    every, source, mirror, dataset, error: null, scheduledAt: new Date().toISOString(),
+  });
+  return { action, id };
+}
+
+/** Kick a backup now: trigger the schedule if there is one, else a one-off Job. */
+export async function runBackupNow(cfg) {
+  const state = loadState();
+  if (state.scheduledJobId) {
+    await run(['jobs', 'scheduled', 'trigger', state.scheduledJobId], { timeout: 120_000 });
+    return { triggered: state.scheduledJobId };
+  }
+  const source = sourceBucket();
+  if (!source) throw new Error('no bucket is mounted on this Space — nothing to back up');
+  const d = await defaultsFor();
+  const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
+  const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
+  if (!validRepoId(dataset)) throw new Error(`not a valid dataset id: ${dataset}`);
+  if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
+  const out = await run(jobArgs({ source, mirror, dataset }), { timeout: 180_000 });
+  return { job: (out.match(/id=(\S+)/) || [])[1] || null };
+}
+
+/**
+ * Status for the settings row. Reports the schedule as the HUB sees it, not as
+ * we last left it — a backup nobody can verify the state of is a backup nobody
+ * trusts, and the destination's privacy is the one thing that must be visible.
+ */
+export async function backupStatus(cfg) {
+  const state = loadState();
+  const every = cfg?.backup?.every || 'never';
+  const source = sourceBucket();
+  const d = await defaultsFor();
+  const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
+  const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
+  const sched = await findSchedule(state.scheduledJobId);
+
+  let priv = null;
+  if (every !== 'never' && dataset) {
+    priv = await datasetPrivate(dataset);
+  }
+
+  return {
+    every,
+    source,
+    mirror,
+    dataset,
+    defaults: d,
+    scheduled: sched
+      ? { id: sched.id, cron: sched.schedule, suspended: !!sched.suspend,
+          lastRun: sched.last_run && sched.last_run !== 'N/A' ? sched.last_run : null,
+          nextRun: sched.next_run || null }
+      : null,
+    datasetPrivate: priv,   // null = unknown/not created yet
+    error: state.error || null,
+  };
+}
+
+// One small authed read; the settings row needs the CURRENT answer, because a
+// repo holding credentials can be flipped public at any time.
+async function datasetPrivate(dataset) {
+  try {
+    const out = await run(['datasets', 'info', dataset, '--json'], { timeout: 30_000 });
+    const j = JSON.parse(out);
+    return j.private === true;
+  } catch (e) {
+    if (/404|not found|RepositoryNotFound/i.test(e.stderr || e.message || '')) return null;
+    return null;
+  }
+}

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -5,47 +5,48 @@ import { DATA_DIR } from './config.js';
 import { visibility } from './visibility.js';
 import { shareNamespace } from './share.js';
 
-// Bucket backup: a periodic, Hub-side copy of this Space's bucket.
-// Design and rationale: docs/bucket-backup.md (§3 verified behaviour, §5 pipeline).
+// Bucket backup: every 1h/3h/24h, launch one HF Job that copies this Space's
+// bucket to private Hub storage. Design: docs/bucket-backup.md
 //
-// Two steps, neither of which runs here:
+// The whole feature is one loop: if it is switched on and enough time has
+// passed, launch a Job. Nothing else. The Job does two things, because a mirror
+// alone is not a backup:
 //
 //   1. bucket → bucket, server-side by Xet hash. No bytes move (13,482 files in
 //      20s, measured) and a restore from it is equally instant. Overwritten each
-//      run — it is the "get the Space back" copy.
-//   2. the same bucket, mounted READ-ONLY inside the Job, → a private dataset
-//      repo. This is the version history a bucket cannot give: buckets are
-//      mutable and non-versioned, so without this an overwritten file is simply
-//      gone (§10.1).
+//      run — this is the "get the Space back" copy.
+//   2. the same bucket, mounted READ-ONLY in the Job, → a private dataset repo.
+//      Buckets are mutable and non-versioned, so without this an overwritten
+//      file is simply gone. This is the "get yesterday's file back" copy.
 //
-// Both steps run in a SCHEDULED HF JOB, which is the whole point: the work
-// happens on the Hub, so backups continue while this Space is asleep, cost it no
-// I/O at all, and never touch the FUSE mount whose cold walk runs to minutes.
-// This app has wedged once on synchronous work; a job that fires every hour
-// should not be the next cause, and the safest way to achieve that is for the
-// hour to not belong to us.
+// The copying happens on the Hub, not here: we launch the Job and forget it. So
+// a backup costs this Space one API call, never reads /data (whose cold walk runs
+// to minutes), and cannot wedge the event loop that pumps the terminals.
 //
-// Why a dataset for history and a bucket for the mirror, rather than one of
-// them: bucket storage is accounted in logical bytes — two identical snapshots
-// measured as exactly 2× — while a git repo stores each distinct blob once and
-// skips empty commits entirely. So history is far cheaper in the dataset, and
-// instant restore is only possible from the bucket (§9).
+// Requires HF_TOKEN in the environment — there is no way to launch a Job or write
+// to the Hub without one, so with no token the feature reports itself
+// unavailable rather than failing every hour in the logs.
 
 const STATE_FILE = path.join(DATA_DIR, 'backup-state.json');
 const SPACE_ID = process.env.SPACE_ID || '';
 const spaceName = () => SPACE_ID.split('/')[1] || 'agent-manager';
 
-// 50 minutes: a run that hangs must die before the next hour fires, so a stuck
-// backup can never stack up behind itself.
-const JOB_TIMEOUT = '3000s';
+export const EVERY_MS = {
+  '1h': 3_600_000,
+  '3h': 10_800_000,
+  '24h': 86_400_000,
+};
+export const INTERVALS = ['never', ...Object.keys(EVERY_MS)];
+export const intervalMs = (every) => EVERY_MS[every] || 0;
+
+// How often we ask "is a backup due?". Cheap: reads a file, compares two numbers.
+const TICK_MS = 300_000; // 5 min
+// A Job that hangs must die well inside the shortest interval so runs cannot
+// stack up behind each other.
+const JOB_TIMEOUT = '3000s'; // 50 min
 const JOB_IMAGE = 'python:3.12';
 
-export const CRON = {
-  hour: '0 * * * *',
-  '6h': '0 */6 * * *',
-  day: '0 3 * * *', // small hours, when a bucket is least likely to be mid-write
-};
-export const cronFor = (every) => CRON[every] || null;
+export const hasToken = () => !!(process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN);
 
 // A bucket/dataset id arrives from PUT /api/config and ends up in a Job's
 // argument list. Anything outside this charset is refused rather than escaped —
@@ -56,11 +57,7 @@ export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_
 function run(args, { timeout = 120_000 } = {}) {
   return new Promise((resolve, reject) => {
     execFile('hf', args, { timeout, env: process.env, maxBuffer: 8 << 20 }, (err, stdout, stderr) => {
-      if (err) {
-        err.stderr = String(stderr || '');
-        err.stdout = String(stdout || '');
-        return reject(err);
-      }
+      if (err) { err.stderr = String(stderr || ''); return reject(err); }
       resolve(String(stdout || ''));
     });
   });
@@ -69,8 +66,10 @@ function run(args, { timeout = 120_000 } = {}) {
 export function loadState() {
   try { return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8')); } catch { return {}; }
 }
-function saveState(s) {
-  try { fs.writeFileSync(STATE_FILE, JSON.stringify(s, null, 2)); } catch {}
+function saveState(patch) {
+  const next = { ...loadState(), ...patch };
+  try { fs.writeFileSync(STATE_FILE, JSON.stringify(next, null, 2)); } catch {}
+  return next;
 }
 
 // The bucket mounted at /data, as discovered by visibility.js from
@@ -85,15 +84,15 @@ export function sourceBucket() {
 export async function defaultsFor() {
   const ns = await shareNamespace().catch(() => '');
   if (!ns) return { mirror: '', dataset: '' };
-  return { mirror: `${ns}/${spaceName()}-backup`, dataset: `${ns}/${spaceName()}-backup` };
+  const base = `${ns}/${spaceName()}-backup`;
+  return { mirror: base, dataset: base };
 }
 
 // The script the Job runs. No interpolation: every value arrives as an env var
 // (`-e`), so a config string can never become shell syntax.
 export const JOB_SCRIPT = `set -euo pipefail
 # Plain package, no [cli] extra: 1.26.0 dropped it ("does not provide the extra
-# 'cli'") and ships the CLI in the base install. Asking for it only earns a
-# warning in the run logs.
+# 'cli'") and ships the CLI in the base install.
 pip install -q huggingface_hub
 
 # A backup carries every saved login on the bucket — agent OAuth tokens, the Web
@@ -122,174 +121,160 @@ if [ -n "\${AM_MIRROR:-}" ]; then
 fi
 
 # 2. Version history, read from the bucket mounted read-only at /live — the
-#    Hub's copy, not any Space's disk. Unchanged files transfer nothing and
-#    produce no commit; --delete mirrors removals into the new commit while the
-#    previous commit keeps them recoverable.
+#    Hub's copy, not this Space's disk. Unchanged files transfer nothing and
+#    produce no commit at all; --delete makes the newest commit match the bucket
+#    while every earlier commit keeps deleted files recoverable.
 hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
   --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
 `;
 
 // Job arguments, as an array (never a shell string). Exported for the tests:
 // asserting on this is how we know a config value cannot reach a shell.
-export function jobArgs({ source, mirror, dataset, cron = null, name }) {
-  const spec = [
+export function jobArgs({ source, mirror, dataset }) {
+  return [
+    'jobs', 'run', '--detach',
+    '--name', `am-backup-${spaceName()}`.slice(0, 40),
     '--secrets', 'HF_TOKEN',
     '-e', `AM_SOURCE=${source}`,
     '-e', `AM_MIRROR=${mirror || ''}`,
     '-e', `AM_DATASET=${dataset}`,
+    // Read-only: a backup must not be able to write to what it is reading.
     '-v', `hf://buckets/${source}:/live:ro`,
     '--timeout', JOB_TIMEOUT,
     JOB_IMAGE, 'bash', '-c', JOB_SCRIPT,
   ];
-  if (name) spec.unshift('--name', name);
-  return cron
-    ? ['jobs', 'scheduled', 'run', cron, ...spec]
-    : ['jobs', 'run', '--detach', ...spec];
-}
-
-// What the config asks for, as one comparable string. If this changes, the
-// schedule is replaced — there is no "update" verb for a scheduled Job, only
-// run/delete, so a change means delete-then-create.
-export const fingerprint = ({ cron, source, mirror, dataset }) =>
-  [cron, source, mirror || '-', dataset].join('|');
-
-export function reconcile(existing, desired) {
-  if (!desired) return existing ? 'delete' : 'keep';
-  if (!existing) return 'create';
-  if (existing.fingerprint !== desired.fingerprint) return 'replace';
-  if (existing.suspend) return 'replace';
-  return 'keep';
-}
-
-async function listSchedules() {
-  try { return JSON.parse(await run(['jobs', 'scheduled', 'ls', '--json'])) || []; } catch { return []; }
-}
-
-async function findSchedule(id) {
-  if (!id) return null;
-  return (await listSchedules()).find((s) => s.id === id) || null;
 }
 
 /**
- * Make the Hub match the operator's config: create, replace, or remove the
- * scheduled Job. Called on boot and after PUT /api/config. Never throws — a
- * backup that cannot be scheduled records why and leaves the app alone.
+ * Why a backup cannot run right now, or null if it can. One place, so the timer
+ * and the settings row always agree about it.
  */
-export async function ensureSchedule(cfg) {
-  const state = loadState();
-  const every = cfg?.backup?.every || 'never';
-  const cron = cronFor(every);
-  const existing = await findSchedule(state.scheduledJobId);
-  const existingRec = existing ? { fingerprint: state.fingerprint, suspend: !!existing.suspend } : null;
-
-  if (!cron) {
-    if (existing) await run(['jobs', 'scheduled', 'delete', existing.id]).catch(() => {});
-    saveState({ ...state, scheduledJobId: null, fingerprint: null, every: 'never', error: null });
-    return { action: existing ? 'deleted' : 'none' };
-  }
-
-  const source = sourceBucket();
-  if (!source) {
-    saveState({ ...state, error: 'no bucket is mounted on this Space — nothing to back up' });
-    return { action: 'blocked', error: 'no bucket mounted' };
-  }
-  const d = await defaultsFor();
-  const mirror = (cfg.backup.mirror || d.mirror || '').trim();
-  const dataset = (cfg.backup.dataset || d.dataset || '').trim();
-  for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
-    if (label === 'mirror' && !id) continue;
-    if (!validRepoId(id)) {
-      const error = `refusing to schedule: ${label} "${id}" is not a valid repo id`;
-      saveState({ ...state, error });
-      return { action: 'blocked', error };
-    }
-  }
-
-  const desired = { fingerprint: fingerprint({ cron, source, mirror, dataset }) };
-  const action = reconcile(existingRec, desired);
-  if (action === 'keep') return { action };
-
-  // The mirror bucket has to exist and be private before anything is copied
-  // into it. The dataset is created private by the upload itself.
-  if (mirror) {
-    await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
-  }
-
-  if (action === 'replace' && existing) {
-    await run(['jobs', 'scheduled', 'delete', existing.id]).catch(() => {});
-  }
-  const name = `am-backup-${spaceName()}`.slice(0, 40);
-  const out = await run(jobArgs({ source, mirror, dataset, cron, name }), { timeout: 180_000 });
-  const id = (out.match(/id=(\S+)/) || [])[1] || null;
-  saveState({
-    ...state, scheduledJobId: id, fingerprint: desired.fingerprint,
-    every, source, mirror, dataset, error: null, scheduledAt: new Date().toISOString(),
-  });
-  return { action, id };
+export function unavailableReason(cfg) {
+  if (!hasToken()) return 'needs a write-scoped HF_TOKEN secret on the Space';
+  if (!sourceBucket()) return 'no bucket is mounted on this Space';
+  if ((cfg?.backup?.every || 'never') === 'never') return 'switched off';
+  return null;
 }
 
-/** Kick a backup now: trigger the schedule if there is one, else a one-off Job. */
-export async function runBackupNow(cfg) {
-  const state = loadState();
-  if (state.scheduledJobId) {
-    await run(['jobs', 'scheduled', 'trigger', state.scheduledJobId], { timeout: 120_000 });
-    return { triggered: state.scheduledJobId };
-  }
-  const source = sourceBucket();
-  if (!source) throw new Error('no bucket is mounted on this Space — nothing to back up');
+/** Resolve the destinations, falling back to <namespace>/<space>-backup. */
+async function targets(cfg) {
   const d = await defaultsFor();
   const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
   const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
-  if (!validRepoId(dataset)) throw new Error(`not a valid dataset id: ${dataset}`);
+  return { mirror, dataset, defaults: d };
+}
+
+/** Launch one backup Job now. Returns { job } — the Hub does the rest. */
+export async function runBackupNow(cfg) {
+  if (!hasToken()) throw new Error('needs a write-scoped HF_TOKEN secret on the Space');
+  const source = sourceBucket();
+  if (!source) throw new Error('no bucket is mounted on this Space — nothing to back up');
+  const { mirror, dataset } = await targets(cfg);
+  for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
+    if (label === 'mirror' && !id) continue;
+    if (!validRepoId(id)) throw new Error(`${label} "${id}" is not a valid repo id`);
+  }
+  // The mirror bucket must exist and be private before anything is copied into
+  // it; the dataset is created private by the upload itself.
   if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
+
   const out = await run(jobArgs({ source, mirror, dataset }), { timeout: 180_000 });
-  return { job: (out.match(/id=(\S+)/) || [])[1] || null };
+  const job = (out.match(/id=(\S+)/) || [])[1] || null;
+  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null });
+  return { job };
+}
+
+/** Terminal state of the last launched Job, or null while it is still going. */
+async function jobStage(jobId) {
+  if (!jobId) return null;
+  try {
+    const j = JSON.parse(await run(['jobs', 'inspect', jobId, '--json'], { timeout: 30_000 }));
+    const s = Array.isArray(j) ? j[0] : j;
+    return (s && s.status && s.status.stage) || null;
+  } catch { return null; }
+}
+
+const DONE = new Set(['COMPLETED', 'ERROR', 'FAILED', 'CANCELED']);
+
+/**
+ * One tick: launch a backup if one is due. Deliberately dumb — no cron, no
+ * catch-up queue. "Due" is just "the last one started more than an interval
+ * ago", which behaves correctly across restarts because it is derived from the
+ * timestamp on disk rather than from an in-memory schedule.
+ */
+export async function tick(cfg) {
+  if (unavailableReason(cfg)) return { skipped: unavailableReason(cfg) };
+  const state = loadState();
+  const due = Date.now() - (state.startedAt || 0) >= intervalMs(cfg.backup.every);
+  if (!due) return { skipped: 'not due' };
+
+  // Never let two runs overlap: a big first backup can outlast an interval.
+  if (state.jobId && !DONE.has(await jobStage(state.jobId))) {
+    return { skipped: 'previous backup still running' };
+  }
+  try {
+    const r = await runBackupNow(cfg);
+    console.log(`[backup] launched job ${r.job} (every ${cfg.backup.every})`);
+    return r;
+  } catch (e) {
+    const error = e.stderr || e.message;
+    saveState({ error, erroredAt: Date.now() });
+    console.warn('[backup] launch failed:', error);
+    return { error };
+  }
 }
 
 /**
- * Status for the settings row. Reports the schedule as the HUB sees it, not as
- * we last left it — a backup nobody can verify the state of is a backup nobody
- * trusts, and the destination's privacy is the one thing that must be visible.
+ * Start the loop. One unref'd timer that asks every 5 minutes whether a backup
+ * is due; the config is re-read each time, so switching the interval takes
+ * effect without restarting anything.
+ */
+export function startBackupTimer(getConfig) {
+  const t = setInterval(() => { tick(getConfig()).catch(() => {}); }, TICK_MS);
+  if (t.unref) t.unref();
+  // First check shortly after boot, once bucket discovery has landed.
+  const first = setTimeout(() => { tick(getConfig()).catch(() => {}); }, 30_000);
+  if (first.unref) first.unref();
+  return () => { clearInterval(t); clearTimeout(first); };
+}
+
+/**
+ * Status for the settings row. A backup nobody can see the state of is a backup
+ * nobody trusts — and the destination's privacy is the one thing that must be
+ * visible, so it is re-read here rather than remembered.
  */
 export async function backupStatus(cfg) {
   const state = loadState();
   const every = cfg?.backup?.every || 'never';
   const source = sourceBucket();
-  const d = await defaultsFor();
-  const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
-  const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
-  const sched = await findSchedule(state.scheduledJobId);
-
-  let priv = null;
-  if (every !== 'never' && dataset) {
-    priv = await datasetPrivate(dataset);
-  }
-
+  const { mirror, dataset, defaults } = await targets(cfg);
+  const [stage, priv] = await Promise.all([
+    every === 'never' ? null : jobStage(state.jobId),
+    every === 'never' || !dataset ? null : datasetPrivate(dataset),
+  ]);
   return {
     every,
     source,
     mirror,
     dataset,
-    defaults: d,
-    scheduled: sched
-      ? { id: sched.id, cron: sched.schedule, suspended: !!sched.suspend,
-          lastRun: sched.last_run && sched.last_run !== 'N/A' ? sched.last_run : null,
-          nextRun: sched.next_run || null }
+    defaults,
+    hasToken: hasToken(),
+    unavailable: unavailableReason(cfg),
+    last: state.startedAt
+      ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || 'RUNNING' }
       : null,
-    datasetPrivate: priv,   // null = unknown/not created yet
+    nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
+    datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,
   };
 }
 
-// One small authed read; the settings row needs the CURRENT answer, because a
+// One small authed read: the settings row needs the CURRENT answer, because a
 // repo holding credentials can be flipped public at any time.
 async function datasetPrivate(dataset) {
+  if (!validRepoId(dataset)) return null;
   try {
-    const out = await run(['datasets', 'info', dataset, '--json'], { timeout: 30_000 });
-    const j = JSON.parse(out);
+    const j = JSON.parse(await run(['datasets', 'info', dataset, '--json'], { timeout: 30_000 }));
     return j.private === true;
-  } catch (e) {
-    if (/404|not found|RepositoryNotFound/i.test(e.stderr || e.message || '')) return null;
-    return null;
-  }
+  } catch { return null; }
 }

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -45,6 +45,11 @@ const TICK_MS = 300_000; // 5 min
 // stack up behind each other.
 const JOB_TIMEOUT = '3000s'; // 50 min
 const JOB_IMAGE = 'python:3.12';
+// Pinned, not left to the default: the operator pays for this. cpu-basic is the
+// cheapest tier ($0.0002/min) and the work is API calls and file hashing, so
+// nothing here benefits from more machine. Pinning also means a change to the
+// Hub's default flavour cannot silently make hourly backups more expensive.
+export const JOB_FLAVOR = 'cpu-basic';
 
 export const hasToken = () => !!(process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN);
 
@@ -140,6 +145,7 @@ export function jobArgs({ source, mirror, dataset }) {
     '-e', `AM_DATASET=${dataset}`,
     // Read-only: a backup must not be able to write to what it is reading.
     '-v', `hf://buckets/${source}:/live:ro`,
+    '--flavor', JOB_FLAVOR,
     '--timeout', JOB_TIMEOUT,
     JOB_IMAGE, 'bash', '-c', JOB_SCRIPT,
   ];

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -94,10 +94,13 @@ export async function defaultsFor() {
 }
 
 const HF = 'https://huggingface.co';
-// A Job's page lives under the namespace that launched it. The settings row
-// links to it while a backup runs, because that page is the only place the
-// progress actually is — the work is on the Hub, not here.
-export const jobUrl = (ns, jobId) => (ns && jobId ? `${HF}/jobs/${ns}/${jobId}` : null);
+
+// Every run is launched with `--name am-backup-<space>`, which the Hub stores as
+// a `name=` label. So one static URL lists this Space's backup runs — past,
+// present and failed — and the row never has to track a job id to link to them.
+export const jobName = () => `am-backup-${spaceName()}`.slice(0, 40);
+export const jobsUrl = () =>
+  `${HF}/settings/jobs?label=${encodeURIComponent(`name=${jobName()}`)}`;
 
 // The script the Job runs. No interpolation: every value arrives as an env var
 // (`-e`), so a config string can never become shell syntax.
@@ -144,7 +147,7 @@ hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
 export function jobArgs({ source, mirror, dataset }) {
   return [
     'jobs', 'run', '--detach',
-    '--name', `am-backup-${spaceName()}`.slice(0, 40),
+    '--name', jobName(),
     '--secrets', 'HF_TOKEN',
     '-e', `AM_SOURCE=${source}`,
     '-e', `AM_MIRROR=${mirror || ''}`,
@@ -297,13 +300,10 @@ export async function backupStatus(cfg) {
     running: !!stage && !DONE.has(stage),
     unavailable: unavailableReason(cfg),
     last: state.startedAt
-      ? {
-          at: state.startedAt,
-          jobId: state.jobId || null,
-          stage: stage || 'RUNNING',
-          url: jobUrl((dataset || mirror || '').split('/')[0], state.jobId),
-        }
+      ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || 'RUNNING' }
       : null,
+    jobName: jobName(),
+    jobsUrl: jobsUrl(),
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -142,6 +142,29 @@ hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
   --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
 `;
 
+/**
+ * The Job id out of `hf jobs run --detach` output, whatever shape it comes in.
+ *
+ * This is deliberately format-agnostic. The image installs huggingface_hub
+ * unpinned, so the CLI here is not the CLI a dev machine has, and a version that
+ * printed the id differently silently left us with `jobId: null` — which killed
+ * overlap protection and made the status row report a stage it had invented.
+ * Accepts `id=<id>`, a bare id on its own line, or one embedded in a job URL.
+ */
+export function parseJobId(out) {
+  const text = String(out || '');
+  const looksLikeId = (s) => /^[a-f0-9]{16,32}$/i.test(s || '');
+  const tagged = text.match(/\bid=([A-Za-z0-9]+)/);
+  if (tagged && looksLikeId(tagged[1])) return tagged[1];
+  const fromUrl = text.match(/\/jobs\/[^\s/]+\/([A-Za-z0-9]+)/);
+  if (fromUrl && looksLikeId(fromUrl[1])) return fromUrl[1];
+  for (const line of text.split('\n').map((l) => l.trim()).reverse()) {
+    const last = line.split(/\s+/).pop();
+    if (looksLikeId(last)) return last;
+  }
+  return null;
+}
+
 // Job arguments, as an array (never a shell string). Exported for the tests:
 // asserting on this is how we know a config value cannot reach a shell.
 export function jobArgs({ source, mirror, dataset }) {
@@ -207,7 +230,10 @@ export async function runBackupNow(cfg) {
   if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
 
   const out = await run(jobArgs({ source, mirror, dataset }), { timeout: 180_000 });
-  const job = (out.match(/id=(\S+)/) || [])[1] || null;
+  const job = parseJobId(out);
+  // A launch we cannot identify still happened — record it, but say so, because
+  // without an id there is nothing to poll and no overlap to detect.
+  if (!job) console.warn('[backup] launched a Job but could not parse its id from:', out.slice(0, 200));
   saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null });
   return { job };
 }
@@ -222,15 +248,24 @@ async function jobStage(jobId) {
   } catch { return null; }
 }
 
-const DONE = new Set(['COMPLETED', 'ERROR', 'FAILED', 'CANCELED']);
+// Stages that mean a run is genuinely in flight. Observed from the Hub:
+// SCHEDULING and RUNNING while live, COMPLETED or ERROR once finished.
+//
+// Deliberately a list of ACTIVE stages rather than terminal ones, so anything
+// unrecognised — a new stage name, or `inspect` failing and returning nothing —
+// counts as NOT running. Enumerating terminal stages had it the wrong way round:
+// an unknown answer read as "running", which is the worse mistake twice over. It
+// showed a run in progress that had long finished, and it would have blocked
+// every future backup behind a job that no longer exists.
+const ACTIVE = new Set(['SCHEDULING', 'RUNNING']);
+export const isActiveStage = (stage) => !!stage && ACTIVE.has(stage);
 
-/** Is the last launched Job still going? Unknown stage counts as finished, so a
- *  Hub hiccup can never wedge backups off forever. */
+/** Is the last launched Job still going? Unknown counts as finished, so a Hub
+ *  hiccup can never wedge backups off forever. */
 async function isRunning() {
   const { jobId } = loadState();
   if (!jobId) return false;
-  const stage = await jobStage(jobId);
-  return !!stage && !DONE.has(stage);
+  return isActiveStage(await jobStage(jobId));
 }
 
 /**
@@ -297,10 +332,10 @@ export async function backupStatus(cfg) {
     defaults,
     hasToken: hasToken(),
     canRunNow: !runNowBlockedBy(),
-    running: !!stage && !DONE.has(stage),
+    running: isActiveStage(stage),
     unavailable: unavailableReason(cfg),
     last: state.startedAt
-      ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || 'RUNNING' }
+      ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || null }
       : null,
     jobName: jobName(),
     jobsUrl: jobsUrl(),

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -93,6 +93,12 @@ export async function defaultsFor() {
   return { mirror: base, dataset: base };
 }
 
+const HF = 'https://huggingface.co';
+// A Job's page lives under the namespace that launched it. The settings row
+// links to it while a backup runs, because that page is the only place the
+// progress actually is — the work is on the Hub, not here.
+export const jobUrl = (ns, jobId) => (ns && jobId ? `${HF}/jobs/${ns}/${jobId}` : null);
+
 // The script the Job runs. No interpolation: every value arrives as an env var
 // (`-e`), so a config string can never become shell syntax.
 export const JOB_SCRIPT = `set -euo pipefail
@@ -291,7 +297,12 @@ export async function backupStatus(cfg) {
     running: !!stage && !DONE.has(stage),
     unavailable: unavailableReason(cfg),
     last: state.startedAt
-      ? { at: state.startedAt, jobId: state.jobId || null, stage: stage || 'RUNNING' }
+      ? {
+          at: state.startedAt,
+          jobId: state.jobId || null,
+          stage: stage || 'RUNNING',
+          url: jobUrl((dataset || mirror || '').split('/')[0], state.jobId),
+        }
       : null,
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -25,6 +25,7 @@ import { kindOfName, kindOfFile, mimeOf, readTextHead, TEXT_MAX } from './previe
 import { startWatchdog } from './watchdog.js';
 import { shareSession, shareNamespace, findTrace, shareAccess, grantAccess, revokeAccess,
          importBundle, listBundles, SHAREABLE_CLIS } from './share.js';
+import * as backup from './backup.js';
 
 ensureDirs();
 refreshVersions();
@@ -878,6 +879,14 @@ function loadAmConfig() {
     archive: {
       after: ['week', 'month', 'never'].includes(saved.archive?.after) ? saved.archive.after : 'month',
     },
+    // How often the bucket is mirrored to private Hub storage. Off by default:
+    // it copies this machine's contents — saved logins included — into another
+    // Hub resource, which is the operator's call to make. docs/bucket-backup.md
+    backup: {
+      every: ['never', 'hour', '6h', 'day'].includes(saved.backup?.every) ? saved.backup.every : 'never',
+      mirror: (saved.backup?.mirror || '').trim(),
+      dataset: (saved.backup?.dataset || '').trim(),
+    },
   };
 }
 app.get('/api/config', (_req, res) => res.json({ ...loadAmConfig(), defaultArtifactsSpace: defaultArtifactsSpace() }));
@@ -891,10 +900,28 @@ app.put('/api/config', (req, res) => {
     },
     jobs: { askAboveUsd: Math.max(0, Number(b.jobs?.askAboveUsd) || 0) },
     archive: { after: ['week', 'month', 'never'].includes(b.archive?.after) ? b.archive.after : 'month' },
+    backup: {
+      every: ['never', 'hour', '6h', 'day'].includes(b.backup?.every) ? b.backup.every : 'never',
+      mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
+      dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
+    },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}
   generateEnvSkill(loadSecretNotes());
+  // The schedule lives on the Hub, so saving config means reconciling it there.
+  // Never blocks the response: a Hub hiccup must not fail a settings save.
+  backup.ensureSchedule(cfg).catch((e) => console.warn('[backup] schedule failed:', e.message));
   res.json({ ok: true });
+});
+
+// ---------- bucket backup: status + run-now (docs/bucket-backup.md) ----------
+app.get('/api/backup/status', async (_req, res) => {
+  try { res.json(await backup.backupStatus(loadAmConfig())); }
+  catch (e) { res.status(500).json({ error: e.message }); }
+});
+app.post('/api/backup/run', async (_req, res) => {
+  try { res.json(await backup.runBackupNow(loadAmConfig())); }
+  catch (e) { res.status(500).json({ error: e.stderr || e.message }); }
 });
 
 // The artifacts section teaches agents to publish rich HTML results to a
@@ -2217,6 +2244,15 @@ generateEnvSkill(loadSecretNotes()); // keep the environment skill current on bo
 // destabilize a fresh container. The Usage page fetches per-provider on open
 // (skeletons + stale-while-revalidate), so nothing is lost but the boot risk.
 setTimeout(() => { traceDigests().catch(() => {}); }, 4000);
+
+// Reconcile the backup schedule with the config once the bucket id has been
+// discovered (visibility.js supplies it, and the boot check is bounded to 9s
+// above). Idempotent: with nothing changed this is one list call and no writes.
+setTimeout(() => {
+  backup.ensureSchedule(loadAmConfig())
+    .then((r) => { if (r && r.action && r.action !== 'keep' && r.action !== 'none') console.log('[backup]', r.action, r.id || r.error || ''); })
+    .catch((e) => console.warn('[backup] schedule failed:', e.message));
+}, 12_000);
 
 // Off-thread stall detector — must start early so it's watching before the
 // first heavy build. Logs any event-loop wedge to the run logs (see watchdog.js).

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -879,11 +879,11 @@ function loadAmConfig() {
     archive: {
       after: ['week', 'month', 'never'].includes(saved.archive?.after) ? saved.archive.after : 'month',
     },
-    // How often the bucket is mirrored to private Hub storage. Off by default:
-    // it copies this machine's contents — saved logins included — into another
-    // Hub resource, which is the operator's call to make. docs/bucket-backup.md
+    // How often the bucket is copied to private Hub storage. Off by default: it
+    // copies this machine's contents — saved logins included — into another Hub
+    // resource, which is the operator's call to make. docs/bucket-backup.md
     backup: {
-      every: ['never', 'hour', '6h', 'day'].includes(saved.backup?.every) ? saved.backup.every : 'never',
+      every: backup.INTERVALS.includes(saved.backup?.every) ? saved.backup.every : 'never',
       mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
     },
@@ -901,16 +901,13 @@ app.put('/api/config', (req, res) => {
     jobs: { askAboveUsd: Math.max(0, Number(b.jobs?.askAboveUsd) || 0) },
     archive: { after: ['week', 'month', 'never'].includes(b.archive?.after) ? b.archive.after : 'month' },
     backup: {
-      every: ['never', 'hour', '6h', 'day'].includes(b.backup?.every) ? b.backup.every : 'never',
+      every: backup.INTERVALS.includes(b.backup?.every) ? b.backup.every : 'never',
       mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}
   generateEnvSkill(loadSecretNotes());
-  // The schedule lives on the Hub, so saving config means reconciling it there.
-  // Never blocks the response: a Hub hiccup must not fail a settings save.
-  backup.ensureSchedule(cfg).catch((e) => console.warn('[backup] schedule failed:', e.message));
   res.json({ ok: true });
 });
 
@@ -2245,14 +2242,10 @@ generateEnvSkill(loadSecretNotes()); // keep the environment skill current on bo
 // (skeletons + stale-while-revalidate), so nothing is lost but the boot risk.
 setTimeout(() => { traceDigests().catch(() => {}); }, 4000);
 
-// Reconcile the backup schedule with the config once the bucket id has been
-// discovered (visibility.js supplies it, and the boot check is bounded to 9s
-// above). Idempotent: with nothing changed this is one list call and no writes.
-setTimeout(() => {
-  backup.ensureSchedule(loadAmConfig())
-    .then((r) => { if (r && r.action && r.action !== 'keep' && r.action !== 'none') console.log('[backup]', r.action, r.id || r.error || ''); })
-    .catch((e) => console.warn('[backup] schedule failed:', e.message));
-}, 12_000);
+// Bucket backup: ask every few minutes whether one is due, and if so launch a
+// Job to do it on the Hub (docs/bucket-backup.md). Costs nothing when off or
+// when there is no HF_TOKEN — it reads the config and returns.
+backup.startBackupTimer(loadAmConfig);
 
 // Off-thread stall detector — must start early so it's watching before the
 // first heavy build. Logs any event-loop wedge to the run logs (see watchdog.js).

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -2,8 +2,37 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
-  hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl,
+  hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
 } from '../src/backup.js';
+
+// The image installs huggingface_hub unpinned, so the CLI in the Space is not the
+// one on a dev machine. A version whose launch output differs left jobId null,
+// which killed overlap protection outright — so the parse must not depend on one
+// output shape.
+test('parseJobId survives any of the shapes the CLI prints', () => {
+  const ID = '6a7245596b79c09949c227fc';
+  assert.equal(parseJobId(`id=${ID} url=https://huggingface.co/jobs/lvwerra/${ID}`), ID);
+  assert.equal(parseJobId(`https://huggingface.co/jobs/lvwerra/${ID}`), ID);
+  assert.equal(parseJobId(ID), ID);
+  assert.equal(parseJobId(`Job started\n${ID}\n`), ID);
+  // Nothing id-shaped must never be mistaken for an id.
+  assert.equal(parseJobId(''), null);
+  assert.equal(parseJobId('Hint: pass --name to rename it'), null);
+  assert.equal(parseJobId(undefined), null);
+  assert.equal(parseJobId('id=short'), null);
+});
+
+// An unknown answer must never read as "running": that showed a finished run as
+// in-progress, and would have blocked every later backup behind a job that no
+// longer exists. Unrecognised stages count as finished, on purpose.
+test('only known active stages count as running', () => {
+  assert.equal(isActiveStage('RUNNING'), true);
+  assert.equal(isActiveStage('SCHEDULING'), true);
+  for (const s of ['COMPLETED', 'ERROR', 'FAILED', 'CANCELED', 'CANCELLED', 'DELETED',
+                   'SOMETHING_NEW', '', null, undefined]) {
+    assert.equal(isActiveStage(s), false, `${String(s)} must not count as running`);
+  }
+});
 
 // The jobs link filters the Hub's job list by the label every run carries, so
 // the name used to launch a Job and the name used to find it must not drift.

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -1,0 +1,112 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CRON, cronFor, validRepoId, jobArgs, fingerprint, reconcile, JOB_SCRIPT,
+} from '../src/backup.js';
+
+// The interval enum is the operator-facing contract; every value the config
+// accepts must map to a cron, and 'never' must map to nothing at all.
+test('cronFor covers the config enum and only that', () => {
+  for (const every of ['hour', '6h', 'day']) {
+    assert.ok(cronFor(every), `${every} should have a cron`);
+    assert.match(cronFor(every), /^[\d*\/ ,-]+$/);
+  }
+  assert.equal(cronFor('never'), null);
+  assert.equal(cronFor('nonsense'), null);
+  assert.equal(cronFor(undefined), null);
+  assert.equal(Object.keys(CRON).length, 3);
+});
+
+// A run must be dead before the next one is due, or a hung backup stacks up
+// behind itself.
+test('the job timeout is shorter than the shortest interval', () => {
+  const args = jobArgs({ source: 'ns/b', mirror: '', dataset: 'ns/d', cron: CRON.hour, name: 'x' });
+  const secs = Number(args[args.indexOf('--timeout') + 1].replace('s', ''));
+  assert.ok(secs < 3600, `timeout ${secs}s must be under the hourly cadence`);
+});
+
+test('validRepoId accepts real ids and rejects shell metacharacters', () => {
+  for (const ok of ['lvwerra/agent-manager-data', 'org/a.b-c_d', 'a1/b2']) {
+    assert.ok(validRepoId(ok), `${ok} should be valid`);
+  }
+  for (const bad of [
+    'no-slash', '/leading', 'trailing/', 'a/b/c', '-dash/start', 'a/$(whoami)',
+    'a/b;rm -rf /', 'a/b`id`', 'a/b|c', 'a/b c', 'a/b\nc', '', null, undefined, 42,
+    `x/${'y'.repeat(200)}`,
+  ]) {
+    assert.equal(validRepoId(bad), false, `${String(bad)} should be rejected`);
+  }
+});
+
+// The security property of this module: operator-supplied strings travel as
+// argv/env, never as shell syntax. If someone later interpolates a config value
+// into JOB_SCRIPT, this fails.
+test('config values reach the job as env vars, not shell text', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: 'ns/mir', dataset: 'ns/ds', cron: CRON.hour, name: 'am-backup-x' });
+  assert.ok(args.includes('-e'));
+  assert.ok(args.includes('AM_SOURCE=ns/src'));
+  assert.ok(args.includes('AM_MIRROR=ns/mir'));
+  assert.ok(args.includes('AM_DATASET=ns/ds'));
+  // The script is one argument, and it names only env vars.
+  const script = args[args.length - 1];
+  assert.equal(script, JOB_SCRIPT);
+  for (const id of ['ns/src', 'ns/mir', 'ns/ds']) {
+    assert.ok(!script.includes(id), 'ids must not be interpolated into the script');
+  }
+});
+
+// A backup must never be able to write to the bucket it is reading.
+test('the source bucket is mounted read-only', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', cron: CRON.day, name: 'x' });
+  const vol = args[args.indexOf('-v') + 1];
+  assert.equal(vol, 'hf://buckets/ns/src:/live:ro');
+  assert.ok(vol.endsWith(':ro'));
+});
+
+test('no cron means a one-off detached job, not a schedule', () => {
+  const once = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  assert.deepEqual(once.slice(0, 3), ['jobs', 'run', '--detach']);
+  const sched = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', cron: CRON.hour });
+  assert.deepEqual(sched.slice(0, 4), ['jobs', 'scheduled', 'run', CRON.hour]);
+});
+
+// The upload has to create the dataset private, and re-verify privacy every run:
+// the mirror carries live agent credentials (docs/bucket-backup.md §4).
+test('the job script gates on privacy and creates private', () => {
+  assert.match(JOB_SCRIPT, /--private/);
+  assert.match(JOB_SCRIPT, /refusing to back up/);
+  assert.match(JOB_SCRIPT, /dataset_info/);
+  assert.match(JOB_SCRIPT, /bucket_info/);
+  assert.match(JOB_SCRIPT, /set -euo pipefail/);
+});
+
+// There is no "update" verb for a scheduled Job, so any change is a
+// delete-then-create. Missing a change would silently keep backing up to the
+// old destination.
+test('reconcile replaces on any change and removes when disabled', () => {
+  const fp = (o) => ({ fingerprint: fingerprint(o), suspend: false });
+  const base = { cron: CRON.hour, source: 'ns/s', mirror: 'ns/m', dataset: 'ns/d' };
+
+  assert.equal(reconcile(null, fp(base)), 'create');
+  assert.equal(reconcile(fp(base), fp(base)), 'keep');
+  assert.equal(reconcile(fp(base), null), 'delete');
+  assert.equal(reconcile(null, null), 'keep');
+
+  for (const changed of [
+    { ...base, cron: CRON.day },
+    { ...base, source: 'ns/other' },
+    { ...base, mirror: '' },
+    { ...base, dataset: 'ns/other' },
+  ]) {
+    assert.equal(reconcile(fp(base), fp(changed)), 'replace', JSON.stringify(changed));
+  }
+
+  // A suspended schedule is not a working backup — bring it back.
+  assert.equal(reconcile({ fingerprint: fingerprint(base), suspend: true }, fp(base)), 'replace');
+});
+
+test('fingerprint distinguishes an empty mirror from a named one', () => {
+  const a = fingerprint({ cron: CRON.hour, source: 'ns/s', mirror: '', dataset: 'ns/d' });
+  const b = fingerprint({ cron: CRON.hour, source: 'ns/s', mirror: 'ns/m', dataset: 'ns/d' });
+  assert.notEqual(a, b);
+});

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -1,28 +1,28 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  CRON, cronFor, validRepoId, jobArgs, fingerprint, reconcile, JOB_SCRIPT,
+  EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT,
+  hasToken, unavailableReason,
 } from '../src/backup.js';
 
-// The interval enum is the operator-facing contract; every value the config
-// accepts must map to a cron, and 'never' must map to nothing at all.
-test('cronFor covers the config enum and only that', () => {
-  for (const every of ['hour', '6h', 'day']) {
-    assert.ok(cronFor(every), `${every} should have a cron`);
-    assert.match(cronFor(every), /^[\d*\/ ,-]+$/);
-  }
-  assert.equal(cronFor('never'), null);
-  assert.equal(cronFor('nonsense'), null);
-  assert.equal(cronFor(undefined), null);
-  assert.equal(Object.keys(CRON).length, 3);
+// The interval enum is the operator-facing contract: off, 1h, 3h, 24h.
+test('the interval enum is exactly off/1h/3h/24h', () => {
+  assert.deepEqual(INTERVALS, ['never', '1h', '3h', '24h']);
+  assert.equal(intervalMs('1h'), 3_600_000);
+  assert.equal(intervalMs('3h'), 3 * 3_600_000);
+  assert.equal(intervalMs('24h'), 24 * 3_600_000);
+  // 'never' has no interval, so "is it due?" can never be true.
+  assert.equal(intervalMs('never'), 0);
+  assert.equal(intervalMs('nonsense'), 0);
+  assert.equal(intervalMs(undefined), 0);
 });
 
 // A run must be dead before the next one is due, or a hung backup stacks up
 // behind itself.
 test('the job timeout is shorter than the shortest interval', () => {
-  const args = jobArgs({ source: 'ns/b', mirror: '', dataset: 'ns/d', cron: CRON.hour, name: 'x' });
+  const args = jobArgs({ source: 'ns/b', mirror: '', dataset: 'ns/d' });
   const secs = Number(args[args.indexOf('--timeout') + 1].replace('s', ''));
-  assert.ok(secs < 3600, `timeout ${secs}s must be under the hourly cadence`);
+  assert.ok(secs * 1000 < EVERY_MS['1h'], `timeout ${secs}s must be under 1h`);
 });
 
 test('validRepoId accepts real ids and rejects shell metacharacters', () => {
@@ -42,12 +42,10 @@ test('validRepoId accepts real ids and rejects shell metacharacters', () => {
 // argv/env, never as shell syntax. If someone later interpolates a config value
 // into JOB_SCRIPT, this fails.
 test('config values reach the job as env vars, not shell text', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: 'ns/mir', dataset: 'ns/ds', cron: CRON.hour, name: 'am-backup-x' });
-  assert.ok(args.includes('-e'));
+  const args = jobArgs({ source: 'ns/src', mirror: 'ns/mir', dataset: 'ns/ds' });
   assert.ok(args.includes('AM_SOURCE=ns/src'));
   assert.ok(args.includes('AM_MIRROR=ns/mir'));
   assert.ok(args.includes('AM_DATASET=ns/ds'));
-  // The script is one argument, and it names only env vars.
   const script = args[args.length - 1];
   assert.equal(script, JOB_SCRIPT);
   for (const id of ['ns/src', 'ns/mir', 'ns/ds']) {
@@ -57,21 +55,19 @@ test('config values reach the job as env vars, not shell text', () => {
 
 // A backup must never be able to write to the bucket it is reading.
 test('the source bucket is mounted read-only', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', cron: CRON.day, name: 'x' });
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
   const vol = args[args.indexOf('-v') + 1];
   assert.equal(vol, 'hf://buckets/ns/src:/live:ro');
-  assert.ok(vol.endsWith(':ro'));
 });
 
-test('no cron means a one-off detached job, not a schedule', () => {
-  const once = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
-  assert.deepEqual(once.slice(0, 3), ['jobs', 'run', '--detach']);
-  const sched = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', cron: CRON.hour });
-  assert.deepEqual(sched.slice(0, 4), ['jobs', 'scheduled', 'run', CRON.hour]);
+test('a backup is one detached job launch', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  assert.deepEqual(args.slice(0, 3), ['jobs', 'run', '--detach']);
+  assert.ok(args.includes('--secrets') && args.includes('HF_TOKEN'));
 });
 
-// The upload has to create the dataset private, and re-verify privacy every run:
-// the mirror carries live agent credentials (docs/bucket-backup.md §4).
+// The upload has to create the dataset private and re-verify privacy every run:
+// the copy carries live agent credentials (docs/bucket-backup.md §4).
 test('the job script gates on privacy and creates private', () => {
   assert.match(JOB_SCRIPT, /--private/);
   assert.match(JOB_SCRIPT, /refusing to back up/);
@@ -80,33 +76,31 @@ test('the job script gates on privacy and creates private', () => {
   assert.match(JOB_SCRIPT, /set -euo pipefail/);
 });
 
-// There is no "update" verb for a scheduled Job, so any change is a
-// delete-then-create. Missing a change would silently keep backing up to the
-// old destination.
-test('reconcile replaces on any change and removes when disabled', () => {
-  const fp = (o) => ({ fingerprint: fingerprint(o), suspend: false });
-  const base = { cron: CRON.hour, source: 'ns/s', mirror: 'ns/m', dataset: 'ns/d' };
+// Without a token there is no way to launch a Job or write to the Hub, so the
+// feature must report itself unavailable rather than failing every interval.
+test('no HF_TOKEN means unavailable, with the token as the stated reason', () => {
+  const saved = [process.env.HF_TOKEN, process.env.HUGGING_FACE_HUB_TOKEN, process.env.AM_BACKUP_SOURCE];
+  try {
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGING_FACE_HUB_TOKEN;
+    process.env.AM_BACKUP_SOURCE = 'ns/bucket';
+    assert.equal(hasToken(), false);
+    assert.match(unavailableReason({ backup: { every: '1h' } }), /HF_TOKEN/);
 
-  assert.equal(reconcile(null, fp(base)), 'create');
-  assert.equal(reconcile(fp(base), fp(base)), 'keep');
-  assert.equal(reconcile(fp(base), null), 'delete');
-  assert.equal(reconcile(null, null), 'keep');
-
-  for (const changed of [
-    { ...base, cron: CRON.day },
-    { ...base, source: 'ns/other' },
-    { ...base, mirror: '' },
-    { ...base, dataset: 'ns/other' },
-  ]) {
-    assert.equal(reconcile(fp(base), fp(changed)), 'replace', JSON.stringify(changed));
+    process.env.HF_TOKEN = 'hf_test';
+    assert.equal(hasToken(), true);
+    // With a token, a bucket and an interval, nothing stands in the way.
+    assert.equal(unavailableReason({ backup: { every: '1h' } }), null);
+    // Off is off, whatever else is true.
+    assert.equal(unavailableReason({ backup: { every: 'never' } }), 'switched off');
+    assert.equal(unavailableReason({}), 'switched off');
+    // No bucket to read means nothing to back up.
+    delete process.env.AM_BACKUP_SOURCE;
+    assert.match(unavailableReason({ backup: { every: '1h' } }), /no bucket/);
+  } finally {
+    [process.env.HF_TOKEN, process.env.HUGGING_FACE_HUB_TOKEN, process.env.AM_BACKUP_SOURCE] = saved;
+    for (const [k, v] of [['HF_TOKEN', saved[0]], ['HUGGING_FACE_HUB_TOKEN', saved[1]], ['AM_BACKUP_SOURCE', saved[2]]]) {
+      if (v === undefined) delete process.env[k];
+    }
   }
-
-  // A suspended schedule is not a working backup — bring it back.
-  assert.equal(reconcile({ fingerprint: fingerprint(base), suspend: true }, fp(base)), 'replace');
-});
-
-test('fingerprint distinguishes an empty mirror from a named one', () => {
-  const a = fingerprint({ cron: CRON.hour, source: 'ns/s', mirror: '', dataset: 'ns/d' });
-  const b = fingerprint({ cron: CRON.hour, source: 'ns/s', mirror: 'ns/m', dataset: 'ns/d' });
-  assert.notEqual(a, b);
 });

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -2,8 +2,17 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
-  hasToken, unavailableReason, runNowBlockedBy,
+  hasToken, unavailableReason, runNowBlockedBy, jobUrl,
 } from '../src/backup.js';
+
+// The row links to the running Job, so the URL has to be right — and absent
+// rather than broken when either half is missing.
+test('jobUrl points at the Hub job page, or is null', () => {
+  assert.equal(jobUrl('lvwerra', 'abc123'), 'https://huggingface.co/jobs/lvwerra/abc123');
+  assert.equal(jobUrl('', 'abc123'), null);
+  assert.equal(jobUrl('lvwerra', null), null);
+  assert.equal(jobUrl(undefined, undefined), null);
+});
 
 // "Back up now" must not require a schedule: taking one backup before a risky
 // change is the main reason to want the button at all.

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -1,9 +1,18 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
-  EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT,
+  EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason,
 } from '../src/backup.js';
+
+// The operator pays for every run, so the tier is pinned rather than inherited
+// from the Hub's default — which could change under us and quietly make hourly
+// backups more expensive.
+test('the job hardware is pinned to the cheapest tier', () => {
+  assert.equal(JOB_FLAVOR, 'cpu-basic');
+  const args = jobArgs({ source: 'ns/b', mirror: '', dataset: 'ns/d' });
+  assert.equal(args[args.indexOf('--flavor') + 1], 'cpu-basic');
+});
 
 // The interval enum is the operator-facing contract: off, 1h, 3h, 24h.
 test('the interval enum is exactly off/1h/3h/24h', () => {

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -2,16 +2,18 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
-  hasToken, unavailableReason, runNowBlockedBy, jobUrl,
+  hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl,
 } from '../src/backup.js';
 
-// The row links to the running Job, so the URL has to be right — and absent
-// rather than broken when either half is missing.
-test('jobUrl points at the Hub job page, or is null', () => {
-  assert.equal(jobUrl('lvwerra', 'abc123'), 'https://huggingface.co/jobs/lvwerra/abc123');
-  assert.equal(jobUrl('', 'abc123'), null);
-  assert.equal(jobUrl('lvwerra', null), null);
-  assert.equal(jobUrl(undefined, undefined), null);
+// The jobs link filters the Hub's job list by the label every run carries, so
+// the name used to launch a Job and the name used to find it must not drift.
+test('the jobs link filters by the same name the Job is launched with', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  assert.equal(args[args.indexOf('--name') + 1], jobName());
+  assert.equal(jobsUrl(), `https://huggingface.co/settings/jobs?label=name%3D${jobName()}`);
+  // The label has to arrive encoded, or the Hub reads it as a second parameter.
+  assert.ok(jobsUrl().includes('%3D'));
+  assert.ok(!jobsUrl().includes('label=name='));
 });
 
 // "Back up now" must not require a schedule: taking one backup before a risky

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -2,8 +2,33 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
-  hasToken, unavailableReason,
+  hasToken, unavailableReason, runNowBlockedBy,
 } from '../src/backup.js';
+
+// "Back up now" must not require a schedule: taking one backup before a risky
+// change is the main reason to want the button at all.
+test('on demand works with the schedule off, but not without a token', () => {
+  const saved = { t: process.env.HF_TOKEN, h: process.env.HUGGING_FACE_HUB_TOKEN, s: process.env.AM_BACKUP_SOURCE };
+  try {
+    process.env.HF_TOKEN = 'hf_test';
+    process.env.AM_BACKUP_SOURCE = 'ns/bucket';
+    // Off is a reason the TIMER stays quiet, never a reason to refuse on demand.
+    assert.equal(unavailableReason({ backup: { every: 'never' } }), 'switched off');
+    assert.equal(runNowBlockedBy(), null);
+
+    // The prerequisites are still prerequisites.
+    delete process.env.HF_TOKEN;
+    delete process.env.HUGGING_FACE_HUB_TOKEN;
+    assert.match(runNowBlockedBy(), /HF_TOKEN/);
+    process.env.HF_TOKEN = 'hf_test';
+    delete process.env.AM_BACKUP_SOURCE;
+    assert.match(runNowBlockedBy(), /no bucket/);
+  } finally {
+    for (const [k, v] of [['HF_TOKEN', saved.t], ['HUGGING_FACE_HUB_TOKEN', saved.h], ['AM_BACKUP_SOURCE', saved.s]]) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  }
+});
 
 // The operator pays for every run, so the tier is pinned rather than inherited
 // from the Hub's default — which could change under us and quietly make hourly

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -97,7 +97,8 @@ export interface BackupStatus {
   canRunNow: boolean;
   running: boolean;
   unavailable: string | null;
-  last: { at: number; jobId: string | null; stage: string } | null;
+  // stage is null when the Hub did not answer — never guessed.
+  last: { at: number; jobId: string | null; stage: string | null } | null;
   // One static URL lists every run by its `name=` label, so the row never
   // needs a job id to link to them.
   jobName: string;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -97,7 +97,7 @@ export interface BackupStatus {
   canRunNow: boolean;
   running: boolean;
   unavailable: string | null;
-  last: { at: number; jobId: string | null; stage: string } | null;
+  last: { at: number; jobId: string | null; stage: string; url: string | null } | null;
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -97,7 +97,11 @@ export interface BackupStatus {
   canRunNow: boolean;
   running: boolean;
   unavailable: string | null;
-  last: { at: number; jobId: string | null; stage: string; url: string | null } | null;
+  last: { at: number; jobId: string | null; stage: string } | null;
+  // One static URL lists every run by its `name=` label, so the row never
+  // needs a job id to link to them.
+  jobName: string;
+  jobsUrl: string;
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -94,6 +94,8 @@ export interface BackupStatus {
   dataset: string;
   defaults: { mirror: string; dataset: string };
   hasToken: boolean;
+  canRunNow: boolean;
+  running: boolean;
   unavailable: string | null;
   last: { at: number; jobId: string | null; stage: string } | null;
   nextDue: number | null;
@@ -101,8 +103,10 @@ export interface BackupStatus {
   error: string | null;
 }
 export const backupStatus = (): Promise<BackupStatus> => fetch('/api/backup/status').then(json);
-export const runBackup = (): Promise<{ job?: string; error?: string }> =>
-  fetch('/api/backup/run', { method: 'POST' }).then(json);
+// jsonOrError, not json: the refusals worth showing ("a backup is already
+// running") are in the body, and json() throws them away for a bare status.
+export const runBackup = (): Promise<{ job?: string }> =>
+  fetch('/api/backup/run', { method: 'POST' }).then(jsonOrError);
 
 export interface SecretsData { detected: string[]; notes: Record<string, string>; }
 export const getSecrets = (): Promise<SecretsData> => fetch('/api/secrets').then(json);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -78,11 +78,27 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
+  backup: { every: 'never' | 'hour' | '6h' | 'day'; mirror: string; dataset: string };
   defaultArtifactsSpace?: string;
 }
 export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json);
 export const saveConfig = (c: AmConfig) =>
   fetch('/api/config', { method: 'PUT', headers: HEADERS, body: JSON.stringify(c) }).then(json);
+
+// ---- bucket backup: the schedule lives on the Hub, so status is read from it ----
+export interface BackupStatus {
+  every: 'never' | 'hour' | '6h' | 'day';
+  source: string | null;
+  mirror: string;
+  dataset: string;
+  defaults: { mirror: string; dataset: string };
+  scheduled: { id: string; cron: string; suspended: boolean; lastRun: string | null; nextRun: string | null } | null;
+  datasetPrivate: boolean | null;
+  error: string | null;
+}
+export const backupStatus = (): Promise<BackupStatus> => fetch('/api/backup/status').then(json);
+export const runBackup = (): Promise<{ triggered?: string; job?: string; error?: string }> =>
+  fetch('/api/backup/run', { method: 'POST' }).then(json);
 
 export interface SecretsData { detected: string[]; notes: Record<string, string>; }
 export const getSecrets = (): Promise<SecretsData> => fetch('/api/secrets').then(json);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -78,26 +78,30 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
-  backup: { every: 'never' | 'hour' | '6h' | 'day'; mirror: string; dataset: string };
+  backup: { every: BackupEvery; mirror: string; dataset: string };
   defaultArtifactsSpace?: string;
 }
 export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json);
 export const saveConfig = (c: AmConfig) =>
   fetch('/api/config', { method: 'PUT', headers: HEADERS, body: JSON.stringify(c) }).then(json);
 
-// ---- bucket backup: the schedule lives on the Hub, so status is read from it ----
+// ---- bucket backup: a Job on the Hub does the copying (docs/bucket-backup.md) ----
+export type BackupEvery = 'never' | '1h' | '3h' | '24h';
 export interface BackupStatus {
-  every: 'never' | 'hour' | '6h' | 'day';
+  every: BackupEvery;
   source: string | null;
   mirror: string;
   dataset: string;
   defaults: { mirror: string; dataset: string };
-  scheduled: { id: string; cron: string; suspended: boolean; lastRun: string | null; nextRun: string | null } | null;
+  hasToken: boolean;
+  unavailable: string | null;
+  last: { at: number; jobId: string | null; stage: string } | null;
+  nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;
 }
 export const backupStatus = (): Promise<BackupStatus> => fetch('/api/backup/status').then(json);
-export const runBackup = (): Promise<{ triggered?: string; job?: string; error?: string }> =>
+export const runBackup = (): Promise<{ job?: string; error?: string }> =>
   fetch('/api/backup/run', { method: 'POST' }).then(json);
 
 export interface SecretsData { detected: string[]; notes: Record<string, string>; }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -437,15 +437,12 @@ export default function SettingsView({
                           <span>Backup jobs</span>
                           <b><a href={bk.jobsUrl} target="_blank" rel="noreferrer">{bk.jobName}</a></b>
                         </div>
+                        {/* A timestamp, not a stage. The job's own state belongs
+                            on the jobs page linked above — reporting it here meant
+                            reporting it wrongly whenever the Hub did not answer. */}
                         <div>
                           <span>Last updated</span>
-                          <b>
-                            {bk.running
-                              ? 'backing up now…'
-                              : bk.last
-                                ? `${new Date(bk.last.at).toLocaleString()}${bk.last.stage ? ` (${bk.last.stage.toLowerCase()})` : ''}`
-                                : 'never'}
-                          </b>
+                          <b>{bk.last ? new Date(bk.last.at).toLocaleString() : 'never'}</b>
                         </div>
                         {bk.error && (
                           <div>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -379,13 +379,18 @@ export default function SettingsView({
                     <div className="s-help">
                       Copies your whole bucket — workspaces, history, saved logins — to private Hub storage:
                       a bucket you can restore from instantly, and a dataset that keeps version history.
-                      The copy runs on the Hub as a Job, so it costs this Space nothing. Nothing is ever
-                      deleted from your bucket.
+                      Nothing is ever deleted from your bucket.
+                    </div>
+                    <div className="s-help" style={{ marginTop: 6 }}>
+                      Each run is an <b>HF Job billed to your account</b> — cpu-basic, $0.01 per hour of
+                      runtime, so a few minutes per backup — plus Hub storage for both copies (the mirror is
+                      about the size of your bucket). Every 1h means 24 runs a day.
                     </div>
                     {!bk?.hasToken && (
-                      <div className="s-help" style={{ marginTop: 6 }}>
-                        This needs a write-scoped <span className="mono">HF_TOKEN</span> Space secret —
-                        without one there is no way to launch the Job or write to the Hub.
+                      <div className="s-warn">
+                        Only <b>off</b> is available: backing up needs a write-scoped{' '}
+                        <span className="mono">HF_TOKEN</span> Space secret, and this Space has none. Without
+                        one there is no way to launch the Job or write to the Hub.
                       </div>
                     )}
                     {bk?.hasToken && cfg.backup.every !== 'never' && (

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -181,14 +181,28 @@ export default function SettingsView({
   // Hub says about the last one rather than anything we remember locally.
   const [bk, setBk] = useState<api.BackupStatus | null>(null);
   const [bkBusy, setBkBusy] = useState(false);
+  const [bkMsg, setBkMsg] = useState('');
   const loadBackup = () => api.backupStatus().then(setBk).catch(() => {});
   useEffect(() => { loadBackup(); }, []);
   // Re-read after a save lands, so the interval and privacy dot stop disagreeing
   // with what was just chosen.
   useEffect(() => { if (cfgSaved === 'saved') loadBackup(); }, [cfgSaved]);
+  // While a Job is in flight, follow it: the copying happens on the Hub, so the
+  // only way to see it finish is to ask.
+  useEffect(() => {
+    if (!bk?.running) return;
+    const t = setInterval(loadBackup, 10_000);
+    return () => clearInterval(t);
+  }, [bk?.running]);
   const doBackup = async () => {
     setBkBusy(true);
-    try { await api.runBackup(); } catch {}
+    setBkMsg('');
+    try {
+      const r = await api.runBackup();
+      setBkMsg(r.job ? `Launched on the Hub as job ${r.job}.` : 'Launched.');
+    } catch (e) {
+      setBkMsg((e as Error).message || 'Could not launch the backup.');
+    }
     await loadBackup();
     setBkBusy(false);
   };
@@ -381,7 +395,7 @@ export default function SettingsView({
                       a bucket you can restore from instantly, and a dataset that keeps version history.
                       Nothing is ever deleted from your bucket.
                     </div>
-                    {bk?.hasToken && cfg.backup.every !== 'never' && (
+                    {bk?.canRunNow && (bk.last || cfg.backup.every !== 'never') && (
                       <div className="s-help" style={{ marginTop: 6 }}>
                         <span className="mono">{bk.mirror || bk.defaults.mirror}</span>
                         {bk.datasetPrivate === false
@@ -397,11 +411,21 @@ export default function SettingsView({
                         {bk.error && <> · <span style={{ color: 'var(--warn, #d97757)' }}>{bk.error}</span></>}
                       </div>
                     )}
-                    {bk?.hasToken && cfg.backup.every !== 'never' && (
-                      <button className="btn-ghost" style={{ marginTop: 8 }} disabled={bkBusy} onClick={doBackup}>
-                        {bkBusy ? 'Launching…' : 'Back up now'}
+                    {/* On demand regardless of the interval: taking one backup
+                        before a risky change should not mean switching on a
+                        schedule. Disabled while a run is in flight — two Jobs
+                        uploading to one dataset would race. */}
+                    {bk?.canRunNow && (
+                      <button
+                        className="btn-ghost"
+                        style={{ marginTop: 8 }}
+                        disabled={bkBusy || bk.running}
+                        onClick={doBackup}
+                      >
+                        {bkBusy ? 'Launching…' : bk.running ? 'Backing up…' : 'Back up now'}
                       </button>
                     )}
+                    {bkMsg && <div className="s-help" style={{ marginTop: 6 }}>{bkMsg}</div>}
                   </div>
                   <span className="cfg-ctl">
                     <div className="seg cfg-seg">

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -198,8 +198,9 @@ export default function SettingsView({
     setBkBusy(true);
     setBkMsg('');
     try {
-      const r = await api.runBackup();
-      setBkMsg(r.job ? `Launched on the Hub as job ${r.job}.` : 'Launched.');
+      // On success the status line takes over — it names the running job and
+      // links to it, so repeating the id here would just be noise.
+      await api.runBackup();
     } catch (e) {
       setBkMsg((e as Error).message || 'Could not launch the backup.');
     }
@@ -397,17 +398,53 @@ export default function SettingsView({
                     </div>
                     {bk?.canRunNow && (bk.last || cfg.backup.every !== 'never') && (
                       <div className="s-help" style={{ marginTop: 6 }}>
-                        <span className="mono">{bk.mirror || bk.defaults.mirror}</span>
+                        {/* Two destinations, named separately: one is a dataset
+                            and one is a bucket, and they default to the same id
+                            string — so showing one unlabelled name was telling
+                            you which only by luck. */}
+                        History{' '}
+                        <a
+                          className="mono"
+                          href={`https://huggingface.co/datasets/${bk.dataset || bk.defaults.dataset}`}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          {bk.dataset || bk.defaults.dataset}
+                        </a>
                         {bk.datasetPrivate === false
                           ? ' — NOT private, so backups are refused until you fix that'
                           : bk.datasetPrivate === true ? ' — private' : ' — created private on the first run'}
-                        {bk.last && (
+                        {(bk.mirror || bk.defaults.mirror) && (
+                          <>
+                            {' · mirror '}
+                            <a
+                              className="mono"
+                              href={`https://huggingface.co/buckets/${bk.mirror || bk.defaults.mirror}`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              {bk.mirror || bk.defaults.mirror}
+                            </a>
+                          </>
+                        )}
+                        {bk.running ? (
+                          <>
+                            {' · backing up now'}
+                            {bk.last?.url && (
+                              <> — <a href={bk.last.url} target="_blank" rel="noreferrer">follow the job ↗</a></>
+                            )}
+                          </>
+                        ) : bk.last ? (
                           <>
                             {' · last run '}
                             {new Date(bk.last.at).toLocaleString()}
-                            {bk.last.stage ? ` (${bk.last.stage.toLowerCase()})` : ''}
+                            {bk.last.stage ? ' (' : ''}
+                            {bk.last.stage && bk.last.url
+                              ? <a href={bk.last.url} target="_blank" rel="noreferrer">{bk.last.stage.toLowerCase()}</a>
+                              : bk.last.stage?.toLowerCase()}
+                            {bk.last.stage ? ')' : ''}
                           </>
-                        )}
+                        ) : null}
                         {bk.error && <> · <span style={{ color: 'var(--warn, #d97757)' }}>{bk.error}</span></>}
                       </div>
                     )}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -381,18 +381,6 @@ export default function SettingsView({
                       a bucket you can restore from instantly, and a dataset that keeps version history.
                       Nothing is ever deleted from your bucket.
                     </div>
-                    <div className="s-help" style={{ marginTop: 6 }}>
-                      Each run is an <b>HF Job billed to your account</b> — cpu-basic, $0.01 per hour of
-                      runtime, so a few minutes per backup — plus Hub storage for both copies (the mirror is
-                      about the size of your bucket). Every 1h means 24 runs a day.
-                    </div>
-                    {!bk?.hasToken && (
-                      <div className="s-warn">
-                        Only <b>off</b> is available: backing up needs a write-scoped{' '}
-                        <span className="mono">HF_TOKEN</span> Space secret, and this Space has none. Without
-                        one there is no way to launch the Job or write to the Hub.
-                      </div>
-                    )}
                     {bk?.hasToken && cfg.backup.every !== 'never' && (
                       <div className="s-help" style={{ marginTop: 6 }}>
                         <span className="mono">{bk.mirror || bk.defaults.mirror}</span>
@@ -430,6 +418,22 @@ export default function SettingsView({
                     </div>
                   </span>
                 </div>
+                {/* Full width, outside the row: whichever of these applies is the
+                    thing to read before touching the control above. Without a
+                    token, why the intervals are dead; with one, who pays. */}
+                {!bk?.hasToken ? (
+                  <div className="s-warn">
+                    Only <b>off</b> is available: backing up needs a write-scoped{' '}
+                    <span className="mono">HF_TOKEN</span> Space secret, and this Space has none. Without one
+                    there is no way to launch the Job or write to the Hub.
+                  </div>
+                ) : (
+                  <div className="s-warn">
+                    Each run is an <b>HF Job billed to your account</b> — cpu-basic, $0.01 per hour of runtime,
+                    so a few minutes per backup — plus Hub storage for both copies (the mirror is about the size
+                    of your bucket). Every 1h means 24 runs a day.
+                  </div>
+                )}
 
                 <div className="setting-row">
                   <div>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -177,6 +177,22 @@ export default function SettingsView({
     return () => clearTimeout(t);
   }, [cfg, savedCfg]);
 
+  // Bucket backup: the copying happens in an HF Job, so the row reports what the
+  // Hub says about the last one rather than anything we remember locally.
+  const [bk, setBk] = useState<api.BackupStatus | null>(null);
+  const [bkBusy, setBkBusy] = useState(false);
+  const loadBackup = () => api.backupStatus().then(setBk).catch(() => {});
+  useEffect(() => { loadBackup(); }, []);
+  // Re-read after a save lands, so the interval and privacy dot stop disagreeing
+  // with what was just chosen.
+  useEffect(() => { if (cfgSaved === 'saved') loadBackup(); }, [cfgSaved]);
+  const doBackup = async () => {
+    setBkBusy(true);
+    try { await api.runBackup(); } catch {}
+    await loadBackup();
+    setBkBusy(false);
+  };
+
   // App self-update: version check on open, update on confirm.
   const [upd, setUpd] = useState<api.UpdateCheck | null>(null);
   const [updState, setUpdState] = useState<{ busy?: boolean; msg?: string; confirm?: boolean }>({});
@@ -354,6 +370,59 @@ export default function SettingsView({
                       value={cfg.jobs.askAboveUsd}
                       onChange={(e) => setCfg({ ...cfg, jobs: { askAboveUsd: Math.max(0, Number(e.target.value) || 0) } })}
                     />
+                  </span>
+                </div>
+
+                <div className="setting-row">
+                  <div>
+                    <div className="s-label">Back up the bucket</div>
+                    <div className="s-help">
+                      Copies your whole bucket — workspaces, history, saved logins — to private Hub storage:
+                      a bucket you can restore from instantly, and a dataset that keeps version history.
+                      The copy runs on the Hub as a Job, so it costs this Space nothing. Nothing is ever
+                      deleted from your bucket.
+                    </div>
+                    {!bk?.hasToken && (
+                      <div className="s-help" style={{ marginTop: 6 }}>
+                        This needs a write-scoped <span className="mono">HF_TOKEN</span> Space secret —
+                        without one there is no way to launch the Job or write to the Hub.
+                      </div>
+                    )}
+                    {bk?.hasToken && cfg.backup.every !== 'never' && (
+                      <div className="s-help" style={{ marginTop: 6 }}>
+                        <span className="mono">{bk.mirror || bk.defaults.mirror}</span>
+                        {bk.datasetPrivate === false
+                          ? ' — NOT private, so backups are refused until you fix that'
+                          : bk.datasetPrivate === true ? ' — private' : ' — created private on the first run'}
+                        {bk.last && (
+                          <>
+                            {' · last run '}
+                            {new Date(bk.last.at).toLocaleString()}
+                            {bk.last.stage ? ` (${bk.last.stage.toLowerCase()})` : ''}
+                          </>
+                        )}
+                        {bk.error && <> · <span style={{ color: 'var(--warn, #d97757)' }}>{bk.error}</span></>}
+                      </div>
+                    )}
+                    {bk?.hasToken && cfg.backup.every !== 'never' && (
+                      <button className="btn-ghost" style={{ marginTop: 8 }} disabled={bkBusy} onClick={doBackup}>
+                        {bkBusy ? 'Launching…' : 'Back up now'}
+                      </button>
+                    )}
+                  </div>
+                  <span className="cfg-ctl">
+                    <div className="seg cfg-seg">
+                      {(['never', '1h', '3h', '24h'] as const).map((e) => (
+                        <button
+                          key={e}
+                          className={cfg.backup.every === e ? 'on' : ''}
+                          disabled={!bk?.hasToken && e !== 'never'}
+                          onClick={() => setCfg({ ...cfg, backup: { ...cfg.backup, every: e } })}
+                        >
+                          {e === 'never' ? 'off' : e}
+                        </button>
+                      ))}
+                    </div>
                   </span>
                 </div>
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -396,56 +396,63 @@ export default function SettingsView({
                       a bucket you can restore from instantly, and a dataset that keeps version history.
                       Nothing is ever deleted from your bucket.
                     </div>
+                    {/* A kv table, not a run-on sentence: three destinations and a
+                        timestamp are things you scan, not read. The two repos
+                        default to the same id string — one a dataset, one a
+                        bucket — so each row says which it is. */}
                     {bk?.canRunNow && (bk.last || cfg.backup.every !== 'never') && (
-                      <div className="s-help" style={{ marginTop: 6 }}>
-                        {/* Two destinations, named separately: one is a dataset
-                            and one is a bucket, and they default to the same id
-                            string — so showing one unlabelled name was telling
-                            you which only by luck. */}
-                        History{' '}
-                        <a
-                          className="mono"
-                          href={`https://huggingface.co/datasets/${bk.dataset || bk.defaults.dataset}`}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          {bk.dataset || bk.defaults.dataset}
-                        </a>
-                        {bk.datasetPrivate === false
-                          ? ' — NOT private, so backups are refused until you fix that'
-                          : bk.datasetPrivate === true ? ' — private' : ' — created private on the first run'}
-                        {(bk.mirror || bk.defaults.mirror) && (
-                          <>
-                            {' · mirror '}
+                      <div className="kv kv-inline">
+                        <div>
+                          <span>Backup dataset</span>
+                          <b>
                             <a
                               className="mono"
-                              href={`https://huggingface.co/buckets/${bk.mirror || bk.defaults.mirror}`}
+                              href={`https://huggingface.co/datasets/${bk.dataset || bk.defaults.dataset}`}
                               target="_blank"
                               rel="noreferrer"
                             >
-                              {bk.mirror || bk.defaults.mirror}
+                              {bk.dataset || bk.defaults.dataset}
                             </a>
-                          </>
-                        )}
-                        {bk.running ? (
-                          <>
-                            {' · backing up now'}
-                            {bk.last?.url && (
-                              <> — <a href={bk.last.url} target="_blank" rel="noreferrer">follow the job ↗</a></>
+                            {bk.datasetPrivate === false && (
+                              <span style={{ color: 'var(--danger)' }}> — not private</span>
                             )}
-                          </>
-                        ) : bk.last ? (
-                          <>
-                            {' · last run '}
-                            {new Date(bk.last.at).toLocaleString()}
-                            {bk.last.stage ? ' (' : ''}
-                            {bk.last.stage && bk.last.url
-                              ? <a href={bk.last.url} target="_blank" rel="noreferrer">{bk.last.stage.toLowerCase()}</a>
-                              : bk.last.stage?.toLowerCase()}
-                            {bk.last.stage ? ')' : ''}
-                          </>
-                        ) : null}
-                        {bk.error && <> · <span style={{ color: 'var(--warn, #d97757)' }}>{bk.error}</span></>}
+                          </b>
+                        </div>
+                        {(bk.mirror || bk.defaults.mirror) && (
+                          <div>
+                            <span>Mirror bucket</span>
+                            <b>
+                              <a
+                                className="mono"
+                                href={`https://huggingface.co/buckets/${bk.mirror || bk.defaults.mirror}`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                {bk.mirror || bk.defaults.mirror}
+                              </a>
+                            </b>
+                          </div>
+                        )}
+                        <div>
+                          <span>Backup jobs</span>
+                          <b><a href={bk.jobsUrl} target="_blank" rel="noreferrer">{bk.jobName}</a></b>
+                        </div>
+                        <div>
+                          <span>Last updated</span>
+                          <b>
+                            {bk.running
+                              ? 'backing up now…'
+                              : bk.last
+                                ? `${new Date(bk.last.at).toLocaleString()}${bk.last.stage ? ` (${bk.last.stage.toLowerCase()})` : ''}`
+                                : 'never'}
+                          </b>
+                        </div>
+                        {bk.error && (
+                          <div>
+                            <span>Last error</span>
+                            <b style={{ color: 'var(--danger)' }}>{bk.error}</b>
+                          </div>
+                        )}
                       </div>
                     )}
                     {/* On demand regardless of the interval: taking one backup

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -915,6 +915,14 @@ a.btn-ghost { text-decoration: none; }
 .kv > div:last-child { border-bottom: none; }
 .kv span { color: var(--muted); }
 .kv b { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; max-width: 65%; }
+/* Links in a kv table read as part of the value, not as web-1.0 blue: same
+   restraint as .trace-hint a — inherit the text colour, hint with a dotted rule,
+   and only take the accent on hover. */
+.kv a { color: inherit; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; }
+.kv a:hover { color: var(--accent); text-decoration-style: solid; }
+/* A kv used inside a setting's description sits tighter than a section-level one. */
+.kv-inline { margin-top: 8px; }
+.kv-inline > div { padding: 6px 2px; font-size: 12.5px; }
 .placeholder { background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-xl); padding: 20px; }
 .placeholder p { margin: 0 0 8px; }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -965,6 +965,10 @@ a.btn-ghost { text-decoration: none; }
 .seg { display: inline-flex; border: 1px solid var(--border); border-radius: var(--r-md); overflow: hidden; }
 .seg button { background: var(--panel); border: none; padding: 5px 12px; font: inherit; font-size: 12px; color: var(--muted); cursor: pointer; }
 .seg button.on { background: var(--accent); color: var(--accent-fg); }
+/* An unavailable option has to LOOK unavailable — `disabled` alone only stops
+   the click, so a greyed-out control was still rendering as a live one. */
+.seg button:disabled { opacity: 0.4; cursor: not-allowed; }
+.seg button:disabled:hover { background: var(--panel); }
 .skill-text { height: 62vh; width: 100%; resize: vertical; border: 1px solid var(--border); border-radius: var(--r-lg); background: var(--term-bg); color: var(--text); font-family: var(--font-mono); font-size: 13px; padding: 12px; line-height: 1.5; }
 .skill-text:focus { outline: 2px solid color-mix(in srgb, var(--accent) 40%, transparent); border-color: var(--accent); }
 


### PR DESCRIPTION
## What this is

A PoC for backing up the bucket — the one thing here that cannot be rebuilt. The
image is in the Dockerfile, the app is on GitHub, the CLIs reinstall on a factory
reboot, but `/data` holds the workspaces agents have been working in, their
transcripts, and the session list.

**The workflow is one loop.** Every five minutes the app asks whether the last run
started more than an interval ago. If so it launches one detached HF Job and
forgets it. No cron, no reconciliation, no catch-up queue. "Due" comes from a
timestamp on disk, so it survives restarts, and the config is re-read each tick so
changing the interval needs no restart.

Intervals: **off / 1h / 3h / 24h**, off by default — it copies this machine's
contents into another Hub resource, which is the operator's call.

**It requires `HF_TOKEN`.** There is no way to launch a Job or write to the Hub
without one, so with no token the intervals are disabled and the row says why.

## Two destinations, because a mirror alone is not a backup

The Job does two things on the Hub:

1. **bucket → bucket**, server-side by Xet hash. No bytes move. The "get the Space
   back" copy, and a restore from it is equally instant.
2. **the same bucket, mounted read-only → a private dataset**. Buckets are mutable
   and non-versioned, so without this an overwritten or corrupted file is simply
   gone. The "get yesterday's file back" copy.

They are cheap at opposite things, which is why both exist. Bucket storage is
accounted in *logical* bytes — two identical snapshots measured **exactly 2×** — so
dated bucket snapshots multiply cost. A dataset stores each distinct blob once and
skips empty commits entirely, so **an idle hour of history costs nothing**.

Neither step reads `/data`: the copying happens on the Hub, so a backup costs this
Space one API call and cannot wedge the loop that pumps the terminals (the mount's
cold walk runs to minutes). It does cost the *operator* — each run bills a Job, and
the settings row says so.

## The settings row

```
Back up the bucket                              [ off | 1h | 3h | 24h ]

  Backup dataset    lvwerra/am-dev-2-backup     → the dataset page
  Mirror bucket     lvwerra/am-dev-2-backup     → the bucket page
  Backup jobs       am-backup-am-dev-2          → every run, by label
  Last updated      4 Aug 20:08

  [ Back up now ]

  ┌────────────────────────────────────────────────────────────────────┐
  │ Each run is an HF Job billed to your account — cpu-basic, $0.01    │
  │ per hour of runtime… Every 1h means 24 runs a day.                 │
  └────────────────────────────────────────────────────────────────────┘
```

- **A kv table**, reusing the block the Space section already uses. Both repos are
  named because they default to the same id string — one a dataset, one a bucket —
  so a single unlabelled name told you which only by luck.
- **The jobs link is static**: every run carries a `name=am-backup-<space>` label, so
  one URL lists them all, including failures. No job id to track. A test pins the
  launch name and the filter together so they cannot drift.
- **One full-width notice**, never both: without a token, why the intervals are
  dead; with one, who pays. `cpu-basic` is **pinned** rather than inherited, so a
  change to the Hub's default cannot quietly make hourly backups pricier.
- **"Back up now" ignores the schedule** — taking one backup before a risky change
  is the main reason to want it, and that is exactly when nothing is scheduled.
- **Links inherit the text colour** with a dotted underline, matching the rest of
  the app rather than browser-default blue.

## The security gate, verified by breaking it

The copy contains live agent OAuth tokens, the Web Push private key and
`session-secret`. Credentials are included deliberately — a restored Space comes
back signed-in — which makes the destination's privacy the load-bearing control.

The check runs **inside the Job, on every run**, because a repo can be flipped
public long after it was created:

```
refusing to back up: dataset lvwerra/… is not private
Job failed with exit code: 1
```

No commit landed. Also: the source is mounted `:ro` so a backup cannot write to
what it is reading; repo ids arrive from `PUT /api/config` and are **validated, not
escaped**, because they end up in an argument list; the job timeout is under the
shortest interval so a hung run cannot stack up; and concurrent runs are refused
rather than silently skipped.

## Verified

Behaviour the design leans on, measured against the real Hub:

- **bucket → dataset is not possible today.** `hf cp` refuses it, the CLI calls it a
  server limitation, and the docs say twice it is "not yet available, but is on the
  roadmap". Hence step 2 going through a mounted Job. If it lands, step 2 collapses
  into one `hf cp`.
- **A Job can mount the live bucket `:ro` while the Space holds it** — that
  concurrent mount is what makes step 2 possible at all.
- **bucket → bucket**: 13,482 files server-side in 20 s; a whole small bucket in 1 s.
- **Idle upload**: "No files have been modified since last commit. Skipping to
  prevent empty commit." — same sha, no new commit.

And end to end on a real Space (`am-dev-2`, 49 files): off and no-token skip with a
reason, the first tick launches, the next says "not due", the Job completes both
steps, and `lvwerra/am-dev-2-backup` now holds **four private snapshot commits** —
two of them the operator's own runs, before this branch's last two fixes.

## Two bugs the review found, and what they were really about

The status row reported `(running)` for runs that had long finished. It was not a
display quirk:

- **`stage || 'RUNNING'` invented an answer** whenever the Hub did not give one, and
  terminal stages were enumerated instead of active ones — so anything unrecognised
  counted as running. Wrong way round twice over: it lied about finished runs, and
  it would have blocked every later backup behind a job that no longer exists. Now
  `SCHEDULING`/`RUNNING` mean in flight and everything else means finished, so the
  feature cannot wedge itself off. The stage is gone from the table entirely — a
  Job's state belongs on its own page.
- **The job id was never captured on the Space**, only in the harness. The image
  installs `huggingface_hub` unpinned, so the CLI there is not the 1.25.1 used in
  testing, and its launch output did not match the one format the regex expected.
  `jobId: null` disabled overlap detection outright and left nothing to poll.
  `parseJobId` now accepts `id=<id>`, a bare id, or one inside a job URL, and logs
  the raw output when it still finds nothing.

The second one is the reason to be wary of anything here that was only exercised
locally: the Space's toolchain is not a dev machine's.

## Testing

- 13 tests (`server/test/backup.test.mjs`): the token gate, on-demand surviving
  `every: 'never'`, the interval enum, `:ro` mounting, the pinned flavour, the
  sub-interval timeout, job-id parsing across formats, that unknown stages never
  read as running, that the jobs link and launch name match, and that config values
  reach the Job as env vars rather than shell text.
- `tsc --noEmit` and the web build are clean. The settings row was checked in a
  headless browser, not by grepping the bundle: notice width, greyed options at
  opacity 0.4, link colour equal to body text, and the resolved hrefs.
- `server/test/repin.test.mjs` fails in a fresh clone for want of `node-pty`,
  identically on `main` — a missing `npm install`, not this change.
- Every probe dataset, bucket and job created while verifying was deleted.

## Not done

- **The production bucket has never been backed up.** Every number for 11.4 GB /
  102,691 files is extrapolated from 13,482 files in 20 s. Cheap to learn, and the
  next thing worth learning.
- **Nothing has ever been restored.** Restore is documented — and `repo → bucket`
  *is* server-side, so it can be Hub-side too — but unexercised, so the feature is a
  hypothesis until it runs once for real.
- **Transcript churn in the dataset is unbounded**: append-only JSONL under
  `state/*/projects/` means each hour's version is kept. Options (squash, or letting
  session sharing own that data with its redaction) are in the doc, undecided.
- The Hub-side `hf jobs scheduled` cron — which fires even while the Space sleeps —
  was built and verified working, then dropped to keep this simple. Kept as the
  alternative in §1.1.
- Incidental, outside this feature: the Dockerfile installs `huggingface_hub[cli]`
  and 1.26.0 dropped that extra. Harmless today, warns on rebuilds.

Design, measurements and open questions: `docs/bucket-backup.md`.
