### PR TITLE
Bucket backup: snapshot over the API, scrub secrets, and never trust a default

### DIFF
--- a/docs/bucket-backup.md
+++ b/docs/bucket-backup.md
@@ -470,6 +470,89 @@ live rather than remembering.
   bad, leaves an operator exactly as wrongly confident as a failing run — and looks
   perfectly healthy without this check.
 
+## 3.11 Why the mount had to go (measured)
+
+The old step 2 handed a mounted folder to `hf upload` and let it enumerate. That
+enumeration is the entire cost, and it is paid on every file whether wanted or not.
+
+| | files | time |
+|---|---|---|
+| stat-only walk of the FUSE mount (`find /live -type f`) | 108,960 | **14m51s** |
+| the same tree over the Hub API (`list_bucket_tree`) | 108,960 | **8 s** |
+| walk of the same content on the Job's local disk | 39,873 | **0.14 s** |
+
+~8 ms per file on the mount; ~6,000x faster on local disk. The Job has 453 GB of
+local disk, so the download is bounded by bandwidth (~5 MB/s measured), not space.
+
+Three failure modes died with the mount, all seen on this Space's own runs:
+
+1. **`.cache/` paths are rejected outright.** `cannot update files under a
+   '.cache/' folder` — the dataset held one commit, `initial commit`, for a day of
+   hourly runs.
+2. **`Job timeout` at 1h33m–2h07m**, against the `--timeout 3000s` we ask for,
+   which is not honoured.
+3. **`not a file on the local file system`** — the live bucket is written while the
+   run works, and a file rotated away mid-walk killed the whole snapshot. The
+   frozen staging snapshot removes this by construction.
+
+A fourth is not about speed and cannot be outrun: **the Hub secret-scans dataset
+commits and buckets are not scanned.** A commit carrying a live token is rejected —
+and TruffleHog verifies its find by authenticating with the token, which
+**invalidates it**. One of this Space's tokens was invalidated exactly that way.
+Hence §7.2.
+
+Measured end to end at prod scale: list 8.3 s → snapshot 12 s → download 129 s →
+scrub 2 s → verify → commit 113 s. **4m24s total**, for a job that had never once
+succeeded.
+
+## 7.2 Secrets never reach the history
+
+Two mechanisms, because either alone is insufficient:
+
+- **Skip** files that exist to hold credentials, matched on the exact final path
+  segment. A substring test for `/credentials` sails straight past
+  `/.credentials.json` — that gap put a credentials file into a probe commit.
+- **Scrub** stray occurrences in text files, then **verify**, then commit. The
+  verify is mandatory: if anything still matches, the run ends with no commit.
+
+Patterns are boundary-anchored. A looser `sk-[A-Za-z0-9_-]{24,}` matched
+`sk-abstraction-and-chart-selection` inside ordinary prose — a scrub that silently
+rewrites real content is worse than one that over-reports. Re-scanning 73 flagged
+files with tight patterns: 52 real, 21 false positives.
+
+## 3.12 Nothing is private by default
+
+Both verified against the Hub:
+
+| call | result |
+|---|---|
+| `create_bucket(id)` with no `private=` | **public** |
+| `hf upload <new-dataset>` (repo does not exist) | **public** |
+
+The second was live in this file, under a comment asserting the opposite:
+*"Not existing yet is fine — the upload below creates it private."* On any Space
+whose backup dataset did not exist yet, the first run published the bucket.
+
+So: every destination is created with visibility stated explicitly, then **read
+back and checked** before a byte is written. Not inferred, not assumed from a
+sibling call. The source bucket is gated too.
+
+## 9.1 There is no mirror
+
+Removed. It cost a second full copy of the bucket, and `hf cp` never deletes — so
+the mirror accumulated every file the bucket had ever held, including credentials
+long since rotated out (174 files present in the mirror and absent from the live
+bucket, measured). Deleting a leaked secret from the bucket did not remove it from
+the mirror.
+
+What it bought — "the Space exactly as it was, latest only" — is what the bucket
+already is. Restarts never involved backup: the bucket *is* the persistent store,
+which is why logins survive them.
+
+The trade this accepts: a lost bucket now means re-logging in, because the history
+holds no credentials by design (§7.2). An existing mirror bucket is **not** deleted
+automatically — that is the operator's call.
+
 ## 8. Restore
 
 The direction the Hub *does* support server-side, pleasingly:

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -9,15 +9,21 @@ import { shareNamespace } from './share.js';
 // bucket to private Hub storage. Design: docs/bucket-backup.md
 //
 // The whole feature is one loop: if it is switched on and enough time has
-// passed, launch a Job. Nothing else. The Job does two things, because a mirror
-// alone is not a backup:
+// passed, launch a Job. Nothing else. The Job builds one versioned snapshot:
 //
-//   1. bucket → bucket, server-side by Xet hash. No bytes move (13,482 files in
-//      20s, measured) and a restore from it is equally instant. Overwritten each
-//      run — this is the "get the Space back" copy.
-//   2. the same bucket, mounted READ-ONLY in the Job, → a private dataset repo.
-//      Buckets are mutable and non-versioned, so without this an overwritten
-//      file is simply gone. This is the "get yesterday's file back" copy.
+//   1. list the bucket over the API — 8 s for 108,960 files, against 14m51s to
+//      stat the same tree through a FUSE mount (§3.11).
+//   2. decide the scope in code, then copy just those paths server-side by Xet
+//      hash into a private, EPHEMERAL staging bucket. Metadata only, no bytes.
+//      Being frozen is what makes a run self-consistent: the live bucket is
+//      written while we work.
+//   3. download the snapshot to the Job's local disk, scrub secrets, verify none
+//      remain, commit to a private dataset repo, delete the staging bucket.
+//
+// There is no persistent mirror. It cost a second full copy of the bucket, never
+// deleted anything (so it archived every credential the Space ever held), and the
+// restore it offered — "the Space exactly as it was, latest only" — is what the
+// bucket itself already is.
 //
 // The copying happens on the Hub, not here: we launch the Job and forget it. So
 // a backup costs this Space one API call, never reads /data (whose cold walk runs
@@ -73,24 +79,39 @@ export const MAX_EXCLUDES = 40;
 /**
  * What a fresh install skips until the operator says otherwise.
  *
- * Chosen by walking this Space's own bucket rather than from taste: across 24
- * workspace folders it holds 11 `node_modules`, 6 `.venv`, 4 `.cache`, and a
- * `$HOME/.cache` carrying `ms-playwright`, `google-chrome-for-testing-headless`,
- * `huggingface`, `uv`, `node-gyp` and the `claude-cli-nodejs` transcripts that
- * make a dataset commit fail outright (§3.10). Every name here is something a
- * package manager or toolchain rebuilds on demand.
+ * One criterion, and it is not size: **a command can put it back**. Everything
+ * here is owned by a package manager, a toolchain installer, a cache or a temp
+ * dir. Nothing is excluded for being large — a 292 MB session transcript is the
+ * most history-shaped thing on the bucket, and an earlier draft of this list
+ * dropped it to a per-file size cap, which was wrong.
  *
- * Two names were deliberately left OUT, and both matter more than what is in:
- *   - `.git` appears 11 times, more often than anything else, and is the single
- *     thing you would most want back. A size-ranked "junk" heuristic picks it
- *     first; it is history, not cache.
- *   - `dist` / `build` / `target` appear too, but they are ambiguous — a source
- *     folder is called `build` often enough, and a default that silently drops
- *     work is worse than one that copies some junk. Add them per-install.
+ * Measured against this Space's own bucket (110,590 files / 11.82 GB):
+ * excluding only the names below drops 86,615 files and 8.05 GB, leaving 23,975
+ * files and 3.78 GB. The heavy hitters were `node_modules` (25,184 files),
+ * `.cache` (11,319), `.tmp` (10,151), `.lake/packages` (9,606, 0.65 GB),
+ * `.elan/toolchains` (13,904, 2.75 GB) and `.npm/_cacache` (1.03 GB).
+ *
+ * Deliberately NOT here:
+ *   - `.git` — appears more often than anything else and holds the work you
+ *     would most want back: unpushed commits and staged changes live nowhere
+ *     else. Cheap to keep, and a partially-copied `.git` is a corrupt repo.
+ *   - git worktrees as a class. A clone looks reproducible from its remote, but
+ *     uncommitted work in it is not.
+ *   - `dist` / `build` / `target` — genuinely ambiguous names for a source
+ *     folder. A default that silently drops work is worse than one that copies
+ *     some junk. Add them per-install.
  */
 export const DEFAULT_EXCLUDE = Object.freeze([
-  'node_modules', '.venv', 'venv', '__pycache__', '.cache', '.npm', '.pnpm-store',
-  '.pytest_cache', '.mypy_cache', '.ruff_cache', '.ipynb_checkpoints', '.next', '.turbo',
+  // dependency trees
+  'node_modules', '.venv', 'venv', 'site-packages', '.lake/packages', '.pnpm-store',
+  // caches, by manager
+  '.cache', '.npm/_cacache', '.npm/_npx', '.yarn/cache', '.cargo/registry', 'pkg/mod',
+  '__pycache__', '.pytest_cache', '.mypy_cache', '.ruff_cache', '.ipynb_checkpoints',
+  '.gradle/caches', '.m2/repository', '.deno', '.bun/install/cache', '.turbo', '.next',
+  // toolchains an installer re-fetches
+  '.elan/toolchains', '.rustup/toolchains', '.nvm/versions', '.pyenv/versions',
+  // scratch
+  '.tmp', '.elan/tmp', '.lake/build',
 ]);
 
 /**
@@ -117,27 +138,6 @@ export function normalizeExclude(list) {
     if (!out.includes(t)) out.push(t);
   }
   return out.slice(0, MAX_EXCLUDES);
-}
-
-/**
- * Tokens -> `hf upload --exclude` globs.
- *
- * A bare name becomes TWO patterns, which is not obvious: `**\/env/**` does not
- * match a top-level `env/`, verified against the Hub — `**\/` needs at least one
- * leading segment. So excluding `env` needs `env/**` as well, or the copy at the
- * bucket root silently still goes up.
- *
- * A token with a slash is a path and anchors at the bucket root; one containing
- * `*` or `?` is already a glob and is passed through untouched.
- */
-export function excludePatterns(tokens) {
-  const pats = [];
-  for (const t of normalizeExclude(tokens)) {
-    if (t.includes('*') || t.includes('?')) pats.push(t);
-    else if (t.includes('/')) pats.push(`${t}/**`);
-    else pats.push(`${t}/**`, `**/${t}/**`);
-  }
-  return pats;
 }
 
 function run(args, { timeout = 120_000 } = {}) {
@@ -169,9 +169,15 @@ export function sourceBucket() {
 
 export async function defaultsFor() {
   const ns = await shareNamespace().catch(() => '');
-  if (!ns) return { mirror: '', dataset: '' };
-  const base = `${ns}/${spaceName()}-backup`;
-  return { mirror: base, dataset: base };
+  if (!ns) return { dataset: '', staging: '' };
+  return {
+    dataset: `${ns}/${spaceName()}-backup`,
+    // Ephemeral: created private at the start of a run, deleted at the end of it.
+    // A distinct name from the dataset so a half-finished run can never be
+    // confused with the history, and so an operator's existing mirror bucket is
+    // never written to by the new pipeline.
+    staging: `${ns}/${spaceName()}-snapshot`,
+  };
 }
 
 const HF = 'https://huggingface.co';
@@ -186,56 +192,192 @@ export const jobsUrl = () =>
 // The script the Job runs. No interpolation: every value arrives as an env var
 // (`-e`), so a config string can never become shell syntax.
 export const JOB_SCRIPT = `set -euo pipefail
-# Plain package, no [cli] extra: 1.26.0 dropped it ("does not provide the extra
-# 'cli'") and ships the CLI in the base install.
-pip install -q huggingface_hub
+# Plain package, no [cli] extra: 1.26.0 dropped it and ships the CLI in the base
+# install. hf_xet speeds up the one leg that actually moves bytes.
+pip install -q "huggingface_hub[hf_xet]"
 
-# A backup carries every saved login on the bucket — agent OAuth tokens, the Web
-# Push private key, session-secret (docs/bucket-backup.md §4). So a public
-# destination is a stop, not a warning. Re-checked HERE, on every run, because a
-# repo can be flipped public long after it was created.
-python - <<'PY'
-import os, sys
+python - <<'EOPY'
+import os, re, sys, time, collections
 from huggingface_hub import HfApi
+
 api = HfApi()
-ds, mirror = os.environ["AM_DATASET"], os.environ.get("AM_MIRROR", "")
+SRC = os.environ["AM_SOURCE"]
+DATASET = os.environ["AM_DATASET"]
+STAGING = os.environ["AM_STAGING"]
+# Folder-name tokens, space-joined. Matched here rather than handed to an
+# uploader: an uploader enumerates the folder first and filters second, which
+# pays exactly the walk this pipeline exists to avoid.
+EXCLUDE = [t for t in os.environ.get("AM_EXCLUDE", "").split(" ") if t]
+WORK = "/work"
+
+def say(m): print(m, flush=True)
+
+# ---------------------------------------------------------------- privacy gate
+# A backup carries every saved login on the bucket (docs/bucket-backup.md §4), so
+# a public destination is a stop, not a warning. Re-checked HERE on every run,
+# because a repo can be flipped public long after it was created.
+#
+# Never inferred from a default: create_bucket() with no private= yields a PUBLIC
+# bucket, and hf upload into a repo that does not exist creates it PUBLIC. Both
+# verified against the Hub (§3.12). So every destination is created explicitly
+# private and then read back before a single byte is written.
+def must_be_private(kind, rid):
+    info = api.bucket_info(rid) if kind == "bucket" else api.dataset_info(rid)
+    if getattr(info, "private", None) is not True:
+        sys.exit("refusing to back up: " + kind + " " + rid + " is not private")
+
+must_be_private("bucket", SRC)
+api.create_repo(DATASET, repo_type="dataset", private=True, exist_ok=True)
+must_be_private("dataset", DATASET)
+api.create_bucket(STAGING, private=True, exist_ok=True)
+must_be_private("bucket", STAGING)
+say("destinations verified private: " + DATASET + ", " + STAGING)
+
+def cleanup():
+    # Left behind, staging is a second full copy of the bucket, so failing to
+    # remove it is loud rather than silent.
+    try:
+        api.delete_bucket(STAGING)
+        say("staging bucket deleted: " + STAGING)
+    except Exception as e:
+        say("WARNING could not delete staging bucket " + STAGING + ": " + str(e))
+
 try:
-    if api.dataset_info(ds).private is not True:
-        sys.exit(f"refusing to back up: dataset {ds} is not private")
-except Exception as e:
-    # Not existing yet is fine — the upload below creates it private.
-    if "404" not in str(e) and "RepositoryNotFound" not in type(e).__name__:
-        raise
-if mirror and api.bucket_info(mirror).private is not True:
-    sys.exit(f"refusing to back up: bucket {mirror} is not private")
-PY
+    # ------------------------------------------------------------------ 1. list
+    # Over the API, never a mount. The mount costs ~8 ms per file: a stat-only
+    # walk of this bucket took 14m51s for 108,960 files; the same tree lists in
+    # 8 s here. That gap is the whole reason for this rewrite.
+    t = time.time()
+    entries = [f for f in api.list_bucket_tree(SRC, recursive=True) if hasattr(f, "size")]
+    say("listed " + str(len(entries)) + " files in " + format(time.time() - t, ".1f") + "s")
 
-# 1. Server-side mirror: hashes move, not bytes.
-if [ -n "\${AM_MIRROR:-}" ]; then
-  hf cp "hf://buckets/\$AM_SOURCE/" "hf://buckets/\$AM_MIRROR/latest/"
-fi
+    # ------------------------------------------------------------- 2. the scope
+    def excluded(path):
+        q = "/" + path + "/"
+        return any(("/" + t.strip("/") + "/") in q for t in EXCLUDE)
 
-# Folders the operator asked to skip, as one --exclude per pattern. read -ra
-# splits on the spaces the server joined them with and nothing else: no globbing
-# against the container's filesystem, and each pattern reaches hf as a single
-# quoted argv element. Patterns are validated server-side to hold no whitespace,
-# which is what makes this split exact.
-EXCLUDE_ARGS=()
-if [ -n "\${AM_EXCLUDE:-}" ]; then
-  read -ra AM_EXCLUDE_PATS <<< "\$AM_EXCLUDE"
-  for p in "\${AM_EXCLUDE_PATS[@]}"; do EXCLUDE_ARGS+=(--exclude "\$p"); done
-  echo "skipping: \$AM_EXCLUDE"
-fi
+    # Files that exist to hold credentials, matched on the exact final path
+    # segment rather than as a substring: a substring test for "/credentials"
+    # sails straight past "/.credentials.json", which is how one got into a probe
+    # commit before the scrub existed.
+    CRED_NAMES = {
+        ".credentials.json", ".claude.json", "credentials.json", "auth.json",
+        "hosts.yml", "token", "stored_tokens", ".netrc", ".env", ".env.local",
+        "id_rsa", "id_ed25519", "credentials",
+    }
+    CRED_DIRS = ("/shell_snapshots/",)
 
-# 2. Version history, read from the bucket mounted read-only at /live — the
-#    Hub's copy, not this Space's disk. Unchanged files transfer nothing and
-#    produce no commit at all; --delete makes the newest commit match the bucket
-#    while every earlier commit keeps deleted files recoverable — including
-#    anything newly excluded, which drops out of the newest commit but stays
-#    recoverable in the ones before it.
-hf upload "\$AM_DATASET" /live . --repo-type dataset --private --delete "*" \\
-  "\${EXCLUDE_ARGS[@]}" \\
-  --commit-message "Bucket snapshot \$(date -u +%Y-%m-%dT%H:%MZ)"
+    def is_credential(path):
+        if any(d in "/" + path for d in CRED_DIRS):
+            return True
+        return path.rsplit("/", 1)[-1] in CRED_NAMES
+
+    keep = []
+    n_excl = n_cred = n_nohash = 0
+    for f in entries:
+        if excluded(f.path):
+            n_excl += 1
+        elif is_credential(f.path):
+            n_cred += 1
+        elif not f.xet_hash:
+            n_nohash += 1
+        else:
+            keep.append(f)
+    kb = sum((f.size or 0) for f in keep)
+    say("scope: keeping " + str(len(keep)) + " files (" + format(kb / 1e9, ".2f") + " GB); skipped "
+        + str(n_excl) + " reproducible, " + str(n_cred) + " credential-bearing, "
+        + str(n_nohash) + " without a hash")
+    if not keep:
+        sys.exit("refusing to commit: the scope matched no files")
+
+    # -------------------------------------------------- 3. frozen snapshot copy
+    # Server-side, by xet hash: metadata only, no bytes, ~880 files/s measured.
+    # The snapshot is also what makes a run self-consistent. The live bucket is
+    # written while we work, and reading it directly used to die with "not a file
+    # on the local file system" when the Space rotated a file away mid-run.
+    t = time.time()
+    for i in range(0, len(keep), 2000):
+        api.batch_bucket_files(
+            STAGING,
+            copy=[("bucket", SRC, f.xet_hash, f.path) for f in keep[i:i + 2000]],
+        )
+    say("snapshot: " + str(len(keep)) + " paths copied server-side in " + format(time.time() - t, ".0f") + "s")
+
+    # ------------------------------------------------------------ 4. sync local
+    # Local disk, so the walk before the commit is free: 0.14 s for 39,873 files
+    # against 14m51s for the same work on the mount.
+    os.makedirs(WORK, exist_ok=True)
+    t = time.time()
+    api.sync_bucket("hf://buckets/" + STAGING, WORK)
+    got = sum(len(fs) for _, _, fs in os.walk(WORK))
+    say("downloaded " + str(got) + " files in " + format(time.time() - t, ".0f") + "s")
+
+    # ---------------------------------------------------------------- 5. scrub
+    # Tight patterns on purpose: a looser sk-[A-Za-z0-9_-]{24,} matched
+    # "sk-abstraction-and-chart-selection" in ordinary prose, and a scrub that
+    # rewrites real content is worse than one that over-reports.
+    BEF = "(?<![A-Za-z0-9_-])"
+    AFT = "(?![A-Za-z0-9_-])"
+    SECRETS = [
+        ("hf", re.compile((BEF + "hf_[A-Za-z0-9]{34}" + AFT).encode())),
+        ("openai", re.compile((BEF + "sk-(?:proj-)?[A-Za-z0-9]{20,}" + AFT).encode())),
+        ("anthropic", re.compile((BEF + "sk-ant-[A-Za-z0-9_-]{24,}" + AFT).encode())),
+        ("github", re.compile((BEF + "gh[pousr]_[A-Za-z0-9]{36}" + AFT).encode())),
+        ("aws", re.compile((BEF + "AKIA[0-9A-Z]{16}" + AFT).encode())),
+        ("google", re.compile((BEF + "AIza[0-9A-Za-z_-]{35}" + AFT).encode())),
+    ]
+    NUL = bytes([0])
+
+    def textfiles():
+        for root, _, fs in os.walk(WORK):
+            for fn in fs:
+                fp = os.path.join(root, fn)
+                try:
+                    data = open(fp, "rb").read()
+                except OSError:
+                    continue
+                if NUL in data[:8192]:
+                    continue
+                yield fp, data
+
+    hits = collections.Counter()
+    touched = 0
+    t = time.time()
+    for fp, data in textfiles():
+        orig = data
+        for name, rx in SECRETS:
+            data, k = rx.subn(b"[REDACTED-SECRET]", data)
+            if k:
+                hits[name] += k
+        if data != orig:
+            open(fp, "wb").write(data)
+            touched += 1
+    say("scrub: redacted " + str(sum(hits.values())) + " secrets in " + str(touched)
+        + " files " + str(dict(hits)) + " in " + format(time.time() - t, ".0f") + "s")
+
+    # --------------------------------------------------------------- 6. verify
+    # Mandatory, not a nicety. The Hub's scanner is TruffleHog and it verifies a
+    # find by authenticating with it, which INVALIDATES a live token. A commit
+    # that leaks one does not merely fail: it breaks the operator's credentials.
+    left = [os.path.relpath(fp, WORK) for fp, d in textfiles()
+            if any(rx.search(d) for _, rx in SECRETS)]
+    if left:
+        sys.exit("refusing to commit: secrets still present in " + ", ".join(left[:5])
+                 + ((" (+" + str(len(left) - 5) + " more)") if len(left) > 5 else ""))
+    say("verified: no secret patterns remain")
+
+    # --------------------------------------------------------------- 7. commit
+    # delete_patterns makes the newest commit match the scope, while every
+    # earlier commit keeps since-removed files recoverable.
+    t = time.time()
+    api.upload_folder(
+        folder_path=WORK, repo_id=DATASET, repo_type="dataset", delete_patterns="*",
+        commit_message="Bucket snapshot " + time.strftime("%Y-%m-%dT%H:%MZ", time.gmtime()),
+    )
+    say("committed to " + DATASET + " in " + format(time.time() - t, ".0f") + "s")
+finally:
+    cleanup()
+EOPY
 `;
 
 /**
@@ -263,19 +405,21 @@ export function parseJobId(out) {
 
 // Job arguments, as an array (never a shell string). Exported for the tests:
 // asserting on this is how we know a config value cannot reach a shell.
-export function jobArgs({ source, mirror, dataset, exclude = [] }) {
+export function jobArgs({ source, dataset, staging, exclude = [] }) {
   return [
     'jobs', 'run', '--detach',
     '--name', jobName(),
     '--secrets', 'HF_TOKEN',
     '-e', `AM_SOURCE=${source}`,
-    '-e', `AM_MIRROR=${mirror || ''}`,
     '-e', `AM_DATASET=${dataset}`,
-    // Space-joined: the tokens are validated to contain no whitespace, so the
-    // Job can split them back apart exactly.
-    '-e', `AM_EXCLUDE=${excludePatterns(exclude).join(' ')}`,
-    // Read-only: a backup must not be able to write to what it is reading.
-    '-v', `hf://buckets/${source}:/live:ro`,
+    '-e', `AM_STAGING=${staging}`,
+    // Folder-name tokens, space-joined. They are validated to contain no
+    // whitespace, so the Job splits them back apart exactly. Tokens, not globs:
+    // the Job matches them against the API listing itself, so the two-pattern
+    // glob dance `hf upload --exclude` needed is gone.
+    '-e', `AM_EXCLUDE=${normalizeExclude(exclude).join(' ')}`,
+    // No `-v`: nothing is mounted. The pipeline reads the bucket through the API
+    // and downloads to local disk, which is ~6,000x faster to walk (§3.11).
     '--flavor', JOB_FLAVOR,
     '--timeout', JOB_TIMEOUT,
     JOB_IMAGE, 'bash', '-c', JOB_SCRIPT,
@@ -305,9 +449,9 @@ export function unavailableReason(cfg) {
 /** Resolve the destinations, falling back to <namespace>/<space>-backup. */
 async function targets(cfg) {
   const d = await defaultsFor();
-  const mirror = (cfg?.backup?.mirror || d.mirror || '').trim();
   const dataset = (cfg?.backup?.dataset || d.dataset || '').trim();
-  return { mirror, dataset, defaults: d, exclude: normalizeExclude(cfg?.backup?.exclude) };
+  const staging = (cfg?.backup?.staging || d.staging || '').trim();
+  return { dataset, staging, defaults: d, exclude: excludeFromConfig(cfg?.backup?.exclude) };
 }
 
 /** Launch one backup Job now. Returns { job } — the Hub does the rest. */
@@ -319,21 +463,19 @@ export async function runBackupNow(cfg) {
   // loud rather than silently doing nothing.
   if (await isRunning()) throw new Error('a backup is already running');
   const source = sourceBucket();
-  const { mirror, dataset, exclude } = await targets(cfg);
-  for (const [label, id] of [['source', source], ['dataset', dataset], ['mirror', mirror]]) {
-    if (label === 'mirror' && !id) continue;
+  const { dataset, staging, exclude } = await targets(cfg);
+  for (const [label, id] of [['source', source], ['dataset', dataset], ['staging', staging]]) {
     if (!validRepoId(id)) throw new Error(`${label} "${id}" is not a valid repo id`);
   }
-  // The mirror bucket must exist and be private before anything is copied into
-  // it; the dataset is created private by the upload itself.
-  if (mirror) await run(['buckets', 'create', mirror, '--private', '--exist-ok']).catch(() => {});
-
-  const out = await run(jobArgs({ source, mirror, dataset, exclude }), { timeout: 180_000 });
+  // Nothing is pre-created here. Both destinations are created explicitly
+  // private INSIDE the Job and then read back before anything is written —
+  // creating them from two places is how you end up trusting a default.
+  const out = await run(jobArgs({ source, dataset, staging, exclude }), { timeout: 180_000 });
   const job = parseJobId(out);
   // A launch we cannot identify still happened — record it, but say so, because
   // without an id there is nothing to poll and no overlap to detect.
   if (!job) console.warn('[backup] launched a Job but could not parse its id from:', out.slice(0, 200));
-  saveState({ jobId: job, startedAt: Date.now(), source, mirror, dataset, error: null, outcomeFor: null });
+  saveState({ jobId: job, startedAt: Date.now(), source, dataset, staging, error: null, outcomeFor: null });
   return { job };
 }
 
@@ -513,7 +655,7 @@ export async function backupStatus(cfg) {
   const state = loadState();
   const every = cfg?.backup?.every || 'never';
   const source = sourceBucket();
-  const { mirror, dataset, defaults, exclude } = await targets(cfg);
+  const { dataset, staging, defaults, exclude } = await targets(cfg);
   // Not gated on the interval: an on-demand backup is a real backup, and its
   // result has to be visible even with the schedule off.
   const [stage, priv] = await Promise.all([
@@ -523,8 +665,8 @@ export async function backupStatus(cfg) {
   return {
     every,
     source,
-    mirror,
     dataset,
+    staging,
     defaults,
     hasToken: hasToken(),
     canRunNow: !runNowBlockedBy(),
@@ -535,10 +677,12 @@ export async function backupStatus(cfg) {
       : null,
     jobName: jobName(),
     jobsUrl: jobsUrl(),
-    // The tokens as stored, and the globs they become — a skip list nobody can
-    // see the expansion of is a skip list nobody can debug.
+    // The tokens as stored, plus the shipped defaults, so Settings can offer
+    // "restore defaults" and show whether the current list differs from them.
     exclude,
-    excludePatterns: excludePatterns(exclude),
+    excludeDefaults: [...DEFAULT_EXCLUDE],
+    excludeIsDefault: exclude.length === DEFAULT_EXCLUDE.length
+      && exclude.every((t, i) => t === DEFAULT_EXCLUDE[i]),
     health: backupHealth(cfg),
     failures: state.failures || 0,
     lastFailure: state.lastFailure || null,

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -903,7 +903,6 @@ function loadAmConfig() {
     // resource, which is the operator's call to make. docs/bucket-backup.md
     backup: {
       every: backup.INTERVALS.includes(saved.backup?.every) ? saved.backup.every : 'never',
-      mirror: (saved.backup?.mirror || '').trim(),
       dataset: (saved.backup?.dataset || '').trim(),
       // Folder names to keep out of the history — the slow, regenerable kind.
       // Prepopulated on a config that has never set one, so a fresh install is
@@ -925,7 +924,6 @@ app.put('/api/config', (req, res) => {
     archive: { after: ['week', 'month', 'never'].includes(b.archive?.after) ? b.archive.after : 'month' },
     backup: {
       every: backup.INTERVALS.includes(b.backup?.every) ? b.backup.every : 'never',
-      mirror: typeof b.backup?.mirror === 'string' ? b.backup.mirror.trim() : '',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
       // Normalized here, not trusted: these end up in a Job's argument list.
       // Same undefined-vs-empty rule as the read path: a body that omits the key

--- a/server/test/backup.test.mjs
+++ b/server/test/backup.test.mjs
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
   EVERY_MS, INTERVALS, intervalMs, validRepoId, jobArgs, JOB_SCRIPT, JOB_FLAVOR,
   hasToken, unavailableReason, runNowBlockedBy, jobName, jobsUrl, isActiveStage, parseJobId,
-  normalizeExclude, excludePatterns, MAX_EXCLUDES, DEFAULT_EXCLUDE, excludeFromConfig,
+  normalizeExclude, MAX_EXCLUDES, DEFAULT_EXCLUDE, excludeFromConfig,
 } from '../src/backup.js';
 
 // The rule that is not obvious and cost a Hub round-trip to learn: `**/x/**` does
@@ -32,7 +32,7 @@ test('the default skip list is caches only — never .git, never ambiguous build
     assert.ok(!DEFAULT_EXCLUDE.includes(keep), `${keep} must not be skipped by default`);
   }
   // The names actually found in this Space's bucket are covered.
-  for (const junk of ['node_modules', '.venv', '__pycache__', '.cache', '.npm']) {
+  for (const junk of ['node_modules', '.venv', '__pycache__', '.cache', '.npm/_cacache']) {
     assert.ok(DEFAULT_EXCLUDE.includes(junk), `${junk} should be skipped by default`);
   }
   // Every default has to survive the validator it will be fed through, fit the
@@ -45,32 +45,6 @@ test('the default skip list is caches only — never .git, never ambiguous build
   assert.throws(() => DEFAULT_EXCLUDE.push('dist'));
   excludeFromConfig(undefined).push('dist');
   assert.ok(!DEFAULT_EXCLUDE.includes('dist'));
-});
-
-test('the default reaches a Job as splittable patterns, root and nested', () => {
-  const pats = excludePatterns([...DEFAULT_EXCLUDE]);
-  assert.equal(pats.length, DEFAULT_EXCLUDE.length * 2);
-  for (const p of pats) assert.ok(!/\s/.test(p), `${p} would break the shell split`);
-  assert.ok(pats.includes('node_modules/**') && pats.includes('**/node_modules/**'));
-  const env = jobArgs({ source: 'u/s', mirror: 'u/m', dataset: 'u/d', exclude: [...DEFAULT_EXCLUDE] })
-    .find((a) => String(a).startsWith('AM_EXCLUDE='));
-  assert.ok(env.includes('.cache/**') && env.includes('**/.cache/**'));
-});
-
-test('a bare folder token excludes it at the root AND nested', () => {
-  assert.deepEqual(excludePatterns(['env']), ['env/**', '**/env/**']);
-  assert.deepEqual(excludePatterns(['node_modules', '.venv']),
-    ['node_modules/**', '**/node_modules/**', '.venv/**', '**/.venv/**']);
-});
-
-test('a path anchors at the root, and an explicit glob is left alone', () => {
-  // A slash means "this exact place", so it is not also matched anywhere.
-  assert.deepEqual(excludePatterns(['state/claude/cache']), ['state/claude/cache/**']);
-  // Already a glob: passed through untouched, however odd.
-  assert.deepEqual(excludePatterns(['**/*.pyc']), ['**/*.pyc']);
-  assert.deepEqual(excludePatterns(['cache-*']), ['cache-*']);
-  assert.deepEqual(excludePatterns([]), []);
-  assert.deepEqual(excludePatterns(undefined), []);
 });
 
 test('normalizeExclude tidies input and refuses anything shell-shaped', () => {
@@ -93,25 +67,6 @@ test('normalizeExclude tidies input and refuses anything shell-shaped', () => {
 
 // The patterns cross into the Job as one space-joined env var and are split back
 // apart by the shell. If either side of that contract changes, this fails.
-test('patterns reach the Job as one env var the shell can split exactly', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds', exclude: ['env', 'node_modules'] });
-  const env = args[args.indexOf('AM_EXCLUDE=env/** **/env/** node_modules/** **/node_modules/**')];
-  assert.ok(env, `AM_EXCLUDE not passed as expected; got ${JSON.stringify(args.filter((a) => String(a).startsWith('AM_')))}`);
-  // No pattern may contain whitespace, or the split inside the Job is wrong.
-  for (const pat of excludePatterns(['env', 'node_modules'])) assert.ok(!/\s/.test(pat));
-  // Nothing to skip is an empty value, not a missing variable.
-  const none = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
-  assert.ok(none.includes('AM_EXCLUDE='));
-  // And the script must build the args itself rather than have them interpolated.
-  assert.match(JOB_SCRIPT, /read -ra AM_EXCLUDE_PATS/);
-  assert.match(JOB_SCRIPT, /EXCLUDE_ARGS\+=\(--exclude "\$p"\)/);
-  assert.ok(!JOB_SCRIPT.includes('node_modules/**'), 'patterns must not be baked into the script');
-});
-
-// The image installs huggingface_hub unpinned, so the CLI in the Space is not the
-// one on a dev machine. A version whose launch output differs left jobId null,
-// which killed overlap protection outright — so the parse must not depend on one
-// output shape.
 test('parseJobId survives any of the shapes the CLI prints', () => {
   const ID = '6a7245596b79c09949c227fc';
   assert.equal(parseJobId(`id=${ID} url=https://huggingface.co/jobs/lvwerra/${ID}`), ID);
@@ -219,38 +174,44 @@ test('validRepoId accepts real ids and rejects shell metacharacters', () => {
 // argv/env, never as shell syntax. If someone later interpolates a config value
 // into JOB_SCRIPT, this fails.
 test('config values reach the job as env vars, not shell text', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: 'ns/mir', dataset: 'ns/ds' });
+  const args = jobArgs({ source: 'ns/src', dataset: 'ns/ds', staging: 'ns/snap' });
   assert.ok(args.includes('AM_SOURCE=ns/src'));
-  assert.ok(args.includes('AM_MIRROR=ns/mir'));
+  assert.ok(args.includes('AM_STAGING=ns/snap'));
   assert.ok(args.includes('AM_DATASET=ns/ds'));
   const script = args[args.length - 1];
   assert.equal(script, JOB_SCRIPT);
-  for (const id of ['ns/src', 'ns/mir', 'ns/ds']) {
+  for (const id of ['ns/src', 'ns/snap', 'ns/ds']) {
     assert.ok(!script.includes(id), 'ids must not be interpolated into the script');
   }
 });
 
-// A backup must never be able to write to the bucket it is reading.
-test('the source bucket is mounted read-only', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
-  const vol = args[args.indexOf('-v') + 1];
-  assert.equal(vol, 'hf://buckets/ns/src:/live:ro');
+// The bucket used to be mounted read-only so a backup could not write to what it
+// was reading. Nothing is mounted now, which is the stronger version of the same
+// property — and it is why a run no longer pays 8 ms per file to walk it.
+test('nothing is mounted, so a backup cannot touch the source at all', () => {
+  const args = jobArgs({ source: 'ns/src', dataset: 'ns/ds', staging: 'ns/snap' });
+  assert.equal(args.indexOf('-v'), -1);
+  assert.ok(!args.some((a) => typeof a === 'string' && a.includes('/live')));
+  assert.ok(!JOB_SCRIPT.includes('/live'));
 });
 
 test('a backup is one detached job launch', () => {
-  const args = jobArgs({ source: 'ns/src', mirror: '', dataset: 'ns/ds' });
+  const args = jobArgs({ source: 'ns/src', dataset: 'ns/ds', staging: 'ns/snap' });
   assert.deepEqual(args.slice(0, 3), ['jobs', 'run', '--detach']);
   assert.ok(args.includes('--secrets') && args.includes('HF_TOKEN'));
 });
 
 // The upload has to create the dataset private and re-verify privacy every run:
 // the copy carries live agent credentials (docs/bucket-backup.md §4).
-test('the job script gates on privacy and creates private', () => {
-  assert.match(JOB_SCRIPT, /--private/);
+test('the job script gates on privacy and states it when creating', () => {
+  assert.match(JOB_SCRIPT, /private=True/);
   assert.match(JOB_SCRIPT, /refusing to back up/);
   assert.match(JOB_SCRIPT, /dataset_info/);
   assert.match(JOB_SCRIPT, /bucket_info/);
   assert.match(JOB_SCRIPT, /set -euo pipefail/);
+  // The source is gated too: reading a public bucket into a dataset is still a
+  // copy of something that should not have been readable.
+  assert.ok(JOB_SCRIPT.includes('must_be_private("bucket", SRC)'));
 });
 
 // Without a token there is no way to launch a Job or write to the Hub, so the
@@ -280,4 +241,99 @@ test('no HF_TOKEN means unavailable, with the token as the stated reason', () =>
       if (v === undefined) delete process.env[k];
     }
   }
+});
+
+// ---------------------------------------------------------------------------
+// The pipeline: what the Job is asked to do, and what it must refuse.
+// ---------------------------------------------------------------------------
+
+test('the Job gets tokens, a staging bucket, and no mount', () => {
+  const args = jobArgs({ source: 'ns/src', dataset: 'ns/ds', staging: 'ns/snap', exclude: ['node_modules', '.cache'] });
+  assert.ok(args.includes('-e'));
+  assert.ok(args.includes('AM_STAGING=ns/snap'));
+  assert.ok(args.includes('AM_DATASET=ns/ds'));
+  // Tokens, not globs: the Job matches them against the API listing itself.
+  assert.ok(args.includes('AM_EXCLUDE=node_modules .cache'));
+  // Nothing is mounted any more — the mount is the thing that cost 14m51s.
+  assert.equal(args.filter((a) => a === '-v').length, 0);
+  assert.ok(!args.some((a) => typeof a === 'string' && a.includes(':/live')));
+  // And no config value is ever spliced into a shell string.
+  assert.equal(args.at(-3), 'bash');
+  assert.equal(args.at(-2), '-c');
+  assert.equal(args.at(-1), JOB_SCRIPT);
+});
+
+test('no mirror survives anywhere in the launch', () => {
+  const args = jobArgs({ source: 'ns/src', dataset: 'ns/ds', staging: 'ns/snap' });
+  assert.ok(!args.some((a) => typeof a === 'string' && a.includes('AM_MIRROR')));
+  assert.ok(!JOB_SCRIPT.includes('AM_MIRROR'));
+});
+
+test('every destination is created explicitly private, then re-read', () => {
+  // The bug this replaces: a comment claiming `hf upload` creates a repo private.
+  // It creates it PUBLIC, so the assertion has to be in the code, not a comment.
+  assert.ok(JOB_SCRIPT.includes('private=True'), 'creates must state visibility');
+  assert.ok(!/creates it private/.test(JOB_SCRIPT), 'the wrong comment must be gone');
+  for (const rid of ['SRC', 'DATASET', 'STAGING']) {
+    assert.ok(JOB_SCRIPT.includes(`must_be_private("bucket", ${rid})`)
+      || JOB_SCRIPT.includes(`must_be_private("dataset", ${rid})`), `${rid} is gated`);
+  }
+  assert.ok(JOB_SCRIPT.includes('is not private'), 'a non-private destination stops the run');
+});
+
+test('the staging bucket is always torn down', () => {
+  // A staging bucket left behind is a second full copy of the operator's data.
+  assert.ok(JOB_SCRIPT.includes('delete_bucket(STAGING)'));
+  assert.ok(/finally:\s*\n\s*cleanup\(\)/.test(JOB_SCRIPT), 'cleanup runs even on a crash');
+});
+
+test('the commit is gated on a scrub that verified itself', () => {
+  assert.ok(JOB_SCRIPT.includes('refusing to commit: secrets still present'));
+  // The verify must come before the commit, or it proves nothing.
+  assert.ok(JOB_SCRIPT.indexOf('secrets still present') < JOB_SCRIPT.indexOf('upload_folder'));
+  // Tight patterns: a loose one rewrote ordinary prose containing "sk-".
+  assert.ok(JOB_SCRIPT.includes('(?<![A-Za-z0-9_-])'), 'secret patterns are boundary-anchored');
+  assert.ok(!JOB_SCRIPT.includes('sk-(?:proj-)?[A-Za-z0-9_-]{24,}'), 'the loose pattern is gone');
+});
+
+test('credential files are matched by exact name, not substring', () => {
+  // "/credentials" is not a substring of "/.credentials.json" — that gap put a
+  // credentials file into a probe commit.
+  assert.ok(JOB_SCRIPT.includes('CRED_NAMES'));
+  assert.ok(JOB_SCRIPT.includes('.credentials.json'));
+  assert.ok(JOB_SCRIPT.includes('rsplit("/", 1)[-1] in CRED_NAMES'));
+});
+
+test('an empty scope refuses rather than committing nothing', () => {
+  assert.ok(JOB_SCRIPT.includes('the scope matched no files'));
+});
+
+// ---------------------------------------------------------------------------
+// The default skip list: reproducibility is the only criterion.
+// ---------------------------------------------------------------------------
+
+test('defaults skip only what a command can put back', () => {
+  for (const t of ['node_modules', '.venv', '.cache', '__pycache__', '.lake/packages',
+                   '.elan/toolchains', '.npm/_cacache', '.tmp']) {
+    assert.ok(DEFAULT_EXCLUDE.includes(t), `${t} should be skipped by default`);
+  }
+});
+
+test('defaults never drop work: no .git, no worktrees, no size rule', () => {
+  // .git holds unpushed commits and staged changes: they exist nowhere else.
+  assert.ok(!DEFAULT_EXCLUDE.includes('.git'));
+  assert.ok(!DEFAULT_EXCLUDE.some((t) => t.includes('.git')));
+  // Ambiguous build names stay opt-in — a source folder is called `build` often.
+  for (const t of ['dist', 'build', 'target']) assert.ok(!DEFAULT_EXCLUDE.includes(t));
+  // And nothing anywhere decides by file size.
+  assert.ok(!/size\s*>/.test(JOB_SCRIPT), 'no size threshold in the pipeline');
+  assert.ok(!JOB_SCRIPT.includes('CAP'), 'no size cap survives');
+});
+
+test('restore-defaults has something to restore to, and knows when it does not', async () => {
+  // excludeIsDefault is what hides the button when pressing it would do nothing.
+  const trimmed = normalizeExclude(DEFAULT_EXCLUDE.slice(0, 3));
+  assert.notDeepEqual(trimmed, [...DEFAULT_EXCLUDE]);
+  assert.deepEqual(excludeFromConfig(undefined), [...DEFAULT_EXCLUDE]);
+  assert.deepEqual(excludeFromConfig([]), [], 'an emptied list stays empty');
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -86,7 +86,7 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
-  backup: { every: BackupEvery; mirror: string; dataset: string; exclude: string[] };
+  backup: { every: BackupEvery; dataset: string; exclude: string[] };
   defaultArtifactsSpace?: string;
 }
 export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json);
@@ -98,9 +98,9 @@ export type BackupEvery = 'never' | '1h' | '3h' | '24h';
 export interface BackupStatus {
   every: BackupEvery;
   source: string | null;
-  mirror: string;
+  staging: string;
   dataset: string;
-  defaults: { mirror: string; dataset: string };
+  defaults: { dataset: string; staging: string };
   hasToken: boolean;
   canRunNow: boolean;
   running: boolean;
@@ -113,7 +113,8 @@ export interface BackupStatus {
   jobsUrl: string;
   // The tokens as stored, and the globs they expand to.
   exclude: string[];
-  excludePatterns: string[];
+  excludeDefaults: string[];
+  excludeIsDefault: boolean;
   health: BackupHealth | null;
   failures: number;
   lastFailure: { at: number; jobId: string; stage: string; message: string | null; reason: string | null } | null;

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -403,11 +403,12 @@ export default function SettingsView({
                   <div>
                     <div className="s-label">Back up the bucket</div>
                     <div className="s-help">
-                      Copies your whole bucket — workspaces, history, saved logins — to private Hub storage:
-                      a bucket you can restore from instantly, and a dataset that keeps version history.
-                      Nothing is ever deleted from your bucket.
+                      Snapshots your work — workspaces, transcripts, config — to a private dataset on
+                      the Hub every hour, so you can get back any past version. Caches and dependency
+                      folders are skipped, and saved logins are left out: a snapshot is never a place
+                      to keep credentials. Nothing is ever written to or deleted from your bucket.
                     </div>
-                    {/* A kv table, not a run-on sentence: three destinations and a
+                    {/* A kv table, not a run-on sentence: the destinations and a
                         timestamp are things you scan, not read. The two repos
                         default to the same id string — one a dataset, one a
                         bucket — so each row says which it is. */}
@@ -429,21 +430,6 @@ export default function SettingsView({
                             )}
                           </b>
                         </div>
-                        {(bk.mirror || bk.defaults.mirror) && (
-                          <div>
-                            <span>Mirror bucket</span>
-                            <b>
-                              <a
-                                className="mono"
-                                href={`https://huggingface.co/buckets/${bk.mirror || bk.defaults.mirror}`}
-                                target="_blank"
-                                rel="noreferrer"
-                              >
-                                {bk.mirror || bk.defaults.mirror}
-                              </a>
-                            </b>
-                          </div>
-                        )}
                         <div>
                           <span>Backup jobs</span>
                           <b><a href={bk.jobsUrl} target="_blank" rel="noreferrer">{bk.jobName}</a></b>
@@ -490,11 +476,26 @@ export default function SettingsView({
                         worth keeping — measured, that is 7s of work versus 1s. */}
                     {bk?.canRunNow && (
                       <>
-                        <div className="s-help" style={{ marginTop: 10 }}>
-                          Skip these folders — type a name and press Enter. Anywhere they appear
-                          (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
-                          they stay out of the history and the backup gets quicker. The list starts
-                          on the caches a package manager can rebuild; remove any you want kept.
+                        <div className="s-help skiphead" style={{ marginTop: 10 }}>
+                          <span>
+                            Skip these folders — type a name and press Enter. Anywhere they appear
+                            (<span className="mono">node_modules</span>, <span className="mono">.venv</span>),
+                            they stay out of the history. Everything here is something a command puts
+                            back; nothing is skipped for being large. Remove any you want kept.
+                          </span>
+                          {/* The default list is long and picked from measurements, so an operator
+                              who trims it has no way back without retyping 30 names. Hidden when
+                              the list already matches the defaults, so it is never a no-op —
+                              compared against the local edit rather than the server's copy, or it
+                              would linger until the next status poll. */}
+                          {bk.excludeDefaults?.length > 0
+                            && (cfg.backup.exclude.length !== bk.excludeDefaults.length
+                              || cfg.backup.exclude.some((t, i) => t !== bk.excludeDefaults[i])) && (
+                            <button
+                              className="btn-ghost skiprestore"
+                              onClick={() => setCfg({ ...cfg, backup: { ...cfg.backup, exclude: [...bk.excludeDefaults] } })}
+                            >Restore defaults</button>
+                          )}
                         </div>
                         <div className="tagf" onClick={(e) => {
                           if (e.target === e.currentTarget) (e.currentTarget.querySelector('input') as HTMLInputElement)?.focus();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1352,3 +1352,10 @@ a.btn-ghost { text-decoration: none; }
   padding: 5px 9px; border-top: 1px solid var(--border);
   font-size: 10.5px; color: var(--muted);
 }
+
+/* Skip-list header: help text with the restore control pinned to its right, so
+   the button sits with the list it resets rather than in the row of buttons that
+   run backups. */
+.skiphead { display: flex; align-items: flex-start; gap: 12px; }
+.skiphead > span { flex: 1; min-width: 0; }
+.skiprestore { flex: none; font-size: 11.5px; padding: 3px 8px; white-space: nowrap; }


### PR DESCRIPTION
## Why

The backup on this Space has never once succeeded. `lvwerra/agent-manager-backup`
holds a single commit — `initial commit` — after a day of hourly runs. This PR
replaces the step that fails, and closes a path by which it could have **published
the bucket**.

## 1. The mount had to go (measured)

The old step 2 handed a mounted folder to `hf upload` and let it enumerate. That
enumeration is the entire cost, and it is paid on every file whether wanted or not.

| | files | time |
|---|---|---|
| stat-only walk of the FUSE mount (`find /live -type f`) | 108,960 | **14m51s** |
| the same tree over the Hub API (`list_bucket_tree`) | 108,960 | **8 s** |
| the same content on the Job's local disk | 39,873 | **0.14 s** |

~8 ms per file on the mount; ~6,000× faster on local disk. The Job has 453 GB free,
so the download is bounded by bandwidth (~5 MB/s measured), not space.

The new pipeline: **list over the API → decide the scope in code → copy just those
paths server-side by Xet hash into a private, ephemeral staging bucket (metadata
only, ~880 files/s) → download to local disk → scrub → verify → commit → delete
staging in a `finally`.**

Measured end to end at prod scale: list 8.3 s → snapshot 12 s → download 129 s →
scrub 2 s → verify → commit 113 s. **4m24s**, for a job that had never finished.

Being *frozen* matters as much as being fast. The live bucket is written while a run
works, and reading it directly died with `not a file on the local file system` when
the Space rotated a file away mid-upload. A snapshot cannot change underneath a run.

Three failure modes die with the mount, all observed here: the `.cache/` path
rejection, `Job timeout` at 1h33m–2h07m (against the `--timeout 3000s` we ask for,
which is not honoured), and the vanishing file above.

## 2. Secrets never reach the history

A fourth failure mode can't be outrun: **the Hub secret-scans dataset commits, and
buckets are not scanned.** The scanner is TruffleHog, and it verifies a find by
*authenticating with the token* — which **invalidates it**. One of this Space's HF
tokens was invalidated exactly that way. So this isn't hygiene; a leaking commit
breaks the operator's credentials.

Two mechanisms, because either alone is insufficient:

- **Skip** files that exist to hold credentials, matched on the **exact final path
  segment**. A substring test for `/credentials` sails straight past
  `/.credentials.json` — that gap put a credentials file into a probe commit.
- **Scrub** stray occurrences, then **verify**, then commit. The verify is
  mandatory: a leftover match ends the run with no commit.

Patterns are boundary-anchored. A looser `sk-[A-Za-z0-9_-]{24,}` matched
`sk-abstraction-and-chart-selection` inside ordinary prose — a scrub that silently
rewrites real content is worse than one that over-reports. Re-scanning 73 flagged
files with tight patterns: **52 real, 21 false positives**.

## 3. Nothing is private by default — and this file assumed otherwise

Both verified against the Hub:

| call | result |
|---|---|
| `create_bucket(id)` with no `private=` | **public** |
| `hf upload <new-dataset>` (repo does not exist) | **public** |

The second was live on `main`, under a comment asserting the opposite —
*"Not existing yet is fine — the upload below creates it private"* — with the
privacy gate **skipped in exactly that case**. On any Space whose backup dataset
didn't exist yet, the first run published the bucket. This Space escaped only
because its dataset was created by an earlier iteration and nothing has committed
since.

Now: every destination is created with visibility **stated explicitly**, then
**read back and checked** before a byte is written. The source bucket is gated too.
`hf cp` is fine — it refuses to auto-create in either form.

## 4. The default skip list, rebuilt on reproducibility

One criterion, and it is not size: **a command can put it back.** Excluding only
manager-owned, cache and temp directories drops **86,615 files / 8.05 GB** of this
bucket and keeps **23,975 files / 3.78 GB**.

An earlier draft of mine used a 10 MB per-file cap. It quietly discarded 1.81 GB
including four session transcripts of 292, 237, 142 and 141 MB — the most
history-shaped content on the bucket. **No size rule survives anywhere**, and
there's a test asserting that.

`.git` stays in: unpushed commits and staged changes live nowhere else, and a
partially-copied `.git` is a corrupt repo. Git worktrees stay in as a class, since
uncommitted work in a clone isn't reproducible from its remote. `dist`/`build`/
`target` stay opt-in — a source folder is called `build` often enough.

## 5. The mirror is gone

It was a second full copy that never deleted anything, so it archived every
credential the Space had ever held — **174 files present in the mirror and absent
from the live bucket**. What it offered ("the Space exactly as it was, latest only")
is what the bucket already is; restarts never involved backup, since the bucket *is*
the persistent store.

The trade this accepts: a lost bucket now means re-logging in, because the history
holds no credentials by design. **An existing mirror bucket is not deleted
automatically** — that's the operator's call.

## 6. Restore defaults

The skip list is 30 names picked from measurements, so trimming it otherwise means
retyping them. The control compares against the **local edit**, not the server's
copy, so it disappears the moment it would be a no-op — verified in a browser: 2
chips → click → 30 chips → button gone.

## Verified

- **33 tests pass**, 10 new: tokens-not-globs and no `-v` in the launch, no
  `AM_MIRROR` anywhere, every destination created private *and* re-read, staging
  torn down in a `finally`, commit gated behind a self-verifying scrub, exact-name
  credential matching, empty-scope refusal, defaults-skip-only-reproducible,
  no-`.git`-and-no-size-rule, and restore-defaults semantics.
- `tsc --noEmit` and the web build are clean.
- The pipeline itself was run end to end against this Space's real bucket before
  being written up; the numbers above are from those runs, not estimates.

## Not done

- **The remaining credentials in the bucket are untouched.** 50 `shell_snapshots`
  files with HF tokens, `state/claude/.credentials.json`, `home/.config/gh/hosts.yml`
  still hold live secrets in the bucket and its mirror. This PR keeps them out of
  the history; it does not clean or revoke them, which is the operator's call.
- **`--timeout` being ignored** is still unexplained. It matters less now that a run
  takes ~4 minutes, but a stuck run still occupies whatever the platform's limit is.
- **Media is still included.** `workspaces/the-gatherer/work` is 3,740 files / 1.37 GB
  of downloaded arxiv PDFs — re-downloadable in principle, but not by one command,
  so by the reproducibility rule it stays. It's about a third of the transfer if you
  want it gone.
