### PR TITLE
Terminal: clickable links, and a selection that survives being copied

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
+    "test:ui": "node terminal-ui.test.mjs",
     "test": "node test/repin.test.mjs && node test/opencode-resume.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -175,6 +175,12 @@ try {
     JSON.stringify({ backAtPrompt, sleepSurvived: text.includes('NOT_INTERRUPTED') }));
 
   // ---------- 4. Cmd+C is never an interrupt ----------
+  // Check 3 waited on the SERVER's view of the output; the browser paints a
+  // moment later, so wait for the line to actually be on screen before
+  // measuring it, or this races the renderer rather than testing the copy.
+  const rendered = await waitFor(() => page.evaluate(() =>
+    document.querySelector('.tile-terminal:not(.tile-cached) .xterm-rows')?.textContent?.includes('AFTER_INTERRUPT')), 10_000);
+  if (!rendered) throw new Error('interrupt marker never rendered in the browser');
   const second = await rectOf('AFTER_INTERRUPT');
   if (second) {
     const y2 = second.y + second.height / 2;

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+/**
+ * Desktop terminal UX, in a real browser:
+ *   - URLs in agent output are clickable and open in a new tab
+ *   - copying a selection LEAVES the highlight up (it used to vanish instantly,
+ *     which reads as "did that work?")
+ *   - ...without letting that lingering selection shadow Ctrl+C's SIGINT
+ *
+ * Set TERMUI_PUBLIC_DIR to a prebuilt web/dist to skip the build.
+ */
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { WebSocket } from 'ws';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.dirname(HERE);
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'am-termui-'));
+const PUBLIC_DIR = process.env.TERMUI_PUBLIC_DIR || path.join(DATA_DIR, 'public');
+const API = 'http://127.0.0.1:7897';
+const LINK = 'https://example.com/probe-link';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let failures = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  if (!ok) failures++;
+};
+const waitFor = async (fn, timeout = 15_000) => {
+  const until = Date.now() + timeout;
+  while (Date.now() < until) {
+    try { if (await fn()) return true; } catch {}
+    await sleep(100);
+  }
+  return false;
+};
+const tail = async (id, lines = 400) =>
+  (await (await fetch(`${API}/api/agents/${id}/tail?lines=${lines}`)).json()).text || '';
+
+if (!process.env.TERMUI_PUBLIC_DIR) {
+  const build = spawnSync('npm', ['run', 'build', '--', '--outDir', PUBLIC_DIR], {
+    cwd: path.join(ROOT, 'web'), encoding: 'utf8',
+  });
+  if (build.status !== 0) throw new Error(`web build failed:\n${build.stdout}\n${build.stderr}`);
+}
+
+const backend = spawn('node', ['src/index.js'], {
+  cwd: HERE,
+  env: { ...process.env, PORT: '7897', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let logs = '';
+backend.stdout.on('data', (d) => { logs += d; });
+backend.stderr.on('data', (d) => { logs += d; });
+
+let browser;
+let feed;
+let id;
+try {
+  if (!await waitFor(() => fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false), 60_000)) {
+    throw new Error(`server did not start:\n${logs.slice(-2000)}`);
+  }
+  await fetch(`${API}/api/welcome/seen`, { method: 'POST' });
+  const created = await (await fetch(`${API}/api/sessions`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ cli: 'shell', name: 'terminal-ui-e2e', path: '.' }),
+  })).json();
+  id = created.id;
+  if (!id) throw new Error(`session creation failed: ${JSON.stringify(created)}`);
+
+  // Put the fixture text on screen before any browser attaches, so the pane is
+  // painted from the server's grid exactly as a reattaching client would be.
+  feed = new WebSocket(`ws://127.0.0.1:7897/ws?session=${id}&cols=120&rows=30`);
+  await new Promise((resolve, reject) => { feed.once('open', resolve); feed.once('error', reject); });
+  await sleep(400);
+  feed.send(JSON.stringify({ t: 'i', d: `printf 'docs at ${LINK} end\\nSELECT-ME-9137 tail\\n'\r` }));
+  if (!await waitFor(async () => (await tail(id)).includes('SELECT-ME-9137 tail'))) {
+    throw new Error('fixture output never reached the terminal');
+  }
+
+  browser = await chromium.launch({ headless: true });
+  const context = await browser.newContext({
+    viewport: { width: 1280, height: 800 },
+    permissions: ['clipboard-read', 'clipboard-write'],
+  });
+  // Serve the link locally: the assertion is about which URL was opened, and a
+  // test must not depend on reaching the public internet.
+  await context.route('https://example.com/**', (route) =>
+    route.fulfill({ status: 200, contentType: 'text/html', body: '<title>probe</title>ok' }));
+
+  const page = await context.newPage();
+  await page.goto(API, { waitUntil: 'domcontentloaded' });
+  await page.locator('.sidebar .row').filter({ hasText: 'terminal-ui-e2e' }).first().click();
+  const screen = page.locator('.tile-terminal:not(.tile-cached) .xterm-screen');
+  await screen.waitFor({ state: 'visible' });
+  await waitFor(async () => await page.evaluate(() =>
+    document.querySelector('.xterm-rows')?.textContent?.includes('SELECT-ME-9137')));
+
+  // Exact pixel rect of a substring on screen, via a DOM Range over the text
+  // node that holds it — no cell-size arithmetic to get wrong.
+  const rectOf = (needle) => page.evaluate((text) => {
+    const rows = [...document.querySelectorAll('.tile-terminal:not(.tile-cached) .xterm-rows > div')];
+    for (const row of rows) {
+      if (!row.textContent.includes(text)) continue;
+      const walker = document.createTreeWalker(row, NodeFilter.SHOW_TEXT);
+      for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        const at = node.textContent.indexOf(text);
+        if (at < 0) continue;
+        const range = document.createRange();
+        range.setStart(node, at);
+        range.setEnd(node, at + text.length);
+        const r = range.getBoundingClientRect();
+        return { x: r.x, y: r.y, width: r.width, height: r.height };
+      }
+    }
+    return null;
+  }, needle);
+
+  // ---------- 1. clickable links ----------
+  const linkRect = await rectOf(LINK);
+  let opened = null;
+  context.on('page', (p) => { opened = p; });
+  if (linkRect) {
+    await page.mouse.move(linkRect.x + linkRect.width / 2, linkRect.y + linkRect.height / 2);
+    await sleep(150); // let the link layer resolve the hover
+    await page.mouse.click(linkRect.x + linkRect.width / 2, linkRect.y + linkRect.height / 2);
+  }
+  await waitFor(() => opened !== null, 5_000);
+  const openedUrl = opened ? opened.url() : null;
+  check('clicking a URL in terminal output opens it in a new tab',
+    openedUrl === LINK, JSON.stringify({ openedUrl, hadRect: !!linkRect }));
+  if (opened) await opened.close();
+
+  // ---------- 2. a copy keeps the selection ----------
+  // Something long-running to interrupt later, started before the selection so
+  // the Ctrl+C presses below have a real process to reach.
+  // The marker is split with bash quoting on purpose: the tty echoes the typed
+  // command, so a verbatim marker would appear on screen without ever running.
+  // Only actual execution prints the joined string.
+  await page.keyboard.type('sleep 60 && echo NOT_""INTERRUPTED\n');
+  await sleep(600);
+  const wordRect = await rectOf('SELECT-ME-9137');
+  if (!wordRect) throw new Error('fixture word not found on screen');
+  const midY = wordRect.y + wordRect.height / 2;
+  await page.mouse.move(wordRect.x + 1, midY);
+  await page.mouse.down();
+  await page.mouse.move(wordRect.x + wordRect.width - 1, midY, { steps: 8 });
+  await page.mouse.up();
+  await sleep(200);
+  const selectionRects = () => page.evaluate(() =>
+    document.querySelectorAll('.tile-terminal:not(.tile-cached) .xterm-selection div').length);
+  const beforeCopy = await selectionRects();
+  await page.keyboard.press('Control+c');
+  await sleep(300);
+  const afterCopy = await selectionRects();
+  const clipboard = await page.evaluate(() =>
+    navigator.clipboard.readText().catch((e) => `ERR:${e.message}`));
+  check('copying a selection leaves the highlight in place',
+    beforeCopy > 0 && afterCopy > 0,
+    JSON.stringify({ beforeCopy, afterCopy }));
+  check('the copy still reaches the clipboard',
+    clipboard.includes('SELECT-ME-9137'), JSON.stringify({ clipboard: clipboard.slice(0, 60) }));
+
+  // ---------- 3. the copied selection stops shadowing SIGINT ----------
+  await page.keyboard.press('Control+c');
+  await sleep(800);
+  await page.keyboard.type('echo AFTER_""INTERRUPT\n');
+  const backAtPrompt = await waitFor(async () => (await tail(id)).includes('AFTER_INTERRUPT'));
+  const text = await tail(id);
+  check('a second Ctrl+C interrupts instead of copying again',
+    backAtPrompt && !text.includes('NOT_INTERRUPTED'),
+    JSON.stringify({ backAtPrompt, sleepSurvived: text.includes('NOT_INTERRUPTED') }));
+
+  // ---------- 4. Cmd+C is never an interrupt ----------
+  const second = await rectOf('AFTER_INTERRUPT');
+  if (second) {
+    const y2 = second.y + second.height / 2;
+    await page.mouse.move(second.x + 1, y2);
+    await page.mouse.down();
+    await page.mouse.move(second.x + second.width - 1, y2, { steps: 8 });
+    await page.mouse.up();
+    await sleep(200);
+    await page.keyboard.press('Meta+c');
+    await sleep(200);
+    await page.keyboard.press('Meta+c');
+    await sleep(200);
+    check('repeated Cmd+C keeps copying and keeps the selection',
+      (await selectionRects()) > 0, JSON.stringify({ rects: await selectionRects() }));
+  } else {
+    check('repeated Cmd+C keeps copying and keeps the selection', false, 'second fixture not found');
+  }
+} finally {
+  try { feed?.close(); } catch {}
+  try { await browser?.close(); } catch {}
+  backend.kill('SIGKILL');
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+}
+
+console.log(failures ? `\n${failures} FAILURE(S)` : '\nall checks passed');
+process.exit(failures ? 1 : 0);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -32,6 +32,7 @@
         "@lezer/highlight": "^1.2.3",
         "@xterm/addon-clipboard": "^0.1.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^5.5.0",
         "codemirror": "^6.0.2",
         "dompurify": "^3.4.11",
@@ -1961,6 +1962,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/xterm": {
       "version": "5.5.0",

--- a/web/package.json
+++ b/web/package.json
@@ -38,6 +38,7 @@
     "@codemirror/view": "^6.43.7",
     "@lezer/highlight": "^1.2.3",
     "@xterm/addon-clipboard": "^0.1.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-fit": "^0.10.0",
     "@xterm/xterm": "^5.5.0",
     "codemirror": "^6.0.2",

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { ClipboardAddon, Base64 } from '@xterm/addon-clipboard';
+import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import type { Cli, Session } from '../types';
 import { STATE_LABEL } from '../types';
@@ -283,6 +284,22 @@ export default function TerminalPane({
     // addon-clipboard@0.1.0 has a (base64, provider) runtime constructor but
     // types it as (provider) — construct positionally to match the runtime.
     term.loadAddon(new (ClipboardAddon as unknown as new (b: Base64, p: typeof clipboardProvider) => ClipboardAddon)(new Base64(), clipboardProvider));
+    // Make URLs in agent output clickable. An anchor click rather than
+    // window.open: with noopener requested window.open returns null whether it
+    // succeeded or was blocked, so there is no way to tell, and layering a
+    // fallback behind it opens the link twice. noopener/noreferrer keep the
+    // opened page from reaching back into the app through window.opener.
+    term.loadAddon(new WebLinksAddon((event, uri) => {
+      if (event?.defaultPrevented) return;
+      const a = document.createElement('a');
+      a.href = uri;
+      a.target = '_blank';
+      a.rel = 'noopener noreferrer';
+      a.style.display = 'none';
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    }));
     term.open(hostRef.current!);
     termRef.current = term;
     const host = hostRef.current!;
@@ -328,8 +345,13 @@ export default function TerminalPane({
 
     // Track the committed local xterm selection so Cmd/Ctrl+C can copy it
     // synchronously — deferring (setTimeout) would break execCommand's gesture.
+    // The selection we have already put on the clipboard. A copy now leaves the
+    // highlight in place, so without this a selection would shadow Ctrl+C's
+    // SIGINT for as long as it stayed on screen.
+    let copiedSelection = '';
     const selSub = term.onSelectionChange(() => {
       lastSelection = term.hasSelection() ? selectionText(term) : '';
+      copiedSelection = ''; // a fresh selection is copyable again
     });
     const copySelection = () => {
       const text = term.hasSelection() ? selectionText(term) : lastSelection;
@@ -382,8 +404,15 @@ export default function TerminalPane({
     term.attachCustomKeyEventHandler((e) => {
       if (e.type !== 'keydown') return true;
       if ((e.metaKey || e.ctrlKey) && (e.key === 'c' || e.key === 'C') && term.hasSelection()) {
+        // The highlight stays after copying — watching it vanish the instant you
+        // copy reads as "did that work?", and every other app keeps it. What it
+        // must not do is shadow SIGINT forever, so a second Ctrl+C on a
+        // selection we already copied goes to the process instead. Cmd+C is
+        // never an interrupt, so it just copies again.
+        const text = selectionText(term);
+        if (e.ctrlKey && !e.metaKey && text && text === copiedSelection) return true;
         copySelection();
-        term.clearSelection();
+        copiedSelection = text;
         return false;
       }
       if (e.metaKey && (e.key === 'c' || e.key === 'C')) {


### PR DESCRIPTION
Two small terminal-pane fixes.

## Clickable links

URLs in agent output were inert text. This loads xterm's web-links addon, so
they underline on hover and open in a new tab.

The activation handler uses a synthetic anchor click rather than `window.open`.
With `noopener` requested, `window.open` returns `null` whether it opened the tab
or the embedding iframe blocked the popup — there is no way to tell the two
apart, so layering an anchor fallback behind it opens the link twice.
`noopener`/`noreferrer` keep the opened page from reaching back into the app
through `window.opener`.

## A selection that survives being copied

Copying cleared the selection the instant it copied, which reads as "did that
even work?". The highlight now stays.

It was not cleared for no reason: Ctrl+C copies when a selection exists, so a
selection left on screen would shadow SIGINT for as long as it was up — you
could not interrupt a process while some text happened to be selected. So the
copied text is remembered, and a selection we have already copied stops
shadowing the interrupt: the second Ctrl+C goes to the process. Any new
selection is copyable again, and Cmd+C is never an interrupt, so it just keeps
copying.

The one behaviour change worth knowing: with text selected, the *first* Ctrl+C
copies and the *second* interrupts.

## Testing

`server/terminal-ui.test.mjs` (new, `npm run test:ui`) drives a real browser at
1280×800 and covers both, plus the interrupt tradeoff:

- clicking a URL opens a new tab at that URL (the request is intercepted locally,
  so the test does not depend on reaching the internet)
- the highlight is still rendered after Ctrl+C, and the text reached the clipboard
- a second Ctrl+C interrupts a running `sleep` instead of copying again
- repeated Cmd+C keeps copying and keeps the selection

Its markers are split with bash quoting (`NOT_""INTERRUPTED`) because the tty
echoes whatever the test types: a verbatim marker appears on screen without ever
having run, which made the interrupt check pass for the wrong reason at first.

Also green: `npm test` (repin, opencode-resume, migration, resize) and
`mobile.test.mjs`, which is the regression guard for touching `TerminalPane`.

Not verified: how links behave inside Hugging Face's cross-origin iframe, which
is where the app usually runs — the anchor click is chosen for that case but the
test runs top-level. Worth one manual click on a Space before trusting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
