### PR TITLE
Terminal: drop the viewers/watching badge from the pane header

### DIFF
--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -211,8 +211,6 @@ export default function TerminalPane({
   // something — byte counts lie because a blank-screen repaint can already be
   // kilobytes of escape sequences.
   const [booting, setBooting] = useState(true);
-  const [controller, setController] = useState(false);
-  const [viewers, setViewers] = useState(1);
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(session.name);
   // Fallback paste sheet: shown only when we can't read the clipboard directly.
@@ -381,7 +379,6 @@ export default function TerminalPane({
       // Optimistic locally so the input event following this gesture is not
       // dropped. WebSocket ordering guarantees claim reaches the server first.
       controllerRef.current = true;
-      setController(true);
       send({ t: 'claim' });
     };
     claimRef.current = claimControl;
@@ -463,7 +460,6 @@ export default function TerminalPane({
     };
     const connect = () => {
       controllerRef.current = false;
-      setController(false);
       setConn('connecting');
       // A reconnect keeps the already-rendered xterm visible. On a fresh page,
       // `booting` instead exposes the saved preview until canonical restore has
@@ -495,8 +491,6 @@ export default function TerminalPane({
             const m = JSON.parse(d.slice(MODE_CTRL.length));
             if (m.t === 'grid' || m.t === 'restore') {
               controllerRef.current = !!m.controller;
-              setController(!!m.controller);
-              setViewers(Math.max(1, Number(m.viewers) || 1));
               const applyGrid = () => {
                 try {
                   // xterm can retain the old pixel scrollTop when the viewport
@@ -826,11 +820,6 @@ export default function TerminalPane({
           <span className="ph-title" title={`${pathLabel} · double-click to rename`} onDoubleClick={() => { setDraft(session.name); setEditing(true); }}>{session.name}</span>
         )}
         <div className="ph-right">
-          {viewers > 1 && (
-            <span className={`ph-role${controller ? ' controller' : ''}`} title={controller ? 'This pane controls terminal input and size' : 'Interact with the terminal to take control'}>
-              {controller ? `${viewers} viewers` : 'watching'}
-            </span>
-          )}
           <span className="ph-path" title={pathLabel}>{pathLabel}</span>
           <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
         </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -558,8 +558,6 @@ body {
 .pane-head .ph-left { grid-column: 1; justify-self: start; display: inline-flex; align-items: center; gap: 7px; }
 .pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; text-align: center; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: text; }
 .pane-head .ph-right { grid-column: 3; min-width: 0; display: inline-flex; align-items: center; justify-self: end; gap: 6px; }
-.pane-head .ph-role { flex: none; padding: 2px 6px; border: 1px solid var(--border); border-radius: 999px; color: var(--muted); font-family: var(--font-mono); font-size: 9.5px; line-height: 1.2; }
-.pane-head .ph-role.controller { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 35%, var(--border)); }
 .pane-head .ph-path { min-width: 0; max-width: min(24vw, 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; }
 .pane-head .ph-title-input { width: 100%; text-align: center; font: inherit; font-family: var(--font-mono); font-weight: 600; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
 .pane-head .ph-close { justify-self: end; }


### PR DESCRIPTION
With more than one browser attached to a session, the pane header showed a small pill in `.ph-right`: `N viewers` for the controller, `watching` for everyone else. It is not actionable — the first keystroke claims control (`term.onKey` → `claimControl()` runs before `onData` sends anything), so a watcher who starts typing becomes the controller without ever having read the badge. It just took space next to the path and the close button.

Removed, along with the two `useState` hooks that existed only to feed it (`controller`, `viewers`) and the two `.ph-role` rules.

**No behaviour change.** `controllerRef` is what actually gates input (`if (controllerRef.current) send({t:'i',d})`) and the size lease; the removed `setController` calls only mirrored that ref into render state for the badge. Every `controllerRef` assignment is untouched. The server still sends `controller` and `viewers` on the grid frame — the client now ignores the count and keeps using the flag.

## Verified

- `npm run build` in `web/` — `tsc --noEmit` clean, vite bundle builds. This is the check that matters: removing state hooks is exactly the change that leaves dangling references, and there are none.
- Grepped `viewers` / `ph-role` / `setController` across `web/src` and `server/test`: no remaining references (the only `controller` hits left are two comments about the size lease, still accurate).

Not verified: no test covers the pane header, and I did not run the live app for this one — the removal is a JSX subtree plus dead state, and the typecheck covers it.