### PR TITLE
Bucket backup: a skip list for folders that are slow and worth nothing

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -63,7 +63,17 @@ the bucket, ever.
    nothing. The dataset gets `--delete "*"` so its *newest* commit matches the
    bucket, while every earlier commit keeps the deleted file recoverable — the
    best of both.
-9. **Restore is a documented script, not a button** (§8).
+9. **The skip list applies to the history, not the mirror.** `hf cp` cannot
+   filter (§3.9), and making the mirror filterable would cost the server-side copy
+   that makes it nearly free. The dataset is where thousands of env files actually
+   hurt — every one of them gets hashed on every run — so that is where they are
+   skipped.
+10. **Skip tokens are folder names, expanded server-side.** A bare name becomes
+   both `name/**` and `**/name/**`, because the second does not imply the first
+   (§3.8). Tokens are validated to hold no whitespace or shell characters: they
+   cross into the Job as one space-joined env var and the shell splits them back
+   apart, so the charset is what makes that split exact.
+11. **Restore is a documented script, not a button** (§8).
 
 ## 2. What we already have
 
@@ -162,6 +172,43 @@ The dataset received **no new commit**. This is the one control standing between
 the operator's saved logins and the public internet, so it is verified rather
 than assumed.
 
+### 3.8 Excluding folders: `--exclude` works, and the glob rule surprises
+
+`hf upload` takes repeatable `--exclude` globs, and they do what you want — but
+**`**/env/**` does not match a top-level `env/`**:
+
+| patterns | `env/` at root | `sub/env/` |
+|---|---|---|
+| `**/env/**` | **kept** | excluded |
+| `env/**` + `**/env/**` | excluded | excluded |
+
+So a bare folder token has to become two patterns. With only the `**/` form the
+copy at the bucket root still goes up, which is exactly the case an operator means
+when they type `node_modules`.
+
+What it saves, measured on an 805-file tree (800 of them a `.venv`):
+
+| | files hashed | wall |
+|---|---|---|
+| no excludes | 805 | **7 s** |
+| `.venv` excluded | 5 | **1 s** |
+
+That is local disk; the Job reads a FUSE mount, which is slower, so the real
+saving is larger than this.
+
+### 3.9 The server-side mirror cannot filter
+
+`hf cp` has no `--include/--exclude` at all, and `hf sync` refuses remote→remote
+("One path must be local"). So the skip list applies to the **dataset history
+only** — the mirror is a whole-bucket server-side copy or nothing.
+
+It could be filtered: inside the Job the bucket is mounted at `/live`, so
+`hf buckets sync /live hf://buckets/<mirror>/latest --exclude … --delete` is a
+*local*→remote sync and does support patterns. It would also throw away the
+property that makes the mirror nearly free — no bytes move, hashes only, 13,482
+files in 20 s — and make it read and re-upload 11.4 GB instead. Not worth it for
+files nobody wanted anyway. §10.9.
+
 ### 3.7 Incidental
 
 `pip install "huggingface_hub[cli]"` warns on 1.26.0 — *"does not provide the
@@ -234,12 +281,14 @@ backup: {
   every: 'never' | '1h' | '3h' | '24h',   // default 'never' (§1.7)
   mirror: '',                              // default <ns>/<space>-backup
   dataset: '',                             // default <ns>/<space>-backup
+  exclude: [],                             // folder tokens kept out of the history
 }
 ```
 
 ```
 GET  /api/backup/status  → { every, source, mirror, dataset, defaults, hasToken,
                              canRunNow, running, unavailable,
+                             exclude, excludePatterns,
                              last: { at, jobId, stage }, nextDue,
                              datasetPrivate, error }
 POST /api/backup/run     → launch one Job now (works with the schedule off)
@@ -276,6 +325,9 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   Backup jobs       am-backup-am-dev-2          -> every run of this Space's backup
   Last updated      4 Aug 19:35                 -- a timestamp, never a stage
 
+  Skip these folders — type a name and press Enter
+  [ node_modules × ] [ .venv × ] [ add another…            ]
+
   [ Back up now ]        <- available whenever there is a token, schedule or not;
                             reads "Backing up..." and is disabled while one runs
 ```
@@ -294,6 +346,12 @@ which the Hub keeps as a `name=` label, so
 failed. Strictly better than linking the latest job id: no state to track, and the
 page you land on shows a failure in context. A test pins the launch name and the
 filter to the same value so they cannot drift.
+
+**The skip field is a token field**, because that is what the data is: a short
+list of folder names, each independently removable. Enter or comma commits,
+Backspace on an empty box takes the last one back. The status API also reports the
+expanded globs — a skip list nobody can see the expansion of is one nobody can
+debug, and §3.8 is why the expansion is not obvious.
 
 **No stage in the table.** It read `(running)` for runs that had long finished,
 because `stage || 'RUNNING'` invented an answer whenever the Hub did not give one.
@@ -383,6 +441,13 @@ knows which side should win.
 6. **Sustained hourly Job volume** over weeks is unproven, as is the interaction
    with the Job quota on a free account.
 7. **Bucket→repo is on the roadmap** (§3.1) — re-check before elaborating step 2.
+
+### 10.9 The mirror still holds what the history skips
+
+Excluded folders stay in the bucket mirror (§3.9), so they still occupy its
+storage, and a restore from the mirror brings them back. That is arguably right —
+the mirror exists to put a Space back exactly as it was — but it means "skip" means
+"skip in the history", and the settings copy says so rather than implying more.
 
 ## 11. Phasing
 

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -59,6 +59,51 @@ export const hasToken = () => !!(process.env.HF_TOKEN || process.env.HUGGING_FAC
 const ID_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
 export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_RE.test(s);
 
+// Folders the operator does not want in the history: the slow, regenerable kind
+// (`node_modules`, `.venv`, `env`) that turn one backup into thousands of file
+// hashes. Measured on 805 files: 7s without, 1s with them excluded — and a real
+// bucket's mount is slower than a local disk, so the saving is larger there.
+//
+// Tokens are folder names, or raw globs for anything finer. No whitespace and no
+// shell metacharacters: these are joined into one env var and split apart again
+// inside the Job, so the charset is what makes that split exact.
+const EXCLUDE_RE = /^[A-Za-z0-9._*?/-]+$/;
+export const MAX_EXCLUDES = 40;
+
+export function normalizeExclude(list) {
+  if (!Array.isArray(list)) return [];
+  const out = [];
+  for (const raw of list) {
+    if (typeof raw !== 'string') continue;
+    // Leading and trailing slashes are noise: `/env/` and `env` mean the same.
+    const t = raw.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!t || t.length > 64 || !EXCLUDE_RE.test(t)) continue;
+    if (!out.includes(t)) out.push(t);
+  }
+  return out.slice(0, MAX_EXCLUDES);
+}
+
+/**
+ * Tokens -> `hf upload --exclude` globs.
+ *
+ * A bare name becomes TWO patterns, which is not obvious: `**\/env/**` does not
+ * match a top-level `env/`, verified against the Hub — `**\/` needs at least one
+ * leading segment. So excluding `env` needs `env/**` as well, or the copy at the
+ * bucket root silently still goes up.
+ *
+ * A token with a slash is a path and anchors at the bucket root; one containing
+ * `*` or `?` is already a glob and is passed through untouched.
+ */
+export function excludePatterns(tokens) {
+  const pats = [];
+  for (const t of normalizeExclude(tokens)) {
+    if (t.includes('*') || t.includes('?')) pats.push(t);
+    else if (t.includes('/')) pats.push(`${t}/**`);
+    else pats.push(`${t}/**`, `**/${t}/**`);
+  }
+  return pats;
+}
+
 function run(args, { timeout = 120_000 } = {}) {
   return new Promise((resolve, reject) => {
     execFile('hf', args, { timeout, env: process.env, maxBuffer: 8 << 20 }, (err, stdout, stderr) => {
@@ -134,11 +179,26 @@ if [ -n "\${AM_MIRROR:-}" ]; then
   hf cp "hf://buckets/\$AM_SOURCE/" "hf://buckets/\$AM_MIRROR/latest/"
 fi
 
+# Folders the operator asked to skip, as one --exclude per pattern. read -ra
+# splits on the spaces the server joined them with and nothing else: no globbing
+# against the container's filesystem, and each pattern reaches hf as a single
+# quoted argv element. Patterns are validated server-side to hold no whitespace,
+# which is what makes this split exact.
+EXCLUDE_ARGS=()
+if [ -n "\${AM_EXCLUDE:-}" ]; then
+  read -ra AM_EXCLUDE_PATS <<< "\$AM_EXCLUDE"
+  for p in "\${AM_EXCLUDE_PATS[@]}"; do EXCLUDE_ARGS+=(--exclude "\$p"); done
+  echo "skipping: \$AM_EXCLUDE"
+fi
+
 # 2. Version history, read from the bucket mounted read-only at /live — the
 #    Hub's copy, not this Space's disk. Unchanged files transfer nothing and
 #    produce no commit at all; --delete makes the newest commit match the bucket
-#    while every earlier commit keeps deleted files recoverable.
+#    while every earlier commit keeps deleted files recoverable — including
+#    anything newly excluded, which drops out of the newest commit but stays
+#    recoverable in the ones before it.
 hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
+  "\${EXCLUDE_ARGS[@]}" \\
   --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
 `;
 
@@ -167,7 +227,7 @@ export function parseJobId(out) {
 
 // Job arguments, as an array (never a shell string). Exported for the tests:
 // asserting on this is how we know a config value cannot reach a shell.
-export function jobArgs({ source, mirror, dataset }) {
+export function jobArgs({ source, mirror, dataset, exclude = [] }) {
   return [
     'jobs', 'run', '--detach',
     '--name', jobName(),
@@ -175,6 +235,9 @@ export function jobArgs({ source, mirror, dataset }) {
     '-e', `AM_SOURCE=${source}`,
     '-e', `AM_MIRROR=${mirror || ''}`,
     '-e', `AM_DATASET=${dataset}`,
+    // Space-joined: the tokens are validated to contain no whitespace, so the
+    // Job can split them back apart exactly.
+    '-e', `AM_EXCLUDE=${excludePatterns(exclude).join(' ')}`,
     // Read-only: a backup must not be able to write to what it is reading.
     '-v', `hf://buckets/${source}:/live:ro`,
     '--flavor', JOB_FLAVOR,
@@ -208,7 +271,7 @@ async function targets(cfg) {
   const d = await defaultsFor();
   const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
   const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
-  return { mirror, dataset, defaults: d };
+  return { mirror, dataset, defaults: d, exclude: normalizeExclude(cfg?.backup?.exclude) };
 }
 
 /** Launch one backup Job now. Returns { job } — the Hub does the rest. */
@@ -220,7 +283,7 @@ export async function runBackupNow(cfg) {
   // loud rather than silently doing nothing.
   if (await isRunning()) throw new Error('a backup is already running');
   const source = sourceBucket();
-  const { mirror, dataset } = await targets(cfg);
+  const { mirror, dataset, exclude } = await targets(cfg);
   for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
     if (label === 'mirror' && !id) continue;
     if (!validRepoId(id)) throw new Error(`${label} "${id}" is not a valid repo id`);
@@ -229,7 +292,7 @@ export async function runBackupNow(cfg) {
   // it; the dataset is created private by the upload itself.
   if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
 
-  const out = await run(jobArgs({ source, mirror, dataset }), { timeout: 180_000 });
+  const out = await run(jobArgs({ source, mirror, dataset, exclude }), { timeout: 180_000 });
   const job = parseJobId(out);
   // A launch we cannot identify still happened — record it, but say so, because
   // without an id there is nothing to poll and no overlap to detect.
@@ -317,7 +380,7 @@ export async function backupStatus(cfg) {
   const state = loadState();
   const every = cfg?.backup?.every || 'never';
   const source = sourceBucket();
-  const { mirror, dataset, defaults } = await targets(cfg);
+  const { mirror, dataset, defaults, exclude } = await targets(cfg);
   // Not gated on the interval: an on-demand backup is a real backup, and its
   // result has to be visible even with the schedule off.
   const [stage, priv] = await Promise.all([
@@ -339,6 +402,10 @@ export async function backupStatus(cfg) {
       : null,
     jobName: jobName(),
     jobsUrl: jobsUrl(),
+    // The tokens as stored, and the globs they become — a skip list nobody can
+    // see the expansion of is a skip list nobody can debug.
+    exclude,
+    excludePatterns: excludePatterns(exclude),
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -901,6 +901,8 @@ function loadAmConfig() {
       every: backup.INTERVALS.includes(saved.backup?.every) ? saved.backup.every : 'never',
       mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
+      // Folder names to keep out of the history — the slow, regenerable kind.
+      exclude: backup.normalizeExclude(saved.backup?.exclude),
     },
   };
 }
@@ -919,6 +921,8 @@ app.put('/api/config', (req, res) => {
       every: backup.INTERVALS.includes(b.backup?.every) ? b.backup.every : 'never',
       mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
+      // Normalized here, not trusted: these end up in a Job's argument list.
+      exclude: backup.normalizeExclude(b.backup?.exclude),
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -3,7 +3,63 @@ import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
+  normalizeExclude, excludePatterns, MAX_EXCLUDES,
 } from '../src/backup.js';
+
+// The rule that is not obvious and cost a Hub round-trip to learn: `**/x/**` does
+// NOT match a top-level `x/`, so a bare folder token needs BOTH patterns. Verified
+// against the Hub — with only the `**/` form, the copy at the bucket root still
+// went up.
+test('a bare folder token excludes it at the root AND nested', () => {
+  assert.deepEqual(excludePatterns(['env']), ['env/**', '**/env/**']);
+  assert.deepEqual(excludePatterns(['node_modules', '.venv']),
+    ['node_modules/**', '**/node_modules/**', '.venv/**', '**/.venv/**']);
+});
+
+test('a path anchors at the root, and an explicit glob is left alone', () => {
+  // A slash means "this exact place", so it is not also matched anywhere.
+  assert.deepEqual(excludePatterns(['state/claude/cache']), ['state/claude/cache/**']);
+  // Already a glob: passed through untouched, however odd.
+  assert.deepEqual(excludePatterns(['**/*.pyc']), ['**/*.pyc']);
+  assert.deepEqual(excludePatterns(['cache-*']), ['cache-*']);
+  assert.deepEqual(excludePatterns([]), []);
+  assert.deepEqual(excludePatterns(undefined), []);
+});
+
+test('normalizeExclude tidies input and refuses anything shell-shaped', () => {
+  // Slashes at either end are noise; duplicates and blanks go.
+  assert.deepEqual(normalizeExclude(['  env  ', '/env/', 'env', '', '   ']), ['env']);
+  assert.deepEqual(normalizeExclude(['a', 'b']), ['a', 'b']);
+  // Whitespace is what the Job's split relies on NOT being there.
+  for (const bad of ['two words', 'tab\there', 'new\nline']) {
+    assert.deepEqual(normalizeExclude([bad]), [], `${JSON.stringify(bad)} must be dropped`);
+  }
+  for (const bad of ['$(whoami)', '`id`', 'a;rm -rf /', 'a|b', 'a&b', "a'b", 'a"b', '<a', 'x'.repeat(65)]) {
+    assert.deepEqual(normalizeExclude([bad]), [], `${bad} must be dropped`);
+  }
+  // Non-strings and non-arrays cannot crash it.
+  assert.deepEqual(normalizeExclude([42, null, undefined, {}, 'ok']), ['ok']);
+  assert.deepEqual(normalizeExclude('env'), []);
+  // Unbounded lists are not a thing an operator needs.
+  assert.equal(normalizeExclude(Array.from({ length: 100 }, (_, i) => `d${i}`)).length, MAX_EXCLUDES);
+});
+
+// The patterns cross into the Job as one space-joined env var and are split back
+// apart by the shell. If either side of that contract changes, this fails.
+test('patterns reach the Job as one env var the shell can split exactly', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', exclude: ['env', 'node_modules'] });
+  const env = args[args.indexOf('AM_EXCLUDE=env/** **/env/** node_modules/** **/node_modules/**')];
+  assert.ok(env, `AM_EXCLUDE not passed as expected; got ${JSON.stringify(args.filter((a) => String(a).startsWith('AM_')))}`);
+  // No pattern may contain whitespace, or the split inside the Job is wrong.
+  for (const pat of excludePatterns(['env', 'node_modules'])) assert.ok(!/\s/.test(pat));
+  // Nothing to skip is an empty value, not a missing variable.
+  const none = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  assert.ok(none.includes('AM_EXCLUDE='));
+  // And the script must build the args itself rather than have them interpolated.
+  assert.match(JOB_SCRIPT, /read -ra AM_EXCLUDE_PATS/);
+  assert.match(JOB_SCRIPT, /EXCLUDE_ARGS\+=\(--exclude "\$p"\)/);
+  assert.ok(!JOB_SCRIPT.includes('node_modules/**'), 'patterns must not be baked into the script');
+});
 
 // The image installs huggingface_hub unpinned, so the CLI in the Space is not the
 // one on a dev machine. A version whose launch output differs left jobId null,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -78,7 +78,7 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
-  backup: { every: BackupEvery; mirror: string; dataset: string };
+  backup: { every: BackupEvery; mirror: string; dataset: string; exclude: string[] };
   defaultArtifactsSpace?: string;
 }
 export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json);
@@ -103,6 +103,9 @@ export interface BackupStatus {
   // needs a job id to link to them.
   jobName: string;
   jobsUrl: string;
+  // The tokens as stored, and the globs they expand to.
+  exclude: string[];
+  excludePatterns: string[];
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -182,6 +182,7 @@ export default function SettingsView({
   const [bk, setBk] = useState<api.BackupStatus | null>(null);
   const [bkBusy, setBkBusy] = useState(false);
   const [bkMsg, setBkMsg] = useState('');
+  const [skipDraft, setSkipDraft] = useState('');
   const loadBackup = () => api.backupStatus().then(setBk).catch(() => {});
   useEffect(() => { loadBackup(); }, []);
   // Re-read after a save lands, so the interval and privacy dot stop disagreeing
@@ -194,6 +195,16 @@ export default function SettingsView({
     const t = setInterval(loadBackup, 10_000);
     return () => clearInterval(t);
   }, [bk?.running]);
+  // One token per commit, deduped, whitespace and shell characters dropped — the
+  // server normalizes again, since it is the side that must not be trusted.
+  const addSkip = () => {
+    if (!cfg) return;
+    const t = skipDraft.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+    setSkipDraft('');
+    if (!t || !/^[A-Za-z0-9._*?/-]+$/.test(t) || cfg.backup.exclude.includes(t)) return;
+    setCfg({ ...cfg, backup: { ...cfg.backup, exclude: [...cfg.backup.exclude, t] } });
+  };
+
   const doBackup = async () => {
     setBkBusy(true);
     setBkMsg('');
@@ -456,6 +467,49 @@ export default function SettingsView({
                         before a risky change should not mean switching on a
                         schedule. Disabled while a run is in flight — two Jobs
                         uploading to one dataset would race. */}
+                    {/* Folders to keep out of the history. An env directory is
+                        thousands of files the backup has to hash and none of them
+                        worth keeping — measured, that is 7s of work versus 1s. */}
+                    {bk?.canRunNow && (
+                      <>
+                        <div className="s-help" style={{ marginTop: 10 }}>
+                          Skip these folders — type a name and press Enter. Anywhere they appear
+                          (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
+                          they stay out of the history and the backup gets quicker.
+                        </div>
+                        <div className="tagf" onClick={(e) => {
+                          if (e.target === e.currentTarget) (e.currentTarget.querySelector('input') as HTMLInputElement)?.focus();
+                        }}>
+                          {cfg.backup.exclude.map((t) => (
+                            <span className="tagf-chip mono" key={t}>
+                              {t}
+                              <button
+                                className="tagf-x"
+                                aria-label={`Stop skipping ${t}`}
+                                onClick={() => setCfg({ ...cfg, backup: { ...cfg.backup, exclude: cfg.backup.exclude.filter((x) => x !== t) } })}
+                              >×</button>
+                            </span>
+                          ))}
+                          <input
+                            className="tagf-input mono"
+                            placeholder={cfg.backup.exclude.length ? 'add another…' : 'node_modules'}
+                            value={skipDraft}
+                            onChange={(e) => setSkipDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                              // Enter or comma commits; Backspace on an empty box
+                              // takes the last chip back, as tag fields do.
+                              if (e.key === 'Enter' || e.key === ',') {
+                                e.preventDefault();
+                                addSkip();
+                              } else if (e.key === 'Backspace' && !skipDraft && cfg.backup.exclude.length) {
+                                setCfg({ ...cfg, backup: { ...cfg.backup, exclude: cfg.backup.exclude.slice(0, -1) } });
+                              }
+                            }}
+                            onBlur={addSkip}
+                          />
+                        </div>
+                      </>
+                    )}
                     {bk?.canRunNow && (
                       <button
                         className="btn-ghost"

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -871,6 +871,15 @@ body {
 .cfg-seg button { flex: 1; padding: 6px 0; }
 .cfg-input { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); color: var(--text); font-size: 12.5px; }
 .cfg-input:focus { outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); border-color: var(--accent); }
+/* Token field: chips plus a bare input, sharing one bordered box so it reads as
+   a single control rather than a list next to a textbox. */
+.tagf { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 8px; padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
+.tagf:focus-within { border-color: var(--accent); outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); }
+.tagf-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 4px 2px 7px; border-radius: var(--r-sm); background: var(--panel-2); border: 1px solid var(--border); font-size: 12px; }
+.tagf-x { border: none; background: transparent; color: var(--muted); cursor: pointer; font-size: 13px; line-height: 1; padding: 0 2px; }
+.tagf-x:hover { color: var(--danger); }
+.tagf-input { flex: 1; min-width: 120px; border: none; background: transparent; color: var(--text); font-size: 12.5px; padding: 3px 2px; }
+.tagf-input:focus { outline: none; }
 .cfg-usd { color: var(--muted); }
 .cfg-num { width: 90px; flex: none; text-align: right; }
 /* artifacts sub-settings stay visible when off, just clearly inert */


### PR DESCRIPTION
## What this adds

A token field for folder names to keep out of the backup, on top of the mechanism
from #26. An env directory is thousands of files the Job has to hash on every run,
and not one of them is worth keeping.

```
Skip these folders — type a name and press Enter
[ node_modules × ] [ .venv × ] [ add another…            ]
```

Enter or comma commits, `×` removes, Backspace on an empty box takes the last one
back. Tokens are stored in `am-config.json` under `backup.exclude` and normalized
on both read and write.

**What it saves**, measured on an 805-file tree (800 of them a `.venv`):

| | files hashed | wall |
|---|---|---|
| no excludes | 805 | **7 s** |
| `.venv` skipped | 5 | **1 s** |

That is local disk. The Job reads a FUSE mount, which is slower, so the real
saving is larger.

## The glob rule, which is not obvious

`hf upload` takes repeatable `--exclude` globs, but **`**/env/**` does not match a
top-level `env/`** — verified against the Hub:

| patterns | `env/` at root | `sub/env/` |
|---|---|---|
| `**/env/**` | **kept** | excluded |
| `env/**` + `**/env/**` | excluded | excluded |

So a bare token expands to **both** patterns. With only the `**/` form, the copy at
the bucket root still goes up — exactly the case someone means when they type
`node_modules`. A token containing a slash anchors at the root (`state/claude/cache`
→ `state/claude/cache/**`); one already containing `*` or `?` is passed through
untouched.

The status API reports `exclude` (tokens) and `excludePatterns` (the expansion),
because a skip list nobody can see the expansion of is one nobody can debug.

## Scope: history, not the mirror

The skip list applies to the **dataset history only**. `hf cp` has no
`--include/--exclude` at all, and `hf sync` refuses remote→remote.

The mirror *could* be filtered — inside the Job the bucket is mounted at `/live`, so
`hf buckets sync /live hf://buckets/<mirror>/latest --exclude …` is a local→remote
sync and does support patterns. It would also throw away the property that makes
the mirror nearly free: no bytes move, hashes only, 13,482 files in 20 s. Filtering
it would mean reading and re-uploading 11.4 GB instead, which is a bad trade for
files nobody wanted. So excluded folders still occupy mirror storage and still come
back on a mirror restore, and the settings copy says "stay out of the history"
rather than implying more.

## Safety

Patterns cross into the Job as one space-joined env var and the shell splits them
back apart, so the token charset is what makes that split exact: no whitespace, no
shell metacharacters, 64 chars, 40 tokens max, deduped, leading/trailing slashes
stripped. Validated in the browser *and* server-side, since the server is the side
that must not trust its input.

The script builds the argv itself rather than having patterns interpolated:

```bash
read -ra AM_EXCLUDE_PATS <<< "$AM_EXCLUDE"
for p in "${AM_EXCLUDE_PATS[@]}"; do EXCLUDE_ARGS+=(--exclude "$p"); done
```

Checked in bash *inside a directory containing `env/` and `node_modules/`* to prove
the patterns are not glob-expanded against the container, and with the variable
empty and unset under `set -u` (both give `argc=0`).

Newly excluded folders drop out of the newest commit via the existing
`--delete "*"`, and stay recoverable in the commits before it.

## Verified

End to end with a real Job against the dev bucket, using the real script:

```
skipping: home/** **/home/** state/** **/state/**
Found 30 files to upload          ← bucket holds 61
✓ Uploaded
EXCLUDED FOLDERS LEAKED: none
```

Tokens `['home', 'state', '  /state/  ', 'state']` normalized to `['home','state']`
on the way in, so the dedupe and slash-stripping are exercised too.

The field itself was driven in a headless browser: `Enter` adds a chip, `two words`
is refused, `×` removes.

- 17 tests pass (4 new: the two-pattern rule, path/glob passthrough, normalization
  including shell-shaped input, and that patterns reach the Job as an env var the
  shell can split exactly — with an assertion that they are *not* baked into the
  script).
- `tsc --noEmit` and the web build are clean.
- `server/test/repin.test.mjs` fails in a fresh clone for want of `node-pty`,
  identically on `main` — a missing `npm install`, not this change.
- The probe dataset created while verifying was deleted.

## Not done

- **No presets.** Typing `node_modules` and `.venv` is two actions, and guessing a
  default skip list for someone else's bucket seemed worse than letting them say.
  Easy to add if you want them pre-filled on first run.
- **No effect on an existing history.** Excluded folders already committed stay in
  earlier commits — by design, since that is what history is for — so the dataset
  does not shrink retroactively. `super_squash_history` is the tool for that, and it
  remains undecided (§9).
- The skip field is only shown when a backup could actually run (token + mounted
  bucket), the same gate as the table and the button.

Design, measurements and the glob evidence: `docs/bucket-backup.md` §3.8, §3.9, §10.9.
