### PR TITLE
Bucket backup: prepopulate the skip list with the caches nothing needs

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -196,6 +196,35 @@ What it saves, measured on an 805-file tree (800 of them a `.venv`):
 That is local disk; the Job reads a FUSE mount, which is slower, so the real
 saving is larger than this.
 
+**The list ships prepopulated.** An install that has never set one gets
+`node_modules`, `.venv`, `venv`, `__pycache__`, `.cache`, `.npm`, `.pnpm-store`,
+`.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.next`,
+`.turbo` — every one of them rebuilt on demand by a package manager or toolchain.
+
+The names came from walking this Space's own bucket, not from taste. Across 24
+workspace folders: 11 `node_modules`, 6 `.venv`, 4 `.cache`, plus a `$HOME/.cache`
+holding `ms-playwright`, `google-chrome-for-testing-headless`, `huggingface`, `uv`
+and the `claude-cli-nodejs` transcripts whose paths a dataset commit refuses
+outright.
+
+Two things that survey found are deliberately **not** in the default:
+
+- **`.git` — 11 of them, the most common folder in the bucket.** Rank candidates
+  by size or count and it comes out on top; it is also the one thing you would
+  most want back. Never default it.
+- **`dist`, `build`, `target`** — regenerable in most repos, a hand-written source
+  folder in enough of them. A default that silently drops work is worse than one
+  that copies some junk, so these are opt-in.
+
+An absent key and an empty list mean different things: `undefined` is "never
+asked" and takes the default, `[]` is a list the operator emptied on purpose and
+stays empty. Without that split, clearing the field in Settings would refill
+itself on the next read. Note the consequence for an **existing** install whose
+config predates this: it has no key, so it picks the default up and its next run
+skips those folders. Nothing already backed up is lost — newly excluded files drop
+out of the newest commit but stay in the dataset's history, retrievable from the
+revision that last held them.
+
 ### 3.9 The server-side mirror cannot filter
 
 `hf cp` has no `--include/--exclude` at all, and `hf sync` refuses remote→remote

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -70,6 +70,42 @@ export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_
 const EXCLUDE_RE = /^[A-Za-z0-9._*?/-]+$/;
 export const MAX_EXCLUDES = 40;
 
+/**
+ * What a fresh install skips until the operator says otherwise.
+ *
+ * Chosen by walking this Space's own bucket rather than from taste: across 24
+ * workspace folders it holds 11 `node_modules`, 6 `.venv`, 4 `.cache`, and a
+ * `$HOME/.cache` carrying `ms-playwright`, `google-chrome-for-testing-headless`,
+ * `huggingface`, `uv`, `node-gyp` and the `claude-cli-nodejs` transcripts that
+ * make a dataset commit fail outright. Every name here is something a
+ * package manager or toolchain rebuilds on demand.
+ *
+ * Two names were deliberately left OUT, and both matter more than what is in:
+ *   - `.git` appears 11 times, more often than anything else, and is the single
+ *     thing you would most want back. A size-ranked "junk" heuristic picks it
+ *     first; it is history, not cache.
+ *   - `dist` / `build` / `target` appear too, but they are ambiguous — a source
+ *     folder is called `build` often enough, and a default that silently drops
+ *     work is worse than one that copies some junk. Add them per-install.
+ */
+export const DEFAULT_EXCLUDE = Object.freeze([
+  'node_modules', '.venv', 'venv', '__pycache__', '.cache', '.npm', '.pnpm-store',
+  '.pytest_cache', '.mypy_cache', '.ruff_cache', '.ipynb_checkpoints', '.next', '.turbo',
+]);
+
+/**
+ * The stored value, or the default when the operator has never set one.
+ *
+ * An absent key and an empty list are NOT the same: `undefined` means "never
+ * asked", which takes the default, while `[]` is a list the operator emptied on
+ * purpose and must stay empty — otherwise clearing the field in Settings would
+ * silently refill itself on the next read.
+ */
+export function excludeFromConfig(saved) {
+  if (saved === undefined || saved === null) return [...DEFAULT_EXCLUDE];
+  return normalizeExclude(saved);
+}
+
 export function normalizeExclude(list) {
   if (!Array.isArray(list)) return [];
   const out = [];

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -902,7 +902,9 @@ function loadAmConfig() {
       mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
       // Folder names to keep out of the history — the slow, regenerable kind.
-      exclude: backup.normalizeExclude(saved.backup?.exclude),
+      // Prepopulated on a config that has never set one, so a fresh install is
+      // quick by default; an emptied list stays empty. backup.js explains both.
+      exclude: backup.excludeFromConfig(saved.backup?.exclude),
     },
   };
 }
@@ -922,7 +924,9 @@ app.put('/api/config', (req, res) => {
       mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
       // Normalized here, not trusted: these end up in a Job's argument list.
-      exclude: backup.normalizeExclude(b.backup?.exclude),
+      // Same undefined-vs-empty rule as the read path: a body that omits the key
+      // never asked and takes the default, `[]` is an emptied list and persists.
+      exclude: backup.excludeFromConfig(b.backup?.exclude),
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -3,13 +3,60 @@ import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
-  normalizeExclude, excludePatterns, MAX_EXCLUDES,
+  normalizeExclude, excludePatterns, MAX_EXCLUDES, DEFAULT_EXCLUDE, excludeFromConfig,
 } from '../src/backup.js';
 
 // The rule that is not obvious and cost a Hub round-trip to learn: `**/x/**` does
 // NOT match a top-level `x/`, so a bare folder token needs BOTH patterns. Verified
 // against the Hub — with only the `**/` form, the copy at the bucket root still
 // went up.
+test('a config that never set a skip list gets the default, an emptied one stays empty', () => {
+  // The whole point of the split: `undefined` is "never asked", `[]` is a choice.
+  assert.deepEqual(excludeFromConfig(undefined), [...DEFAULT_EXCLUDE]);
+  assert.deepEqual(excludeFromConfig(null), [...DEFAULT_EXCLUDE]);
+  // An emptied list must NOT refill itself, or clearing the field in Settings
+  // would come back on the next read and the operator could never turn it off.
+  assert.deepEqual(excludeFromConfig([]), []);
+  // A set list is passed through the same validation as anything else.
+  assert.deepEqual(excludeFromConfig(['  env  ', '/env/']), ['env']);
+  assert.deepEqual(excludeFromConfig(['a', 'rm -rf /']), ['a']);
+  // Junk in the config file falls back to nothing rather than to the default:
+  // it IS a set value, just not a usable one.
+  assert.deepEqual(excludeFromConfig('node_modules'), []);
+});
+
+test('the default skip list is caches only — never .git, never ambiguous build dirs', () => {
+  // .git is the most common folder in the bucket and the one most worth keeping.
+  // A size-ranked heuristic would pick it first, so pin it explicitly.
+  for (const keep of ['.git', 'dist', 'build', 'target', 'src', 'data', '.config', '.ssh']) {
+    assert.ok(!DEFAULT_EXCLUDE.includes(keep), `${keep} must not be skipped by default`);
+  }
+  // The names actually found in this Space's bucket are covered.
+  for (const junk of ['node_modules', '.venv', '__pycache__', '.cache', '.npm']) {
+    assert.ok(DEFAULT_EXCLUDE.includes(junk), `${junk} should be skipped by default`);
+  }
+  // Every default has to survive the validator it will be fed through, fit the
+  // cap, and be unique — a default that silently drops would be invisible.
+  assert.deepEqual(normalizeExclude([...DEFAULT_EXCLUDE]), [...DEFAULT_EXCLUDE]);
+  assert.ok(DEFAULT_EXCLUDE.length <= MAX_EXCLUDES);
+  assert.equal(new Set(DEFAULT_EXCLUDE).size, DEFAULT_EXCLUDE.length);
+  // Frozen: it is handed out by reference-copy, and a caller mutating the
+  // module's own array would poison every later read.
+  assert.throws(() => DEFAULT_EXCLUDE.push('dist'));
+  excludeFromConfig(undefined).push('dist');
+  assert.ok(!DEFAULT_EXCLUDE.includes('dist'));
+});
+
+test('the default reaches a Job as splittable patterns, root and nested', () => {
+  const pats = excludePatterns([...DEFAULT_EXCLUDE]);
+  assert.equal(pats.length, DEFAULT_EXCLUDE.length * 2);
+  for (const p of pats) assert.ok(!/\s/.test(p), `${p} would break the shell split`);
+  assert.ok(pats.includes('node_modules/**') && pats.includes('**/node_modules/**'));
+  const env = jobArgs({ source: 'u/s', mirror: 'u/m', dataset: 'u/d', exclude: [...DEFAULT_EXCLUDE] })
+    .find((a) => String(a).startsWith('AM_EXCLUDE='));
+  assert.ok(env.includes('.cache/**') && env.includes('**/.cache/**'));
+});
+
 test('a bare folder token excludes it at the root AND nested', () => {
   assert.deepEqual(excludePatterns(['env']), ['env/**', '**/env/**']);
   assert.deepEqual(excludePatterns(['node_modules', '.venv']),

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -475,7 +475,8 @@ export default function SettingsView({
                         <div className="s-help" style={{ marginTop: 10 }}>
                           Skip these folders — type a name and press Enter. Anywhere they appear
                           (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
-                          they stay out of the history and the backup gets quicker.
+                          they stay out of the history and the backup gets quicker. The list starts
+                          on the caches a package manager can rebuild; remove any you want kept.
                         </div>
                         <div className="tagf" onClick={(e) => {
                           if (e.target === e.currentTarget) (e.currentTarget.querySelector('input') as HTMLInputElement)?.focus();


### PR DESCRIPTION
Stacked on #30 — base is `backup/exclude-folders`, not `main`. Merge #30 first.

#30 gave the operator a skip list. It starts empty, so a fresh install still
crawls every `node_modules` and `.venv` in the bucket and you only find out by
watching the first backup take an hour. This prepopulates it.

### The default

`node_modules`, `.venv`, `venv`, `__pycache__`, `.cache`, `.npm`, `.pnpm-store`,
`.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.next`,
`.turbo`

Picked by walking this Space's own bucket rather than from taste. Across 24
workspace folders: **11 `node_modules`, 6 `.venv`, 4 `.cache`**, plus a
`$HOME/.cache` holding `ms-playwright`, `google-chrome-for-testing-headless`,
`huggingface`, `uv`, `node-gyp` and the `claude-cli-nodejs` transcripts whose
paths a dataset commit refuses outright. Every name is something a package
manager or toolchain rebuilds on demand.

### What the survey found and the default deliberately omits

- **`.git` — 11 of them, the most common folder in the bucket.** Rank candidates
  by size or count and it sorts to the top; it is also the one thing you would
  most want back. A test pins it out of the default so nobody "optimizes" it in.
- **`dist`, `build`, `target`** — regenerable in most repos, hand-written source
  in enough of them. A default that silently drops work is worse than one that
  copies some junk, so they stay opt-in.

### `undefined` and `[]` now mean different things

`undefined` is "never asked" and takes the default; `[]` is a list the operator
emptied on purpose and stays empty. Without that split, clearing the field in
Settings would refill itself on the next read. Applied on both the read and write
paths, so a PUT that omits the key does not silently persist an empty list.

**Consequence worth a second look:** an existing install's config predates the
key, so it picks the default up and its next run skips those folders. Nothing
already backed up is lost — newly excluded files drop out of the newest commit but
remain in the dataset history.

### Verification

- `backup.test.mjs` 20/20 (17 existing + 3 new), full server chain green,
  `mobile` + `terminal-ui` green (SettingsView copy changed).
- End-to-end on a real server with a clean data dir: `GET /api/config` returns the
  13 defaults with no `am-config.json` on disk, so it is the default path and not a
  persisted value.
- Deployed to am-dev-2 (as part of #30+#31 combined). That Space has an explicitly
  set list (`.venv`, `.cache`) and correctly kept it — the prepopulation does not
  override a configured install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
