### PR TITLE
Agents: let a spawned peer join your group, and tell sessions the port

### DIFF
--- a/server/migration.test.mjs
+++ b/server/migration.test.mjs
@@ -20,8 +20,15 @@ const check = (name, ok, detail = '') => {
 };
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+// A test server must not publish skills. `SPACE_ID` is set when this runs inside
+// the Space itself, and it makes generateEnvSkill() fan the environment skill out
+// into every live agent's skills dir — from THIS checkout's template, over the
+// copies the running backend wrote. Those dirs are outside DATA_DIR, so a
+// throwaway DATA_DIR does not contain the damage. Strip both switches.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+
 const srv = spawn('node', ['src/index.js'], {
-  env: { ...process.env, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent' },
+  env: { ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent' },
   stdio: ['ignore', 'pipe', 'pipe'],
 });
 let bootLog = '';

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/spawn-group.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/resize.test.mjs
+++ b/server/resize.test.mjs
@@ -40,10 +40,17 @@ const waitFor = async (fn, timeout = 8000) => {
   return false;
 };
 
+// A test server must not publish skills. `SPACE_ID` is set when this runs inside
+// the Space itself, and it makes generateEnvSkill() fan the environment skill out
+// into every live agent's skills dir — from THIS checkout's template, over the
+// copies the running backend wrote. Those dirs are outside DATA_DIR, so a
+// throwaway DATA_DIR does not contain the damage. Strip both switches.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+
 const srv = spawn('node', ['src/index.js'], {
   cwd: HERE,
   env: {
-    ...process.env,
+    ...BASE_ENV,
     PORT: String(PORT),
     DATA_DIR,
     AM_BASHRC: '/nonexistent',

--- a/server/src/groups.js
+++ b/server/src/groups.js
@@ -90,6 +90,36 @@ export function groupOf(sessionId) {
   return groups.find((g) => g.sessionIds.includes(sessionId)) || null;
 }
 
+/**
+ * Which group a newly spawned session should join, for the agent-facing spawn
+ * API. Mirrors how that route picks a folder: omitted means "same as the caller",
+ * because a peer you spawn is usually working on the same thing you are.
+ *
+ * `requested` is the raw ?group= value: omitted/blank inherits the caller's
+ * group, 'none' opts out and leaves the session loose in the sidebar, and
+ * anything else names a group — by id, or by the display name, which is the
+ * only form an agent ever sees (GET /api/agents reports `group` as a name).
+ *
+ * Returns {groupId} (null = ungrouped) or {error} for a name that matches
+ * nothing. An unknown group is refused rather than created: the sidebar is the
+ * operator's, and a typo should be loud instead of quietly fragmenting it.
+ */
+export function resolveSpawnGroup(requested, callerId) {
+  const raw = typeof requested === 'string' ? requested.trim() : '';
+  if (!raw) {
+    const g = groupOf(callerId);
+    return { groupId: g ? g.id : null };
+  }
+  if (raw.toLowerCase() === 'none') return { groupId: null };
+  const byId = get(raw);
+  if (byId) return { groupId: byId.id };
+  const lower = raw.toLowerCase();
+  const byName = groups.find((g) => (g.name || '').toLowerCase() === lower);
+  if (byName) return { groupId: byName.id };
+  const known = groups.map((g) => g.name).filter(Boolean).join(', ');
+  return { error: `unknown group '${raw}'${known ? ` — groups here: ${known}` : ' — no groups exist yet'}; pass group=none to stay ungrouped` };
+}
+
 /** Remove a session from every group (used on session delete). */
 export function detachSession(sessionId) {
   let changed = false;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1121,6 +1121,24 @@ to leave it ungrouped. The prompt is required — it starts working on it
 immediately. Spawn one agent for one clearly separable job; several agents in
 one folder is fine, but this Space is a small CPU box, so don't build a fleet.
 
+**Into a NEW group** — e.g. "start four agents in a group called taskforce".
+\`group=\` only ever selects a group that already exists; an unknown name is
+refused rather than created, so a typo can't quietly fragment the sidebar. Make
+the group first, then spawn into it:
+
+\`\`\`sh
+GID=$(curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/groups" \\
+  -H 'content-type: application/json' -d '{"name":"taskforce"}' | jq -r .id)
+
+curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents?cli=claude&group=$GID&from=$AM_ID" \\
+  -H 'content-type: text/plain' --data-binary 'Draft the migration plan.'
+\`\`\`
+
+Spawn them one at a time, each with its own prompt, reusing \`$GID\`. Prefer the
+returned id over the name here: nothing stops two groups sharing a name, and
+\`group=<name>\` takes the first match. Creating a group is a manager operation
+rather than an agent-to-agent one, so it takes no \`?from=\`.
+
 ### Stop an agent
 \`\`\`sh
 curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/stop?from=$AM_ID"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1127,7 +1127,7 @@ refused rather than created, so a typo can't quietly fragment the sidebar. Make
 the group first, then spawn into it:
 
 \`\`\`sh
-GID=$(curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/groups" \\
+GID=$(curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/groups?from=$AM_ID" \\
   -H 'content-type: application/json' -d '{"name":"taskforce"}' | jq -r .id)
 
 curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents?cli=claude&group=$GID&from=$AM_ID" \\
@@ -1136,8 +1136,9 @@ curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents?cli=cl
 
 Spawn them one at a time, each with its own prompt, reusing \`$GID\`. Prefer the
 returned id over the name here: nothing stops two groups sharing a name, and
-\`group=<name>\` takes the first match. Creating a group is a manager operation
-rather than an agent-to-agent one, so it takes no \`?from=\`.
+\`group=<name>\` takes the first match. Group creation changes manager state, so
+it carries \`?from=$AM_ID\` like every other mutating agent call; this preserves
+the origin for the operation log.
 
 ### Stop an agent
 \`\`\`sh

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -488,16 +488,24 @@ app.post('/api/agents', promptBody, (req, res) => {
   if (!prompt) return res.status(400).json({ error: 'a spawned agent needs a task — send the prompt as the request body' });
   // Default to the caller's own folder: peers usually work on the same thing.
   const where = typeof q.path === 'string' && q.path.trim() ? q.path : (from.session.path ?? from.session.id);
+  // …and into the caller's own group, by the same reasoning: a peer spawned to
+  // work alongside you belongs beside you in the sidebar, not loose at the top
+  // of it. ?group= overrides (id or display name); ?group=none opts out.
+  const g = groups.resolveSpawnGroup(q.group, from.session.id);
+  if (g.error) return res.status(400).json({ error: g.error });
   const s = createSession({
     name: typeof q.name === 'string' ? q.name : '',
     cli,
+    groupId: g.groupId,
     path: where,
     prompt: `[message from ${from.session.name}:] ${prompt}`,
   });
   if (!s) return res.status(400).json({ error: 'bad path' });
   if (s.error) return res.status(400).json({ error: s.error });
+  const joined = g.groupId ? groups.get(g.groupId) : null;
   res.status(201).json({
     id: s.id, name: s.name, cli: s.cli, path: s.path, workdir: workspacePath(s.path),
+    group: joined ? joined.name : null,
     ...(cat.ready ? {} : { warning: `${def.label} has no credential configured — it may stop at a sign-in prompt` }),
   });
 });
@@ -1030,14 +1038,21 @@ Hermes — alongside plain shells and a file browser.
 - You can see them, watch them, and talk to them — see the next section.
 
 ## Working with the other agents
-The manager exposes a small HTTP API on \`localhost:${PORT}\`. You are \`$AM_ID\`
+The manager exposes a small HTTP API on \`localhost:\${AM_PORT:-${PORT}}\`. You are \`$AM_ID\`
 (\`$AM_NAME\` is your display name). Every call that changes something takes
 \`?from=$AM_ID\` so the other agent, and the operator reading the log later, can
 tell who asked.
 
+Your session exports the port as \`$AM_PORT\` — read it rather than trusting a
+number you remember, and check it before you believe an empty answer: \`curl -s\`
+to a port nothing is listening on prints **nothing at all**, and in some agent
+sandboxes it exits 0 rather than failing. A wrong port therefore reads as "the
+roster is empty, I have no peers" instead of an error. \`curl -sS --fail\` will
+tell you what actually happened.
+
 ### See who is here
 \`\`\`sh
-curl -s "http://localhost:${PORT}/api/agents?from=$AM_ID" | jq .
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents?from=$AM_ID" | jq .
 \`\`\`
 Each entry carries \`id\`, \`name\`, \`cli\`, \`state\`, \`workdir\`, \`sharesFolderWith\`,
 a one-line \`lastPrompt\`/\`lastAnswer\`, \`recentFiles\`, and \`trace\` — the path to
@@ -1052,8 +1067,8 @@ digest for one agent. Read \`state\` before you do anything:
 
 ### Watch instead of asking
 \`\`\`sh
-curl -s "http://localhost:${PORT}/api/agents/$ID/tail?lines=120" | jq -r .text
-curl -s "http://localhost:${PORT}/api/agents/$ID/wait?timeout=120"   # blocks
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/tail?lines=120" | jq -r .text
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=120"   # blocks
 \`\`\`
 \`tail\` returns that agent's screen and scrollback — exactly what a human would
 see in its pane. \`wait\` blocks until it stops working (default: any of
@@ -1068,7 +1083,7 @@ loop asking it whether it's done.
 ### Send an agent a prompt
 Send the text as the request **body** so quoting and newlines never bite you:
 \`\`\`sh
-curl -s -X POST "http://localhost:${PORT}/api/agents/$ID/prompt?from=$AM_ID" \\
+curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/prompt?from=$AM_ID" \\
   -H 'content-type: text/plain' --data-binary @- <<'EOF'
 Please run the test suite in your folder and fix whatever fails.
 EOF
@@ -1092,20 +1107,23 @@ Rules that matter, because nothing enforces them for you:
 
 ### Launch a new agent
 \`\`\`sh
-curl -s -X POST "http://localhost:${PORT}/api/agents?cli=claude&name=reviewer&from=$AM_ID" \\
+curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents?cli=claude&name=reviewer&from=$AM_ID" \\
   -H 'content-type: text/plain' --data-binary @- <<'EOF'
 Review the diff in /data/workspaces/api and report anything that would break in production.
 EOF
 \`\`\`
 \`cli\` is required (the roster's \`clis\` array lists what's installed and
 credentialed). \`path\` defaults to **your own folder**; pass it to put the new
-agent somewhere else. The prompt is required — it starts working on it
+agent somewhere else. \`group\` likewise defaults to **your own group**, so the
+new agent lands beside you in the sidebar — pass \`group=<name>\` to put it in a
+different one (the names are the \`group\` field in the roster), or \`group=none\`
+to leave it ungrouped. The prompt is required — it starts working on it
 immediately. Spawn one agent for one clearly separable job; several agents in
 one folder is fine, but this Space is a small CPU box, so don't build a fleet.
 
 ### Stop an agent
 \`\`\`sh
-curl -s -X POST "http://localhost:${PORT}/api/agents/$ID/stop?from=$AM_ID"
+curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/stop?from=$AM_ID"
 \`\`\`
 **Only when the operator asked you to.** It kills that agent's CLI mid-thought.
 Files and conversation survive, and a later prompt resumes it, but work in
@@ -1117,7 +1135,7 @@ a GPU box — not in this container. They appear in the roster like anyone else 
 you message them the same way:
 
 \`\`\`sh
-curl -s -X POST "http://localhost:${PORT}/api/agents/$ID/prompt?from=$AM_ID" \\
+curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/prompt?from=$AM_ID" \\
   -H 'content-type: text/plain' --data-binary 'can you check the tokenizer?'
 \`\`\`
 
@@ -1159,7 +1177,7 @@ operator explicitly asked for it in their prompt (e.g. "notify me when the
 tests pass") — send exactly ONE message when that condition is met:
 
 \`\`\`sh
-curl -s -X POST http://localhost:${PORT}/api/notify \\
+curl -s -X POST http://localhost:\${AM_PORT:-${PORT}}/api/notify \\
   -H 'content-type: application/json' \\
   -d "{\\"title\\":\\"$AM_NAME\\",\\"body\\":\\"<one-line outcome>\\"}"
 \`\`\`
@@ -1172,7 +1190,7 @@ For DELAYED notifications ("notify me in 10 minutes"), do not block on a long
 immediately (long-running foreground execs can destabilize some sessions):
 
 \`\`\`sh
-(sleep 600 && curl -s -X POST http://localhost:${PORT}/api/notify \\
+(sleep 600 && curl -s -X POST http://localhost:\${AM_PORT:-${PORT}}/api/notify \\
   -H 'content-type: application/json' \\
   -d "{\\"title\\":\\"$AM_NAME\\",\\"body\\":\\"reminder\\"}") >/dev/null 2>&1 &
 \`\`\`

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -4,7 +4,7 @@ import pty from 'node-pty';
 import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import { remoteState, setPaused } from './remote.js';
-import { cliById, isRemote, STATE_DIR, WORKSPACES_DIR } from './config.js';
+import { cliById, isRemote, PORT, STATE_DIR, WORKSPACES_DIR } from './config.js';
 import { update, list } from './sessions.js';
 import { captureOpencodeSession, opencodeSessionExists, readTrace } from './traces.js';
 import {
@@ -1428,6 +1428,10 @@ export function ensureRunning(session, cols = 120, rows = 34) {
     AM_ID: session.id,
     AM_USER,
     AM_ROOT: WORKSPACES_DIR, // prompt shows $PWD relative to this
+    // The port the agent API answers on. PORT is configurable, so a session
+    // must be able to READ it rather than trust a number baked into a doc when
+    // that doc was generated.
+    AM_PORT: String(PORT),
   };
   const term = pty.spawn('bash', ['-lc', full], {
     name: 'xterm-256color', cols, rows, cwd: workdir, env,

--- a/server/test/spawn-group.test.mjs
+++ b/server/test/spawn-group.test.mjs
@@ -64,6 +64,15 @@ console.log('\na non-string group is ignored rather than stringified');
 check('array falls back to inherit', groups.resolveSpawnGroup(['a', 'b'], CALLER).groupId, cowrite.id);
 check('object falls back to inherit', groups.resolveSpawnGroup({ x: 1 }, CALLER).groupId, cowrite.id);
 
+// The skill tells agents to create a group and then spawn into the id it
+// returns, rather than the name. This is why: nothing dedupes group names.
+console.log('\nduplicate names resolve to the first match; ids stay exact');
+const dupe = groups.create('Co-write');
+check('two groups can share a name', groups.list().filter((x) => x.name === 'Co-write').length, 2);
+check('by name takes the first', groups.resolveSpawnGroup('Co-write', LONER).groupId, cowrite.id);
+check('by id reaches the second', groups.resolveSpawnGroup(dupe.id, LONER).groupId, dupe.id);
+groups.remove(dupe.id);
+
 console.log('\nthe resolved id actually places the session (what the route then does)');
 const spawned = 'spawned-1';
 groups.attach(groups.resolveSpawnGroup(undefined, CALLER).groupId, spawned);

--- a/server/test/spawn-group.test.mjs
+++ b/server/test/spawn-group.test.mjs
@@ -1,0 +1,80 @@
+// Which group a spawned agent joins.
+//
+// POST /api/agents used to drop `groupId` on the floor: an agent spawning a peer
+// got it into the right FOLDER but loose in the sidebar, outside the group it was
+// meant to work in. The route now resolves a group the same way it resolves a
+// path — inherit the caller's, unless told otherwise.
+// Run with: node test/spawn-group.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'spawn-group-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const groups = await import('../src/groups.js');
+groups.init();
+
+let pass = 0, fail = 0;
+const check = (name, got, want) => {
+  const ok = got === want;
+  ok ? pass++ : fail++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `\n          got ${got}  want ${want}`}`);
+};
+
+const cowrite = groups.create('Co-write');
+const other = groups.create('RL-wiki-llm');
+const CALLER = 'caller-1';       // a grouped agent doing the spawning
+const LONER = 'loner-1';         // an agent that belongs to no group
+groups.attach(cowrite.id, CALLER);
+
+console.log('\nomitted group: the new agent lands beside the caller');
+check('inherits the caller group', groups.resolveSpawnGroup(undefined, CALLER).groupId, cowrite.id);
+check('blank is the same as omitted', groups.resolveSpawnGroup('   ', CALLER).groupId, cowrite.id);
+check('no error on the happy path', groups.resolveSpawnGroup(undefined, CALLER).error, undefined);
+
+console.log('\nan ungrouped caller spawns an ungrouped peer, not a crash');
+check('loner inherits nothing', groups.resolveSpawnGroup(undefined, LONER).groupId, null);
+check('loner is not an error', groups.resolveSpawnGroup(undefined, LONER).error, undefined);
+check('unknown caller id is treated as ungrouped',
+  groups.resolveSpawnGroup(undefined, 'never-existed').groupId, null);
+
+console.log('\nnaming a group: by display name (what the roster shows) or by id');
+check('by name', groups.resolveSpawnGroup('RL-wiki-llm', CALLER).groupId, other.id);
+check('by name, case-insensitively', groups.resolveSpawnGroup('rl-WIKI-llm', CALLER).groupId, other.id);
+check('by name, padded', groups.resolveSpawnGroup('  Co-write  ', CALLER).groupId, cowrite.id);
+check('by id', groups.resolveSpawnGroup(other.id, CALLER).groupId, other.id);
+
+console.log('\nopting out is explicit, because omitted already means "inherit"');
+check('none', groups.resolveSpawnGroup('none', CALLER).groupId, null);
+check('NONE', groups.resolveSpawnGroup('NONE', CALLER).groupId, null);
+check('none is not an error', groups.resolveSpawnGroup('none', CALLER).error, undefined);
+
+console.log('\na group that does not exist is refused, not created');
+const bad = groups.resolveSpawnGroup('Cowrite', CALLER); // typo: no hyphen
+check('no group id', bad.groupId, undefined);
+check('names the bad value', bad.error.includes("'Cowrite'"), true);
+check('lists the real groups', bad.error.includes('Co-write') && bad.error.includes('RL-wiki-llm'), true);
+check('points at the opt-out', bad.error.includes('group=none'), true);
+check('nothing was created', groups.list().length, 2);
+
+console.log('\na non-string group is ignored rather than stringified');
+// Express gives ?group=a&group=b as an array, and ?group[x]=1 as an object.
+check('array falls back to inherit', groups.resolveSpawnGroup(['a', 'b'], CALLER).groupId, cowrite.id);
+check('object falls back to inherit', groups.resolveSpawnGroup({ x: 1 }, CALLER).groupId, cowrite.id);
+
+console.log('\nthe resolved id actually places the session (what the route then does)');
+const spawned = 'spawned-1';
+groups.attach(groups.resolveSpawnGroup(undefined, CALLER).groupId, spawned);
+check('peer is in the caller group', groups.groupOf(spawned)?.id, cowrite.id);
+check('caller is still there too', groups.groupOf(CALLER)?.id, cowrite.id);
+check('and it survives a reload', (groups.init(), groups.groupOf(spawned)?.id), cowrite.id);
+
+console.log('\nan ungrouped spawn is left for the sidebar to prepend');
+check('null id means "no attach call"', groups.resolveSpawnGroup('none', CALLER).groupId, null);
+check('the loner really is in no group', groups.groupOf(LONER), null);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+fs.rmSync(TMP, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);


### PR DESCRIPTION
Three things an agent could not do from inside the Space. All three were found while trying to start four sessions inside an existing group from another agent.

## A spawned peer could not join a group

`POST /api/agents` read `cli`, `name` and `path` from the query and never passed `groupId`. `createSession` has always accepted it, and the UI's `POST /api/sessions` passes it — only the agent-facing route didn't. So an agent spawning a peer got it into the right *folder* but loose in the sidebar, outside the group it was meant to work in.

The route now resolves a group the same way it already resolves a path, and the reasoning is the route's own: it defaults `path` to the caller's folder because "peers usually work on the same thing". By exactly that logic the group defaults to the caller's too — a peer spawned to work alongside you belongs beside you in the sidebar.

The rest follows from keeping `path` and `group` consistent:

- **Omitted → the caller's group.** An ungrouped caller spawns an ungrouped peer; nothing special-cased.
- **`?group=` names another one, by id or by display name.** The name matters: `GET /api/agents` reports `group` as a *name*, so a name is the only form an agent ever sees. Matching is case-insensitive and trimmed.
- **`?group=none` opts out.** `path` gets its opt-out for free (`path=.` is the workspaces root); a group needs an explicit sentinel, since "omitted" is already taken by inherit.
- **An unknown name is a 400, not a new group.** This is the one place I deliberately did *not* mirror `path`, which creates a missing folder. A folder is the caller's own business and cheap; the sidebar is the operator's, and group names come from a small set the caller can read off the roster first. A typo should be loud rather than quietly fragmenting the sidebar. The error lists the groups that do exist and points at `group=none`.

The 201 now reports the `group` it joined, so the caller can confirm without re-reading the roster.

## Sessions had no way to learn the API port

`PORT` is configurable (`config.js`, and `Dockerfile` sets `ENV PORT=7860`), but nothing exported it into session environments — sessions got `AM_SESSION`, `AM_NAME`, `AM_ID`, `AM_USER`, `AM_ROOT` and nothing else. The only other source was the number interpolated into the environment skill *at generation time*, and a generated-once document cannot stay correct across a port change.

Sessions now get `AM_PORT`, and the skill template reads `${AM_PORT:-<port>}` rather than baking in a constant. The fallback is the generation-time port, so the doc is still correct for a session started before this change, or by any path that misses the export.

## A wrong port fails silently, which is worse than it sounds

`curl -s` to a port nothing is listening on prints *nothing at all*, and under some agent sandboxes exits 0 rather than failing. The failure therefore reads as "the roster is empty, I have no peers" rather than "wrong port" — a genuinely expensive thing to debug. The skill now says so and points at `curl -sS --fail`.

## Tests

`server/test/spawn-group.test.mjs`, in the style of the existing `test/*.test.mjs` (plain node, no harness, `check(name, got, want)`, temp `DATA_DIR`), wired into `npm test`. 25 checks covering: inheriting the caller's group, the ungrouped-caller case, an unknown caller id, naming a group by id and by display name, the `none` opt-out, an unknown name being refused without creating anything, non-string `?group=` values (Express hands you an array for `?group=a&group=b`), and that the resolved id actually places the session and survives a reload.

Also verified by hand against a server booted on a throwaway `DATA_DIR`: an unknown group is rejected for both a grouped and an ungrouped caller, and group resolution correctly runs after the prompt check, so a promptless request still fails first. The existing suites pass (`repin`, `opencode-resume`, `terminal-modes`, `trace-tail`, and the `migration` boot suite, which confirms the server still boots with these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
