### PR TITLE
opencode: resume the pinned conversation, not the folder's most recent

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test": "node test/repin.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/repin.test.mjs && node test/opencode-resume.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -5,7 +5,7 @@ import fs from 'node:fs';
 import { remoteState, setPaused } from './remote.js';
 import { cliById, isRemote, STATE_DIR, WORKSPACES_DIR } from './config.js';
 import { update, list } from './sessions.js';
-import { captureOpencodeSession, readTrace } from './traces.js';
+import { captureOpencodeSession, opencodeSessionExists, readTrace } from './traces.js';
 import {
   buildPaletteIndex, snapshotToRestoreAnsi, styledSnapshotLines, textColumns,
 } from './snapshot.js';
@@ -1018,7 +1018,12 @@ function scheduleOpencodeCapture(session, workdir) {
 // Single-quote a string for embedding in an `sh -lc` command line.
 const shq = (t) => `'${String(t).replace(/'/g, `'\\''`)}'`;
 
-function commandFor(session) {
+// Conversation ids reach the launch line unquoted, and this one comes back out
+// of a database rather than from us (Claude's uuid we mint ourselves). Shape-check
+// it so nothing but an opencode session id can ever be interpolated.
+const SES_ID = /^ses_[A-Za-z0-9_-]+$/;
+
+export function commandFor(session) {
   const cli = cliById(session.cli) || cliById('shell');
   if (cli.id === 'shell') return bashLaunch;
   // Quickstart: a prompt queued at creation rides the FIRST launch command
@@ -1073,11 +1078,24 @@ function commandFor(session) {
     const guard = 'G="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/opencode.json"; '
       + 'mkdir -p "$(dirname "$G")"; [ -d "$G" ] && rm -rf "$G"; '
       + '[ -e "$G" ] || { [ -f "${G}c" ] && cp "${G}c" "$G" || echo "{}" > "$G"; }; ';
-    // `--continue` resumes the most-recent conversation in the CWD, so two
-    // opencode agents sharing a folder would resume onto the SAME conversation
-    // (cross-talk) — same hazard as codex `resume --last`. Only continue when
-    // this session holds its folder alone; otherwise start fresh, and capture
-    // pins the new conversation right away (see scheduleOpencodeCapture).
+    // Resume the conversation this session is PINNED to, by id. `--continue`
+    // (below) takes the most-recent conversation in the CWD instead, which
+    // ignores the pin entirely: after a reset a restart came back on whichever
+    // conversation the folder touched last, and the pin the watcher maintains —
+    // the one the digest, the trace panel and sharing all read — described a
+    // different thread than the pane was showing. Existence-checked in JS rather
+    // than in the shell, because the db is one file for all conversations (no
+    // per-conversation path to test) and a missing row is fatal, not a fallback.
+    const pin = session.opencodeSessionId;
+    if (session.everStarted && pin && SES_ID.test(pin) && opencodeSessionExists(pin)) {
+      return `${guard}exec opencode --session ${pin}`;
+    }
+    // Unpinned (or the conversation is gone): `--continue` resumes the
+    // most-recent conversation in the CWD, so two opencode agents sharing a
+    // folder would resume onto the SAME one (cross-talk) — same hazard as codex
+    // `resume --last`. Only continue when this session holds its folder alone;
+    // otherwise start fresh, and capture pins the new conversation right away
+    // (see scheduleOpencodeCapture).
     const folder = session.path ?? session.id;
     const shared = list().some((o) => o.id !== session.id && o.cli === 'opencode' && (o.path ?? o.id) === folder);
     const base = session.everStarted && cli.cont && !shared

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -433,6 +433,21 @@ export function captureOpencodeSession(directory, sinceMs, claimed) {
   } catch { return null; } finally { try { db.close(); } catch {} }
 }
 
+// Does a pinned opencode conversation still exist? The launch line resumes by id
+// (`opencode --session <ses_…>`), and opencode exits 1 with "Session not found"
+// the moment the row is gone — verified on 1.18.9 — which would kill the pane on
+// sight. So the pin is checked here, before it can reach the shell: a purged
+// conversation starts fresh instead, the same honest fallback the Claude
+// transcript check and the codex rollout check give.
+export function opencodeSessionExists(id) {
+  if (!DatabaseSync || !id) return false;
+  let db;
+  try { db = new DatabaseSync(opencodeDbPath(), { readOnly: true }); } catch { return false; }
+  try {
+    return !!db.prepare('select 1 from session where id = ?').get(id);
+  } catch { return false; } finally { try { db.close(); } catch {} }
+}
+
 // ---------- Hermes (SQLite: ~/.hermes/state.db, WAL) ----------
 // sessions carry cwd + token totals; messages carry role/content/tool_name.
 // Timestamps are float SECONDS — converted to ms for digest fields.

--- a/server/test/opencode-resume.test.mjs
+++ b/server/test/opencode-resume.test.mjs
@@ -1,0 +1,97 @@
+// Which conversation an opencode pane comes back on after a restart.
+//
+// Regression cover for the bug where the launch line used `--continue` — the
+// most-recent conversation in the CWD — and so ignored the pin the watcher
+// maintains: a restart could land on a conversation the pane had left, or in a
+// shared folder on a sibling's. Run with: node test/opencode-resume.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-resume-'));
+const XDG = path.join(TMP, 'xdg');
+const DATA = path.join(TMP, 'data');
+fs.mkdirSync(path.join(XDG, 'opencode'), { recursive: true });
+fs.mkdirSync(DATA, { recursive: true });
+
+process.env.XDG_DATA_HOME = XDG;
+process.env.DATA_DIR = DATA;
+
+// Only the columns the runner reads. opencode's real table has ~30 more; a
+// narrower one still proves the query, and drifts less.
+const DB = path.join(XDG, 'opencode', 'opencode.db');
+const db = new DatabaseSync(DB);
+db.exec('create table session (id text primary key, directory text not null, time_created integer not null)');
+const addRow = (id, directory, timeCreated) =>
+  db.prepare('insert into session (id, directory, time_created) values (?, ?, ?)').run(id, directory, timeCreated);
+
+const sessions = await import('../src/sessions.js');
+const runner = await import('../src/runner.js');
+const traces = await import('../src/traces.js');
+sessions.init();
+
+let pass = 0, fail = 0;
+const check = (name, got, want) => {
+  const ok = got === want;
+  ok ? pass++ : fail++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `\n          got ${got}\n         want ${want}`}`);
+};
+const has = (name, hay, needle) => check(name, String(hay).includes(needle), true);
+
+const LIVE = 'ses_0325987abffej9UeLKjc55GHK8';
+const GONE = 'ses_099999999ffezzzzzzzzzzzzzzz';
+addRow(LIVE, '/data/workspaces/proj-a', 1770000000000);
+
+console.log('\nthe db decides whether a pin is still resumable');
+check('live row found', traces.opencodeSessionExists(LIVE), true);
+check('purged row not found', traces.opencodeSessionExists(GONE), false);
+check('no id is not a row', traces.opencodeSessionExists(null), false);
+
+console.log('\na restart resumes the pinned conversation, not the folder\'s newest');
+const s = sessions.create({ name: 'oc', cli: 'opencode', path: 'proj-a' });
+sessions.update(s.id, { everStarted: true, opencodeSessionId: LIVE });
+const cmd = runner.commandFor(sessions.get(s.id));
+has('resumes by id', cmd, `exec opencode --session ${LIVE}`);
+check('does not fall back to --continue', cmd.includes('--continue'), false);
+has('keeps the opencode.json guard', cmd, 'opencode/opencode.json');
+
+console.log('\na pin whose conversation is gone starts fresh, it does not die');
+// opencode exits 1 with "Session not found" on a missing id (verified on
+// 1.18.9), so emitting the flag here would kill the pane on sight.
+sessions.update(s.id, { opencodeSessionId: GONE });
+const purged = runner.commandFor(sessions.get(s.id));
+check('no --session for a missing row', purged.includes('--session'), false);
+has('continues in its own folder instead', purged, '--continue');
+
+console.log('\nan id that is not an opencode id never reaches the shell');
+for (const bad of ['ses_a; rm -rf /', 'ses_$(whoami)', '../../etc/passwd', 'ses_a b']) {
+  addRow(bad, '/data/workspaces/proj-a', 1770000000000); // even if the db says it exists
+  sessions.update(s.id, { opencodeSessionId: bad });
+  check(`rejected: ${JSON.stringify(bad)}`, runner.commandFor(sessions.get(s.id)).includes('--session'), false);
+}
+
+console.log('\nthe pin wins over the folder, so siblings cannot cross-talk');
+// Two live opencode sessions in one folder: `--continue` would have given BOTH
+// the same conversation. Each pinned session resumes its own.
+const other = sessions.create({ name: 'oc-2', cli: 'opencode', path: 'proj-a' });
+const MINE = 'ses_0aaaaaaaaffeaaaaaaaaaaaaaaa';
+const THEIRS = 'ses_0bbbbbbbbffebbbbbbbbbbbbbbb';
+addRow(MINE, '/data/workspaces/proj-a', 1770000001000);
+addRow(THEIRS, '/data/workspaces/proj-a', 1770000002000); // newer: --continue would pick this
+sessions.update(s.id, { opencodeSessionId: MINE });
+sessions.update(other.id, { everStarted: true, opencodeSessionId: THEIRS });
+has('this session resumes its own', runner.commandFor(sessions.get(s.id)), `--session ${MINE}`);
+has('the sibling resumes its own', runner.commandFor(sessions.get(other.id)), `--session ${THEIRS}`);
+
+console.log('\na first launch has nothing to resume');
+const fresh = sessions.create({ name: 'oc-3', cli: 'opencode', path: 'proj-b' });
+sessions.update(fresh.id, { opencodeSessionId: LIVE }); // pinned but never started
+const first = runner.commandFor(sessions.get(fresh.id));
+check('no --session on first launch', first.includes('--session'), false);
+check('no --continue on first launch', first.includes('--continue'), false);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+try { db.close(); } catch {}
+fs.rmSync(TMP, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
## The gap

#17 taught the watcher to keep an opencode session's `ses_…` pin current. The launch line never asked for it: opencode was resumed with `--continue`, which takes the **most-recent conversation in the working directory**.

So the pin decided what the Overview digest, the trace panel and sharing read, while `--continue` decided what the pane actually came back on — two different conversations whenever the folder's newest wasn't this session's own. Exactly the two cases the pin exists for:

- **after a reset** the watcher follows the successor, but a restart took whichever conversation the folder touched last
- **in a folder shared by two live opencode sessions** `--continue` hands *both* the same conversation, which is why resuming there was refused outright and a restart silently started fresh

Claude and codex were never in this position — they resume by pinned id (`--resume <uuid>`, `codex resume <id>`).

## The fix

opencode does take a conversation id — `--session <ses_…>` — so ask for the pinned one. A session with its folder to itself keeps its conversation across restarts; two sessions sharing a folder now each get their own back instead of neither.

Two guards, both because this id is unlike Claude's:

- **Existence-checked against the db before it reaches the shell.** A missing row is fatal, not a fallback: opencode exits 1 with `Session not found` on sight, which would kill the pane. Checked in JS rather than in the launch line because the db is one file for all conversations — there's no per-conversation path to test the way Claude's transcript and codex's rollout have. A purged conversation falls back to the old `--continue`/fresh path.
- **Shape-checked** (`/^ses_[A-Za-z0-9_-]+$/`). Claude's uuid we mint ourselves; this one comes back out of a database and is interpolated unquoted.

## Testing

`server/test/opencode-resume.test.mjs`, added to `npm test` — 16 checks: the db existence check, resume-by-pin, the purged-row fallback, four rejected id shapes (including `ses_a; rm -rf /`, which the test inserts into the db so only the shape check can stop it), two siblings in one folder each resuming their own, and a first launch resuming nothing.

Verified against the installed opencode (**1.18.9**): `--session <real id>` keeps the TUI up; `--session <unknown>` exits 1 with `Session not found` immediately — which is what the existence check is protecting against. Server boots clean on this branch (`/api/health` → `engine=libghostty`).

Not verified end-to-end: a full Space restart resuming a real opencode conversation. That needs an authenticated opencode session to reset and restart; the flag behaviour it depends on is verified directly above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
