### PR TITLE
Bucket backup: say so on the dashboard when it is failing

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -162,6 +162,34 @@ The dataset received **no new commit**. This is the one control standing between
 the operator's saved logins and the public internet, so it is verified rather
 than assumed.
 
+### 3.8 What actually fails on a real bucket
+
+This Space's backups had been failing for a day before anyone noticed, which is
+the whole reason §7.1 exists. Two separate causes, from the Job logs:
+
+**The Hub refuses `.cache/` paths.** The mirror step succeeds, then:
+
+```
+✓ Copied
+Error: Invalid value. Invalid `path_in_repo` in CommitOperation:
+cannot update files under a '.cache/' folder
+(path: 'home/.cache/claude-cli-nodejs/…/2026-07-09T08-43-35-094Z.jsonl')
+```
+
+A bucket with an agent cache under `home/.cache/` can therefore *never* produce a
+dataset commit. `lvwerra/agent-manager-backup` held exactly one commit — "initial
+commit" — for a day of hourly runs.
+
+**The walk does not fit the job.** Failed runs show `Job timeout` after 1h33m to
+2h7m, against a `--timeout 3000s` (50 min) we asked for — so that flag is not
+being honoured either, and something around 1h30m is. Successful runs on a
+49-file bucket take 14–17 s; this bucket is 102,691 files on a FUSE mount.
+
+Excluding `.cache`, `node_modules`, `.venv` and `__pycache__` was **still running
+after 40 minutes** with no "Found N files" line, i.e. still walking. So exclusions
+fix the `.cache` rejection but may not fix the walk: `hf upload` appears to
+enumerate the tree before filtering it. Unresolved — §10.10.
+
 ### 3.7 Incidental
 
 `pip install "huggingface_hub[cli]"` warns on 1.26.0 — *"does not provide the
@@ -333,6 +361,29 @@ The privacy dots are not decoration: they are the state of the §1.4 gate, and t
 one thing an operator must be able to see at a glance about a copy of their
 credentials.
 
+## 7.1 Making failure visible
+
+A backup that fails quietly is worse than no backup, because the operator stops
+thinking about it. Nothing wrote a failure down before: the settings row learned of
+one only if somebody happened to open it, and `/api/backup/status` asked the Hub
+live rather than remembering.
+
+- **The timer records how each run ended**, once per job id, into
+  `backup-state.json`: stage, the platform's message, and one line of reason
+  lifted from the Job's own logs. That is where "cannot update files under a
+  '.cache/' folder" comes from — the platform only says `Job timeout`, which tells
+  an operator nothing about what to do.
+- **`/api/info` carries a health object**, or null when all is well. It is read
+  from state, never the Hub, because every open tab polls that route every 15
+  seconds. Withheld while the Space is public, like `secrets`.
+- **A strip above the stage**, on every view, not dismissible — a dismissed
+  warning is silence again, and silence is the failure mode. It shows the reason,
+  links to the filtered jobs list, and opens Settings.
+- **Staleness counts as unwell.** Three intervals with no successful run raises the
+  strip even when nothing errored. A timer that never fires, or a token that went
+  bad, leaves an operator exactly as wrongly confident as a failing run — and looks
+  perfectly healthy without this check.
+
 ## 8. Restore
 
 The direction the Hub *does* support server-side, pleasingly:
@@ -383,6 +434,17 @@ knows which side should win.
 6. **Sustained hourly Job volume** over weeks is unproven, as is the interaction
    with the Job quota on a free account.
 7. **Bucket→repo is on the roadmap** (§3.1) — re-check before elaborating step 2.
+
+### 10.10 The walk may not fit any job
+
+Failed runs on this bucket are killed around 1h30m (§3.8), and `--timeout 3000s`
+is not honoured. Excluding the obvious noise did not visibly shorten the walk in a
+40-minute observation, which suggests `hf upload` enumerates before it filters. If
+that holds, the fix is not a longer list of exclusions but a different step 2 —
+uploading a subtree at a time, or letting the mirror be the only whole-bucket copy
+and giving the dataset a narrower job (sessions, config, transcripts) rather than
+everything. Undecided, and the reason §7.1 matters in the meantime: the operator
+should be told it is broken even while it stays broken.
 
 ## 11. Phasing
 

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -234,18 +234,68 @@ export async function runBackupNow(cfg) {
   // A launch we cannot identify still happened — record it, but say so, because
   // without an id there is nothing to poll and no overlap to detect.
   if (!job) console.warn('[backup] launched a Job but could not parse its id from:', out.slice(0, 200));
-  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null });
+  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null, outcomeFor: null });
   return { job };
+}
+
+/** Stage and the platform's own message for a Job — "Job timeout" lives in the
+ *  message, and it is the difference between "it broke" and "it never finished". */
+async function jobStatus(jobId) {
+  if (!jobId) return { stage: null, message: null };
+  try {
+    const j = JSON.parse(await run(['jobs', 'inspect', jobId, '--json'], { timeout: 30_000 }));
+    const s = Array.isArray(j) ? j[0] : j;
+    return { stage: (s && s.status && s.status.stage) || null, message: (s && s.status && s.status.message) || null };
+  } catch { return { stage: null, message: null }; }
 }
 
 /** Terminal state of the last launched Job, or null while it is still going. */
 async function jobStage(jobId) {
-  if (!jobId) return null;
+  return (await jobStatus(jobId)).stage;
+}
+
+/**
+ * Why a run failed, in one line, from its own logs.
+ *
+ * The platform message says "Job timeout"; the logs say the bucket has a
+ * `.cache/` path the Hub will not commit. The second is the one that tells an
+ * operator what to do, so both are kept and this is the one shown first.
+ */
+async function failureReason(jobId) {
   try {
-    const j = JSON.parse(await run(['jobs', 'inspect', jobId, '--json'], { timeout: 30_000 }));
-    const s = Array.isArray(j) ? j[0] : j;
-    return (s && s.status && s.status.stage) || null;
+    const out = await run(['jobs', 'logs', jobId], { timeout: 90_000 });
+    const lines = out.split('\n').map((l) => l.trim())
+      .filter((l) => l && !/^(WARNING|Hint:|\[notice\])/.test(l));
+    const telling = [...lines].reverse()
+      .find((l) => /error|refus|denied|invalid|cannot|failed|timeout/i.test(l));
+    return (telling || lines[lines.length - 1] || '').slice(0, 300) || null;
   } catch { return null; }
+}
+
+/**
+ * Record how the last run ended, once, so the answer survives in state instead
+ * of needing a Hub call to discover.
+ *
+ * This is the whole point of the feature: a backup that fails quietly is worse
+ * than no backup at all, because the operator believes they are covered. Until
+ * now nothing wrote a failure down — the settings row only learned of one if
+ * somebody happened to open it while the evidence was still fresh.
+ */
+async function recordOutcome() {
+  const st = loadState();
+  if (!st.jobId || st.outcomeFor === st.jobId) return;
+  const { stage, message } = await jobStatus(st.jobId);
+  if (!stage || isActiveStage(stage)) return; // still running, or the Hub did not say
+  if (stage === 'COMPLETED') {
+    saveState({ outcomeFor: st.jobId, failures: 0, lastFailure: null, lastSuccessAt: Date.now() });
+    return;
+  }
+  saveState({
+    outcomeFor: st.jobId,
+    failures: (st.failures || 0) + 1,
+    lastFailure: { at: Date.now(), jobId: st.jobId, stage, message: message || null, reason: await failureReason(st.jobId) },
+  });
+  console.warn(`[backup] run ${st.jobId} ended ${stage}${message ? ` (${message})` : ''}`);
 }
 
 // Stages that mean a run is genuinely in flight. Observed from the Hub:
@@ -275,6 +325,9 @@ async function isRunning() {
  * timestamp on disk rather than from an in-memory schedule.
  */
 export async function tick(cfg) {
+  // How the last run ended is recorded even when this tick does nothing else —
+  // otherwise a failure is only noticed by someone opening the settings page.
+  if (hasToken()) await recordOutcome().catch(() => {});
   if (unavailableReason(cfg)) return { skipped: unavailableReason(cfg) };
   const state = loadState();
   const due = Date.now() - (state.startedAt || 0) >= intervalMs(cfg.backup.every);
@@ -299,13 +352,57 @@ export async function tick(cfg) {
  * is due; the config is re-read each time, so switching the interval takes
  * effect without restarting anything.
  */
+/** Note when the schedule was first switched on, so "no success yet" can go
+ *  stale for a backup that has never once worked — which is this Space today. */
+export function armStaleClock(cfg) {
+  if (!intervalMs(cfg?.backup?.every)) return;
+  const st = loadState();
+  if (!st.firstArmedAt) saveState({ firstArmedAt: Date.now() });
+}
+
 export function startBackupTimer(getConfig) {
-  const t = setInterval(() => { tick(getConfig()).catch(() => {}); }, TICK_MS);
+  armStaleClock(getConfig());
+  const t = setInterval(() => { armStaleClock(getConfig()); tick(getConfig()).catch(() => {}); }, TICK_MS);
   if (t.unref) t.unref();
   // First check shortly after boot, once bucket discovery has landed.
   const first = setTimeout(() => { tick(getConfig()).catch(() => {}); }, 30_000);
   if (first.unref) first.unref();
   return () => { clearInterval(t); clearTimeout(first); };
+}
+
+/**
+ * Backup health, from state alone — no Hub calls, because this rides on
+ * /api/info which every open tab polls every 15 seconds.
+ *
+ * Returns null when there is nothing wrong, so the dashboard shows nothing at
+ * all in the normal case. Two ways to be unwell:
+ *   - `failing`: the last run ended in ERROR (or was killed).
+ *   - `stale`: no successful run in three intervals. A silent stall — the timer
+ *     never firing, the token going bad — leaves an operator just as wrongly
+ *     confident as an outright failure, and looks fine without this.
+ */
+export function backupHealth(cfg) {
+  const every = cfg?.backup?.every || 'never';
+  const ms = intervalMs(every);
+  if (!ms) return null; // switched off: silence is correct
+  const st = loadState();
+  const f = st.lastFailure || null;
+  const lastSuccessAt = st.lastSuccessAt || null;
+  const since = lastSuccessAt || st.firstArmedAt || null;
+  const stale = !!since && Date.now() - since > ms * 3;
+  if (!f && !stale) return null;
+  return {
+    failing: !!f,
+    stale,
+    failures: st.failures || 0,
+    at: f ? f.at : null,
+    jobId: f ? f.jobId : null,
+    stage: f ? f.stage : null,
+    message: f ? f.message || null : null,
+    reason: f ? f.reason || null : null,
+    lastSuccessAt,
+    jobsUrl: jobsUrl(),
+  };
 }
 
 /**
@@ -339,6 +436,10 @@ export async function backupStatus(cfg) {
       : null,
     jobName: jobName(),
     jobsUrl: jobsUrl(),
+    health: backupHealth(cfg),
+    failures: state.failures || 0,
+    lastFailure: state.lastFailure || null,
+    lastSuccessAt: state.lastSuccessAt || null,
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -734,6 +734,10 @@ app.get('/api/info', (_req, res) => res.json({
   // True when the Space is private but we couldn't verify its bucket is private
   // (no HF_TOKEN to discover the bucket). Non-blocking; the UI shows a warning.
   bucketUnverified: !isPublic() && !!visibility().bucketUnverified,
+  // Backup health, or null when there is nothing wrong. Read from state, never
+  // the Hub: every open tab polls this route every 15s. Withheld while public
+  // for the same reason as `secrets` — it names the operator's repos.
+  backup: isPublic() ? null : backup.backupHealth(loadAmConfig()),
   // First-run welcome: shown once per Space (flag persists on the bucket).
   welcomeSeen: welcomeSeen(),
   // Demo mode: current sessions hidden from view; forces the welcome to show.

--- a/server/test/backup-health.test.mjs
+++ b/server/test/backup-health.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// backupHealth reads DATA_DIR/backup-state.json, so point DATA_DIR at a temp dir
+// before the module resolves it.
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'am-health-'));
+process.env.DATA_DIR = dir;
+process.env.AM_BACKUP_SOURCE = 'ns/bucket';
+process.env.HF_TOKEN = 'hf_test';
+const { backupHealth, EVERY_MS } = await import('../src/backup.js');
+
+const state = (o) => fs.writeFileSync(path.join(dir, 'backup-state.json'), JSON.stringify(o));
+const HOUR = EVERY_MS['1h'];
+
+test('silence when the feature is off, whatever the state says', () => {
+  state({ lastFailure: { at: Date.now(), jobId: 'j', stage: 'ERROR' }, failures: 9 });
+  assert.equal(backupHealth({ backup: { every: 'never' } }), null);
+  assert.equal(backupHealth({}), null);
+  assert.equal(backupHealth(undefined), null);
+});
+
+test('silence when the last run succeeded — the normal case shows nothing', () => {
+  state({ lastSuccessAt: Date.now() - 60_000, failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('a failed run surfaces, with the reason and the count', () => {
+  state({
+    failures: 3,
+    lastSuccessAt: Date.now() - 60_000,
+    lastFailure: { at: 1785900000000, jobId: 'j1', stage: 'ERROR', message: 'Job timeout', reason: "cannot update files under a '.cache/' folder" },
+  });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.equal(h.failing, true);
+  assert.equal(h.failures, 3);
+  assert.equal(h.jobId, 'j1');
+  assert.equal(h.message, 'Job timeout');
+  assert.match(h.reason, /\.cache/);
+  assert.match(h.jobsUrl, /^https:\/\/huggingface\.co\/settings\/jobs\?label=/);
+});
+
+// The failure mode this feature exists for: nothing is erroring, because nothing
+// is running. Looks perfectly healthy without a staleness check.
+test('a silent stall surfaces as stale, not as failing', () => {
+  state({ lastSuccessAt: Date.now() - HOUR * 4, failures: 0, lastFailure: null });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.ok(h, 'four hours with no success on an hourly schedule must not read as healthy');
+  assert.equal(h.stale, true);
+  assert.equal(h.failing, false);
+
+  // Within tolerance: a couple of missed ticks is not an alarm.
+  state({ lastSuccessAt: Date.now() - HOUR * 2, failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('never having succeeded goes stale from when it was switched on', () => {
+  // Armed long ago, no success ever — this Space's actual situation.
+  state({ firstArmedAt: Date.now() - HOUR * 10, failures: 0, lastFailure: null });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.equal(h.stale, true);
+  assert.equal(h.lastSuccessAt, null);
+  // Just armed: give it a chance before complaining.
+  state({ firstArmedAt: Date.now(), failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('the staleness window scales with the interval', () => {
+  state({ lastSuccessAt: Date.now() - HOUR * 4, failures: 0, lastFailure: null });
+  // 4h is stale hourly, but nowhere near stale on a daily schedule.
+  assert.ok(backupHealth({ backup: { every: '1h' } }));
+  assert.equal(backupHealth({ backup: { every: '24h' } }), null);
+});
+
+test('an empty state file is not a problem', () => {
+  state({});
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import ShareDialog from './components/ShareDialog';
 import Logo from './components/Logo';
 import Overview from './components/Overview';
 import Locked from './components/Locked';
+import BackupBanner from './components/BackupBanner';
 import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewFilter, Session, Tree } from './types';
@@ -885,6 +886,9 @@ export default function App() {
             )}
           </div>
         )}
+        {/* Visible where you already are, on every view. Rides on /api/info,
+            which is polled every 15s, so no new request for the normal case. */}
+        <BackupBanner health={info?.backup} onOpenSettings={() => { setSettingsPage('general'); setSettingsOpen(true); }} />
         <div className="stage">
           {renderTiles(
             isMobile && !mobileStage

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -55,6 +55,14 @@ export const deleteGroup = (id: string) =>
 export const move = (ref: string, to: MoveTarget) =>
   fetch('/api/move', { method: 'POST', headers: HEADERS, body: JSON.stringify({ ref, to }) }).then(json);
 
+// Present only when a backup is unwell; null the rest of the time, so the
+// dashboard shows nothing in the normal case.
+export interface BackupHealth {
+  failing: boolean; stale: boolean; failures: number;
+  at: number | null; jobId: string | null; stage: string | null;
+  message: string | null; reason: string | null;
+  lastSuccessAt: number | null; jobsUrl: string;
+}
 export const getInfo = () => fetch('/api/info').then(json);
 
 export const dismissWelcome = () => fetch('/api/welcome/seen', { method: 'POST' }).then(json);
@@ -103,6 +111,10 @@ export interface BackupStatus {
   // needs a job id to link to them.
   jobName: string;
   jobsUrl: string;
+  health: BackupHealth | null;
+  failures: number;
+  lastFailure: { at: number; jobId: string; stage: string; message: string | null; reason: string | null } | null;
+  lastSuccessAt: number | null;
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/components/BackupBanner.tsx
+++ b/web/src/components/BackupBanner.tsx
@@ -1,0 +1,39 @@
+import type { BackupHealth } from '../api';
+
+/**
+ * The one line that stops a broken backup from looking like a working one.
+ *
+ * Renders nothing when `health` is null, which is the normal case — the server
+ * only sends this object when a backup is failing or has gone quiet. Not
+ * dismissible on purpose: the whole failure mode here is silence being mistaken
+ * for health, and a dismissed warning is silence again.
+ */
+export default function BackupBanner({ health, onOpenSettings }: {
+  health: BackupHealth | null | undefined;
+  onOpenSettings: () => void;
+}) {
+  if (!health) return null;
+  return (
+    <div className="bkfail" role="status">
+      <span className="bkfail-dot" aria-hidden="true" />
+      <span className="bkfail-txt">
+        {health.failing ? (
+          <>
+            <b>Bucket backup is failing.</b>{' '}
+            {health.failures > 1 ? `${health.failures} runs in a row. ` : ''}
+            {health.reason ? <span className="mono bkfail-why">{health.reason}</span> : null}
+          </>
+        ) : (
+          <>
+            <b>Bucket backup has not succeeded recently.</b>{' '}
+            {health.lastSuccessAt
+              ? `Last good run ${new Date(health.lastSuccessAt).toLocaleString()}.`
+              : 'It has never completed a run.'}
+          </>
+        )}
+      </span>
+      <a className="bkfail-link" href={health.jobsUrl} target="_blank" rel="noreferrer">the runs ↗</a>
+      <button className="bkfail-link" onClick={onOpenSettings}>settings</button>
+    </div>
+  );
+}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -442,11 +442,29 @@ export default function SettingsView({
                             reporting it wrongly whenever the Hub did not answer. */}
                         <div>
                           <span>Last updated</span>
-                          <b>{bk.last ? new Date(bk.last.at).toLocaleString() : 'never'}</b>
+                          <b>{bk.lastSuccessAt ? new Date(bk.lastSuccessAt).toLocaleString() : 'never'}</b>
                         </div>
+                        {/* The dashboard strip says a backup is failing; this says
+                            what the Job actually reported, which is what tells you
+                            whether it is yours to fix. */}
+                        {bk.lastFailure && (
+                          <div>
+                            <span>Last failure</span>
+                            <b style={{ color: 'var(--danger)', whiteSpace: 'normal', textAlign: 'right' }}>
+                              {new Date(bk.lastFailure.at).toLocaleString()}
+                              {bk.lastFailure.message ? ` — ${bk.lastFailure.message}` : ''}
+                              {bk.failures > 1 ? ` (${bk.failures} in a row)` : ''}
+                              {bk.lastFailure.reason && (
+                                <div className="mono" style={{ fontWeight: 400, color: 'var(--muted)', fontSize: 11.5, marginTop: 2 }}>
+                                  {bk.lastFailure.reason}
+                                </div>
+                              )}
+                            </b>
+                          </div>
+                        )}
                         {bk.error && (
                           <div>
-                            <span>Last error</span>
+                            <span>Could not launch</span>
                             <b style={{ color: 'var(--danger)' }}>{bk.error}</b>
                           </div>
                         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -71,6 +71,14 @@ body {
 .sidebar { width: 282px; flex: none; background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
 .main { flex: 1; min-width: 0; padding: 12px; overflow: hidden; display: flex; flex-direction: column; }
 .stage { flex: 1; min-height: 0; }
+/* Backup failure strip: one line above whatever view you are on. Loud enough to
+   not be mistaken for chrome, quiet enough to live there until it is fixed. */
+.bkfail { display: flex; align-items: center; gap: 8px; margin: 0 0 8px; padding: 7px 10px; border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border)); background: color-mix(in srgb, var(--danger) 10%, transparent); border-radius: var(--r-md); font-size: 12.5px; line-height: 1.35; }
+.bkfail-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--danger); }
+.bkfail-txt { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bkfail-why { color: var(--muted); }
+.bkfail-link { flex: none; border: none; background: transparent; padding: 0; font: inherit; font-size: 12px; color: inherit; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; cursor: pointer; }
+.bkfail-link:hover { color: var(--danger); text-decoration-style: solid; }
 .zoombar { display: flex; align-items: center; gap: 4px; padding: 4px 8px; margin-top: 8px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-lg); flex: none; }
 .zoombar .spacer { flex: 1; }
 /* overview bottom bar: filter + view segments, centered */


### PR DESCRIPTION
## Why

The backups on this Space had been failing for about a day and nothing said so.
The dataset held exactly one commit — `initial commit` — while the settings row
showed a cheerful "Last updated" timestamp, because the *mirror* step kept
succeeding and only the dataset step was broken.

A backup that fails quietly is worse than no backup: you stop thinking about it.

## What was actually wrong

Two causes, from the Job logs (both recorded in `docs/bucket-backup.md` §3.8):

**1. The Hub refuses `.cache/` paths.**

```
✓ Copied
Error: Invalid value. Invalid `path_in_repo` in CommitOperation:
cannot update files under a '.cache/' folder
(path: 'home/.cache/claude-cli-nodejs/…/2026-07-09T08-43-35-094Z.jsonl')
```

Any bucket with an agent cache under `home/.cache/` can therefore *never* produce
a dataset commit.

**2. The walk does not fit the job.** Failures report `Job timeout` after
1h33m–2h7m — against the `--timeout 3000s` (50 min) we pass, so that flag is not
being honoured and something near 1h30m is. Runs against the 49-file dev bucket
finish in 14–17 s; this bucket is 102,691 files on a FUSE mount.

## What this PR does

It does **not** fix either cause. It makes them impossible to miss.

- **The timer records how each run ended**, once per job id, into
  `backup-state.json`: stage, the platform's message, and one line of reason
  lifted from the Job's own logs. The logs are where the useful part lives — the
  platform says `Job timeout`, the logs say the Hub won't commit a `.cache/` path,
  and only the second tells you what to do.
- **`/api/info` carries a health object**, or `null` when all is well — so the
  normal case shows nothing and costs nothing. Read from state, never the Hub,
  because every open tab polls that route every 15 s. Withheld while the Space is
  public, like `secrets`, since it names the operator's repos.
- **A strip above the stage**, on every view, **not dismissible** — a dismissed
  warning is silence again, and silence is the failure mode. It shows the reason,
  links to the label-filtered job list, and opens Settings.
- **Settings gains the detail**: a `Last failure` row with the timestamp, the
  platform message, the run count, and the reason underneath. `Last updated` now
  reads from the last *successful* run rather than the last attempt, which is what
  made the old row misleading.
- **Staleness counts as unwell.** Three intervals with no successful run raises the
  strip even when nothing errored. A timer that never fires, or a token gone bad,
  leaves you exactly as wrongly confident as a failing run — and looks perfectly
  healthy without the check.

## Verified

`BackupBanner` is its own component so it can be rendered in isolation; checked in
a headless browser inside a replica of the real shell (`.app` → `.main`), which is
what confirmed the layout under a long reason:

| state | result |
|---|---|
| failing, 7 in a row, real `.cache` error | one line, reason ellipsised, both links reachable |
| failing once, `Job timeout` | one line |
| stale, never succeeded | "It has never completed a run." |
| stale, succeeded 26 h ago | shows the last good run |
| healthy | renders nothing |

- 20 tests pass; 7 are new and all about *when* the strip appears: silence when
  off, silence when healthy, failing with reason and count, stale after three
  intervals, stale from arming when nothing ever succeeded, the window scaling
  with the interval, and an empty state file.
- `tsc --noEmit` and the web build are clean.
- `server/test/repin.test.mjs` fails in a fresh clone for want of `node-pty`,
  identically on `main`.

## Not done

- **Neither root cause is fixed here.** #30's skip list handles the `.cache`
  rejection if you add `.cache` as a token — and arguably `.cache` should be
  excluded unconditionally, since the Hub cannot accept those paths at all. Say the
  word and I'll add that to #30.
- **The walk may not be fixable with exclusions.** A prod-scale run with `.cache`,
  `node_modules`, `.venv` and `__pycache__` excluded was still walking after 40
  minutes, which suggests `hf upload` enumerates before it filters. If that holds,
  step 2 needs to change shape — a subtree at a time, or a narrower dataset scope —
  rather than a longer exclusion list. §10.10.
- **`--timeout` being ignored** is unexplained; worth a separate look, since it
  means a stuck run occupies whatever the platform's own limit is.
