### PR TITLE
Expose harness cost and usage to agents

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1139,6 +1139,22 @@ sandboxes it exits 0 rather than failing. A wrong port therefore reads as "the
 roster is empty, I have no peers" instead of an error. \`curl -sS --fail\` will
 tell you what actually happened.
 
+### Check harness usage and quota
+The same API exposes usage from harness logs on this Space. Claude and Codex
+include their latest 5-hour and weekly quota snapshots; OpenCode exposes tokens
+and estimated model cost (it has no single quota because sessions may use
+different providers):
+
+\`\`\`sh
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=claude" | jq .providers.claude
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=codex" | jq .providers.codex
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=opencode" | jq .providers.opencode
+\`\`\`
+
+These values reflect local calls made from this Space, as of each harness's
+last model call here; activity on another machine is not included. This is a
+read-only call, so it does not take \`?from=\`.
+
 ### See who is here
 \`\`\`sh
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents?from=$AM_ID" | jq .

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1141,14 +1141,16 @@ tell you what actually happened.
 
 ### Check harness usage and quota
 The same API exposes usage from harness logs on this Space. Claude and Codex
-include their latest 5-hour and weekly quota snapshots; OpenCode exposes tokens
-and estimated model cost (it has no single quota because sessions may use
-different providers):
+include their latest 5-hour and weekly quota snapshots. OpenCode, Hermes, and
+OpenClaw expose tokens and estimated model cost; they have no single quota
+because sessions may use different providers:
 
 \`\`\`sh
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=claude" | jq .providers.claude
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=codex" | jq .providers.codex
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=opencode" | jq .providers.opencode
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=hermes" | jq .providers.hermes
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/usage?provider=openclaw" | jq .providers.openclaw
 \`\`\`
 
 These values reflect local calls made from this Space, as of each harness's

--- a/server/src/usage.js
+++ b/server/src/usage.js
@@ -66,6 +66,27 @@ function claudeEnv() {
   return { ...process.env, CLAUDE_CONFIG_DIR: dirs.join(',') };
 }
 
+// Hermes' live SQLite database is deliberately kept off the durable FUSE mount
+// at $AM_LOCAL/hermes (entrypoint.sh), while ccusage only discovers
+// $HOME/.hermes/state.db and has no path flag. Give the child a tiny local HOME
+// shim whose .hermes symlink points at the live directory. Never replace an
+// unexpected existing path: falling back to the normal HOME is safer.
+function hermesEnv() {
+  const home = process.env.HOME || '';
+  const normal = path.join(home, '.hermes', 'state.db');
+  const localRoot = process.env.AM_LOCAL || '';
+  const live = localRoot ? path.join(localRoot, 'hermes') : '';
+  if (!live || !fs.existsSync(path.join(live, 'state.db')) || fs.existsSync(normal)) return process.env;
+  const shim = path.join(localRoot, 'ccusage-hermes-home');
+  const link = path.join(shim, '.hermes');
+  try {
+    fs.mkdirSync(shim, { recursive: true });
+    if (!fs.existsSync(link)) fs.symlinkSync(live, link, 'dir');
+    if (fs.realpathSync(link) !== fs.realpathSync(live)) return process.env;
+    return { ...process.env, HOME: shim };
+  } catch { return process.env; }
+}
+
 // YYYYMMDD a few days back — the widest window the card shows is "this week",
 // so ccusage never needs to aggregate the whole (possibly huge) history.
 function sinceArg(days = 9) {
@@ -79,11 +100,17 @@ function sinceArg(days = 9) {
 // the model-pricing network fetch (a real source of multi-second hangs).
 function providerUsage(prov) {
   return cached(`u:${prov}`, async () => {
-    const env = prov === 'claude' ? claudeEnv() : process.env;
+    const env = prov === 'claude' ? claudeEnv() : prov === 'hermes' ? hermesEnv() : process.env;
+    const args = [prov, 'daily', '--json', '--offline', '--single-thread', '--since', sinceArg()];
+    // OpenClaw also lives on local disk, under an explicit state root rather
+    // than ccusage's ~/.openclaw default. Unlike Hermes, ccusage has a path flag.
+    if (prov === 'openclaw' && process.env.OPENCLAW_STATE_DIR) {
+      args.push('--open-claw-path', process.env.OPENCLAW_STATE_DIR);
+    }
     let out;
     try {
       ({ stdout: out } = await execFile(
-        'ccusage', [prov, 'daily', '--json', '--offline', '--single-thread', '--since', sinceArg()],
+        'ccusage', args,
         { encoding: 'utf8', timeout: 60_000, maxBuffer: 16 * 1024 * 1024, env },
       ));
     } catch { return null; }
@@ -240,6 +267,8 @@ async function debugInfo() {
       claude: await raw('claude'),
       codex: await raw('codex'),
       opencode: await raw('opencode'),
+      hermes: await raw('hermes'),
+      openclaw: await raw('openclaw'),
       gemini: await raw('gemini'),
     },
   };
@@ -254,10 +283,12 @@ async function buildUsageImpl(debug = false, only = null) {
   // parallel and render whichever answers first — one slow/hung provider
   // (ccusage has a 20s timeout) no longer blocks the rest.
   const wants = (p) => !only || only === p;
-  const [uClaude, uCodex, uOpencode, uGemini, qClaude, qCodex] = await Promise.all([
+  const [uClaude, uCodex, uOpencode, uHermes, uOpenclaw, uGemini, qClaude, qCodex] = await Promise.all([
     wants('claude') ? providerUsage('claude') : null,
     wants('codex') ? providerUsage('codex') : null,
     wants('opencode') ? providerUsage('opencode') : null,
+    wants('hermes') ? providerUsage('hermes') : null,
+    wants('openclaw') ? providerUsage('openclaw') : null,
     wants('gemini') ? providerUsage('gemini') : null,
     wants('claude') ? claudeQuota() : null,
     wants('codex') ? codexQuota() : null,
@@ -269,6 +300,8 @@ async function buildUsageImpl(debug = false, only = null) {
   // it has no single subscription quota: the underlying provider depends on
   // the model selected for each session.
   if (wants('opencode')) providers.opencode = { ...(uOpencode || {}), quota: null };
+  if (wants('hermes')) providers.hermes = { ...(uHermes || {}), quota: null };
+  if (wants('openclaw')) providers.openclaw = { ...(uOpenclaw || {}), quota: null };
   if (wants('gemini')) providers.gemini = { ...(uGemini || {}), quota: null };
   const out = { providers, generatedAt: new Date().toISOString() };
   if (debug) out._debug = await debugInfo();

--- a/server/src/usage.js
+++ b/server/src/usage.js
@@ -236,7 +236,12 @@ async function debugInfo() {
     ccusage,
     claudeDirs,
     codexRolloutFiles: (await codexRollouts()).length,
-    raw: { claude: await raw('claude'), codex: await raw('codex'), gemini: await raw('gemini') },
+    raw: {
+      claude: await raw('claude'),
+      codex: await raw('codex'),
+      opencode: await raw('opencode'),
+      gemini: await raw('gemini'),
+    },
   };
 }
 
@@ -249,9 +254,10 @@ async function buildUsageImpl(debug = false, only = null) {
   // parallel and render whichever answers first — one slow/hung provider
   // (ccusage has a 20s timeout) no longer blocks the rest.
   const wants = (p) => !only || only === p;
-  const [uClaude, uCodex, uGemini, qClaude, qCodex] = await Promise.all([
+  const [uClaude, uCodex, uOpencode, uGemini, qClaude, qCodex] = await Promise.all([
     wants('claude') ? providerUsage('claude') : null,
     wants('codex') ? providerUsage('codex') : null,
+    wants('opencode') ? providerUsage('opencode') : null,
     wants('gemini') ? providerUsage('gemini') : null,
     wants('claude') ? claudeQuota() : null,
     wants('codex') ? codexQuota() : null,
@@ -259,6 +265,10 @@ async function buildUsageImpl(debug = false, only = null) {
   const providers = {};
   if (wants('claude')) providers.claude = { ...(uClaude || {}), quota: qClaude };
   if (wants('codex')) providers.codex = { ...(uCodex || {}), quota: qCodex };
+  // OpenCode records token and model-cost data that ccusage can aggregate, but
+  // it has no single subscription quota: the underlying provider depends on
+  // the model selected for each session.
+  if (wants('opencode')) providers.opencode = { ...(uOpencode || {}), quota: null };
   if (wants('gemini')) providers.gemini = { ...(uGemini || {}), quota: null };
   const out = { providers, generatedAt: new Date().toISOString() };
   if (debug) out._debug = await debugInfo();

--- a/server/test/usage.test.mjs
+++ b/server/test/usage.test.mjs
@@ -22,6 +22,11 @@ fs.chmodSync(BIN, 0o755);
 process.env.PATH = TMP;
 process.env.AM_LOCAL = LOCAL;
 process.env.OPENCLAW_STATE_DIR = OPENCLAW;
+// Own the HOME the shim decides against, so the decision is about the fixtures
+// and not about whatever ~/.hermes the machine running the test happens to have.
+const HOME_BLIND = path.join(TMP, 'home-blind');
+fs.mkdirSync(HOME_BLIND, { recursive: true });
+process.env.HOME = HOME_BLIND;
 
 const { buildUsage } = await import('../src/usage.js');
 
@@ -59,6 +64,20 @@ try {
     check(`${name} exposes today/week estimated cost`, got.costToday === 0.4567 && got.costWeek === 0.4567);
     check(`${name} does not invent a subscription quota`, got.quota === null);
   }
+
+  // The deployment's actual layout: entrypoint.sh points $HOME/.hermes at the
+  // live local directory, so ccusage's own discovery already works and the shim
+  // must stand down rather than redirect HOME a second time. Fresh module
+  // instance because usage.js caches each provider's answer for 5 minutes.
+  const HOME_LINKED = path.join(TMP, 'home-linked');
+  fs.mkdirSync(HOME_LINKED, { recursive: true });
+  fs.symlinkSync(HERMES, path.join(HOME_LINKED, '.hermes'), 'dir');
+  process.env.HOME = HOME_LINKED;
+  const { buildUsage: buildUsageLinked } = await import('../src/usage.js?home=linked');
+  await buildUsageLinked(false, 'hermes');
+  const linkedCall = fs.readFileSync(CALLS, 'utf8').trim().split('\n')
+    .map((line) => line.split('\t').filter(Boolean)).filter((row) => row[1] === 'hermes').pop() || [];
+  check('Hermes keeps the normal HOME when ccusage can already find its state', linkedCall[0] === HOME_LINKED, linkedCall[0]);
 } finally {
   fs.rmSync(TMP, { recursive: true, force: true });
 }

--- a/server/test/usage.test.mjs
+++ b/server/test/usage.test.mjs
@@ -3,16 +3,25 @@ import os from 'node:os';
 import path from 'node:path';
 
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-usage-'));
-const ARGS = path.join(TMP, 'args.txt');
+const CALLS = path.join(TMP, 'calls.txt');
 const BIN = path.join(TMP, 'ccusage');
+const LOCAL = path.join(TMP, 'local');
+const HERMES = path.join(LOCAL, 'hermes');
+const OPENCLAW = path.join(LOCAL, 'openclaw');
+fs.mkdirSync(HERMES, { recursive: true });
+fs.mkdirSync(OPENCLAW, { recursive: true });
+fs.writeFileSync(path.join(HERMES, 'state.db'), 'fixture');
+
 const today = new Date().toISOString().slice(0, 10);
 const payload = JSON.stringify({
   daily: [{ date: today, totalTokens: 12345, totalCost: 0.4567 }],
   totals: { totalTokens: 12345, totalCost: 0.4567 },
 });
-fs.writeFileSync(BIN, `#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(ARGS)}\nprintf '%s' '${payload}'\n`);
+fs.writeFileSync(BIN, `#!/bin/sh\nprintf '%s\\t' "$HOME" >> ${JSON.stringify(CALLS)}\nprintf '%s\\t' "$@" >> ${JSON.stringify(CALLS)}\nprintf '\\n' >> ${JSON.stringify(CALLS)}\nprintf '%s' '${payload}'\n`);
 fs.chmodSync(BIN, 0o755);
 process.env.PATH = TMP;
+process.env.AM_LOCAL = LOCAL;
+process.env.OPENCLAW_STATE_DIR = OPENCLAW;
 
 const { buildUsage } = await import('../src/usage.js');
 
@@ -24,19 +33,32 @@ const check = (name, ok, detail = '') => {
 };
 
 try {
-  const out = await buildUsage(false, 'opencode');
-  const got = out.providers.opencode;
-  const args = fs.readFileSync(ARGS, 'utf8').trim().split('\n');
+  const opencode = (await buildUsage(false, 'opencode')).providers.opencode;
+  const hermes = (await buildUsage(false, 'hermes')).providers.hermes;
+  const openclaw = (await buildUsage(false, 'openclaw')).providers.openclaw;
+  const calls = fs.readFileSync(CALLS, 'utf8').trim().split('\n').map((line) => line.split('\t').filter(Boolean));
+  const call = (provider) => calls.find((row) => row[1] === provider) || [];
+  const opencodeCall = call('opencode');
+  const hermesCall = call('hermes');
+  const openclawCall = call('openclaw');
 
-  check('OpenCode is a selectable usage provider', Object.keys(out.providers).join(',') === 'opencode');
-  check('ccusage receives the OpenCode provider command', args[0] === 'opencode' && args[1] === 'daily', args.slice(0, 2).join(' '));
-  check('the bounded/offline scan flags are retained', args.includes('--offline') && args.includes('--single-thread') && args.includes('--since'));
-  check('today tokens are exposed', got.tokensToday === 12345, String(got.tokensToday));
-  check('weekly tokens are exposed', got.tokensWeek === 12345, String(got.tokensWeek));
-  check('today cost is exposed', got.costToday === 0.4567, String(got.costToday));
-  check('weekly cost is exposed', got.costWeek === 0.4567, String(got.costWeek));
-  check('aggregate cost is exposed', got.totalCost === 0.4567, String(got.totalCost));
-  check('OpenCode does not invent a subscription quota', got.quota === null);
+  check('OpenCode uses its ccusage provider command', opencodeCall[2] === 'daily');
+  check('Hermes uses its ccusage provider command', hermesCall[2] === 'daily');
+  check('OpenClaw uses its ccusage provider command', openclawCall[2] === 'daily');
+  check('the bounded/offline scan flags are retained for every provider',
+    [opencodeCall, hermesCall, openclawCall].every((args) => args.includes('--offline') && args.includes('--single-thread') && args.includes('--since')));
+
+  check('Hermes receives a HOME shim for its local SQLite state',
+    hermesCall[0] !== process.env.HOME
+      && fs.realpathSync(path.join(hermesCall[0], '.hermes')) === fs.realpathSync(HERMES), hermesCall[0]);
+  const clawPath = openclawCall.indexOf('--open-claw-path');
+  check('OpenClaw receives its explicit local state path', clawPath >= 0 && openclawCall[clawPath + 1] === OPENCLAW);
+
+  for (const [name, got] of [['OpenCode', opencode], ['Hermes', hermes], ['OpenClaw', openclaw]]) {
+    check(`${name} exposes today/week tokens`, got.tokensToday === 12345 && got.tokensWeek === 12345);
+    check(`${name} exposes today/week estimated cost`, got.costToday === 0.4567 && got.costWeek === 0.4567);
+    check(`${name} does not invent a subscription quota`, got.quota === null);
+  }
 } finally {
   fs.rmSync(TMP, { recursive: true, force: true });
 }

--- a/server/test/usage.test.mjs
+++ b/server/test/usage.test.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-usage-'));
+const ARGS = path.join(TMP, 'args.txt');
+const BIN = path.join(TMP, 'ccusage');
+const today = new Date().toISOString().slice(0, 10);
+const payload = JSON.stringify({
+  daily: [{ date: today, totalTokens: 12345, totalCost: 0.4567 }],
+  totals: { totalTokens: 12345, totalCost: 0.4567 },
+});
+fs.writeFileSync(BIN, `#!/bin/sh\nprintf '%s\\n' "$@" > ${JSON.stringify(ARGS)}\nprintf '%s' '${payload}'\n`);
+fs.chmodSync(BIN, 0o755);
+process.env.PATH = TMP;
+
+const { buildUsage } = await import('../src/usage.js');
+
+let pass = 0;
+let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? ` — ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+
+try {
+  const out = await buildUsage(false, 'opencode');
+  const got = out.providers.opencode;
+  const args = fs.readFileSync(ARGS, 'utf8').trim().split('\n');
+
+  check('OpenCode is a selectable usage provider', Object.keys(out.providers).join(',') === 'opencode');
+  check('ccusage receives the OpenCode provider command', args[0] === 'opencode' && args[1] === 'daily', args.slice(0, 2).join(' '));
+  check('the bounded/offline scan flags are retained', args.includes('--offline') && args.includes('--single-thread') && args.includes('--since'));
+  check('today tokens are exposed', got.tokensToday === 12345, String(got.tokensToday));
+  check('weekly tokens are exposed', got.tokensWeek === 12345, String(got.tokensWeek));
+  check('today cost is exposed', got.costToday === 0.4567, String(got.costToday));
+  check('weekly cost is exposed', got.costWeek === 0.4567, String(got.costWeek));
+  check('aggregate cost is exposed', got.totalCost === 0.4567, String(got.totalCost));
+  check('OpenCode does not invent a subscription quota', got.quota === null);
+} finally {
+  fs.rmSync(TMP, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/web/src/components/UsagePanel.tsx
+++ b/web/src/components/UsagePanel.tsx
@@ -7,6 +7,8 @@ const PROVS = [
   { id: 'claude', label: 'Claude Code', color: '#d97757' },
   { id: 'codex', label: 'Codex', color: '#5eb6a6' },
   { id: 'opencode', label: 'OpenCode', color: '#8a93a0' },
+  { id: 'hermes', label: 'Hermes', color: '#a78bfa' },
+  { id: 'openclaw', label: 'OpenClaw', color: '#c83636' },
   { id: 'gemini', label: 'Gemini CLI', color: '#4796e3' },
 ];
 
@@ -122,7 +124,7 @@ export default function UsagePanel() {
                   </div>
                 ) : p.id === 'gemini' ? (
                   <div className="s-help">No quota (consumer tier deprecated — uses an API key).</div>
-                ) : p.id === 'opencode' ? (
+                ) : ['opencode', 'hermes', 'openclaw'].includes(p.id) ? (
                   <div className="s-help">No single quota — cost depends on the model provider used by each session.</div>
                 ) : (
                   <div className="s-help">No quota yet — run a session to populate.</div>

--- a/web/src/components/UsagePanel.tsx
+++ b/web/src/components/UsagePanel.tsx
@@ -6,11 +6,13 @@ import Logo from './Logo';
 const PROVS = [
   { id: 'claude', label: 'Claude Code', color: '#d97757' },
   { id: 'codex', label: 'Codex', color: '#5eb6a6' },
+  { id: 'opencode', label: 'OpenCode', color: '#8a93a0' },
   { id: 'gemini', label: 'Gemini CLI', color: '#4796e3' },
 ];
 
 const fmtTok = (n = 0) =>
   n >= 1e9 ? `${(n / 1e9).toFixed(1)}B` : n >= 1e6 ? `${(n / 1e6).toFixed(1)}M` : n >= 1e3 ? `${(n / 1e3).toFixed(1)}K` : String(n);
+const fmtCost = (n: number) => `$${n >= 100 ? n.toFixed(0) : n >= 1 ? n.toFixed(2) : n.toFixed(3)}`;
 const resetStr = (s?: number) => {
   if (!s) return '';
   const mins = Math.round((s * 1000 - Date.now()) / 60000);
@@ -101,8 +103,16 @@ export default function UsagePanel() {
             ) : (
               <>
                 <div className="usage-stats">
-                  <div><span className="s-muted">Today</span><b>{d.tokensToday == null ? '—' : `${fmtTok(d.tokensToday)} tok`}</b></div>
-                  <div><span className="s-muted">This week</span><b>{d.tokensWeek == null ? '—' : `${fmtTok(d.tokensWeek)} tok`}</b></div>
+                  <div>
+                    <span className="s-muted">Today</span>
+                    <b>{d.tokensToday == null ? '—' : `${fmtTok(d.tokensToday)} tok`}</b>
+                    {d.costToday != null && <span className="s-muted">{fmtCost(d.costToday)} est.</span>}
+                  </div>
+                  <div>
+                    <span className="s-muted">This week</span>
+                    <b>{d.tokensWeek == null ? '—' : `${fmtTok(d.tokensWeek)} tok`}</b>
+                    {d.costWeek != null && <span className="s-muted">{fmtCost(d.costWeek)} est.</span>}
+                  </div>
                 </div>
                 {q ? (
                   <div className="usage-quota">
@@ -112,6 +122,8 @@ export default function UsagePanel() {
                   </div>
                 ) : p.id === 'gemini' ? (
                   <div className="s-help">No quota (consumer tier deprecated — uses an API key).</div>
+                ) : p.id === 'opencode' ? (
+                  <div className="s-help">No single quota — cost depends on the model provider used by each session.</div>
                 ) : (
                   <div className="s-help">No quota yet — run a session to populate.</div>
                 )}


### PR DESCRIPTION
## Why

The Usage backend already extracts Claude and Codex 5-hour/weekly quota snapshots, and `/api/usage` is reachable from agent sessions, but the generated environment skill never tells agents that endpoint exists. OpenCode, Hermes, and OpenClaw all record token/cost information, yet none was fully exposed in the Usage cards.

As a result, “check our Claude/Codex 5h or weekly limit” is possible but undiscoverable, while model cost from the other harnesses is missing from the Usage page.

## What changed

- Add `opencode`, `hermes`, and `openclaw` to the bounded/offline `ccusage <provider> daily` aggregation and `/api/usage?provider=<name>` response.
- Adapt the deployment's real local-state layout:
  - Hermes lives at `$AM_LOCAL/hermes`, while ccusage only discovers `$HOME/.hermes`; a safe local HOME shim points ccusage at the live SQLite database.
  - OpenClaw receives `--open-claw-path "$OPENCLAW_STATE_DIR"` instead of relying on its default `~/.openclaw` lookup.
- Add OpenCode, Hermes, and OpenClaw cards to Settings → Usage.
- Show estimated today/week cost under token counts for every provider.
- Keep OpenCode/Hermes/OpenClaw quota explicitly `null`: each can use different model providers, and their logs contain no honest single subscription quota.
- Document agent-readable commands for:
  - Claude 5-hour and weekly quota
  - Codex 5-hour and weekly quota
  - OpenCode, Hermes, and OpenClaw tokens and estimated model cost
- State the locality/freshness limitation directly: values come from calls made on this Space and update after the harness's latest model call here.

The usage reads are GETs, so they intentionally do not carry a mutation origin.

## Verification

- `node test/usage.test.mjs` — 15 checks against a deterministic fake `ccusage`, covering all three provider commands, bounded/offline flags, the Hermes HOME shim, the OpenClaw path flag, tokens, costs, and no fabricated quotas.
- `node --check src/usage.js`
- `node --check src/index.js`
- `npm run build` in `web/`
- Manually verified the installed `ccusage 20.0.19` parses the deployment's historical Hermes and OpenClaw data when pointed at their live paths, as well as current OpenCode model-cost records.
