### PR TITLE
Repin: fix the pane root, take the transcript scan off the event loop

### DIFF
--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -976,16 +976,23 @@ function takeClaudeBreadcrumb(sessionId) {
   try { return JSON.parse(raw); } catch { return null; }
 }
 
-// The pane's root process (what tmux spawned). After `exec claude` this IS
-// claude; in the `claude --session-id … || exec claude` branch claude is a
-// child of it. Either way the hook's $CLAUDE_PID must descend from it.
-function paneRootPid(sessionId) {
-  try {
-    const out = execFileSync('tmux', ['list-panes', '-t', tmuxName(sessionId), '-F', '#{pane_pid}'],
-      { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], env: TERM_ENV });
-    const pid = parseInt(out.trim().split('\n')[0], 10);
-    return Number.isInteger(pid) && pid > 1 ? pid : null;
-  } catch { return null; }
+// The pane's root process — the PTY this server spawned for the session. After
+// `exec claude` this IS claude; in the `claude --session-id … || exec claude`
+// branch claude is a child of it. Either way the hook's $CLAUDE_PID must descend
+// from it.
+//
+// This used to ask tmux for `#{pane_pid}`. Replacing tmux with a server-held grid
+// left the call behind referencing two identifiers that no longer exist here
+// (`tmuxName`, `execFileSync`), so it threw a ReferenceError into its own bare
+// `catch` on every tick and returned null. That failed EVERY breadcrumb as 'pid
+// not in pane' and silently disabled the whole hook path — observed live: the
+// only breadcrumb outcome in the Space logs was `breadcrumb rejected (pid not in
+// pane)`. The server owns the PTY now, so the pane root is a property read and
+// there is no subprocess per tick either.
+// Exported for server/test/repin.test.mjs.
+export function paneRootPid(sessionId) {
+  const pid = hosts.get(sessionId)?.pty?.pid;
+  return Number.isInteger(pid) && pid > 1 ? pid : null;
 }
 
 // Walk /proc ppid links. comm in /proc/<pid>/stat may contain spaces and
@@ -1058,6 +1065,34 @@ export function installClaudeRepinHook(hookCmd = '/app/scripts/am-repin-hook.sh'
   } catch (e) { console.warn(`[claude] repin hook install failed: ${e.message}`); return false; }
 }
 
+// Once the pane's SessionStart hook has proven itself, the transcript scan is a
+// backstop rather than the mechanism, and it runs on this cadence instead of
+// REPIN_MS. The scan is the expensive half of a tick and the breadcrumb is the
+// authoritative one: `claudeTranscriptsSince` is a readdirSync per project dir
+// plus a statSync per transcript, and on the Space those land on the FUSE bucket
+// (CLAUDE_CONFIG_DIR is under /data). Measured there: ~3ms when the mount's
+// attribute cache is warm, 1.1-1.3s when it is cold — a synchronous block of the
+// one event loop that also carries every session's PTY. At the REPIN_MS beat,
+// once per live pane, that was a terminal freeze roughly every 20 seconds.
+//
+// This is the window in which a pin can be stale if a breadcrumb is ever LOST
+// (the hook fired but its crumb never reached us). The breadcrumb path itself
+// stays on the REPIN_MS beat — it reads one file on local disk and costs nothing.
+const SCAN_BACKSTOP_MS = 10 * 60_000;
+
+/**
+ * Should this tick run the transcript scan?
+ *
+ * Before the hook has proven itself the cadence is unchanged, so a pane with no
+ * working hook (hook newly installed, crumb lost, a harness with no hook at all)
+ * keeps the pre-existing behaviour and nothing regresses. Pure so the cadence is
+ * testable without a live pane; exported for server/test/repin.test.mjs.
+ */
+export function claudeScanDue({ hookProven, lastScanAt }, now = Date.now()) {
+  if (!hookProven) return true;
+  return now - (lastScanAt || 0) >= SCAN_BACKSTOP_MS;
+}
+
 function scheduleClaudeCapture(session, workdir) {
   // A relaunch restarts the watch with a fresh window, so `since` can't drift
   // older and start admitting pre-relaunch threads as candidates.
@@ -1065,6 +1100,10 @@ function scheduleClaudeCapture(session, workdir) {
   if (prev) clearTimeout(prev);
   const since = Date.now() - 2000;
   let warnedShared = false;
+  // Has a breadcrumb from this pane ever named this pane's OWN conversation? That
+  // is what demotes the scan to a backstop — see claudeScanDue.
+  let hookProven = false;
+  let lastScanAt = 0;
 
   const tick = () => {
     if (!isRunning(session.id)) { claudeCapturing.delete(session.id); return; }
@@ -1082,6 +1121,12 @@ function scheduleClaudeCapture(session, workdir) {
         claimed: new Set(list().filter((s) => s.id !== session.id && s.sessionUuid).map((s) => s.sessionUuid)),
         pidTrusted: !!root && pidHasAncestor(crumb.claudePid, root),
       });
+      // A crumb that named this pane's own conversation — whether it moved the
+      // pin or was already on it (the `resume` no-op) — proves the hook fires
+      // here, so the scan can step down to a backstop. A crumb rejected for any
+      // other reason proves nothing about this pane: 'pid not in pane' is a
+      // nested `claude -p`, 'cwd mismatch' is someone else's run.
+      if (verdict.repin || verdict.why === 'already pinned') hookProven = true;
       if (verdict.repin) {
         console.warn(`[claude] re-pinning ${session.id}: ${pinned} -> ${verdict.repin} (breadcrumb, source: ${crumb.payload?.source || '?'})`);
         update(session.id, { sessionUuid: verdict.repin });
@@ -1098,7 +1143,8 @@ function scheduleClaudeCapture(session, workdir) {
         warnedShared = true;
         console.warn(`[claude] ${session.id}: folder shared with another live session — following /clear only via breadcrumbs here`);
       }
-    } else {
+    } else if (claudeScanDue({ hookProven, lastScanAt })) {
+      lastScanAt = Date.now();
       const hit = claudeCandidate(session.id, workdir, since);
       if (hit && hit.uuid !== pinned) {
         const why = transcriptExists(pinned) ? 'conversation was replaced (/clear)' : '--session-id was not honoured';

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -2,6 +2,7 @@ import os from 'node:os';
 import path from 'node:path';
 import pty from 'node-pty';
 import fs from 'node:fs';
+import fsp from 'node:fs/promises';
 import { remoteState, setPaused } from './remote.js';
 import { cliById, isRemote, STATE_DIR, WORKSPACES_DIR } from './config.js';
 import { update, list } from './sessions.js';
@@ -703,18 +704,21 @@ function codexRolloutsSince(sinceMs) {
 // truncate the JSON and make every capture silently fail.
 // The first line of a transcript that records a `cwd`, with its timestamp.
 // Bounded on lines AND bytes: a file-history-snapshot line can be megabytes.
-function transcriptHead(p) {
-  // openSync INSIDE the try: on the bucket mount a transcript can rotate away
+// Async, like the rest of the claude scan: every read here is against the FUSE
+// bucket, where a cold one costs tens of ms, and this is on the one event loop
+// that carries every session's PTY. See claudeTranscriptsSince.
+async function transcriptHead(p) {
+  // open() INSIDE the try: on the bucket mount a transcript can rotate away
   // between the stat that found it and this open, and the only caller runs in a
   // setTimeout where a throw is unhandled.
-  let fd = null;
+  let fh = null;
   try {
-    fd = fs.openSync(p, 'r');
+    fh = await fsp.open(p, 'r');
     const CHUNK = 65536, MAX_BYTES = 512 * 1024, MAX_LINES = 64;
     let carry = '', pos = 0, lines = 0;
     while (pos < MAX_BYTES && lines < MAX_LINES) {
       const b = Buffer.alloc(Math.min(CHUNK, MAX_BYTES - pos));
-      const n = fs.readSync(fd, b, 0, b.length, pos);
+      const { bytesRead: n } = await fh.read(b, 0, b.length, pos);
       if (!n) break;
       pos += n;
       carry += b.toString('utf8', 0, n);
@@ -731,7 +735,7 @@ function transcriptHead(p) {
       if (n < b.length) break; // EOF
     }
     return null;
-  } catch { return null; } finally { if (fd !== null) { try { fs.closeSync(fd); } catch {} } }
+  } catch { return null; } finally { if (fh) { try { await fh.close(); } catch {} } }
 }
 
 function firstLine(p) {
@@ -854,47 +858,70 @@ function claudeProjectDirs() {
 }
 
 // Every transcript, newest first, touched since `sinceMs`.
-function claudeTranscriptsSince(sinceMs) {
+//
+// Async, and that is the point rather than a style choice. This is a readdir per
+// project dir plus a stat per transcript, and on the Space CLAUDE_CONFIG_DIR is
+// on the FUSE bucket. Measured there over 32 transcripts: ~3ms when the mount's
+// attribute cache is warm, 1.1-1.3s when it is cold (~37ms per stat round trip).
+// The sync version spent all of that ON the one event loop that also carries
+// every session's PTY, so a cold scan was a hard freeze of every terminal — at
+// the REPIN_MS beat, once per live pane, every ~20 seconds.
+//
+// The awaited version does the same I/O for the same wall time, but on the
+// libuv threadpool: measured over 302 files, 11.6s of wall time for 26ms of
+// event-loop block. Sequential rather than Promise.all on purpose — 32 parallel
+// FUSE stats would saturate the 4-thread pool and push every other fs
+// operation in the process behind them, and nothing here is waiting on the
+// result.
+async function claudeTranscriptsSince(sinceMs) {
   const out = [];
   for (const proj of claudeProjectDirs()) {
     let dirs = [];
-    try { dirs = fs.readdirSync(proj, { withFileTypes: true }); } catch { continue; }
+    try { dirs = await fsp.readdir(proj, { withFileTypes: true }); } catch { continue; }
     for (const d of dirs) {
       if (!d.isDirectory()) continue;
       let files = [];
-      try { files = fs.readdirSync(path.join(proj, d.name)); } catch { continue; }
+      try { files = await fsp.readdir(path.join(proj, d.name)); } catch { continue; }
       for (const f of files) {
         if (!f.endsWith('.jsonl')) continue;
         const p = path.join(proj, d.name, f);
-        try { const st = fs.statSync(p); if (st.mtimeMs >= sinceMs) out.push({ p, m: st.mtimeMs }); } catch {}
+        try { const st = await fsp.stat(p); if (st.mtimeMs >= sinceMs) out.push({ p, m: st.mtimeMs }); } catch {}
       }
     }
   }
   return out.sort((a, b) => b.m - a.m);
 }
 
-const transcriptExists = (uuid) =>
-  !!uuid && claudeProjectDirs().some((proj) => {
+// Async for the same reason as claudeTranscriptsSince — plain loops rather than
+// .some(), which cannot await a predicate. Only reached when a re-pin is about to
+// happen, and only to say which of the two reasons it is.
+async function transcriptExists(uuid) {
+  if (!uuid) return false;
+  for (const proj of claudeProjectDirs()) {
     let dirs = [];
-    try { dirs = fs.readdirSync(proj, { withFileTypes: true }); } catch { return false; }
-    return dirs.some((d) => {
-      if (!d.isDirectory()) return false;
-      try { return fs.readdirSync(path.join(proj, d.name)).some((f) => f.startsWith(uuid)); } catch { return false; }
-    });
-  });
+    try { dirs = await fsp.readdir(proj, { withFileTypes: true }); } catch { continue; }
+    for (const d of dirs) {
+      if (!d.isDirectory()) continue;
+      try {
+        const files = await fsp.readdir(path.join(proj, d.name));
+        if (files.some((f) => f.startsWith(uuid))) return true;
+      } catch { /* dir vanished mid-walk */ }
+    }
+  }
+  return false;
+}
 
 // A transcript's opening cwd/timestamp never changes once written, and the
 // filename IS the conversation id, so a path is never reused for a different
 // conversation. That makes the head safe to remember — which matters because the
-// watcher rescans every REPIN_MS for the life of every session, and on the Space
-// these are synchronous reads against a FUSE mount. Without this, every tick
-// re-read every transcript on disk and would show up as event-loop lag.
+// watcher rescans for the life of every session, and on the Space these are reads
+// against a FUSE mount. Without this, every tick re-read every transcript on disk.
 const headMemo = new Map(); // transcript path -> head
 
-function transcriptHeadCached(p) {
+async function transcriptHeadCached(p) {
   const hit = headMemo.get(p);
   if (hit) return hit;
-  const head = transcriptHead(p);
+  const head = await transcriptHead(p);
   // Only remember a definite answer: null can just mean the file has no cwd line
   // yet (still being written), and caching that would poison it for the process.
   if (head) {
@@ -909,10 +936,10 @@ function transcriptHeadCached(p) {
 // what distinguishes a /clear-spawned successor from the thread it replaced —
 // both keep receiving mtime updates, only the successor is newly born.
 // Exported for server/test/repin.test.mjs.
-export function claudeCandidate(sessionId, workdir, sinceMs) {
+export async function claudeCandidate(sessionId, workdir, sinceMs) {
   const claimed = new Set(list().filter((s) => s.id !== sessionId && s.sessionUuid).map((s) => s.sessionUuid));
   let best = null;
-  for (const c of claudeTranscriptsSince(sinceMs)) {
+  for (const c of await claudeTranscriptsSince(sinceMs)) {
     const uuid = path.basename(c.p).replace(/\.jsonl$/, '');
     if (claimed.has(uuid)) continue;
     // The cwd is NOT on the first line: a transcript opens with metadata lines
@@ -920,7 +947,7 @@ export function claudeCandidate(sessionId, workdir, sinceMs) {
     // that have no cwd, and only the conversation lines carry one — line 4 or 5
     // in every real transcript measured. Reading line 1 made this check always
     // fail, so the re-pin could never actually claim anything.
-    const head = transcriptHeadCached(c.p);
+    const head = await transcriptHeadCached(c.p);
     // Only claim a conversation started in THIS session's folder.
     if (!head || head.cwd !== workdir) continue;
     const start = Date.parse(head.timestamp || '') || 0;
@@ -1066,19 +1093,14 @@ export function installClaudeRepinHook(hookCmd = '/app/scripts/am-repin-hook.sh'
 }
 
 // Once the pane's SessionStart hook has proven itself, the transcript scan is a
-// backstop rather than the mechanism, and it runs on this cadence instead of
-// REPIN_MS. The scan is the expensive half of a tick and the breadcrumb is the
-// authoritative one: `claudeTranscriptsSince` is a readdirSync per project dir
-// plus a statSync per transcript, and on the Space those land on the FUSE bucket
-// (CLAUDE_CONFIG_DIR is under /data). Measured there: ~3ms when the mount's
-// attribute cache is warm, 1.1-1.3s when it is cold — a synchronous block of the
-// one event loop that also carries every session's PTY. At the REPIN_MS beat,
-// once per live pane, that was a terminal freeze roughly every 20 seconds.
-//
-// This is the window in which a pin can be stale if a breadcrumb is ever LOST
-// (the hook fired but its crumb never reached us). The breadcrumb path itself
-// stays on the REPIN_MS beat — it reads one file on local disk and costs nothing.
-const SCAN_BACKSTOP_MS = 10 * 60_000;
+// backstop rather than the mechanism, so it runs on this cadence instead of
+// REPIN_MS. Now that the scan is awaited rather than synchronous this is no longer
+// about event-loop block time — it is only about not walking the bucket 3x a
+// minute per pane for an answer the breadcrumb already gave. So it can be short:
+// this is also the window in which a pin stays stale if a breadcrumb is ever LOST
+// (the hook fired but its crumb never reached us), and a minute of staleness in
+// that already-unlikely case costs one late Overview digest.
+const SCAN_BACKSTOP_MS = 60_000;
 
 /**
  * Should this tick run the transcript scan?
@@ -1105,8 +1127,13 @@ function scheduleClaudeCapture(session, workdir) {
   let hookProven = false;
   let lastScanAt = 0;
 
-  const tick = () => {
-    if (!isRunning(session.id)) { claudeCapturing.delete(session.id); return; }
+  // Returns whether to keep watching. Rearming is the caller's job (see `run`):
+  // the scan awaits now, so a throw lands as a rejected promise rather than as an
+  // exception in a setTimeout callback, and exactly one place deciding the next
+  // beat is what keeps a failed tick from either killing the watcher or arming
+  // two timers.
+  const tick = async () => {
+    if (!isRunning(session.id)) { claudeCapturing.delete(session.id); return false; }
     const pinned = (list().find((s) => s.id === session.id) || session).sessionUuid;
 
     // Breadcrumb first: the pane's own SessionStart hook told us which
@@ -1130,10 +1157,7 @@ function scheduleClaudeCapture(session, workdir) {
       if (verdict.repin) {
         console.warn(`[claude] re-pinning ${session.id}: ${pinned} -> ${verdict.repin} (breadcrumb, source: ${crumb.payload?.source || '?'})`);
         update(session.id, { sessionUuid: verdict.repin });
-        const t = setTimeout(tick, REPIN_MS);
-        if (t.unref) t.unref();
-        claudeCapturing.set(session.id, t);
-        return;
+        return true;
       }
       if (verdict.why !== 'already pinned') console.warn(`[claude] ${session.id}: breadcrumb rejected (${verdict.why})`);
     }
@@ -1144,22 +1168,38 @@ function scheduleClaudeCapture(session, workdir) {
         console.warn(`[claude] ${session.id}: folder shared with another live session — following /clear only via breadcrumbs here`);
       }
     } else if (claudeScanDue({ hookProven, lastScanAt })) {
-      lastScanAt = Date.now();
-      const hit = claudeCandidate(session.id, workdir, since);
-      if (hit && hit.uuid !== pinned) {
-        const why = transcriptExists(pinned) ? 'conversation was replaced (/clear)' : '--session-id was not honoured';
-        console.warn(`[claude] re-pinning ${session.id}: ${pinned} -> ${hit.uuid} (${why})`);
+      lastScanAt = Date.now(); // stamped BEFORE the await, so one scan is in flight at a time
+      const hit = await claudeCandidate(session.id, workdir, since);
+      // The scan yielded, so re-read the pin rather than trusting the one read at
+      // the top of this tick — a breadcrumb tick cannot have run (the next beat is
+      // armed only after this returns), but an explicit relaunch can have re-pinned.
+      const now = (list().find((s) => s.id === session.id) || session).sessionUuid;
+      if (hit && hit.uuid !== now) {
+        const why = await transcriptExists(now) ? 'conversation was replaced (/clear)' : '--session-id was not honoured';
+        console.warn(`[claude] re-pinning ${session.id}: ${now} -> ${hit.uuid} (${why})`);
         update(session.id, { sessionUuid: hit.uuid });
       }
     }
-    const t = setTimeout(tick, REPIN_MS);
-    if (t.unref) t.unref();
-    claudeCapturing.set(session.id, t);
+    return true;
   };
 
-  const t0 = setTimeout(tick, 5000);
-  if (t0.unref) t0.unref();
-  claudeCapturing.set(session.id, t0);
+  // One rearm per tick, whatever the tick did. A tick that throws logs and keeps
+  // the watcher alive: dropping it would silently stop following /clear for the
+  // rest of the pane's life, which is the failure this whole mechanism exists for.
+  const run = () => tick()
+    .catch((e) => {
+      console.warn(`[claude] ${session.id}: repin tick failed (${e && e.message}) — retrying next beat`);
+      return isRunning(session.id);
+    })
+    .then((again) => { if (again) rearm(); else claudeCapturing.delete(session.id); });
+
+  function rearm(ms = REPIN_MS) {
+    const t = setTimeout(run, ms);
+    if (t.unref) t.unref();
+    claudeCapturing.set(session.id, t);
+  }
+
+  rearm(5000);
 }
 
 const opencodeCapturing = new Map(); // id -> pending re-pin timer

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -1097,9 +1097,12 @@ export function installClaudeRepinHook(hookCmd = '/app/scripts/am-repin-hook.sh'
 // REPIN_MS. Now that the scan is awaited rather than synchronous this is no longer
 // about event-loop block time — it is only about not walking the bucket 3x a
 // minute per pane for an answer the breadcrumb already gave. So it can be short:
-// this is also the window in which a pin stays stale if a breadcrumb is ever LOST
-// (the hook fired but its crumb never reached us), and a minute of staleness in
-// that already-unlikely case costs one late Overview digest.
+// this also bounds how long a pin stays stale if a breadcrumb is ever LOST (the
+// hook fired but its crumb never reached us), and that staleness costs one late
+// Overview digest. Note the bound is this PLUS up to one beat, not exactly this:
+// only a tick can scan, ticks come every REPIN_MS, and each one is armed after the
+// previous finishes — so the first tick at or past the backstop can be as late as
+// SCAN_BACKSTOP_MS + REPIN_MS, plus the new scan's own duration.
 const SCAN_BACKSTOP_MS = 60_000;
 
 /**
@@ -1131,6 +1134,15 @@ function scheduleClaudeCapture(session, workdir) {
   let hookProven = false;
   let lastScanAt = 0;
 
+  // Read fresh, never captured: the scan awaits, so anything read before it is a
+  // stale view of the world by the time it returns.
+  const currentPin = () => (list().find((s) => s.id === session.id) || session).sessionUuid;
+  const claimedByOthers = () =>
+    new Set(list().filter((s) => s.id !== session.id && s.sessionUuid).map((s) => s.sessionUuid));
+  // Is this watch still the pane's? A relaunch spawns a new host and a new watch,
+  // and that one owns the pin from then on.
+  const stillOurs = () => hosts.get(session.id) === host;
+
   // Returns whether to keep watching. Rearming is the caller's job (see `run`):
   // the scan awaits now, so a throw lands as a rejected promise rather than as an
   // exception in a setTimeout callback, and exactly one place deciding the next
@@ -1138,7 +1150,7 @@ function scheduleClaudeCapture(session, workdir) {
   // two timers.
   const tick = async () => {
     if (!isRunning(session.id)) { claudeCapturing.delete(session.id); return false; }
-    const pinned = (list().find((s) => s.id === session.id) || session).sessionUuid;
+    const pinned = currentPin();
 
     // Breadcrumb first: the pane's own SessionStart hook told us which
     // conversation it is on, so no guessing — and no shared-folder refusal —
@@ -1149,7 +1161,7 @@ function scheduleClaudeCapture(session, workdir) {
       const verdict = breadcrumbVerdict(crumb, session.id, {
         workdir,
         pinned,
-        claimed: new Set(list().filter((s) => s.id !== session.id && s.sessionUuid).map((s) => s.sessionUuid)),
+        claimed: claimedByOthers(),
         pidTrusted: !!root && pidHasAncestor(crumb.claudePid, root),
       });
       // A crumb that named this pane's own conversation — whether it moved the
@@ -1172,16 +1184,36 @@ function scheduleClaudeCapture(session, workdir) {
         console.warn(`[claude] ${session.id}: folder shared with another live session — following /clear only via breadcrumbs here`);
       }
     } else if (claudeScanDue({ hookProven, lastScanAt })) {
-      lastScanAt = Date.now(); // stamped BEFORE the await, so one scan is in flight at a time
       const hit = await claudeCandidate(session.id, workdir, since);
-      // The scan yielded, so re-read the pin rather than trusting the one read at
-      // the top of this tick — a breadcrumb tick cannot have run (the next beat is
-      // armed only after this returns), but an explicit relaunch can have re-pinned.
-      const now = (list().find((s) => s.id === session.id) || session).sessionUuid;
-      if (hit && hit.uuid !== now) {
-        const why = await transcriptExists(now) ? 'conversation was replaced (/clear)' : '--session-id was not honoured';
-        console.warn(`[claude] re-pinning ${session.id}: ${now} -> ${hit.uuid} (${why})`);
-        update(session.id, { sessionUuid: hit.uuid });
+      // Stamped AFTER the scan resolves, not before it. Nothing can overlap it —
+      // the next beat is armed only once this tick returns — and stamping first
+      // meant a scan that threw was not retried on the next beat the way `run`
+      // logs, but skipped until the backstop expired.
+      lastScanAt = Date.now();
+      // Every input that decision rests on was read BEFORE the scan awaited, so
+      // re-read them rather than mutating a world that has moved on:
+      //   - this pane may have been relaunched, and the new watch owns the pin now
+      //     (its `since` is newer, so `hit` may be pre-relaunch and wrong);
+      //   - another claude pane may have gone live in this folder, which is
+      //     precisely the case folderIsShared refuses to guess at — and it was
+      //     false when this tick started;
+      //   - `hit` may since have been pinned by the session it belongs to;
+      //     claudeCandidate snapshots `claimed` before it walks the disk, so a
+      //     conversation that was unclaimed then can be claimed now. Taking it
+      //     anyway would make the owner's own breadcrumb bounce off 'claimed by
+      //     another session' for good.
+      if (hit && stillOurs() && !claimedByOthers().has(hit.uuid)
+          && !folderIsShared(session.id, workdir, 'claude')) {
+        const pin = currentPin();
+        if (hit.uuid !== pin) {
+          const why = await transcriptExists(pin) ? 'conversation was replaced (/clear)' : '--session-id was not honoured';
+          // transcriptExists awaited too, so confirm ownership once more before
+          // the write itself.
+          if (stillOurs()) {
+            console.warn(`[claude] re-pinning ${session.id}: ${pin} -> ${hit.uuid} (${why})`);
+            update(session.id, { sessionUuid: hit.uuid });
+          }
+        }
       }
     }
     return true;
@@ -1197,17 +1229,25 @@ function scheduleClaudeCapture(session, workdir) {
     })
     .then((again) => { if (again) rearm(); else claudeCapturing.delete(session.id); });
 
+  let armed = null;
   function rearm(ms = REPIN_MS) {
-    // A relaunch during an in-flight scan already started a fresh watch and owns
-    // the map entry. Without this check that watch's timer gets overwritten here
-    // and BOTH chains stay alive, only one of them reachable by clearTimeout: the
-    // pane then walks the bucket twice a beat, and the orphan keeps its own
-    // `hookProven`/`lastScanAt` (so it never steps down to the backstop) and its
-    // own pre-relaunch `since`. Same host-identity guard the grid timers use.
-    if (hosts.get(session.id) !== host) return;
-    const t = setTimeout(run, ms);
-    if (t.unref) t.unref();
-    claudeCapturing.set(session.id, t);
+    // This watch is no longer the pane's: either a relaunch during an in-flight
+    // scan started a fresh one — which already owns the map entry, and arming here
+    // would leave BOTH chains beating with only one reachable by clearTimeout, the
+    // orphan keeping its own hookProven/lastScanAt and its own pre-relaunch
+    // `since` — or the pane simply exited and nothing replaced it. Same
+    // host-identity guard the grid timers use.
+    if (!stillOurs()) {
+      // Drop OUR entry on the way out. A fired Timeout still holds its callback
+      // (node does not release `_onTimeout`), so leaving it in the map retains this
+      // closure and the disposed host until the session next starts. Only ours
+      // though: a newer watch's timer has to survive untouched.
+      if (claudeCapturing.get(session.id) === armed) claudeCapturing.delete(session.id);
+      return;
+    }
+    armed = setTimeout(run, ms);
+    if (armed.unref) armed.unref();
+    claudeCapturing.set(session.id, armed);
   }
 
   rearm(5000);

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -1121,6 +1121,10 @@ function scheduleClaudeCapture(session, workdir) {
   const prev = claudeCapturing.get(session.id);
   if (prev) clearTimeout(prev);
   const since = Date.now() - 2000;
+  // The host this watch belongs to. Clearing `prev` above only cancels a PENDING
+  // beat; now that a tick awaits, one can be mid-scan when a relaunch calls this
+  // again, and that tick still has a rearm ahead of it — see rearm.
+  const host = hosts.get(session.id);
   let warnedShared = false;
   // Has a breadcrumb from this pane ever named this pane's OWN conversation? That
   // is what demotes the scan to a backstop — see claudeScanDue.
@@ -1194,6 +1198,13 @@ function scheduleClaudeCapture(session, workdir) {
     .then((again) => { if (again) rearm(); else claudeCapturing.delete(session.id); });
 
   function rearm(ms = REPIN_MS) {
+    // A relaunch during an in-flight scan already started a fresh watch and owns
+    // the map entry. Without this check that watch's timer gets overwritten here
+    // and BOTH chains stay alive, only one of them reachable by clearTimeout: the
+    // pane then walks the bucket twice a beat, and the orphan keeps its own
+    // `hookProven`/`lastScanAt` (so it never steps down to the backstop) and its
+    // own pre-relaunch `since`. Same host-identity guard the grid timers use.
+    if (hosts.get(session.id) !== host) return;
     const t = setTimeout(run, ms);
     if (t.unref) t.unref();
     claudeCapturing.set(session.id, t);

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -56,25 +56,25 @@ const B = 'bbbbbbbb-0000-0000-0000-000000000002';
 console.log('\n/clear: the later-born conversation in this folder wins');
 transcript(A, { startMs: NOW });
 transcript(B, { startMs: NOW + 60_000 });
-check('follows the successor', runner.claudeCandidate('s1', WORKDIR, SINCE)?.uuid, B);
+check('follows the successor', (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, B);
 
 console.log('\na conversation in a different folder is never claimed');
 transcript('cccccccc-0000-0000-0000-000000000003',
   { cwd: path.join(cfg.WORKSPACES_DIR, 'proj-b'), startMs: NOW + 120_000, projDir: '-proj-b' });
-check('other folder ignored', runner.claudeCandidate('s1', WORKDIR, SINCE)?.uuid, B);
+check('other folder ignored', (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, B);
 
 console.log('\nan older thread that merely received writes is not a successor');
 transcript('dddddddd-0000-0000-0000-000000000004', { startMs: NOW - 3600_000, mtimeMs: NOW + 180_000 });
 check('pre-window thread rejected despite a fresh mtime',
-  runner.claudeCandidate('s1', WORKDIR, SINCE)?.uuid, B);
+  (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, B);
 
 console.log('\na conversation another session has pinned is left to it');
 const rival = sessions.create({ name: 'rival', cli: 'claude', path: 'proj-a' });
 sessions.update(rival.id, { sessionUuid: B });
-check('claimed uuid skipped', runner.claudeCandidate('s1', WORKDIR, SINCE)?.uuid, A);
+check('claimed uuid skipped', (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, A);
 
 console.log('\nnothing new in the window means no re-pin');
-check('no candidate', runner.claudeCandidate('s1', path.join(cfg.WORKSPACES_DIR, 'empty'), SINCE), null);
+check('no candidate', await runner.claudeCandidate('s1', path.join(cfg.WORKSPACES_DIR, 'empty'), SINCE), null);
 
 // ---------- breadcrumbs: attribution the scan cannot do in shared folders ----------
 const E = 'eeeeeeee-0000-0000-0000-000000000005';
@@ -129,23 +129,23 @@ try {
 }
 
 // ---------- scan cadence: the breadcrumb is the mechanism, the scan a backstop ----------
-// The scan is a readdirSync + a statSync per transcript, and CLAUDE_CONFIG_DIR is
-// on the FUSE bucket on the Space: ~1.2s of blocked event loop whenever the
-// mount's attribute cache is cold. At the REPIN_MS beat that froze the terminal
-// every ~20s per live pane, so once the hook has proven itself it steps down.
+// With the scan awaited the cadence is no longer about event-loop block time — it
+// is about not walking the bucket 3x a minute per pane for an answer the
+// breadcrumb already gave. So the backstop is a minute, and a minute is also the
+// longest a pin can stay stale if a crumb is ever lost.
 const MINUTE = 60_000;
 console.log('\nwithout a proven hook the scan runs every tick (unchanged)');
 check('no proof: due immediately', runner.claudeScanDue({ hookProven: false, lastScanAt: NOW }, NOW), true);
 check('no proof: still due 20s later',
   runner.claudeScanDue({ hookProven: false, lastScanAt: NOW }, NOW + 20_000), true);
 
-console.log('\na proven hook steps the scan down to a backstop cadence');
+console.log('\na proven hook steps the scan down to the backstop cadence');
 check('proven: not due on the next beat',
   runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 20_000), false);
-check('proven: not due after 9 minutes',
-  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 9 * MINUTE), false);
-check('proven: due again after 10 minutes',
-  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 10 * MINUTE), true);
+check('proven: not due at 59s',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + MINUTE - 1000), false);
+check('proven: due again at a minute',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + MINUTE), true);
 
 console.log('\na proven pane still scans once before its first backstop');
 check('proven but never scanned: due',

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -117,15 +117,22 @@ check('null crumb rejected', verdict(null, facts()).repin, null);
 // so this asserts against a REAL running session rather than a mock.
 console.log('\nthe pane root is the session PTY the server holds');
 check('unknown session has no pane root', runner.paneRootPid('nope'), null);
-const live = sessions.create({ name: 'live', cli: 'shell', path: 'proj-a' });
-let liveRoot = null;
-try {
-  runner.ensureRunning(live, 80, 24);
-  liveRoot = runner.paneRootPid(live.id);
-  check('live session has a pane root', Number.isInteger(liveRoot) && liveRoot > 1, true);
-  check('the pane root is a live process', fs.existsSync(`/proc/${liveRoot}`), true);
-} finally {
-  runner.stop(live.id);
+// Spawning a real pane needs libghostty's native addon, which not every checkout
+// has built. Skip rather than throw out of ensureRunning: an unhandled throw here
+// aborts the process and takes the cadence and installer checks below with it,
+// which reads as a broken test run rather than a missing optional dependency.
+if (!runner.ghosttyReady()) {
+  console.log('  SKIP  live pane checks (libghostty-vt unavailable)');
+} else {
+  const live = sessions.create({ name: 'live', cli: 'shell', path: 'proj-a' });
+  try {
+    runner.ensureRunning(live, 80, 24);
+    const liveRoot = runner.paneRootPid(live.id);
+    check('live session has a pane root', Number.isInteger(liveRoot) && liveRoot > 1, true);
+    check('the pane root is a live process', fs.existsSync(`/proc/${liveRoot}`), true);
+  } finally {
+    runner.stop(live.id);
+  }
 }
 
 // ---------- scan cadence: the breadcrumb is the mechanism, the scan a backstop ----------

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -109,6 +109,48 @@ check('malformed session_id rejected',
   verdict(crumb({ payload: { session_id: 'not-a-uuid', cwd: WORKDIR } }), facts()).repin, null);
 check('null crumb rejected', verdict(null, facts()).repin, null);
 
+// ---------- the pane root: the fact every breadcrumb is trusted against ----------
+// paneRootPid used to shell out to `tmux list-panes`. The libghostty migration
+// removed tmux but left the call, referencing identifiers that no longer exist —
+// so it threw into its own bare catch, returned null, and every breadcrumb was
+// rejected as 'pid not in pane'. A null pane root disables the hook path wholesale,
+// so this asserts against a REAL running session rather than a mock.
+console.log('\nthe pane root is the session PTY the server holds');
+check('unknown session has no pane root', runner.paneRootPid('nope'), null);
+const live = sessions.create({ name: 'live', cli: 'shell', path: 'proj-a' });
+let liveRoot = null;
+try {
+  runner.ensureRunning(live, 80, 24);
+  liveRoot = runner.paneRootPid(live.id);
+  check('live session has a pane root', Number.isInteger(liveRoot) && liveRoot > 1, true);
+  check('the pane root is a live process', fs.existsSync(`/proc/${liveRoot}`), true);
+} finally {
+  runner.stop(live.id);
+}
+
+// ---------- scan cadence: the breadcrumb is the mechanism, the scan a backstop ----------
+// The scan is a readdirSync + a statSync per transcript, and CLAUDE_CONFIG_DIR is
+// on the FUSE bucket on the Space: ~1.2s of blocked event loop whenever the
+// mount's attribute cache is cold. At the REPIN_MS beat that froze the terminal
+// every ~20s per live pane, so once the hook has proven itself it steps down.
+const MINUTE = 60_000;
+console.log('\nwithout a proven hook the scan runs every tick (unchanged)');
+check('no proof: due immediately', runner.claudeScanDue({ hookProven: false, lastScanAt: NOW }, NOW), true);
+check('no proof: still due 20s later',
+  runner.claudeScanDue({ hookProven: false, lastScanAt: NOW }, NOW + 20_000), true);
+
+console.log('\na proven hook steps the scan down to a backstop cadence');
+check('proven: not due on the next beat',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 20_000), false);
+check('proven: not due after 9 minutes',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 9 * MINUTE), false);
+check('proven: due again after 10 minutes',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: NOW }, NOW + 10 * MINUTE), true);
+
+console.log('\na proven pane still scans once before its first backstop');
+check('proven but never scanned: due',
+  runner.claudeScanDue({ hookProven: true, lastScanAt: 0 }, NOW), true);
+
 // ---------- hook installer: merge, never replace; idempotent; refuse corrupt ----------
 console.log('\ninstaller merges into existing settings and is idempotent');
 const settings = path.join(CFG, 'settings.json');


### PR DESCRIPTION
## The reported symptom

The terminal works for 2-3s, freezes for ~5s, then repeats. Input typed during the freeze arrives all at once afterwards, but the cursor keeps blinking and you can switch windows — because the freeze is **server-side**, not in the browser. While the one event loop is blocked the server can neither drain PTY output nor forward keystrokes; the blinking cursor is a CSS animation and the window switch is your OS.

## What it actually was

`claudeTranscriptsSince()` was a `readdirSync` per project dir plus a `statSync` per transcript — fully synchronous — running every `REPIN_MS` (20s) for the life of **every** live session. `CLAUDE_CONFIG_DIR` is on the FUSE bucket (`/data/state/claude`). Replaying that exact scan against the real directory, 8 times:

```
one scan: 12 readdirSync + 32 statSync -> 2 recent
8 scans (ms): 2, 3, 3, 3, 3, 77, 1111, 1260
```

Bimodal: ~3ms when the mount's attribute cache is warm, **1.1-1.3s cold** (~37ms per `statSync` round trip). Each cold scan was a full main-thread block, once per live pane, every 20 seconds.

Confirmed from the outside too. Probing `/api/health` — which does no I/O, so its latency *is* block time — gave blocks of 0.9-1.8s at periods of **20.2, 21.3, 21.2, 21.4s**. Not 20.0s: the drift equals the block, which is the signature of a `setTimeout(tick, N)` chain that reschedules *after* its work. Under load the watchdog logged the same thing as `main loop STALLED 5-6s … maxLag=12671ms`.

Ruled out along the way: `buildTraces` (11.6s of wall time but only **26ms** of blocking — properly async, and the `activity=buildTraces` breadcrumb is misleading because `tracked()` spans awaits); cgroup CPU throttling (`nr_throttled` flat, load 4.1/8); GC or CPU-bound JS (**zero** CPU ticks consumed across each block); sync fs on `/data` generally (p50 0.2ms); stdout pipe backpressure (async on POSIX).

## How this got here

Both halves of this PR trace back to specific earlier changes, and the order matters — this is not a regression introduced by something recent.

| when | what | effect |
|---|---|---|
| `5b5da0e` 06-29 | defines the `tmuxName` helper (tmux session name per pane) | — |
| `12a7e8c` 07-30 | **Replace tmux with a server-held libghostty grid** — deletes that definition | tmux idiom is gone from `runner.js` |
| `9fb59f5` **#17** 07-31 | conversation pins get a life-of-the-pane watcher on a 20s beat | **the freeze**: turns a once-per-launch scan into one every 20s per pane |
| `7112a46` **#23** 08-04 | adds `paneRootPid()`, calling `tmuxName` and `execFileSync` | **dead on arrival**: neither identifier exists in that file |

**#17** is where the cost comes from. It changed the pin from captured-once-at-launch to re-checked forever, which was the right fix for a real bug (`/clear` orphaning the pin, so `--resume` restored the pre-`/clear` thread). Its own description anticipated exactly this hazard — *"this scan now runs for the life of every session against a FUSE mount rather than once per launch"* — and memoized transcript **heads** to bound it. That memoization holds; what it did not cover is the `statSync` sweep that finds the candidates in the first place, which is the 1.2s measured above.

**#23** added the breadcrumb path to fix what the scan cannot do: attribute a new conversation when several live claude panes share a folder. But it introduced `paneRootPid()` as a `tmux list-panes` call five days after `12a7e8c` deleted `tmuxName`, and `execFileSync` is not imported in `runner.js` either. `git log -S tmuxName --all` shows the definition added in `5b5da0e`, removed in `12a7e8c`, and referenced again only by `7112a46`; `paneRootPid` itself first appears in `7112a46`. So it has never returned anything but `null` — it throws a `ReferenceError` straight into its own bare `catch` on every tick.

A null pane root makes `pidTrusted` false for every breadcrumb, which is what the live logs show, invariably:

```
[claude] agent-manager-4-ba3fbf: breadcrumb rejected (pid not in pane)
[claude] agent-manager-1-f79577: breadcrumb rejected (pid not in pane)
```

So **#23's mechanism has never run**, and the bug it was written for — `/clear` in a shared folder never being followed — is still live today. This PR is the first point at which that mechanism can work at all, which is also why the cheap fix for the freeze (lean on the breadcrumb, scan less) had to be preceded by repairing the thing it leans on.

## Three changes

### 1. The pane root

`paneRootPid` now reads `hosts.get(id).pty.pid`: the same semantic tmux's `pane_pid` had — the process this server spawned for the session, which `exec claude` replaces in place — as a property read, with no subprocess per tick.

### 2. The scan is awaited

The scan's cost was never the I/O, it was doing the I/O on the event loop. `claudeTranscriptsSince`, `transcriptHead`, `transcriptExists` and `claudeCandidate` now await, and the watcher tick is async. Measured against the real bucket directory, same code path either way:

| | wall time | event-loop block |
|---|---|---|
| sync | 1111-1260ms | **all of it** |
| async | 466ms cold, 5-8ms warm | **1ms** |

Sequential rather than `Promise.all` on purpose: 32 parallel FUSE stats would saturate the 4-thread libuv pool and push every other fs operation in the process behind them, and nothing is waiting on the result.

### 3. The scan steps down to a backstop

For any pane whose hook has proven itself — a breadcrumb that named that pane's own conversation, either a re-pin or the `resume` no-op `already pinned` — the scan runs once a minute instead of every beat. A crumb rejected for any other reason proves nothing about the pane and does not count. A pane with **no** working hook keeps the old every-tick cadence, so nothing regresses where the scan is still the only mechanism.

Because the scan no longer blocks, this cadence is not trading staleness against freezing any more; it only limits how often we walk the bucket for an answer the breadcrumb already gave. That is why it is a minute and not the ten first proposed — a minute is also the longest a pin can stay stale if a crumb is ever *lost* (the hook fired but its crumb never reached us), and the cost of being wrong there is one late Overview digest.

Rearming moved out of `tick` into one place. An awaited tick that throws surfaces as a rejected promise rather than an exception in a `setTimeout` callback, so `run` catches, logs and rearms — dropping the watcher would silently stop following `/clear` for the rest of the pane's life. Exactly one rearm per tick, so a failure can neither kill the watcher nor arm two timers. The scan also re-reads the pin after awaiting rather than trusting the value read at the top of the tick.

## Scope

Not touched: the codex and opencode watchers from #17 run on the same 20s beat, but read local disk (`/home/node/local/codex-home`, and opencode's SQLite was moved off FUSE in `1dfb753`), so they are cheap. `firstLine` stays synchronous for the same reason — it is only on the codex rollout path. Claude's scan was the one on the bucket.

## Testing

`server/test/repin.test.mjs` — 30 checks, up from 21. Full `npm test` green (all 5 suites).

- **3 new checks on the pane root**, asserted against a **real running session** rather than a mock, because a mock cannot catch this class of bug. Verified they have teeth: restoring the tmux version fails 2 of them (`got false want true`). Note it is the live-session check that catches it — `paneRootPid('unknown')` returns `null` under both the broken and fixed versions, which is part of why #23's own 21 checks passed while the function never worked.
- **6 new checks on the cadence** via a pure `claudeScanDue()`: unchanged every-tick behaviour without a proven hook, no scan on the next beat or at 59s with one, due again at a minute, and a proven pane still scanning once before its first backstop.
- The 5 existing `claudeCandidate` checks now await it; their assertions are unchanged, so they still cover the launch window, folder scoping and other sessions' pins across the async conversion.
- The async block measurement above was taken by importing the new `claudeCandidate` and pointing it at the real `/data/state/claude` while sampling event-loop lag, rather than inferred from the shape of the change.

Not covered by tests: the `run` wrapper's throw-and-rearm behaviour, which needs a driven watcher loop rather than a pure function. And not verified end-to-end: that a `/clear` in a shared folder now re-pins via a trusted breadcrumb on the live Space — that needs this deployed, since the running container still has the broken `paneRootPid`, which is why the log evidence above shows only rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
