### PR TITLE
Restore terminal interaction modes on reattach

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/repin.test.mjs && node test/opencode-resume.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -13,6 +13,7 @@ import {
   createTerminalHistoryCheckpoint, loadTerminalHistory, TERMINAL_HISTORY_VERSION,
   traceHistoryLines,
 } from './history-store.js';
+import { createTerminalModeTracker } from './terminal-modes.js';
 
 // libghostty-vt ships prebuilts for linux x64/arm64 and macOS arm64. Loading it
 // is guarded so a platform without a prebuilt still boots and says so, rather
@@ -384,6 +385,14 @@ function styledSnapshot(host, vt, snap) {
   return { ...snap, scrollbackLines: withHistoryStyles(host, snap.scrollbackLines) };
 }
 
+// A Ghostty snapshot restores the rendered grid. Append the interaction modes
+// observed on the PTY so a newly attached xterm also behaves like the terminal
+// that saw the TUI start (mouse reporting, bracketed paste, cursor-key mode…).
+function viewerRestoreAnsi(host, vt, snap) {
+  return snapshotToRestoreAnsi(styledSnapshot(host, vt, snap))
+    + host.terminalModes.restoreAnsi();
+}
+
 /**
  * Commit one captured agent repaint without duplicating its overflow rows.
  *
@@ -448,7 +457,7 @@ function finishCapturedGrid(host, txn) {
       // diverge after a narrow zoom, even when the server history is correct.
       notifyGrid(host, true);
       const committed = host.vt.snapshot({ includeCells: true, includeScrollback: true });
-      const ansi = snapshotToRestoreAnsi(styledSnapshot(host, host.vt, committed));
+      const ansi = viewerRestoreAnsi(host, host.vt, committed);
       for (const sub of host.subs) sub.onData(ansi);
       try { previous.dispose(); } catch {}
       sampleScreen(host);
@@ -622,7 +631,7 @@ function armTraceHydration(host) {
       host.repaintArchive = view.archive;
       notifyGrid(host, true);
       const committed = host.vt.snapshot({ includeCells: true, includeScrollback: true });
-      const ansi = snapshotToRestoreAnsi(styledSnapshot(host, host.vt, committed));
+      const ansi = viewerRestoreAnsi(host, host.vt, committed);
       for (const sub of host.subs) sub.onData(ansi);
       try { previous.dispose(); } catch {}
       sampleScreen(host);
@@ -1314,6 +1323,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
     repaintArchive: null,
     historyStyles: new Map((persistedHistory?.lines || [])
       .filter((line) => line.text && line.ansi).map((line) => [line.text, line.ansi])),
+    terminalModes: createTerminalModeTracker(),
     startupHistory: captureResize ? persistedHistory : null,
     historyCheckpoint: null,
     traceHistoryPage: null,
@@ -1348,6 +1358,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
 
   term.onData((chunk) => {
     host.lastOutputAt = Date.now();
+    host.terminalModes.feed(chunk);
     if (host.traceHistoryTimer) {
       clearTimeout(host.traceHistoryTimer);
       host.traceHistoryTimer = null;
@@ -1464,7 +1475,7 @@ export function attach(session, cols, rows) {
       let snap;
       try { snap = host.vt.snapshot({ includeCells: true, includeScrollback: true }); } catch { return null; }
       return {
-        ansi: snapshotToRestoreAnsi(styledSnapshot(host, host.vt, snap)),
+        ansi: viewerRestoreAnsi(host, host.vt, snap),
         cols: snap.cols,
         rows: snap.rows,
         viewers: host.subs.size,

--- a/server/src/terminal-modes.js
+++ b/server/src/terminal-modes.js
@@ -1,0 +1,93 @@
+// libghostty's structured snapshot exposes the screen and cursor, but not the
+// input modes a TUI enabled before a browser attached. Keep the small subset of
+// terminal state that changes how xterm turns browser interaction into PTY
+// bytes, so a canonical repaint can restore behavior as well as pixels.
+
+const MOUSE_PROTOCOL_MODES = new Set([9, 1000, 1002, 1003]);
+const MOUSE_ENCODING_MODES = new Set([1005, 1006, 1015, 1016]);
+
+export function createTerminalModeTracker() {
+  let applicationCursorKeys = false;
+  let mouseProtocol = 0;
+  let mouseEncoding = 0;
+  let sendFocus = false;
+  let bracketedPaste = false;
+
+  // 0 ground, 1 ESC, 2 CSI, 3 CSI ? parameters. State is retained across PTY
+  // chunks because escape sequences are not guaranteed to arrive atomically.
+  let parserState = 0;
+  let parameters = '';
+
+  const reset = () => {
+    applicationCursorKeys = false;
+    mouseProtocol = 0;
+    mouseEncoding = 0;
+    sendFocus = false;
+    bracketedPaste = false;
+  };
+
+  const applyPrivateMode = (mode, enabled) => {
+    if (mode === 1) applicationCursorKeys = enabled;
+    else if (MOUSE_PROTOCOL_MODES.has(mode)) mouseProtocol = enabled ? mode : 0;
+    else if (MOUSE_ENCODING_MODES.has(mode)) mouseEncoding = enabled ? mode : 0;
+    else if (mode === 1004) sendFocus = enabled;
+    else if (mode === 2004) bracketedPaste = enabled;
+  };
+
+  const finishPrivateMode = (enabled) => {
+    for (const value of parameters.split(';')) {
+      if (!/^\d+$/.test(value)) continue;
+      applyPrivateMode(Number(value), enabled);
+    }
+    parameters = '';
+  };
+
+  const feed = (data) => {
+    const text = typeof data === 'string' ? data : Buffer.from(data).toString('latin1');
+    for (const char of text) {
+      if (parserState === 0) {
+        if (char === '\x1b') parserState = 1;
+        else if (char === '\x9b') parserState = 2;
+        continue;
+      }
+
+      if (parserState === 1) {
+        if (char === '[') parserState = 2;
+        else if (char === 'c') { reset(); parserState = 0; }
+        else parserState = char === '\x1b' ? 1 : 0;
+        continue;
+      }
+
+      if (parserState === 2) {
+        if (char === '?') { parameters = ''; parserState = 3; }
+        else parserState = char === '\x1b' ? 1 : 0;
+        continue;
+      }
+
+      if ((char >= '0' && char <= '9') || char === ';') {
+        // A real mode list is tiny. Bound malformed output so it cannot grow a
+        // retained parser string without limit.
+        if (parameters.length < 128) parameters += char;
+        else { parameters = ''; parserState = 0; }
+      } else if (char === 'h' || char === 'l') {
+        finishPrivateMode(char === 'h');
+        parserState = 0;
+      } else {
+        parameters = '';
+        parserState = char === '\x1b' ? 1 : 0;
+      }
+    }
+  };
+
+  const restoreAnsi = () => {
+    let out = '';
+    if (applicationCursorKeys) out += '\x1b[?1h';
+    if (mouseProtocol) out += `\x1b[?${mouseProtocol}h`;
+    if (mouseEncoding) out += `\x1b[?${mouseEncoding}h`;
+    if (sendFocus) out += '\x1b[?1004h';
+    if (bracketedPaste) out += '\x1b[?2004h';
+    return out;
+  };
+
+  return { feed, reset, restoreAnsi };
+}

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -58,7 +58,9 @@ backend.stderr.on('data', (d) => { logs += d; });
 
 let browser;
 let feed;
+let mouseFeed;
 let id;
+let mouseId;
 try {
   if (!await waitFor(() => fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false), 60_000)) {
     throw new Error(`server did not start:\n${logs.slice(-2000)}`);
@@ -81,6 +83,25 @@ try {
     throw new Error('fixture output never reached the terminal');
   }
 
+  // OpenCode enables mouse reporting before a browser normally attaches. Its
+  // alternate screen has no xterm scrollback, so losing these modes on restore
+  // makes xterm translate the wheel into Up/Down (prompt history) instead of an
+  // SGR mouse event (the conversation scrollbox).
+  const mouseCreated = await (await fetch(`${API}/api/sessions`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ cli: 'shell', name: 'terminal-mouse-restore', path: '.' }),
+  })).json();
+  mouseId = mouseCreated.id;
+  if (!mouseId) throw new Error(`mouse fixture session creation failed: ${JSON.stringify(mouseCreated)}`);
+  mouseFeed = new WebSocket(`ws://127.0.0.1:7897/ws?session=${mouseId}&cols=120&rows=30`);
+  await new Promise((resolve, reject) => { mouseFeed.once('open', resolve); mouseFeed.once('error', reject); });
+  await sleep(400);
+  mouseFeed.send(JSON.stringify({
+    t: 'i',
+    d: "printf '\\033[?1049h\\033[?1000h\\033[?1002h\\033[?1003h\\033[?1006h\\033[?2004h'\r",
+  }));
+  await sleep(600);
+
   browser = await chromium.launch({ headless: true });
   const context = await browser.newContext({
     viewport: { width: 1280, height: 800 },
@@ -90,6 +111,19 @@ try {
   // test must not depend on reaching the public internet.
   await context.route('https://example.com/**', (route) =>
     route.fulfill({ status: 200, contentType: 'text/html', body: '<title>probe</title>ok' }));
+  await context.addInitScript(() => {
+    const NativeWebSocket = window.WebSocket;
+    window.__terminalMessages = [];
+    window.WebSocket = class RecordedWebSocket extends NativeWebSocket {
+      send(data) {
+        try {
+          const parsed = JSON.parse(String(data));
+          if (parsed?.t === 'i' || parsed?.t === 'claim') window.__terminalMessages.push(parsed);
+        } catch {}
+        return super.send(data);
+      }
+    };
+  });
 
   const page = await context.newPage();
   await page.goto(API, { waitUntil: 'domcontentloaded' });
@@ -198,8 +232,34 @@ try {
   } else {
     check('repeated Cmd+C keeps copying and keeps the selection', false, 'second fixture not found');
   }
+
+  // ---------- 5. restored mouse mode keeps wheel input out of the prompt ----
+  await page.locator('.sidebar .row').filter({ hasText: 'terminal-mouse-restore' }).first().click();
+  const mouseTerm = page.locator('.tile-terminal:not(.tile-cached) .xterm-screen');
+  await mouseTerm.waitFor({ state: 'visible' });
+  const mouseRect = await mouseTerm.boundingBox();
+  if (mouseRect) {
+    const x = mouseRect.x + mouseRect.width / 2;
+    const y = mouseRect.y + mouseRect.height / 3;
+    // A desktop pointer gesture takes the terminal's input lease. Clear its
+    // press/release reports before recording the wheel itself.
+    await page.mouse.click(x, y);
+    await waitFor(() => page.evaluate(() =>
+      window.__terminalMessages.some((message) => message.t === 'claim')));
+    await page.mouse.move(x, y);
+    await page.evaluate(() => { window.__terminalMessages.length = 0; });
+    await page.mouse.wheel(0, -96);
+    await sleep(250);
+  }
+  const wheelInput = await page.evaluate(() =>
+    window.__terminalMessages.filter((message) => message.t === 'i').map((message) => message.d));
+  check('an upward wheel after attach remains an OpenCode-style mouse event',
+    !!mouseRect && wheelInput.some((data) => /^\x1b\[<64;\d+;\d+M$/.test(data))
+      && !wheelInput.some((data) => data.includes('\x1b[A')),
+    JSON.stringify({ wheelInput }));
 } finally {
   try { feed?.close(); } catch {}
+  try { mouseFeed?.close(); } catch {}
   try { await browser?.close(); } catch {}
   backend.kill('SIGKILL');
   fs.rmSync(DATA_DIR, { recursive: true, force: true });

--- a/server/test/terminal-modes.test.mjs
+++ b/server/test/terminal-modes.test.mjs
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+import { createTerminalModeTracker } from '../src/terminal-modes.js';
+
+const tracker = createTerminalModeTracker();
+
+// OpenCode enables these modes during its startup paint. Split the sequences at
+// awkward boundaries to match real node-pty chunking.
+tracker.feed('\x1b[?1h\x1b[?10');
+tracker.feed('00h\x1b[?1002;10');
+tracker.feed('03h\x1b[?1006h\x1b[?1004h\x1b[?2004h');
+assert.equal(
+  tracker.restoreAnsi(),
+  '\x1b[?1h\x1b[?1003h\x1b[?1006h\x1b[?1004h\x1b[?2004h',
+  'restore keeps the effective interaction modes, not every superseded mouse protocol',
+);
+
+tracker.feed('\x1b[?1003l\x1b[?1006l\x1b[?1;1004;2004l');
+assert.equal(tracker.restoreAnsi(), '', 'DECRST returns tracked modes to their defaults');
+
+tracker.feed('\x1b[?1003;1006;2004h');
+tracker.feed('\x1b');
+tracker.feed('c');
+assert.equal(tracker.restoreAnsi(), '', 'RIS resets interaction modes across chunks');
+
+console.log('terminal mode restore checks passed');


### PR DESCRIPTION
## Summary

- track DEC private modes that affect browser-to-PTY interaction, including mouse reporting and bracketed paste
- append the effective modes after initial Ghostty restores and authoritative repaint resets
- add unit and browser regression coverage for late-attaching OpenCode-style alternate screens

## Why

OpenCode enables its alternate screen and mouse reporting during startup, often before a browser attaches. The Ghostty snapshot restored the rendered screen but not those interaction modes. xterm therefore treated the alternate screen as non-mouse-aware and translated wheel input into Up/Down keys, which walked OpenCode prompt history instead of scrolling its conversation.

## Verification

- `cd server && npm test`
- `cd web && npm run build`
- `cd server && npm run test:ui`

The browser regression verifies that wheel-up after a late attach emits an SGR mouse event (`ESC[<64;…M`) and not an Up-arrow sequence.
