### PR TITLE
Audit every state-changing manager operation

### DIFF
--- a/server/migration.test.mjs
+++ b/server/migration.test.mjs
@@ -28,7 +28,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
 
 const srv = spawn('node', ['src/index.js'], {
-  env: { ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent' },
+  env: { ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent', AM_ALLOW_MISSING_ORIGIN: '1' },
   stdio: ['ignore', 'pipe', 'pipe'],
 });
 let bootLog = '';

--- a/server/mobile.test.mjs
+++ b/server/mobile.test.mjs
@@ -52,7 +52,7 @@ const backend = spawn('node', ['src/index.js'], {
   // reached through localhost, and the origin guard should validate it as such.
   env: {
     ...process.env,
-    PORT: '7896', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '',
+    PORT: '7896', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1',
   },
   stdio: ['ignore', 'pipe', 'pipe'],
 });

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/resize.test.mjs
+++ b/server/resize.test.mjs
@@ -54,6 +54,7 @@ const srv = spawn('node', ['src/index.js'], {
     PORT: String(PORT),
     DATA_DIR,
     AM_BASHRC: '/nonexistent',
+    AM_ALLOW_MISSING_ORIGIN: '1',
     AM_HISTORY_SAVE_MS: '50',
     AM_STARTUP_CAPTURE_IDLE_MS: '700',
     AM_STARTUP_CAPTURE_MAX_MS: '3000',

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,6 +37,7 @@ import { shareSession, shareNamespace, findTrace, shareAccess, grantAccess, revo
 import * as backup from './backup.js';
 import * as runstate from './runstate.js';
 import { installSlowFsProbe } from './slowfs.js';
+import { operationMiddleware, readOperations } from './operations.js';
 
 // Before anything else touches the mount: a sync fs call to /data is ~85ms of
 // frozen event loop here, and nothing else in the stack can see it. See slowfs.js.
@@ -178,6 +179,39 @@ app.use((req, res, next) => {
   return res.status(403).json({ error: 'locked', reason: 'public-space' });
 });
 
+// Every state-changing call has an attributable origin and a durable outcome.
+// The private Space has one human operator, represented by the stable
+// `operator` id. Local agents use their session id; remote agents use their
+// immutable remote name. The remote route fallback keeps already-running poll
+// loops compatible while newly generated prompts send the id explicitly.
+const resolveOperationOrigin = (raw, req) => {
+  if (raw === 'operator') {
+    return { id: 'operator', type: 'operator', name: process.env.SPACE_AUTHOR_NAME || process.env.AM_USER || 'operator' };
+  }
+  if (raw) {
+    const session = store.get(raw);
+    if (session) return { id: session.id, type: 'agent', name: session.name, cli: session.cli };
+    if (raw.startsWith('remote:')) {
+      const name = raw.slice('remote:'.length);
+      const remoteSession = store.list().find((s) => s.remote?.name === name);
+      if (remoteSession) return { id: raw, type: 'remote', name, cli: remoteSession.remote?.peer?.harness || 'remote' };
+    }
+    return null;
+  }
+  const match = req.path.match(/^\/api\/remote\/([^/]+)\/(?:hello|messages)$/);
+  if (!match) return null;
+  let name;
+  try { name = decodeURIComponent(match[1]); } catch { return null; }
+  const remoteSession = store.list().find((s) => s.remote?.name === name);
+  return remoteSession ? { id: `remote:${name}`, type: 'remote', name, cli: remoteSession.remote?.peer?.harness || 'remote' } : null;
+};
+app.use(operationMiddleware({
+  resolveOrigin: resolveOperationOrigin,
+  // Test servers explicitly opt out so old endpoint-focused fixtures do not
+  // have to pretend to be the operator. Production never sets this switch.
+  allowMissing: process.env.AM_ALLOW_MISSING_ORIGIN === '1',
+}));
+
 app.get('/api/visibility', (_req, res) => res.json(visibility()));
 
 app.get('/api/health', (_req, res) =>
@@ -186,6 +220,13 @@ app.get('/api/health', (_req, res) =>
 app.get('/api/clis', (_req, res) => res.json(cliCatalog()));
 
 app.get('/api/usage', async (req, res) => res.json(await buildUsage(req.query.debug === '1', req.query.provider || null)));
+
+// Newest first. The JSONL source lives under DATA_DIR; this bounded API is the
+// stable way for the operator or an agent to reconstruct manager operations.
+app.get('/api/operations', (req, res) => {
+  const before = typeof req.query.before === 'string' && req.query.before ? req.query.before : null;
+  res.json({ operations: readOperations(req.query.limit, before), generatedAt: new Date().toISOString() });
+});
 
 app.get('/api/traces', async (_req, res) => res.json(await buildTraces()));
 
@@ -1081,7 +1122,14 @@ Hermes — alongside plain shells and a file browser.
 The manager exposes a small HTTP API on \`localhost:\${AM_PORT:-${PORT}}\`. You are \`$AM_ID\`
 (\`$AM_NAME\` is your display name). Every call that changes something takes
 \`?from=$AM_ID\` so the other agent, and the operator reading the log later, can
-tell who asked.
+tell who asked. The manager durably records these operations and their outcomes;
+prompt and file contents are hashed rather than copied into the audit log.
+
+To reconstruct recent manager operations (newest first):
+
+\`\`\`sh
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/operations?limit=100" | jq .operations
+\`\`\`
 
 Your session exports the port as \`$AM_PORT\` — read it rather than trusting a
 number you remember, and check it before you believe an empty answer: \`curl -s\`
@@ -1236,7 +1284,7 @@ operator explicitly asked for it in their prompt (e.g. "notify me when the
 tests pass") — send exactly ONE message when that condition is met:
 
 \`\`\`sh
-curl -s -X POST http://localhost:\${AM_PORT:-${PORT}}/api/notify \\
+curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/notify?from=$AM_ID" \\
   -H 'content-type: application/json' \\
   -d "{\\"title\\":\\"$AM_NAME\\",\\"body\\":\\"<one-line outcome>\\"}"
 \`\`\`
@@ -1249,7 +1297,7 @@ For DELAYED notifications ("notify me in 10 minutes"), do not block on a long
 immediately (long-running foreground execs can destabilize some sessions):
 
 \`\`\`sh
-(sleep 600 && curl -s -X POST http://localhost:\${AM_PORT:-${PORT}}/api/notify \\
+(sleep 600 && curl -s -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/notify?from=$AM_ID" \\
   -H 'content-type: application/json' \\
   -d "{\\"title\\":\\"$AM_NAME\\",\\"body\\":\\"reminder\\"}") >/dev/null 2>&1 &
 \`\`\`

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -1,0 +1,150 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR } from './config.js';
+
+export const OPERATIONS_FILE = path.join(DATA_DIR, 'operations.jsonl');
+
+const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+const MAX_TEXT = 500;
+const MAX_DEPTH = 5;
+const SENSITIVE_KEY = /(authorization|credential|password|secret|subscription|token|endpoint|private.?key)/i;
+const CONTENT_KEY = /(body|content|data|prompt|text)/i;
+
+const digest = (value) => crypto.createHash('sha256').update(value).digest('hex');
+
+function textSummary(value) {
+  return { present: value.length > 0, chars: value.length, sha256: digest(value) };
+}
+
+/**
+ * Keep the parameters needed to reconstruct an operation without turning the
+ * audit trail into a second store for prompts, file contents, or credentials.
+ */
+export function summarizePayload(value, key = '', depth = 0) {
+  if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
+  if (Buffer.isBuffer(value)) return { bytes: value.length, sha256: digest(value) };
+  if (typeof value === 'string') {
+    if (SENSITIVE_KEY.test(key)) return '[redacted]';
+    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value);
+    return value;
+  }
+  if (depth >= MAX_DEPTH) return '[max-depth]';
+  if (Array.isArray(value)) return value.slice(0, 100).map((v) => summarizePayload(v, key, depth + 1));
+  if (typeof value === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(value).slice(0, 100)) {
+      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1);
+    }
+    return out;
+  }
+  return String(value);
+}
+
+function append(record) {
+  try {
+    fs.mkdirSync(path.dirname(OPERATIONS_FILE), { recursive: true });
+    fs.appendFileSync(OPERATIONS_FILE, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+  } catch (e) {
+    // Auditing must never turn a successfully completed user operation into an
+    // HTTP failure. Make storage trouble loud in the server log instead.
+    console.error('[operations.append]', e && e.message);
+  }
+}
+
+const requestOrigin = (req) => String(
+  req.query?.from
+  || req.headers?.['x-am-origin']
+  || (req.body && !Array.isArray(req.body) && typeof req.body === 'object' ? req.body.from : '')
+  || '',
+).trim();
+
+const cleanQuery = (query) => {
+  const out = { ...(query || {}) };
+  delete out.from;
+  return summarizePayload(out, 'query');
+};
+
+/**
+ * Require an attributable origin for every state-changing API request and
+ * append its outcome to a durable JSONL log.
+ *
+ * resolveOrigin(raw, req) returns {id,type,name?,cli?}, or null when the id is
+ * unknown. It may derive an identity from a protocol route (remote agents do
+ * this for backwards compatibility with already-running polling loops).
+ */
+export function operationMiddleware({ resolveOrigin, allowMissing = false } = {}) {
+  return (req, res, next) => {
+    if (!req.path.startsWith('/api/') || !MUTATING.has(req.method)) return next();
+
+    const raw = requestOrigin(req);
+    let origin = resolveOrigin ? resolveOrigin(raw, req) : (raw ? { id: raw, type: 'unknown' } : null);
+    if (!origin && allowMissing) origin = { id: 'test', type: 'test' };
+    if (!origin) {
+      return res.status(400).json({
+        error: raw
+          ? `unknown origin '${raw}'`
+          : 'from required — mutating calls must pass ?from=<origin id> (agents use $AM_ID)',
+      });
+    }
+
+    req.operationOrigin = origin;
+    const started = Date.now();
+    const operationId = crypto.randomUUID();
+    let responseBody;
+    let recorded = false;
+    const originalJson = res.json.bind(res);
+    res.json = (body) => {
+      responseBody = body;
+      return originalJson(body);
+    };
+    const record = () => {
+      if (recorded) return;
+      recorded = true;
+      append({
+        version: 1,
+        id: operationId,
+        at: new Date(started).toISOString(),
+        origin,
+        method: req.method,
+        path: req.path,
+        query: cleanQuery(req.query),
+        request: summarizePayload(req.body, 'body'),
+        status: res.statusCode,
+        ok: res.statusCode < 400,
+        durationMs: Date.now() - started,
+        result: summarizePayload(responseBody, 'result'),
+      });
+    };
+    res.once('finish', record);
+    res.once('close', record);
+    next();
+  };
+}
+
+export function readOperations(limit = 200, before = null) {
+  const take = Math.max(1, Math.min(1000, Number(limit) || 200));
+  let fd;
+  try {
+    fd = fs.openSync(OPERATIONS_FILE, 'r');
+    const size = fs.fstatSync(fd).size;
+    // A bounded tail keeps this endpoint cheap even after years of operations.
+    // Four MiB comfortably holds the maximum 1,000 compact records in normal use.
+    const start = Math.max(0, size - 4 * 1024 * 1024);
+    const buf = Buffer.alloc(size - start);
+    fs.readSync(fd, buf, 0, buf.length, start);
+    let text = buf.toString('utf8');
+    if (start > 0) text = text.slice(Math.max(0, text.indexOf('\n') + 1));
+    const rows = text.split('\n').filter(Boolean).flatMap((line) => {
+      try { return [JSON.parse(line)]; } catch { return []; }
+    });
+    return rows
+      .filter((row) => !before || row.at < before)
+      .reverse()
+      .slice(0, take);
+  } catch {
+    return [];
+  } finally {
+    if (fd !== undefined) try { fs.closeSync(fd); } catch {}
+  }
+}

--- a/server/src/remote.js
+++ b/server/src/remote.js
@@ -439,6 +439,7 @@ export function remoteInfo(session) {
  */
 export function promptText(name, host, operator) {
   const base = `https://${host}/api/remote/${name}`;
+  const origin = `remote:${name}`;
   const who = operator ? ` (${operator})` : '';
   return `You are the remote agent "${name}" for an Agent Manager${who} running at
 https://${host}. Your job: take work from that pane, do it here on this
@@ -474,7 +475,7 @@ even if you own the Space.
      curl -sS -X POST -H "authorization: Bearer $HF_TOKEN" \\
        -H 'content-type: application/json' \\
        -d '{"harness":"<your cli>","cwd":"'"$PWD"'","host":"'"$(hostname)"'"}' \\
-       "$AM/hello"
+       "$AM/hello?from=${origin}"
 
 3. Then loop. One blocking call waits for work; it returns as soon as there is
    any, or empty when the wait expires:
@@ -501,7 +502,7 @@ even if you own the Space.
 
      curl -sS -X POST -H "authorization: Bearer $HF_TOKEN" \\
        -H 'content-type: text/plain' \\
-       --data-binary @- "$AM/messages" <<'EOF'
+       --data-binary @- "$AM/messages?from=${origin}" <<'EOF'
      Fixed the fixture — pad_token was None on the Qwen config. Suite is green.
      EOF
 

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -49,7 +49,7 @@ if (!process.env.TERMUI_PUBLIC_DIR) {
 
 const backend = spawn('node', ['src/index.js'], {
   cwd: HERE,
-  env: { ...process.env, PORT: '7897', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '' },
+  env: { ...process.env, PORT: '7897', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1' },
   stdio: ['ignore', 'pipe', 'pipe'],
 });
 let logs = '';

--- a/server/test/operations.test.mjs
+++ b/server/test/operations.test.mjs
@@ -1,0 +1,77 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-operations-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const { operationMiddleware, readOperations } = await import('../src/operations.js');
+
+let pass = 0;
+let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+
+const middleware = operationMiddleware({
+  resolveOrigin: (raw) => raw === 'operator'
+    ? { id: 'operator', type: 'operator', name: 'test operator' }
+    : raw === 'agent-1' ? { id: raw, type: 'agent', name: 'agent one', cli: 'codex' } : null,
+});
+
+class Response extends EventEmitter {
+  statusCode = 200;
+  body = undefined;
+  status(code) { this.statusCode = code; return this; }
+  json(body) { this.body = body; this.emit('finish'); return this; }
+}
+
+const invoke = ({ method = 'POST', path: reqPath, query = {}, headers = {}, body }, handler) => {
+  const req = { method, path: reqPath, query, headers, body };
+  const res = new Response();
+  middleware(req, res, () => handler(req, res));
+  return res;
+};
+
+try {
+  console.log('\norigin enforcement');
+  const missing = invoke({ path: '/api/groups', body: { name: 'nope' } }, () => {});
+  check('a mutation without an origin is refused', missing.statusCode === 400, `status ${missing.statusCode}`);
+  const unknown = invoke({ path: '/api/groups', query: { from: 'not-real' }, body: { name: 'nope' } }, () => {});
+  check('an unknown origin is refused', unknown.statusCode === 400, `status ${unknown.statusCode}`);
+
+  console.log('\nrecord successful manager operations');
+  invoke({ path: '/api/groups', headers: { 'x-am-origin': 'operator' }, body: { name: 'taskforce' } },
+    (req, res) => res.status(201).json({ id: 'g-1', name: req.body.name }));
+  invoke({ path: '/api/sessions', query: { from: 'agent-1' }, body: { name: 'without-prompt', cli: 'codex', token: 'must-not-leak' } },
+    (req, res) => res.status(201).json({ id: 's-without', ...req.body }));
+  invoke({ path: '/api/sessions', query: { from: 'agent-1' }, body: { name: 'with-prompt', cli: 'claude', prompt: 'Investigate the flaky test.' } },
+    (req, res) => res.status(201).json({ id: 's-with', ...req.body }));
+  invoke({ path: '/api/agents', query: { from: 'agent-1', cli: 'codex' }, body: 'Review the implementation.' },
+    (_req, res) => res.status(201).json({ id: 'spawned-1' }));
+  let readNext = false;
+  invoke({ method: 'GET', path: '/api/read' }, () => { readNext = true; });
+  check('read-only calls bypass the audit middleware', readNext);
+
+  const rows = readOperations(20).reverse();
+  check('only state-changing accepted calls are recorded', rows.length === 4, `got ${rows.length}`);
+  check('operator group creation keeps its origin', rows[0]?.origin?.id === 'operator');
+  check('group name is reconstructable', rows[0]?.request?.name === 'taskforce');
+  check('created group id is recorded', rows[0]?.result?.id === 'g-1');
+  check('session creation without a prompt is distinguishable', !('prompt' in (rows[1]?.request || {})));
+  check('credentials are redacted', rows[1]?.request?.token === '[redacted]');
+  check('session creation with a prompt records presence and size',
+    rows[2]?.request?.prompt?.present === true && rows[2]?.request?.prompt?.chars === 27);
+  check('prompt content is not copied into the audit log', rows[2]?.request?.prompt?.sha256 && !JSON.stringify(rows[2]).includes('flaky test'));
+  check('plain-text agent prompts are summarized too', rows[3]?.request?.present === true && rows[3]?.request?.chars === 26);
+  check('origin is separate from the recorded query', rows[3]?.origin?.id === 'agent-1' && !('from' in (rows[3]?.query || {})));
+  check('query parameters needed to replay the operation remain', rows[3]?.query?.cli === 'codex');
+} finally {
+  fs.rmSync(TMP, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,6 +1,15 @@
 import type { Cli, Group, MoveTarget, RemoteInfo, RemoteMessage, Session, Tree } from './types';
 
 const HEADERS = { 'content-type': 'application/json' };
+// The browser is the single human operator. Stamp every state-changing request
+// in one place so new API helpers cannot accidentally create unattributed work.
+const fetch = (input: RequestInfo | URL, init?: RequestInit) => {
+  const method = String(init?.method || 'GET').toUpperCase();
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return globalThis.fetch(input, init);
+  const headers = new Headers(init?.headers);
+  headers.set('x-am-origin', 'operator');
+  return globalThis.fetch(input, { ...init, headers });
+};
 // Like `json`, but keeps the server's own words — these routes fail for reasons
 // worth reading ("already exists here").
 const jsonOrError = async (r: Response) => {


### PR DESCRIPTION
## Why

Manager mutations were only partially attributable: agent-to-agent calls carried `?from=`, while operator/UI operations and manager endpoints such as group creation did not. There was also no durable event trail, so creating, changing, moving, or deleting state could not be reconstructed later.

This complements #46: its group-creation example now keeps `?from=$AM_ID`, and this PR makes that origin meaningful everywhere.

## What changed

- Require a known origin for every `POST`, `PUT`, `PATCH`, and `DELETE` under `/api/`.
  - local agents use their session id (`?from=$AM_ID`)
  - the browser API stamps mutations with the stable `operator` origin
  - remote agents use their immutable `remote:<name>` id; route-derived fallback keeps existing polling loops working
- Append every accepted mutation and its outcome to durable `DATA_DIR/operations.jsonl`.
- Add bounded, newest-first `GET /api/operations?limit=...&before=...` access and document it in the generated environment skill.
- Record method, path, replay-relevant query/body fields, origin metadata, result ids, status, and duration.
- Distinguish session/agent creation with and without an initial prompt. Prompts, messages, uploaded/file content, credentials, push endpoints, and other sensitive/large values are represented by presence, byte/character count, and SHA-256 rather than copied into the audit log.
- Put `from=$AM_ID` on the notification examples too.

Test servers opt into a clearly named missing-origin bypass so existing endpoint-focused fixtures remain scoped to what they test; production never enables it.

## Verification

- `node test/operations.test.mjs` — 14 checks covering origin enforcement, operator/agent attribution, group and session creation, with/without-prompt distinction, redaction/hashing, result ids, and query reconstruction.
- `node --check src/operations.js`
- `node --check src/index.js`
- `npm run build` in `web/`
