### PR TITLE
Settings: list only the agents you can actually sign into

### DIFF
--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import type { Cli } from '../types';
+import { isPassive, isRemote, type Cli } from '../types';
 import * as api from '../api';
 import SkillsEditor from './SkillsEditor';
 import UsagePanel from './UsagePanel';
@@ -291,7 +291,11 @@ export default function SettingsView({
             <h3>Agents</h3>
             <div className="s-help">A coloured dot means the agent is configured and ready. Log in once inside a session (or set a key as a Space secret) — credentials persist on the bucket across restarts and all sessions.</div>
             <div className="agent-rows">
-              {clis.filter((c) => c.id !== 'shell' && c.id !== 'files').map((c) => {
+              {/* Only the CLIs this Space installs and you sign into. Shell needs
+                  no credentials; files/trace are panels rather than processes; a
+                  remote agent authenticates wherever it actually runs, so its
+                  readiness was never ours to report. */}
+              {clis.filter((c) => c.id !== 'shell' && !isPassive(c.id) && !isRemote(c.id)).map((c) => {
                 const ready = c.available && c.ready;
                 return (
                   <div key={c.id} className="agent-row">


### PR DESCRIPTION
The Agents list in Settings filtered out `shell` and `files`, which left **Trace** and **Remote agent** in it, both showing a lit dot and the word `ready`.

Neither is something you configure on this Space. Trace is a read-only panel with no binary and nothing to launch; a remote agent signs in on whatever machine it actually runs on. They read as ready for a boring reason — `ready` is `available && isConfigured(id)`, and both fall through `isConfigured`'s `default: return true` ("nothing to configure, therefore configured", `server/src/config.js:142`). Technically true, and a row that can never say anything else is just noise under a heading promising to tell you what needs setup.

The filter now uses the same predicate the server already applies when it decides which CLIs count as agents — `isAgentCli(c.id) && !isRemote(c.id)` at `server/src/index.js:383` — expressed with the `isPassive` / `isRemote` helpers `web/src/types.ts` already exports, rather than another hand-rolled id comparison.

Rows after this change: Claude Code, Codex, Gemini CLI, opencode, hermes, openclaw — the ones with a `bin` and a `setup` hint.

Nothing else moves: the sidebar's new-pane picker still offers Files, Trace and Remote agent, since those are panes you create, and the server keeps reporting them in `/api/clis`.

## Verified

`npm run build` in `web/` — `tsc --noEmit` clean, bundle builds.

Not verified in a running Space: this is a one-line filter over a list already rendered from `/api/clis`, and I confirmed the two dropped ids by reading how `available`/`ready` are computed rather than by watching the page.