### PR TITLE
codex: capture the conversation pin in a shared folder, so a restart can resume it

### DIFF
--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -751,9 +751,13 @@ function firstLine(p) {
   } finally { fs.closeSync(fd); }
 }
 
-function tryCaptureCodexId(sessionId, workdir, sinceMs) {
+// The newest rollout written in `workdir` that no other session has pinned, as
+// { id, p }. `bornBefore` caps how late a conversation may have been BORN and
+// still be taken as ours; in a shared folder that cap is what keeps a sibling's
+// later reset out of reach (see codexCaptureMode).
+// Exported for server/test/repin.test.mjs.
+export function codexCandidate(sessionId, workdir, sinceMs, { bornBefore = Infinity } = {}) {
   const claimed = new Set(list().filter((s) => s.id !== sessionId && s.codexSessionId).map((s) => s.codexSessionId));
-  const pinned = (list().find((s) => s.id === sessionId) || {}).codexSessionId;
   for (const c of codexRolloutsSince(sinceMs)) {
     const m = c.p.match(/rollout-.*-([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.jsonl$/);
     if (!m || claimed.has(m[1])) continue;
@@ -764,20 +768,28 @@ function tryCaptureCodexId(sessionId, workdir, sinceMs) {
     // A sibling's ongoing conversation in the same folder gets fresh writes
     // (mtime) during our capture window — require the rollout to have been
     // CREATED after this launch so we never claim someone else's thread.
-    const created = Date.parse(mp.timestamp || meta.timestamp || '') || 0;
-    if (created && created < sinceMs - 15_000) continue;
+    const born = Date.parse(mp.timestamp || meta.timestamp || '') || 0;
+    if (born && born < sinceMs - 15_000) continue;
+    if (born && born > bornBefore) continue;
     // Skip Codex's internal guardian/subagent rollouts — they share the cwd but
     // aren't this agent's conversation, so pinning one would break resume and
     // the Overview digest.
     if (mp.thread_source === 'subagent' || (mp.source && mp.source.subagent)) continue;
-    // The watcher re-runs for the life of the pane, so the usual outcome is
-    // "still the same conversation" — don't rewrite sessions.json for that.
-    if (m[1] === pinned) return true;
-    if (pinned) console.warn(`[codex] re-pinning ${sessionId}: ${pinned} -> ${m[1]} (conversation was replaced)`);
-    update(sessionId, { codexSessionId: m[1], codexRollout: c.p });
-    return true;
+    return { id: m[1], p: c.p };
   }
-  return false;
+  return null;
+}
+
+function tryCaptureCodexId(sessionId, workdir, sinceMs, opts) {
+  const c = codexCandidate(sessionId, workdir, sinceMs, opts);
+  if (!c) return false;
+  const pinned = (list().find((s) => s.id === sessionId) || {}).codexSessionId;
+  // The watcher re-runs for the life of the pane, so the usual outcome is
+  // "still the same conversation" — don't rewrite sessions.json for that.
+  if (c.id === pinned) return true;
+  if (pinned) console.warn(`[codex] re-pinning ${sessionId}: ${pinned} -> ${c.id} (conversation was replaced)`);
+  update(sessionId, { codexSessionId: c.id, codexRollout: c.p });
+  return true;
 }
 
 // A pin captured before subagents were filtered out (or one whose rollout was
@@ -793,11 +805,38 @@ function pinIsStale(session) {
   } catch { return false; }
 }
 
+// How late after launch a conversation may be born and still be taken as ours
+// when the folder is shared. Codex writes its session_meta line as the TUI
+// starts — 3.5s after launch in the session that motivated this — so two
+// minutes is ample margin, while a sibling's reset minutes or hours in stays
+// out of reach.
+const CODEX_PIN_WINDOW_MS = 120_000;
+
+// What the watcher may do on this tick:
+//   'follow'  — capture, and keep following resets: this pane owns the folder.
+//   'window'  — unpinned in a shared folder. Capture, but only a conversation
+//               born in our launch window. This case used to do NOTHING, which
+//               meant a codex pane sharing a folder never got a pin at all: its
+//               conversation was on disk, and every restart came back empty,
+//               because resumeCmd correctly refuses `resume --last` there.
+//   'pinned'  — pinned in a shared folder: a NEW conversation here is
+//               unattributable (our reset, or a sibling's?), so don't follow it.
+//   'expired' — shared, unpinned, window gone: nothing safe left to take.
+// Exported for server/test/repin.test.mjs.
+export function codexCaptureMode({ shared, pinned, nowMs, sinceMs }) {
+  if (!shared) return 'follow';
+  if (pinned) return 'pinned';
+  return nowMs <= sinceMs + CODEX_PIN_WINDOW_MS ? 'window' : 'expired';
+}
+
 // Same staleness problem as Claude's pin, same remedy: codex starts a fresh
 // conversation — and a fresh rollout file — when the thread is reset, so a pin
 // captured once at launch stops describing the live conversation. Keep watching
 // for as long as the pane is alive and follow the newest rollout this folder
 // produces. tryCaptureCodexId only writes when the id actually changes.
+//
+// A shared folder narrows that to the initial capture only — see
+// codexCaptureMode for which part is safe there and which isn't.
 function scheduleCodexCapture(session, workdir) {
   if (session.codexSessionId && pinIsStale(session)) {
     session = update(session.id, { codexSessionId: undefined, codexRollout: undefined }) || session;
@@ -805,17 +844,25 @@ function scheduleCodexCapture(session, workdir) {
   const prev = codexCapturing.get(session.id);
   if (prev) clearTimeout(prev);
   const since = Date.now() - 2000;
-  let warnedShared = false;
+  let warnedShared = false, warnedExpired = false;
 
   const tick = () => {
     if (!isRunning(session.id)) { codexCapturing.delete(session.id); return; }
-    if (folderIsShared(session.id, workdir, 'codex')) {
-      if (!warnedShared) {
-        warnedShared = true;
-        console.warn(`[codex] ${session.id}: folder shared with another live session — not following thread resets here`);
-      }
-    } else {
-      tryCaptureCodexId(session.id, workdir, since);
+    const mode = codexCaptureMode({
+      shared: folderIsShared(session.id, workdir, 'codex'),
+      pinned: !!(list().find((s) => s.id === session.id) || {}).codexSessionId,
+      nowMs: Date.now(),
+      sinceMs: since,
+    });
+    if (mode === 'follow') tryCaptureCodexId(session.id, workdir, since);
+    else if (mode === 'window') {
+      tryCaptureCodexId(session.id, workdir, since, { bornBefore: since + CODEX_PIN_WINDOW_MS });
+    } else if (mode === 'pinned' && !warnedShared) {
+      warnedShared = true;
+      console.warn(`[codex] ${session.id}: folder shared with another live session — not following thread resets here`);
+    } else if (mode === 'expired' && !warnedExpired) {
+      warnedExpired = true;
+      console.warn(`[codex] ${session.id}: no rollout born in this folder within ${CODEX_PIN_WINDOW_MS / 1000}s of launch — staying unpinned, so a restart will start a fresh conversation`);
     }
     const t = setTimeout(tick, REPIN_MS);
     if (t.unref) t.unref();

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -15,6 +15,7 @@ fs.mkdirSync(DATA, { recursive: true });
 
 process.env.CLAUDE_CONFIG_DIR = CFG;
 process.env.DATA_DIR = DATA;
+process.env.CODEX_HOME = path.join(TMP, 'codex');
 
 const sessions = await import('../src/sessions.js');
 const runner = await import('../src/runner.js');
@@ -108,6 +109,58 @@ check('claimed uuid left to its session',
 check('malformed session_id rejected',
   verdict(crumb({ payload: { session_id: 'not-a-uuid', cwd: WORKDIR } }), facts()).repin, null);
 check('null crumb rejected', verdict(null, facts()).repin, null);
+
+// ---------- codex: the pin a folder-sharing pane never got ----------
+// Codex has no breadcrumb, so a shared folder used to skip capture ENTIRELY and
+// the pane stayed unpinned for life — conversation on disk, every restart empty.
+// The initial capture is safe there; following a later reset is not.
+const R = (n) => `019fd29a-97e5-7d11-b36e-3ce290b0a00${n}`;
+function rollout(id, { cwd = WORKDIR, bornMs, mtimeMs, subagent = false }) {
+  const dir = path.join(process.env.CODEX_HOME, 'sessions', '2026', '08', '05');
+  fs.mkdirSync(dir, { recursive: true });
+  const p = path.join(dir, `rollout-2026-08-05T15-46-14-${id}.jsonl`);
+  const payload = { cwd, timestamp: new Date(bornMs).toISOString() };
+  if (subagent) payload.thread_source = 'subagent';
+  fs.writeFileSync(p, JSON.stringify({ type: 'session_meta', payload }) + '\n');
+  const t = (mtimeMs ?? bornMs) / 1000;
+  fs.utimesSync(p, t, t);
+  return p;
+}
+const WINDOW = { bornBefore: SINCE + 120_000 };
+
+console.log('\ncodex: the conversation born in this launch window is ours');
+rollout(R(1), { bornMs: NOW });
+check('own rollout captured', runner.codexCandidate('c1', WORKDIR, SINCE)?.id, R(1));
+
+console.log('\ncodex: whose folder and whose birth, not whose mtime');
+rollout(R(2), { cwd: path.join(cfg.WORKSPACES_DIR, 'proj-b'), bornMs: NOW + 1000, mtimeMs: NOW + 120_000 });
+check('other folder ignored', runner.codexCandidate('c1', WORKDIR, SINCE)?.id, R(1));
+rollout(R(3), { bornMs: NOW - 3600_000, mtimeMs: NOW + 180_000 });
+check('pre-launch rollout rejected despite a fresh mtime',
+  runner.codexCandidate('c1', WORKDIR, SINCE)?.id, R(1));
+rollout(R(4), { bornMs: NOW + 5000, mtimeMs: NOW + 200_000, subagent: true });
+check('subagent rollout skipped', runner.codexCandidate('c1', WORKDIR, SINCE)?.id, R(1));
+
+console.log('\ncodex: a later conversation is a reset to follow, or a sibling to leave alone');
+rollout(R(5), { bornMs: NOW + 240_000 });
+check('followed when the folder is ours', runner.codexCandidate('c1', WORKDIR, SINCE)?.id, R(5));
+check('out of reach in a shared folder', runner.codexCandidate('c1', WORKDIR, SINCE, WINDOW)?.id, R(1));
+
+console.log('\ncodex: a rollout another session pinned is left to it');
+const rivalCodex = sessions.create({ name: 'rival-codex', cli: 'codex', path: 'proj-a' });
+sessions.update(rivalCodex.id, { codexSessionId: R(1) });
+check('claimed rollout skipped', runner.codexCandidate('c1', WORKDIR, SINCE, WINDOW), null);
+
+console.log('\ncodex: what the watcher may do on a tick');
+const mode = (o) => runner.codexCaptureMode({ nowMs: NOW, sinceMs: SINCE, ...o });
+check('sole pane captures and follows resets', mode({ shared: false, pinned: false }), 'follow');
+check('sole pane keeps following once pinned', mode({ shared: false, pinned: true }), 'follow');
+check('shared and unpinned still captures', mode({ shared: true, pinned: false }), 'window');
+check('shared and pinned stops at the pin', mode({ shared: true, pinned: true }), 'pinned');
+check('window is open at its last instant',
+  mode({ shared: true, pinned: false, nowMs: SINCE + 120_000 }), 'window');
+check('shared, unpinned, window gone',
+  mode({ shared: true, pinned: false, nowMs: SINCE + 120_001 }), 'expired');
 
 // ---------- hook installer: merge, never replace; idempotent; refuse corrupt ----------
 console.log('\ninstaller merges into existing settings and is idempotent');


### PR DESCRIPTION
## The reported symptom

A codex session was stopped and restarted from the UI and came back **empty** — no conversation, no history — after ~3h of work in `/data/workspaces/agent-manager`.

Nothing was lost on disk. The rollout was intact the whole time: `019fd29a-97e5-7d11-b36e-3ce290b0a0c1`, 277 lines, 1.06MB, `payload.cwd` exactly the session's workdir, `thread_source: user`. The manager simply had no record of it.

## What it actually was

`am-image-inputs-aee9c3` had **no `codexSessionId` and no `codexRollout`**, three hours in. The watcher's tick checked the shared-folder guard first and skipped capture entirely:

```js
if (folderIsShared(session.id, workdir, 'codex')) {
  if (!warnedShared) { /* warn once */ }
} else {
  tryCaptureCodexId(session.id, workdir, since);   // ← never reached
}
```

`folderIsShared` was true for the life of the pane: `agent-manager-5-b0fa07` (codex) was live in the same folder. So the pin was never captured — not the initial one, not any. The server said so itself, twice:

```
[codex] am-image-inputs-aee9c3: folder shared with another live session — not following thread resets here
[codex] agent-manager-5-b0fa07: folder shared with another live session — not following thread resets here
```

Unpinned, `resumeCmd` skips the pinned branch and reaches the generic codex one, which **correctly** refuses `resume --last` in a shared folder — `--last` scopes to the cwd, so it could resume a sibling's thread — and runs bare `exec codex`. An empty pane was the only possible outcome. `agent-manager-2-93de86`, same folder, *is* pinned: it launched while it was the only codex there.

Ruled out along the way: `CODEX_HOME` in the server's own env (set correctly, `/home/node/local/codex-home`); the `sessions` symlink onto the bucket breaking the walk (`readdirSync` resolves it, `2026/` is a real dir, depth 3 of 5); the rollout's own metadata failing a gate (`cwd` matched, born 3.5s after launch, `thread_source: user`, not a subagent); FUSE mtime hiding the file from `codexRolloutsSince`.

## Why the guard was there, and what it should have covered

The guard is right about **reset-following**. A new conversation appearing in a shared folder is genuinely unattributable — our `/clear`, or a sibling's? — and claiming one would take a live agent's thread away from it. That is the same problem #23 solved for claude with a breadcrumb, and #35 is what finally makes that breadcrumb work. Codex has no breadcrumb, so it can only refuse.

The **initial** capture has no such ambiguity, and `tryCaptureCodexId` already carries the checks that make it safe in a shared folder: the `claimed` set (never take a rollout another session pinned), the `cwd` match, born-after-this-launch, and the subagent filter. Those are precisely the "don't take someone else's thread" checks. Skipping the whole call threw them away along with the bug they prevent.

## Three changes

### 1. `codexCandidate()`, split out of `tryCaptureCodexId`

Mirrors `claudeCandidate`: all the gates, no writes, returns `{ id, p }` or null. Exported, so the gates are directly testable — they never were before.

### 2. A `bornBefore` cap

`codexCandidate` takes an upper bound on how late a conversation may have been **born** and still count as ours. Used only in the shared case, set to launch + 2 min. Codex writes its `session_meta` line as the TUI starts (3.5s after launch in this session), so it is ~20x the margin needed, and a sibling's reset minutes or hours in stays out of reach — the one hazard that made capture-in-a-shared-folder look unsafe.

### 3. `codexCaptureMode()` — the policy, as a pure function

| mode | when | behaviour |
|---|---|---|
| `follow` | folder is ours | capture, keep following resets — unchanged |
| `window` | shared, unpinned | **capture, bounded to the launch window** — this case used to do nothing |
| `pinned` | shared, pinned | don't follow resets — unchanged, still warns once |
| `expired` | shared, unpinned, window gone | nothing safe left; warns once |

`expired` is new behaviour worth naming: a pane that genuinely never produced a rollout now says so once, instead of silently restarting empty like this one did.

## What this does not fix

Two codex panes launching in the same folder within ~15s of each other are still ambiguous — that is the existing born-after-launch slack, and the sibling's rollout is only excluded by it. Back-to-back restarts further apart are fine: each pane's window opens at its own launch and the earlier rollout falls outside it, plus whoever pins first claims it. A breadcrumb-style trust signal for codex, the equivalent of #23/#35 for claude, is the real fix for that and is not attempted here.

Also unchanged: `resumeCmd`'s shared-folder check counts *stopped* siblings too. That is correct — `resume --last` doesn't care whether the sibling is running, its rollout is still the most recent in the cwd — and it matters much less now, since the pinned branch returns first.

## Testing

`server/test/repin.test.mjs` — **34 checks, up from 21**. Full `npm test` green (5 suites, 50 checks).

- **7 new checks on `codexCandidate`** against real rollout files in a temp `CODEX_HOME`: own conversation captured; another folder ignored; a pre-launch rollout rejected despite a fresh mtime; a subagent rollout skipped; a later conversation followed when the folder is ours but out of reach when shared; a rollout another session pinned left alone.
- **6 new checks on `codexCaptureMode`**, including both sides of the window boundary (`SINCE + 120_000` → `window`, `+120_001` → `expired`).
- Verified the new checks have teeth: dropping the `bornBefore` line fails 2 of them.

Not verified end-to-end on the live Space: that a folder-sharing codex pane now restarts onto its own conversation needs this deployed — the running container still skips capture, which is why the log evidence above shows only the refusal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
