### PR TITLE
Bucket backup: a skip list with sane defaults, and a dashboard that admits failure

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -196,6 +196,34 @@ What it saves, measured on an 805-file tree (800 of them a `.venv`):
 That is local disk; the Job reads a FUSE mount, which is slower, so the real
 saving is larger than this.
 
+**The list ships prepopulated.** An install that has never set one gets
+`node_modules`, `.venv`, `venv`, `__pycache__`, `.cache`, `.npm`, `.pnpm-store`,
+`.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.next`,
+`.turbo` — every one of them rebuilt on demand by a package manager or toolchain.
+
+The names came from walking this Space's own bucket, not from taste. Across 24
+workspace folders: 11 `node_modules`, 6 `.venv`, 4 `.cache`, plus a `$HOME/.cache`
+holding `ms-playwright`, `google-chrome-for-testing-headless`, `huggingface`, `uv`
+and the `claude-cli-nodejs` transcripts of §3.10.
+
+Two things that survey found are deliberately **not** in the default:
+
+- **`.git` — 11 of them, the most common folder in the bucket.** Rank candidates
+  by size or count and it comes out on top; it is also the one thing you would
+  most want back. Never default it.
+- **`dist`, `build`, `target`** — regenerable in most repos, a hand-written source
+  folder in enough of them. A default that silently drops work is worse than one
+  that copies some junk, so these are opt-in.
+
+An absent key and an empty list mean different things: `undefined` is "never
+asked" and takes the default, `[]` is a list the operator emptied on purpose and
+stays empty. Without that split, clearing the field in Settings would refill
+itself on the next read. Note the consequence for an **existing** install whose
+config predates this: it has no key, so it picks the default up and its next run
+skips those folders. Nothing already backed up is lost — newly excluded files drop
+out of the newest commit but stay in the dataset's history, retrievable from the
+revision that last held them.
+
 ### 3.9 The server-side mirror cannot filter
 
 `hf cp` has no `--include/--exclude` at all, and `hf sync` refuses remote→remote

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -63,7 +63,17 @@ the bucket, ever.
    nothing. The dataset gets `--delete "*"` so its *newest* commit matches the
    bucket, while every earlier commit keeps the deleted file recoverable — the
    best of both.
-9. **Restore is a documented script, not a button** (§8).
+9. **The skip list applies to the history, not the mirror.** `hf cp` cannot
+   filter (§3.9), and making the mirror filterable would cost the server-side copy
+   that makes it nearly free. The dataset is where thousands of env files actually
+   hurt — every one of them gets hashed on every run — so that is where they are
+   skipped.
+10. **Skip tokens are folder names, expanded server-side.** A bare name becomes
+   both `name/**` and `**/name/**`, because the second does not imply the first
+   (§3.8). Tokens are validated to hold no whitespace or shell characters: they
+   cross into the Job as one space-joined env var and the shell splits them back
+   apart, so the charset is what makes that split exact.
+11. **Restore is a documented script, not a button** (§8).
 
 ## 2. What we already have
 
@@ -162,6 +172,43 @@ The dataset received **no new commit**. This is the one control standing between
 the operator's saved logins and the public internet, so it is verified rather
 than assumed.
 
+### 3.8 Excluding folders: `--exclude` works, and the glob rule surprises
+
+`hf upload` takes repeatable `--exclude` globs, and they do what you want — but
+**`**/env/**` does not match a top-level `env/`**:
+
+| patterns | `env/` at root | `sub/env/` |
+|---|---|---|
+| `**/env/**` | **kept** | excluded |
+| `env/**` + `**/env/**` | excluded | excluded |
+
+So a bare folder token has to become two patterns. With only the `**/` form the
+copy at the bucket root still goes up, which is exactly the case an operator means
+when they type `node_modules`.
+
+What it saves, measured on an 805-file tree (800 of them a `.venv`):
+
+| | files hashed | wall |
+|---|---|---|
+| no excludes | 805 | **7 s** |
+| `.venv` excluded | 5 | **1 s** |
+
+That is local disk; the Job reads a FUSE mount, which is slower, so the real
+saving is larger than this.
+
+### 3.9 The server-side mirror cannot filter
+
+`hf cp` has no `--include/--exclude` at all, and `hf sync` refuses remote→remote
+("One path must be local"). So the skip list applies to the **dataset history
+only** — the mirror is a whole-bucket server-side copy or nothing.
+
+It could be filtered: inside the Job the bucket is mounted at `/live`, so
+`hf buckets sync /live hf://buckets/<mirror>/latest --exclude … --delete` is a
+*local*→remote sync and does support patterns. It would also throw away the
+property that makes the mirror nearly free — no bytes move, hashes only, 13,482
+files in 20 s — and make it read and re-upload 11.4 GB instead. Not worth it for
+files nobody wanted anyway. §10.9.
+
 ### 3.7 Incidental
 
 `pip install "huggingface_hub[cli]"` warns on 1.26.0 — *"does not provide the
@@ -234,12 +281,14 @@ backup: {
   every: 'never' | '1h' | '3h' | '24h',   // default 'never' (§1.7)
   mirror: '',                              // default <ns>/<space>-backup
   dataset: '',                             // default <ns>/<space>-backup
+  exclude: [],                             // folder tokens kept out of the history
 }
 ```
 
 ```
 GET  /api/backup/status  → { every, source, mirror, dataset, defaults, hasToken,
                              canRunNow, running, unavailable,
+                             exclude, excludePatterns,
                              last: { at, jobId, stage }, nextDue,
                              datasetPrivate, error }
 POST /api/backup/run     → launch one Job now (works with the schedule off)
@@ -276,6 +325,9 @@ Back up the bucket                              [ off | 1h | 3h | 24h ]
   Backup jobs       am-backup-am-dev-2          -> every run of this Space's backup
   Last updated      4 Aug 19:35                 -- a timestamp, never a stage
 
+  Skip these folders — type a name and press Enter
+  [ node_modules × ] [ .venv × ] [ add another…            ]
+
   [ Back up now ]        <- available whenever there is a token, schedule or not;
                             reads "Backing up..." and is disabled while one runs
 ```
@@ -294,6 +346,12 @@ which the Hub keeps as a `name=` label, so
 failed. Strictly better than linking the latest job id: no state to track, and the
 page you land on shows a failure in context. A test pins the launch name and the
 filter to the same value so they cannot drift.
+
+**The skip field is a token field**, because that is what the data is: a short
+list of folder names, each independently removable. Enter or comma commits,
+Backspace on an empty box takes the last one back. The status API also reports the
+expanded globs — a skip list nobody can see the expansion of is one nobody can
+debug, and §3.8 is why the expansion is not obvious.
 
 **No stage in the table.** It read `(running)` for runs that had long finished,
 because `stage || 'RUNNING'` invented an answer whenever the Hub did not give one.
@@ -383,6 +441,13 @@ knows which side should win.
 6. **Sustained hourly Job volume** over weeks is unproven, as is the interaction
    with the Job quota on a free account.
 7. **Bucket→repo is on the roadmap** (§3.1) — re-check before elaborating step 2.
+
+### 10.9 The mirror still holds what the history skips
+
+Excluded folders stay in the bucket mirror (§3.9), so they still occupy its
+storage, and a restore from the mirror brings them back. That is arguably right —
+the mirror exists to put a Space back exactly as it was — but it means "skip" means
+"skip in the history", and the settings copy says so rather than implying more.
 
 ## 11. Phasing
 

--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -209,6 +209,34 @@ property that makes the mirror nearly free — no bytes move, hashes only, 13,48
 files in 20 s — and make it read and re-upload 11.4 GB instead. Not worth it for
 files nobody wanted anyway. §10.9.
 
+### 3.10 What actually fails on a real bucket
+
+This Space's backups had been failing for a day before anyone noticed, which is
+the whole reason §7.1 exists. Two separate causes, from the Job logs:
+
+**The Hub refuses `.cache/` paths.** The mirror step succeeds, then:
+
+```
+✓ Copied
+Error: Invalid value. Invalid `path_in_repo` in CommitOperation:
+cannot update files under a '.cache/' folder
+(path: 'home/.cache/claude-cli-nodejs/…/2026-07-09T08-43-35-094Z.jsonl')
+```
+
+A bucket with an agent cache under `home/.cache/` can therefore *never* produce a
+dataset commit. `lvwerra/agent-manager-backup` held exactly one commit — "initial
+commit" — for a day of hourly runs.
+
+**The walk does not fit the job.** Failed runs show `Job timeout` after 1h33m to
+2h7m, against a `--timeout 3000s` (50 min) we asked for — so that flag is not
+being honoured either, and something around 1h30m is. Successful runs on a
+49-file bucket take 14–17 s; this bucket is 102,691 files on a FUSE mount.
+
+Excluding `.cache`, `node_modules`, `.venv` and `__pycache__` was **still running
+after 40 minutes** with no "Found N files" line, i.e. still walking. So exclusions
+fix the `.cache` rejection but may not fix the walk: `hf upload` appears to
+enumerate the tree before filtering it. Unresolved — §10.10.
+
 ### 3.7 Incidental
 
 `pip install "huggingface_hub[cli]"` warns on 1.26.0 — *"does not provide the
@@ -391,6 +419,29 @@ The privacy dots are not decoration: they are the state of the §1.4 gate, and t
 one thing an operator must be able to see at a glance about a copy of their
 credentials.
 
+## 7.1 Making failure visible
+
+A backup that fails quietly is worse than no backup, because the operator stops
+thinking about it. Nothing wrote a failure down before: the settings row learned of
+one only if somebody happened to open it, and `/api/backup/status` asked the Hub
+live rather than remembering.
+
+- **The timer records how each run ended**, once per job id, into
+  `backup-state.json`: stage, the platform's message, and one line of reason
+  lifted from the Job's own logs. That is where "cannot update files under a
+  '.cache/' folder" comes from — the platform only says `Job timeout`, which tells
+  an operator nothing about what to do.
+- **`/api/info` carries a health object**, or null when all is well. It is read
+  from state, never the Hub, because every open tab polls that route every 15
+  seconds. Withheld while the Space is public, like `secrets`.
+- **A strip above the stage**, on every view, not dismissible — a dismissed
+  warning is silence again, and silence is the failure mode. It shows the reason,
+  links to the filtered jobs list, and opens Settings.
+- **Staleness counts as unwell.** Three intervals with no successful run raises the
+  strip even when nothing errored. A timer that never fires, or a token that went
+  bad, leaves an operator exactly as wrongly confident as a failing run — and looks
+  perfectly healthy without this check.
+
 ## 8. Restore
 
 The direction the Hub *does* support server-side, pleasingly:
@@ -448,6 +499,17 @@ Excluded folders stay in the bucket mirror (§3.9), so they still occupy its
 storage, and a restore from the mirror brings them back. That is arguably right —
 the mirror exists to put a Space back exactly as it was — but it means "skip" means
 "skip in the history", and the settings copy says so rather than implying more.
+
+### 10.10 The walk may not fit any job
+
+Failed runs on this bucket are killed around 1h30m (§3.10), and `--timeout 3000s`
+is not honoured. Excluding the obvious noise did not visibly shorten the walk in a
+40-minute observation, which suggests `hf upload` enumerates before it filters. If
+that holds, the fix is not a longer list of exclusions but a different step 2 —
+uploading a subtree at a time, or letting the mirror be the only whole-bucket copy
+and giving the dataset a narrower job (sessions, config, transcripts) rather than
+everything. Undecided, and the reason §7.1 matters in the meantime: the operator
+should be told it is broken even while it stays broken.
 
 ## 11. Phasing
 

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -70,6 +70,42 @@ export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_
 const EXCLUDE_RE = /^[A-Za-z0-9._*?/-]+$/;
 export const MAX_EXCLUDES = 40;
 
+/**
+ * What a fresh install skips until the operator says otherwise.
+ *
+ * Chosen by walking this Space's own bucket rather than from taste: across 24
+ * workspace folders it holds 11 `node_modules`, 6 `.venv`, 4 `.cache`, and a
+ * `$HOME/.cache` carrying `ms-playwright`, `google-chrome-for-testing-headless`,
+ * `huggingface`, `uv`, `node-gyp` and the `claude-cli-nodejs` transcripts that
+ * make a dataset commit fail outright (§3.10). Every name here is something a
+ * package manager or toolchain rebuilds on demand.
+ *
+ * Two names were deliberately left OUT, and both matter more than what is in:
+ *   - `.git` appears 11 times, more often than anything else, and is the single
+ *     thing you would most want back. A size-ranked "junk" heuristic picks it
+ *     first; it is history, not cache.
+ *   - `dist` / `build` / `target` appear too, but they are ambiguous — a source
+ *     folder is called `build` often enough, and a default that silently drops
+ *     work is worse than one that copies some junk. Add them per-install.
+ */
+export const DEFAULT_EXCLUDE = Object.freeze([
+  'node_modules', '.venv', 'venv', '__pycache__', '.cache', '.npm', '.pnpm-store',
+  '.pytest_cache', '.mypy_cache', '.ruff_cache', '.ipynb_checkpoints', '.next', '.turbo',
+]);
+
+/**
+ * The stored value, or the default when the operator has never set one.
+ *
+ * An absent key and an empty list are NOT the same: `undefined` means "never
+ * asked", which takes the default, while `[]` is a list the operator emptied on
+ * purpose and must stay empty — otherwise clearing the field in Settings would
+ * silently refill itself on the next read.
+ */
+export function excludeFromConfig(saved) {
+  if (saved === undefined || saved === null) return [...DEFAULT_EXCLUDE];
+  return normalizeExclude(saved);
+}
+
 export function normalizeExclude(list) {
   if (!Array.isArray(list)) return [];
   const out = [];

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -59,6 +59,51 @@ export const hasToken = () => !!(process.env.HF_TOKEN || process.env.HUGGING_FAC
 const ID_RE = /^[A-Za-z0-9][\w.-]*\/[A-Za-z0-9][\w.-]*$/;
 export const validRepoId = (s) => typeof s === 'string' && s.length <= 96 && ID_RE.test(s);
 
+// Folders the operator does not want in the history: the slow, regenerable kind
+// (`node_modules`, `.venv`, `env`) that turn one backup into thousands of file
+// hashes. Measured on 805 files: 7s without, 1s with them excluded — and a real
+// bucket's mount is slower than a local disk, so the saving is larger there.
+//
+// Tokens are folder names, or raw globs for anything finer. No whitespace and no
+// shell metacharacters: these are joined into one env var and split apart again
+// inside the Job, so the charset is what makes that split exact.
+const EXCLUDE_RE = /^[A-Za-z0-9._*?/-]+$/;
+export const MAX_EXCLUDES = 40;
+
+export function normalizeExclude(list) {
+  if (!Array.isArray(list)) return [];
+  const out = [];
+  for (const raw of list) {
+    if (typeof raw !== 'string') continue;
+    // Leading and trailing slashes are noise: `/env/` and `env` mean the same.
+    const t = raw.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!t || t.length > 64 || !EXCLUDE_RE.test(t)) continue;
+    if (!out.includes(t)) out.push(t);
+  }
+  return out.slice(0, MAX_EXCLUDES);
+}
+
+/**
+ * Tokens -> `hf upload --exclude` globs.
+ *
+ * A bare name becomes TWO patterns, which is not obvious: `**\/env/**` does not
+ * match a top-level `env/`, verified against the Hub — `**\/` needs at least one
+ * leading segment. So excluding `env` needs `env/**` as well, or the copy at the
+ * bucket root silently still goes up.
+ *
+ * A token with a slash is a path and anchors at the bucket root; one containing
+ * `*` or `?` is already a glob and is passed through untouched.
+ */
+export function excludePatterns(tokens) {
+  const pats = [];
+  for (const t of normalizeExclude(tokens)) {
+    if (t.includes('*') || t.includes('?')) pats.push(t);
+    else if (t.includes('/')) pats.push(`${t}/**`);
+    else pats.push(`${t}/**`, `**/${t}/**`);
+  }
+  return pats;
+}
+
 function run(args, { timeout = 120_000 } = {}) {
   return new Promise((resolve, reject) => {
     execFile('hf', args, { timeout, env: process.env, maxBuffer: 8 << 20 }, (err, stdout, stderr) => {
@@ -134,11 +179,26 @@ if [ -n "\${AM_MIRROR:-}" ]; then
   hf cp "hf://buckets/\$AM_SOURCE/" "hf://buckets/\$AM_MIRROR/latest/"
 fi
 
+# Folders the operator asked to skip, as one --exclude per pattern. read -ra
+# splits on the spaces the server joined them with and nothing else: no globbing
+# against the container's filesystem, and each pattern reaches hf as a single
+# quoted argv element. Patterns are validated server-side to hold no whitespace,
+# which is what makes this split exact.
+EXCLUDE_ARGS=()
+if [ -n "\${AM_EXCLUDE:-}" ]; then
+  read -ra AM_EXCLUDE_PATS <<< "\$AM_EXCLUDE"
+  for p in "\${AM_EXCLUDE_PATS[@]}"; do EXCLUDE_ARGS+=(--exclude "\$p"); done
+  echo "skipping: \$AM_EXCLUDE"
+fi
+
 # 2. Version history, read from the bucket mounted read-only at /live — the
 #    Hub's copy, not this Space's disk. Unchanged files transfer nothing and
 #    produce no commit at all; --delete makes the newest commit match the bucket
-#    while every earlier commit keeps deleted files recoverable.
+#    while every earlier commit keeps deleted files recoverable — including
+#    anything newly excluded, which drops out of the newest commit but stays
+#    recoverable in the ones before it.
 hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
+  "\${EXCLUDE_ARGS[@]}" \\
   --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
 `;
 
@@ -167,7 +227,7 @@ export function parseJobId(out) {
 
 // Job arguments, as an array (never a shell string). Exported for the tests:
 // asserting on this is how we know a config value cannot reach a shell.
-export function jobArgs({ source, mirror, dataset }) {
+export function jobArgs({ source, mirror, dataset, exclude = [] }) {
   return [
     'jobs', 'run', '--detach',
     '--name', jobName(),
@@ -175,6 +235,9 @@ export function jobArgs({ source, mirror, dataset }) {
     '-e', `AM_SOURCE=${source}`,
     '-e', `AM_MIRROR=${mirror || ''}`,
     '-e', `AM_DATASET=${dataset}`,
+    // Space-joined: the tokens are validated to contain no whitespace, so the
+    // Job can split them back apart exactly.
+    '-e', `AM_EXCLUDE=${excludePatterns(exclude).join(' ')}`,
     // Read-only: a backup must not be able to write to what it is reading.
     '-v', `hf://buckets/${source}:/live:ro`,
     '--flavor', JOB_FLAVOR,
@@ -208,7 +271,7 @@ async function targets(cfg) {
   const d = await defaultsFor();
   const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
   const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
-  return { mirror, dataset, defaults: d };
+  return { mirror, dataset, defaults: d, exclude: normalizeExclude(cfg?.backup?.exclude) };
 }
 
 /** Launch one backup Job now. Returns { job } — the Hub does the rest. */
@@ -220,7 +283,7 @@ export async function runBackupNow(cfg) {
   // loud rather than silently doing nothing.
   if (await isRunning()) throw new Error('a backup is already running');
   const source = sourceBucket();
-  const { mirror, dataset } = await targets(cfg);
+  const { mirror, dataset, exclude } = await targets(cfg);
   for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
     if (label === 'mirror' && !id) continue;
     if (!validRepoId(id)) throw new Error(`${label} "${id}" is not a valid repo id`);
@@ -229,7 +292,7 @@ export async function runBackupNow(cfg) {
   // it; the dataset is created private by the upload itself.
   if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
 
-  const out = await run(jobArgs({ source, mirror, dataset }), { timeout: 180_000 });
+  const out = await run(jobArgs({ source, mirror, dataset, exclude }), { timeout: 180_000 });
   const job = parseJobId(out);
   // A launch we cannot identify still happened — record it, but say so, because
   // without an id there is nothing to poll and no overlap to detect.
@@ -317,7 +380,7 @@ export async function backupStatus(cfg) {
   const state = loadState();
   const every = cfg?.backup?.every || 'never';
   const source = sourceBucket();
-  const { mirror, dataset, defaults } = await targets(cfg);
+  const { mirror, dataset, defaults, exclude } = await targets(cfg);
   // Not gated on the interval: an on-demand backup is a real backup, and its
   // result has to be visible even with the schedule off.
   const [stage, priv] = await Promise.all([
@@ -339,6 +402,10 @@ export async function backupStatus(cfg) {
       : null,
     jobName: jobName(),
     jobsUrl: jobsUrl(),
+    // The tokens as stored, and the globs they become — a skip list nobody can
+    // see the expansion of is a skip list nobody can debug.
+    exclude,
+    excludePatterns: excludePatterns(exclude),
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -297,18 +297,68 @@ export async function runBackupNow(cfg) {
   // A launch we cannot identify still happened — record it, but say so, because
   // without an id there is nothing to poll and no overlap to detect.
   if (!job) console.warn('[backup] launched a Job but could not parse its id from:', out.slice(0, 200));
-  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null });
+  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null, outcomeFor: null });
   return { job };
+}
+
+/** Stage and the platform's own message for a Job — "Job timeout" lives in the
+ *  message, and it is the difference between "it broke" and "it never finished". */
+async function jobStatus(jobId) {
+  if (!jobId) return { stage: null, message: null };
+  try {
+    const j = JSON.parse(await run(['jobs', 'inspect', jobId, '--json'], { timeout: 30_000 }));
+    const s = Array.isArray(j) ? j[0] : j;
+    return { stage: (s && s.status && s.status.stage) || null, message: (s && s.status && s.status.message) || null };
+  } catch { return { stage: null, message: null }; }
 }
 
 /** Terminal state of the last launched Job, or null while it is still going. */
 async function jobStage(jobId) {
-  if (!jobId) return null;
+  return (await jobStatus(jobId)).stage;
+}
+
+/**
+ * Why a run failed, in one line, from its own logs.
+ *
+ * The platform message says "Job timeout"; the logs say the bucket has a
+ * `.cache/` path the Hub will not commit. The second is the one that tells an
+ * operator what to do, so both are kept and this is the one shown first.
+ */
+async function failureReason(jobId) {
   try {
-    const j = JSON.parse(await run(['jobs', 'inspect', jobId, '--json'], { timeout: 30_000 }));
-    const s = Array.isArray(j) ? j[0] : j;
-    return (s && s.status && s.status.stage) || null;
+    const out = await run(['jobs', 'logs', jobId], { timeout: 90_000 });
+    const lines = out.split('\n').map((l) => l.trim())
+      .filter((l) => l && !/^(WARNING|Hint:|\[notice\])/.test(l));
+    const telling = [...lines].reverse()
+      .find((l) => /error|refus|denied|invalid|cannot|failed|timeout/i.test(l));
+    return (telling || lines[lines.length - 1] || '').slice(0, 300) || null;
   } catch { return null; }
+}
+
+/**
+ * Record how the last run ended, once, so the answer survives in state instead
+ * of needing a Hub call to discover.
+ *
+ * This is the whole point of the feature: a backup that fails quietly is worse
+ * than no backup at all, because the operator believes they are covered. Until
+ * now nothing wrote a failure down — the settings row only learned of one if
+ * somebody happened to open it while the evidence was still fresh.
+ */
+async function recordOutcome() {
+  const st = loadState();
+  if (!st.jobId || st.outcomeFor === st.jobId) return;
+  const { stage, message } = await jobStatus(st.jobId);
+  if (!stage || isActiveStage(stage)) return; // still running, or the Hub did not say
+  if (stage === 'COMPLETED') {
+    saveState({ outcomeFor: st.jobId, failures: 0, lastFailure: null, lastSuccessAt: Date.now() });
+    return;
+  }
+  saveState({
+    outcomeFor: st.jobId,
+    failures: (st.failures || 0) + 1,
+    lastFailure: { at: Date.now(), jobId: st.jobId, stage, message: message || null, reason: await failureReason(st.jobId) },
+  });
+  console.warn(`[backup] run ${st.jobId} ended ${stage}${message ? ` (${message})` : ''}`);
 }
 
 // Stages that mean a run is genuinely in flight. Observed from the Hub:
@@ -338,6 +388,9 @@ async function isRunning() {
  * timestamp on disk rather than from an in-memory schedule.
  */
 export async function tick(cfg) {
+  // How the last run ended is recorded even when this tick does nothing else —
+  // otherwise a failure is only noticed by someone opening the settings page.
+  if (hasToken()) await recordOutcome().catch(() => {});
   if (unavailableReason(cfg)) return { skipped: unavailableReason(cfg) };
   const state = loadState();
   const due = Date.now() - (state.startedAt || 0) >= intervalMs(cfg.backup.every);
@@ -362,13 +415,57 @@ export async function tick(cfg) {
  * is due; the config is re-read each time, so switching the interval takes
  * effect without restarting anything.
  */
+/** Note when the schedule was first switched on, so "no success yet" can go
+ *  stale for a backup that has never once worked — which is this Space today. */
+export function armStaleClock(cfg) {
+  if (!intervalMs(cfg?.backup?.every)) return;
+  const st = loadState();
+  if (!st.firstArmedAt) saveState({ firstArmedAt: Date.now() });
+}
+
 export function startBackupTimer(getConfig) {
-  const t = setInterval(() => { tick(getConfig()).catch(() => {}); }, TICK_MS);
+  armStaleClock(getConfig());
+  const t = setInterval(() => { armStaleClock(getConfig()); tick(getConfig()).catch(() => {}); }, TICK_MS);
   if (t.unref) t.unref();
   // First check shortly after boot, once bucket discovery has landed.
   const first = setTimeout(() => { tick(getConfig()).catch(() => {}); }, 30_000);
   if (first.unref) first.unref();
   return () => { clearInterval(t); clearTimeout(first); };
+}
+
+/**
+ * Backup health, from state alone — no Hub calls, because this rides on
+ * /api/info which every open tab polls every 15 seconds.
+ *
+ * Returns null when there is nothing wrong, so the dashboard shows nothing at
+ * all in the normal case. Two ways to be unwell:
+ *   - `failing`: the last run ended in ERROR (or was killed).
+ *   - `stale`: no successful run in three intervals. A silent stall — the timer
+ *     never firing, the token going bad — leaves an operator just as wrongly
+ *     confident as an outright failure, and looks fine without this.
+ */
+export function backupHealth(cfg) {
+  const every = cfg?.backup?.every || 'never';
+  const ms = intervalMs(every);
+  if (!ms) return null; // switched off: silence is correct
+  const st = loadState();
+  const f = st.lastFailure || null;
+  const lastSuccessAt = st.lastSuccessAt || null;
+  const since = lastSuccessAt || st.firstArmedAt || null;
+  const stale = !!since && Date.now() - since > ms * 3;
+  if (!f && !stale) return null;
+  return {
+    failing: !!f,
+    stale,
+    failures: st.failures || 0,
+    at: f ? f.at : null,
+    jobId: f ? f.jobId : null,
+    stage: f ? f.stage : null,
+    message: f ? f.message || null : null,
+    reason: f ? f.reason || null : null,
+    lastSuccessAt,
+    jobsUrl: jobsUrl(),
+  };
 }
 
 /**
@@ -406,6 +503,10 @@ export async function backupStatus(cfg) {
     // see the expansion of is a skip list nobody can debug.
     exclude,
     excludePatterns: excludePatterns(exclude),
+    health: backupHealth(cfg),
+    failures: state.failures || 0,
+    lastFailure: state.lastFailure || null,
+    lastSuccessAt: state.lastSuccessAt || null,
     nextDue: state.startedAt && intervalMs(every) ? state.startedAt + intervalMs(every) : null,
     datasetPrivate: priv, // null = unknown or not created yet
     error: state.error || null,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -906,7 +906,9 @@ function loadAmConfig() {
       mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
       // Folder names to keep out of the history — the slow, regenerable kind.
-      exclude: backup.normalizeExclude(saved.backup?.exclude),
+      // Prepopulated on a config that has never set one, so a fresh install is
+      // quick by default; an emptied list stays empty. backup.js explains both.
+      exclude: backup.excludeFromConfig(saved.backup?.exclude),
     },
   };
 }
@@ -926,7 +928,9 @@ app.put('/api/config', (req, res) => {
       mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
       // Normalized here, not trusted: these end up in a Job's argument list.
-      exclude: backup.normalizeExclude(b.backup?.exclude),
+      // Same undefined-vs-empty rule as the read path: a body that omits the key
+      // never asked and takes the default, `[]` is an emptied list and persists.
+      exclude: backup.excludeFromConfig(b.backup?.exclude),
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -901,6 +901,8 @@ function loadAmConfig() {
       every: backup.INTERVALS.includes(saved.backup?.every) ? saved.backup.every : 'never',
       mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
+      // Folder names to keep out of the history — the slow, regenerable kind.
+      exclude: backup.normalizeExclude(saved.backup?.exclude),
     },
   };
 }
@@ -919,6 +921,8 @@ app.put('/api/config', (req, res) => {
       every: backup.INTERVALS.includes(b.backup?.every) ? b.backup.every : 'never',
       mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
+      // Normalized here, not trusted: these end up in a Job's argument list.
+      exclude: backup.normalizeExclude(b.backup?.exclude),
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -734,6 +734,10 @@ app.get('/api/info', (_req, res) => res.json({
   // True when the Space is private but we couldn't verify its bucket is private
   // (no HF_TOKEN to discover the bucket). Non-blocking; the UI shows a warning.
   bucketUnverified: !isPublic() && !!visibility().bucketUnverified,
+  // Backup health, or null when there is nothing wrong. Read from state, never
+  // the Hub: every open tab polls this route every 15s. Withheld while public
+  // for the same reason as `secrets` — it names the operator's repos.
+  backup: isPublic() ? null : backup.backupHealth(loadAmConfig()),
   // First-run welcome: shown once per Space (flag persists on the bucket).
   welcomeSeen: welcomeSeen(),
   // Demo mode: current sessions hidden from view; forces the welcome to show.

--- a/server/test/backup-health.test.mjs
+++ b/server/test/backup-health.test.mjs
@@ -1,0 +1,80 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+// backupHealth reads DATA_DIR/backup-state.json, so point DATA_DIR at a temp dir
+// before the module resolves it.
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'am-health-'));
+process.env.DATA_DIR = dir;
+process.env.AM_BACKUP_SOURCE = 'ns/bucket';
+process.env.HF_TOKEN = 'hf_test';
+const { backupHealth, EVERY_MS } = await import('../src/backup.js');
+
+const state = (o) => fs.writeFileSync(path.join(dir, 'backup-state.json'), JSON.stringify(o));
+const HOUR = EVERY_MS['1h'];
+
+test('silence when the feature is off, whatever the state says', () => {
+  state({ lastFailure: { at: Date.now(), jobId: 'j', stage: 'ERROR' }, failures: 9 });
+  assert.equal(backupHealth({ backup: { every: 'never' } }), null);
+  assert.equal(backupHealth({}), null);
+  assert.equal(backupHealth(undefined), null);
+});
+
+test('silence when the last run succeeded — the normal case shows nothing', () => {
+  state({ lastSuccessAt: Date.now() - 60_000, failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('a failed run surfaces, with the reason and the count', () => {
+  state({
+    failures: 3,
+    lastSuccessAt: Date.now() - 60_000,
+    lastFailure: { at: 1785900000000, jobId: 'j1', stage: 'ERROR', message: 'Job timeout', reason: "cannot update files under a '.cache/' folder" },
+  });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.equal(h.failing, true);
+  assert.equal(h.failures, 3);
+  assert.equal(h.jobId, 'j1');
+  assert.equal(h.message, 'Job timeout');
+  assert.match(h.reason, /\.cache/);
+  assert.match(h.jobsUrl, /^https:\/\/huggingface\.co\/settings\/jobs\?label=/);
+});
+
+// The failure mode this feature exists for: nothing is erroring, because nothing
+// is running. Looks perfectly healthy without a staleness check.
+test('a silent stall surfaces as stale, not as failing', () => {
+  state({ lastSuccessAt: Date.now() - HOUR * 4, failures: 0, lastFailure: null });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.ok(h, 'four hours with no success on an hourly schedule must not read as healthy');
+  assert.equal(h.stale, true);
+  assert.equal(h.failing, false);
+
+  // Within tolerance: a couple of missed ticks is not an alarm.
+  state({ lastSuccessAt: Date.now() - HOUR * 2, failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('never having succeeded goes stale from when it was switched on', () => {
+  // Armed long ago, no success ever — this Space's actual situation.
+  state({ firstArmedAt: Date.now() - HOUR * 10, failures: 0, lastFailure: null });
+  const h = backupHealth({ backup: { every: '1h' } });
+  assert.equal(h.stale, true);
+  assert.equal(h.lastSuccessAt, null);
+  // Just armed: give it a chance before complaining.
+  state({ firstArmedAt: Date.now(), failures: 0, lastFailure: null });
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});
+
+test('the staleness window scales with the interval', () => {
+  state({ lastSuccessAt: Date.now() - HOUR * 4, failures: 0, lastFailure: null });
+  // 4h is stale hourly, but nowhere near stale on a daily schedule.
+  assert.ok(backupHealth({ backup: { every: '1h' } }));
+  assert.equal(backupHealth({ backup: { every: '24h' } }), null);
+});
+
+test('an empty state file is not a problem', () => {
+  state({});
+  assert.equal(backupHealth({ backup: { every: '1h' } }), null);
+});

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -3,13 +3,60 @@ import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
-  normalizeExclude, excludePatterns, MAX_EXCLUDES,
+  normalizeExclude, excludePatterns, MAX_EXCLUDES, DEFAULT_EXCLUDE, excludeFromConfig,
 } from '../src/backup.js';
 
 // The rule that is not obvious and cost a Hub round-trip to learn: `**/x/**` does
 // NOT match a top-level `x/`, so a bare folder token needs BOTH patterns. Verified
 // against the Hub — with only the `**/` form, the copy at the bucket root still
 // went up.
+test('a config that never set a skip list gets the default, an emptied one stays empty', () => {
+  // The whole point of the split: `undefined` is "never asked", `[]` is a choice.
+  assert.deepEqual(excludeFromConfig(undefined), [...DEFAULT_EXCLUDE]);
+  assert.deepEqual(excludeFromConfig(null), [...DEFAULT_EXCLUDE]);
+  // An emptied list must NOT refill itself, or clearing the field in Settings
+  // would come back on the next read and the operator could never turn it off.
+  assert.deepEqual(excludeFromConfig([]), []);
+  // A set list is passed through the same validation as anything else.
+  assert.deepEqual(excludeFromConfig(['  env  ', '/env/']), ['env']);
+  assert.deepEqual(excludeFromConfig(['a', 'rm -rf /']), ['a']);
+  // Junk in the config file falls back to nothing rather than to the default:
+  // it IS a set value, just not a usable one.
+  assert.deepEqual(excludeFromConfig('node_modules'), []);
+});
+
+test('the default skip list is caches only — never .git, never ambiguous build dirs', () => {
+  // .git is the most common folder in the bucket and the one most worth keeping.
+  // A size-ranked heuristic would pick it first, so pin it explicitly.
+  for (const keep of ['.git', 'dist', 'build', 'target', 'src', 'data', '.config', '.ssh']) {
+    assert.ok(!DEFAULT_EXCLUDE.includes(keep), `${keep} must not be skipped by default`);
+  }
+  // The names actually found in this Space's bucket are covered.
+  for (const junk of ['node_modules', '.venv', '__pycache__', '.cache', '.npm']) {
+    assert.ok(DEFAULT_EXCLUDE.includes(junk), `${junk} should be skipped by default`);
+  }
+  // Every default has to survive the validator it will be fed through, fit the
+  // cap, and be unique — a default that silently drops would be invisible.
+  assert.deepEqual(normalizeExclude([...DEFAULT_EXCLUDE]), [...DEFAULT_EXCLUDE]);
+  assert.ok(DEFAULT_EXCLUDE.length <= MAX_EXCLUDES);
+  assert.equal(new Set(DEFAULT_EXCLUDE).size, DEFAULT_EXCLUDE.length);
+  // Frozen: it is handed out by reference-copy, and a caller mutating the
+  // module's own array would poison every later read.
+  assert.throws(() => DEFAULT_EXCLUDE.push('dist'));
+  excludeFromConfig(undefined).push('dist');
+  assert.ok(!DEFAULT_EXCLUDE.includes('dist'));
+});
+
+test('the default reaches a Job as splittable patterns, root and nested', () => {
+  const pats = excludePatterns([...DEFAULT_EXCLUDE]);
+  assert.equal(pats.length, DEFAULT_EXCLUDE.length * 2);
+  for (const p of pats) assert.ok(!/\s/.test(p), `${p} would break the shell split`);
+  assert.ok(pats.includes('node_modules/**') && pats.includes('**/node_modules/**'));
+  const env = jobArgs({ source: 'u/s', mirror: 'u/m', dataset: 'u/d', exclude: [...DEFAULT_EXCLUDE] })
+    .find((a) => String(a).startsWith('AM_EXCLUDE='));
+  assert.ok(env.includes('.cache/**') && env.includes('**/.cache/**'));
+});
+
 test('a bare folder token excludes it at the root AND nested', () => {
   assert.deepEqual(excludePatterns(['env']), ['env/**', '**/env/**']);
   assert.deepEqual(excludePatterns(['node_modules', '.venv']),

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -3,7 +3,63 @@ import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
+  normalizeExclude, excludePatterns, MAX_EXCLUDES,
 } from '../src/backup.js';
+
+// The rule that is not obvious and cost a Hub round-trip to learn: `**/x/**` does
+// NOT match a top-level `x/`, so a bare folder token needs BOTH patterns. Verified
+// against the Hub — with only the `**/` form, the copy at the bucket root still
+// went up.
+test('a bare folder token excludes it at the root AND nested', () => {
+  assert.deepEqual(excludePatterns(['env']), ['env/**', '**/env/**']);
+  assert.deepEqual(excludePatterns(['node_modules', '.venv']),
+    ['node_modules/**', '**/node_modules/**', '.venv/**', '**/.venv/**']);
+});
+
+test('a path anchors at the root, and an explicit glob is left alone', () => {
+  // A slash means "this exact place", so it is not also matched anywhere.
+  assert.deepEqual(excludePatterns(['state/claude/cache']), ['state/claude/cache/**']);
+  // Already a glob: passed through untouched, however odd.
+  assert.deepEqual(excludePatterns(['**/*.pyc']), ['**/*.pyc']);
+  assert.deepEqual(excludePatterns(['cache-*']), ['cache-*']);
+  assert.deepEqual(excludePatterns([]), []);
+  assert.deepEqual(excludePatterns(undefined), []);
+});
+
+test('normalizeExclude tidies input and refuses anything shell-shaped', () => {
+  // Slashes at either end are noise; duplicates and blanks go.
+  assert.deepEqual(normalizeExclude(['  env  ', '/env/', 'env', '', '   ']), ['env']);
+  assert.deepEqual(normalizeExclude(['a', 'b']), ['a', 'b']);
+  // Whitespace is what the Job's split relies on NOT being there.
+  for (const bad of ['two words', 'tab\there', 'new\nline']) {
+    assert.deepEqual(normalizeExclude([bad]), [], `${JSON.stringify(bad)} must be dropped`);
+  }
+  for (const bad of ['$(whoami)', '`id`', 'a;rm -rf /', 'a|b', 'a&b', "a'b", 'a"b', '<a', 'x'.repeat(65)]) {
+    assert.deepEqual(normalizeExclude([bad]), [], `${bad} must be dropped`);
+  }
+  // Non-strings and non-arrays cannot crash it.
+  assert.deepEqual(normalizeExclude([42, null, undefined, {}, 'ok']), ['ok']);
+  assert.deepEqual(normalizeExclude('env'), []);
+  // Unbounded lists are not a thing an operator needs.
+  assert.equal(normalizeExclude(Array.from({ length: 100 }, (_, i) => `d${i}`)).length, MAX_EXCLUDES);
+});
+
+// The patterns cross into the Job as one space-joined env var and are split back
+// apart by the shell. If either side of that contract changes, this fails.
+test('patterns reach the Job as one env var the shell can split exactly', () => {
+  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', exclude: ['env', 'node_modules'] });
+  const env = args[args.indexOf('AM_EXCLUDE=env/** **/env/** node_modules/** **/node_modules/**')];
+  assert.ok(env, `AM_EXCLUDE not passed as expected; got ${JSON.stringify(args.filter((a) => String(a).startsWith('AM_')))}`);
+  // No pattern may contain whitespace, or the split inside the Job is wrong.
+  for (const pat of excludePatterns(['env', 'node_modules'])) assert.ok(!/\s/.test(pat));
+  // Nothing to skip is an empty value, not a missing variable.
+  const none = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  assert.ok(none.includes('AM_EXCLUDE='));
+  // And the script must build the args itself rather than have them interpolated.
+  assert.match(JOB_SCRIPT, /read -ra AM_EXCLUDE_PATS/);
+  assert.match(JOB_SCRIPT, /EXCLUDE_ARGS\+=\(--exclude "\$p"\)/);
+  assert.ok(!JOB_SCRIPT.includes('node_modules/**'), 'patterns must not be baked into the script');
+});
 
 // The image installs huggingface_hub unpinned, so the CLI in the Space is not the
 // one on a dev machine. A version whose launch output differs left jobId null,

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -11,6 +11,7 @@ import ShareDialog from './components/ShareDialog';
 import Logo from './components/Logo';
 import Overview from './components/Overview';
 import Locked from './components/Locked';
+import BackupBanner from './components/BackupBanner';
 import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewFilter, Session, Tree } from './types';
@@ -886,6 +887,9 @@ export default function App() {
             )}
           </div>
         )}
+        {/* Visible where you already are, on every view. Rides on /api/info,
+            which is polled every 15s, so no new request for the normal case. */}
+        <BackupBanner health={info?.backup} onOpenSettings={() => { setSettingsPage('general'); setSettingsOpen(true); }} />
         <div className="stage">
           {renderTiles(
             isMobile && !mobileStage

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -55,6 +55,14 @@ export const deleteGroup = (id: string) =>
 export const move = (ref: string, to: MoveTarget) =>
   fetch('/api/move', { method: 'POST', headers: HEADERS, body: JSON.stringify({ ref, to }) }).then(json);
 
+// Present only when a backup is unwell; null the rest of the time, so the
+// dashboard shows nothing in the normal case.
+export interface BackupHealth {
+  failing: boolean; stale: boolean; failures: number;
+  at: number | null; jobId: string | null; stage: string | null;
+  message: string | null; reason: string | null;
+  lastSuccessAt: number | null; jobsUrl: string;
+}
 export const getInfo = () => fetch('/api/info').then(json);
 
 export const dismissWelcome = () => fetch('/api/welcome/seen', { method: 'POST' }).then(json);
@@ -106,6 +114,10 @@ export interface BackupStatus {
   // The tokens as stored, and the globs they expand to.
   exclude: string[];
   excludePatterns: string[];
+  health: BackupHealth | null;
+  failures: number;
+  lastFailure: { at: number; jobId: string; stage: string; message: string | null; reason: string | null } | null;
+  lastSuccessAt: number | null;
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -78,7 +78,7 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
-  backup: { every: BackupEvery; mirror: string; dataset: string };
+  backup: { every: BackupEvery; mirror: string; dataset: string; exclude: string[] };
   defaultArtifactsSpace?: string;
 }
 export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json);
@@ -103,6 +103,9 @@ export interface BackupStatus {
   // needs a job id to link to them.
   jobName: string;
   jobsUrl: string;
+  // The tokens as stored, and the globs they expand to.
+  exclude: string[];
+  excludePatterns: string[];
   nextDue: number | null;
   datasetPrivate: boolean | null;
   error: string | null;

--- a/web/src/components/BackupBanner.tsx
+++ b/web/src/components/BackupBanner.tsx
@@ -1,0 +1,39 @@
+import type { BackupHealth } from '../api';
+
+/**
+ * The one line that stops a broken backup from looking like a working one.
+ *
+ * Renders nothing when `health` is null, which is the normal case — the server
+ * only sends this object when a backup is failing or has gone quiet. Not
+ * dismissible on purpose: the whole failure mode here is silence being mistaken
+ * for health, and a dismissed warning is silence again.
+ */
+export default function BackupBanner({ health, onOpenSettings }: {
+  health: BackupHealth | null | undefined;
+  onOpenSettings: () => void;
+}) {
+  if (!health) return null;
+  return (
+    <div className="bkfail" role="status">
+      <span className="bkfail-dot" aria-hidden="true" />
+      <span className="bkfail-txt">
+        {health.failing ? (
+          <>
+            <b>Bucket backup is failing.</b>{' '}
+            {health.failures > 1 ? `${health.failures} runs in a row. ` : ''}
+            {health.reason ? <span className="mono bkfail-why">{health.reason}</span> : null}
+          </>
+        ) : (
+          <>
+            <b>Bucket backup has not succeeded recently.</b>{' '}
+            {health.lastSuccessAt
+              ? `Last good run ${new Date(health.lastSuccessAt).toLocaleString()}.`
+              : 'It has never completed a run.'}
+          </>
+        )}
+      </span>
+      <a className="bkfail-link" href={health.jobsUrl} target="_blank" rel="noreferrer">the runs ↗</a>
+      <button className="bkfail-link" onClick={onOpenSettings}>settings</button>
+    </div>
+  );
+}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -493,7 +493,8 @@ export default function SettingsView({
                         <div className="s-help" style={{ marginTop: 10 }}>
                           Skip these folders — type a name and press Enter. Anywhere they appear
                           (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
-                          they stay out of the history and the backup gets quicker.
+                          they stay out of the history and the backup gets quicker. The list starts
+                          on the caches a package manager can rebuild; remove any you want kept.
                         </div>
                         <div className="tagf" onClick={(e) => {
                           if (e.target === e.currentTarget) (e.currentTarget.querySelector('input') as HTMLInputElement)?.focus();

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -182,6 +182,7 @@ export default function SettingsView({
   const [bk, setBk] = useState<api.BackupStatus | null>(null);
   const [bkBusy, setBkBusy] = useState(false);
   const [bkMsg, setBkMsg] = useState('');
+  const [skipDraft, setSkipDraft] = useState('');
   const loadBackup = () => api.backupStatus().then(setBk).catch(() => {});
   useEffect(() => { loadBackup(); }, []);
   // Re-read after a save lands, so the interval and privacy dot stop disagreeing
@@ -194,6 +195,16 @@ export default function SettingsView({
     const t = setInterval(loadBackup, 10_000);
     return () => clearInterval(t);
   }, [bk?.running]);
+  // One token per commit, deduped, whitespace and shell characters dropped — the
+  // server normalizes again, since it is the side that must not be trusted.
+  const addSkip = () => {
+    if (!cfg) return;
+    const t = skipDraft.trim().replace(/^\/+/, '').replace(/\/+$/, '');
+    setSkipDraft('');
+    if (!t || !/^[A-Za-z0-9._*?/-]+$/.test(t) || cfg.backup.exclude.includes(t)) return;
+    setCfg({ ...cfg, backup: { ...cfg.backup, exclude: [...cfg.backup.exclude, t] } });
+  };
+
   const doBackup = async () => {
     setBkBusy(true);
     setBkMsg('');
@@ -456,6 +467,49 @@ export default function SettingsView({
                         before a risky change should not mean switching on a
                         schedule. Disabled while a run is in flight — two Jobs
                         uploading to one dataset would race. */}
+                    {/* Folders to keep out of the history. An env directory is
+                        thousands of files the backup has to hash and none of them
+                        worth keeping — measured, that is 7s of work versus 1s. */}
+                    {bk?.canRunNow && (
+                      <>
+                        <div className="s-help" style={{ marginTop: 10 }}>
+                          Skip these folders — type a name and press Enter. Anywhere they appear
+                          (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
+                          they stay out of the history and the backup gets quicker.
+                        </div>
+                        <div className="tagf" onClick={(e) => {
+                          if (e.target === e.currentTarget) (e.currentTarget.querySelector('input') as HTMLInputElement)?.focus();
+                        }}>
+                          {cfg.backup.exclude.map((t) => (
+                            <span className="tagf-chip mono" key={t}>
+                              {t}
+                              <button
+                                className="tagf-x"
+                                aria-label={`Stop skipping ${t}`}
+                                onClick={() => setCfg({ ...cfg, backup: { ...cfg.backup, exclude: cfg.backup.exclude.filter((x) => x !== t) } })}
+                              >×</button>
+                            </span>
+                          ))}
+                          <input
+                            className="tagf-input mono"
+                            placeholder={cfg.backup.exclude.length ? 'add another…' : 'node_modules'}
+                            value={skipDraft}
+                            onChange={(e) => setSkipDraft(e.target.value)}
+                            onKeyDown={(e) => {
+                              // Enter or comma commits; Backspace on an empty box
+                              // takes the last chip back, as tag fields do.
+                              if (e.key === 'Enter' || e.key === ',') {
+                                e.preventDefault();
+                                addSkip();
+                              } else if (e.key === 'Backspace' && !skipDraft && cfg.backup.exclude.length) {
+                                setCfg({ ...cfg, backup: { ...cfg.backup, exclude: cfg.backup.exclude.slice(0, -1) } });
+                              }
+                            }}
+                            onBlur={addSkip}
+                          />
+                        </div>
+                      </>
+                    )}
                     {bk?.canRunNow && (
                       <button
                         className="btn-ghost"

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -453,11 +453,29 @@ export default function SettingsView({
                             reporting it wrongly whenever the Hub did not answer. */}
                         <div>
                           <span>Last updated</span>
-                          <b>{bk.last ? new Date(bk.last.at).toLocaleString() : 'never'}</b>
+                          <b>{bk.lastSuccessAt ? new Date(bk.lastSuccessAt).toLocaleString() : 'never'}</b>
                         </div>
+                        {/* The dashboard strip says a backup is failing; this says
+                            what the Job actually reported, which is what tells you
+                            whether it is yours to fix. */}
+                        {bk.lastFailure && (
+                          <div>
+                            <span>Last failure</span>
+                            <b style={{ color: 'var(--danger)', whiteSpace: 'normal', textAlign: 'right' }}>
+                              {new Date(bk.lastFailure.at).toLocaleString()}
+                              {bk.lastFailure.message ? ` — ${bk.lastFailure.message}` : ''}
+                              {bk.failures > 1 ? ` (${bk.failures} in a row)` : ''}
+                              {bk.lastFailure.reason && (
+                                <div className="mono" style={{ fontWeight: 400, color: 'var(--muted)', fontSize: 11.5, marginTop: 2 }}>
+                                  {bk.lastFailure.reason}
+                                </div>
+                              )}
+                            </b>
+                          </div>
+                        )}
                         {bk.error && (
                           <div>
-                            <span>Last error</span>
+                            <span>Could not launch</span>
                             <b style={{ color: 'var(--danger)' }}>{bk.error}</b>
                           </div>
                         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -871,6 +871,15 @@ body {
 .cfg-seg button { flex: 1; padding: 6px 0; }
 .cfg-input { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); color: var(--text); font-size: 12.5px; }
 .cfg-input:focus { outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); border-color: var(--accent); }
+/* Token field: chips plus a bare input, sharing one bordered box so it reads as
+   a single control rather than a list next to a textbox. */
+.tagf { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; margin-top: 8px; padding: 6px 8px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
+.tagf:focus-within { border-color: var(--accent); outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); }
+.tagf-chip { display: inline-flex; align-items: center; gap: 5px; padding: 2px 4px 2px 7px; border-radius: var(--r-sm); background: var(--panel-2); border: 1px solid var(--border); font-size: 12px; }
+.tagf-x { border: none; background: transparent; color: var(--muted); cursor: pointer; font-size: 13px; line-height: 1; padding: 0 2px; }
+.tagf-x:hover { color: var(--danger); }
+.tagf-input { flex: 1; min-width: 120px; border: none; background: transparent; color: var(--text); font-size: 12.5px; padding: 3px 2px; }
+.tagf-input:focus { outline: none; }
 .cfg-usd { color: var(--muted); }
 .cfg-num { width: 90px; flex: none; text-align: right; }
 /* artifacts sub-settings stay visible when off, just clearly inert */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -71,6 +71,14 @@ body {
 .sidebar { width: 282px; flex: none; background: var(--panel); border-right: 1px solid var(--border); display: flex; flex-direction: column; overflow: hidden; }
 .main { flex: 1; min-width: 0; padding: 12px; overflow: hidden; display: flex; flex-direction: column; }
 .stage { flex: 1; min-height: 0; }
+/* Backup failure strip: one line above whatever view you are on. Loud enough to
+   not be mistaken for chrome, quiet enough to live there until it is fixed. */
+.bkfail { display: flex; align-items: center; gap: 8px; margin: 0 0 8px; padding: 7px 10px; border: 1px solid color-mix(in srgb, var(--danger) 45%, var(--border)); background: color-mix(in srgb, var(--danger) 10%, transparent); border-radius: var(--r-md); font-size: 12.5px; line-height: 1.35; }
+.bkfail-dot { flex: none; width: 7px; height: 7px; border-radius: 50%; background: var(--danger); }
+.bkfail-txt { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.bkfail-why { color: var(--muted); }
+.bkfail-link { flex: none; border: none; background: transparent; padding: 0; font: inherit; font-size: 12px; color: inherit; text-decoration: underline; text-decoration-style: dotted; text-underline-offset: 2px; cursor: pointer; }
+.bkfail-link:hover { color: var(--danger); text-decoration-style: solid; }
 .zoombar { display: flex; align-items: center; gap: 4px; padding: 4px 8px; margin-top: 8px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-lg); flex: none; }
 .zoombar .spacer { flex: 1; }
 /* overview bottom bar: filter + view segments, centered */


### PR DESCRIPTION
Supersedes and replaces #30, #31 and #32 — one branch off `main`, three commits,
reviewable in order. The skip list is no use without a sane default, and a backup
that can fail quietly is no use at all, so they ship together.

### 1. A skip list for folders that are slow and worth nothing (was #30)

Folder names the operator wants kept out of the history. The rule that cost a Hub
round-trip to learn: **`**/env/**` does not match a top-level `env/`**, so every
bare token expands to two globs (`env/**` *and* `**/env/**`) or the copy at the
bucket root silently still goes up.

| | files hashed | wall |
|---|---|---|
| no excludes | 805 | **7 s** |
| `.venv` excluded | 5 | **1 s** |

That is local disk; the Job reads a FUSE mount, so the real saving is larger.

### 2. Say so on the dashboard when it is failing (was #31)

The backup could fail every hour and the only clue was the absence of a fresh
commit. Failures are now counted and surfaced, with the last error and the last
success time, so a broken run is visible without opening the Jobs page.

### 3. Prepopulate the skip list with the caches nothing needs (was #32)

`node_modules`, `.venv`, `venv`, `__pycache__`, `.cache`, `.npm`, `.pnpm-store`,
`.pytest_cache`, `.mypy_cache`, `.ruff_cache`, `.ipynb_checkpoints`, `.next`,
`.turbo` — an empty list means a fresh install still crawls everything and you
find out by watching the first backup take an hour.

Picked by walking this Space's own bucket rather than from taste. Across 24
workspace folders: **11 `node_modules`, 6 `.venv`, 4 `.cache`**, plus a
`$HOME/.cache` holding `ms-playwright`, `google-chrome-for-testing-headless`,
`huggingface`, `uv`, `node-gyp` and the `claude-cli-nodejs` transcripts of §3.10.

**What that survey found and the default deliberately omits:**

- **`.git` — 11 of them, the most common folder in the bucket.** Rank candidates by
  size or count and it sorts to the top; it is also the one thing you would most
  want back. A test pins it out of the default so nobody optimizes it in later.
- **`dist`, `build`, `target`** — regenerable in most repos, hand-written source in
  enough of them. A default that silently drops work is worse than one that copies
  some junk, so they stay opt-in.

**`undefined` and `[]` now mean different things:** `undefined` is "never asked"
and takes the default; `[]` is a list emptied on purpose and stays empty. Applied
on both the read and write paths, so a PUT that omits the key cannot silently
persist an empty list.

**Worth a second look:** an existing install's config predates the key, so it picks
the default up and its next run skips those folders. Nothing already backed up is
lost — newly excluded files drop out of the newest commit but remain in the dataset
history.

### Verification

- `backup.test.mjs` 20/20, `backup-health.test.mjs` 7/7, full server chain green,
  `mobile` + `terminal-ui` green (both touch `App.tsx` / `SettingsView` / `styles.css`).
- The merged tree is byte-identical to the combination already deployed to am-dev-2
  and am-dev-3, which is what those Spaces have been running.
- Fresh-install path checked end-to-end against a real server with a clean data
  dir: `GET /api/config` returns the 13 defaults with no `am-config.json` on disk,
  so it is the default and not a persisted value. am-dev-2 has an explicitly set
  list (`.venv`, `.cache`) and correctly kept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
