### PR TITLE
Reader follow-ups: the prompt band, the bottom bar, one composer

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -215,6 +215,12 @@ pane with nothing to render (a shell) simply stays a terminal.
   `.markdown` rules are absolute px and would otherwise stay put while the prose grew.
   Spacing does not scale, but anything that lines a column up with a glyph — the prompt's `❯`
   gutter, the step rail, the tool-field labels — is in `em`, or it stops lining up when zoomed.
+- **Nothing of the terminal's may paint over the reader.** Its covers — `restoring last view…`,
+  `starting claude…`, `stopped · output preserved` — sit at `z-index: 4` and were drawn straight
+  over the conversation, so a reconnect turned the reader into a terminal screen with a reader
+  toolbar on top. They are gated off while reading (they belong to the terminal, and the reader
+  is reading a file that does not care whether the PTY is up), and the overlay now outranks
+  anything the terminal can raise.
 - The terminal element stays mounted and connected underneath; the reader draws over it. Toggling
   must not detach tmux — a reattach costs a repaint and can trip the handoff path
   (`HANDOFF_CODE`, `TerminalPane.tsx`). **Verify** this before shipping: xterm needs layout to
@@ -247,6 +253,10 @@ pane with nothing to render (a shell) simply stays a terminal.
   tool call is unusable while a task runs; one that never moves makes you chase it.
 - **The prompt band sticks to the top** while you read a long turn. What you want overhead deep
   in someone's 67-step answer is the question it is answering — not a row of numbers.
+- **The prompt band spans the pane.** Reaching into the left gutter but stopping at the text
+  column on the right made it read as a card floating over the answer rather than as the head of
+  it. Full bleed both sides; the meta row sits tight under the band it belongs to, and one
+  exchange ends well before the next begins.
 - **The reader fills the pane.** A fixed reading column left a gutter of nothing on each
   side while the prompt band still spanned the full width, so the two disagreed about where the
   conversation began. The pane is the measure: narrow the pane and the conversation narrows.
@@ -254,8 +264,17 @@ pane with nothing to render (a shell) simply stays a terminal.
   card has always known that, and a rendered session that could only be read would send you back
   to the terminal to type. It is the card's own composer (`.ov-live`), the same `sendInput`, and the
   same optimistic echo: your prompt appears at the bottom with a `working` line until the
-  transcript catches up. Only a trace with **no agent behind it** — a shared file, an import — is
-  read-only, which is what `readOnly` is for.
+  transcript catches up. Optimistic means *before* the POST returns — it used to wait for the
+  round trip, which left a beat where the box was still full and nothing had happened. A failed
+  send withdraws the echo and puts the text back in the box.
+
+  Only a trace with **no agent behind it** — a shared file, an import — is read-only, which is
+  what `readOnly` is for.
+
+  Both surfaces use one `Composer` component. A composer accretes features — paste-to-attach,
+  history recall, a slash-command menu — and duplicated markup is how one surface quietly gets
+  them and the other does not. `onPasteFiles` and `above` are the seam an attachment strip plugs
+  into, so it arrives in both places at once or in neither.
 - **A half-typed reply is kept** (`drafts.ts`, `useDraft.ts`). Reported from a phone: start typing
   an answer, switch apps, come back, and the text is gone. The pane is not what loses it — App.tsx
   keeps a dozen panes warm, so an in-app trip to the session list already survived — the
@@ -450,6 +469,15 @@ components against **captured conversations** in phone, tablet and desktop frame
 themes, with six scenarios — done, running, just-sent, failed tool, truncated, never-prompted.
 Fixtures are captured by running the app's own reader (`readTraceByPath`), so the harness cannot
 drift from the payload shape.
+
+A second local harness (`web/app-shots.mjs`, with `web/fixtures.mjs` for its fleet — both
+excluded for the same reason) drives a *running* instance rather than rendered components: it
+asserts what the UI actually does on click. Checks today — the list view reads no traces
+and opening a card reads exactly one, `full history ↗` flips an already-open pane, focus stays
+out of the covered terminal, nothing of the terminal's paints over the reader, the bottom bar is
+one height, a sent prompt echoes before the POST returns, a shell keeps its terminal, a failed
+refresh keeps the conversation, and merging two agents switches to their group layout. `fixtures.mjs` writes a Claude transcript and the
+sessions to read it from, so the counts it asserts are the same on every machine.
 
 It also **replays a turn block by block** — a tool call lands, its result comes back, thinking
 between them, the answer only at the end — which is how the live rules in §3.2 and §3.3 were

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -9,7 +9,7 @@ import { rankSessions, sortLabel } from '../lib/overviewSort';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
 import Logo from './Logo';
-import { SendGlyph } from './icons';
+import Composer from './conversation/Composer';
 import ExchangeView from './conversation/Exchange';
 import { useDraft } from './conversation/useDraft';
 import { writePaneMode } from '../lib/paneMode';
@@ -179,15 +179,20 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   const send = async () => {
     const text = draft.trim();
     if (!text || sending) return;
+    // Optimistic — see ConversationView.send: the echo goes up first, and is
+    // withdrawn if the send fails. The card and the reader answer the same way
+    // because they are the same composer.
     setSending(true);
     setFailed(false);
+    setDraft('');
+    setSent({ text, at: Date.now() });
+    setHistIdx(0);
+    if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     try {
       await api.sendInput(s.id, text);
-      setDraft('');
-      setSent({ text, at: Date.now() });
-      setHistIdx(0);
-      if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     } catch {
+      setSent(null);
+      setDraft(text);
       setFailed(true);
       setTimeout(() => setFailed(false), 4000);
     }
@@ -323,31 +328,14 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
         )}
       </div>
 
-      <div className="ov-live">
-        <span className="ov-p mono">❯</span>
-        <textarea
-          ref={inputRef}
-          rows={1}
-          value={draft}
-          disabled={sending}
-          placeholder={sending ? 'sending…' : 'reply…'}
-          autoComplete="off"
-          autoCorrect="off"
-          autoCapitalize="off"
-          spellCheck={false}
-          onChange={(e) => { setDraft(e.target.value); e.currentTarget.style.height = 'auto'; e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`; }}
-          // iOS doesn't resize the layout for the keyboard — scroll the
-          // input into view once the keyboard has animated in.
-          onFocus={(e) => { const el = e.currentTarget; setTimeout(() => el.scrollIntoView({ block: 'center', behavior: 'smooth' }), 300); }}
-          onKeyDown={(e) => {
-            // Desktop: Enter sends, Shift+Enter newlines. Mobile keyboards can't
-            // do Shift+Enter, so Enter always newlines there and the button sends.
-            if (e.key === 'Enter' && !e.shiftKey && !isMobile) { e.preventDefault(); send(); }
-            if (e.key === 'Escape') { setDraft(''); inputRef.current?.blur(); }
-          }}
-        />
-        {draft.trim() && <button className="ov-send" title="Send" onClick={send} disabled={sending}><SendGlyph /></button>}
-      </div>
+      <Composer
+        draft={draft}
+        sending={sending}
+        isMobile={isMobile}
+        inputRef={inputRef}
+        onChange={setDraft}
+        onSend={send}
+      />
       {failed && <div className="ov-note">failed to reach the agent</div>}
     </div>
   );

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -939,7 +939,7 @@ export default function TerminalPane({
           >paste</button>
         </div>
       )}
-      {pasteOpen && (
+      {!reading && pasteOpen && (
         // Reached when the clipboard read was blocked (cross-origin iframe) or
         // came back empty. The textarea is the whole point: long-press inside it
         // and the OS offers Paste, which fires a `paste` event we can read.
@@ -971,18 +971,23 @@ export default function TerminalPane({
           <button className="tp-x" onClick={() => { setPasteOpen(false); focusTerm(); }}>cancel</button>
         </div>
       )}
-      {booting && preview && conn !== 'exited' && (
+      {/* The terminal's own covers — restoring, booting, exited — belong to the
+          terminal. Reader mode is a complete surface over it, reading a file
+          that does not care whether the PTY is reconnecting, and these paint
+          ABOVE the overlay (z-index 4 vs 3): a reconnect turned the reader
+          into a terminal screen with a reader toolbar on top. */}
+      {!reading && booting && preview && conn !== 'exited' && (
         <div className="term-preview mono" aria-label="Restoring terminal">
           <pre style={{ fontSize: `${Math.round((13 * zoom) / 100)}px` }}>{preview.rows.join('\n')}</pre>
           <span>restoring last view…</span>
         </div>
       )}
-      {booting && !preview && conn !== 'exited' && (
+      {!reading && booting && !preview && conn !== 'exited' && (
         <div className="term-boot mono">
           {conn === 'connecting' ? 'connecting' : `starting ${cli?.label || session.cli}`}<span className="et-cursor" />
         </div>
       )}
-      {conn === 'exited' && (
+      {!reading && conn === 'exited' && (
         <div className="term-exit mono">
           <div className="tx-row">
             <span>{cli?.label || session.cli} stopped · output preserved</span>

--- a/web/src/components/conversation/Composer.tsx
+++ b/web/src/components/conversation/Composer.tsx
@@ -1,0 +1,75 @@
+/**
+ * The reply line: `❯`, a textarea that grows, a send key.
+ *
+ * One component, used by the Overview card and by reader mode, because they are
+ * the same act — answering the agent you are reading. It was duplicated markup
+ * for exactly one release and that is how composers drift: a feature lands in
+ * the card (paste-to-attach, PR #39; a slash-command menu; history recall) and
+ * quietly does not exist in the pane. Everything a composer can do belongs here.
+ */
+import type { ClipboardEvent, KeyboardEvent, ReactNode, RefObject } from 'react';
+import { SendGlyph } from '../icons';
+
+export default function Composer({
+  draft, sending, isMobile, inputRef, className = '', above, onChange, onSend, onCancel, onPasteFiles,
+}: {
+  draft: string;
+  sending?: boolean;
+  isMobile?: boolean;
+  inputRef?: RefObject<HTMLTextAreaElement | null>;
+  className?: string;
+  /** Rendered directly above the line — an attachment strip, when there is one. */
+  above?: ReactNode;
+  onChange: (v: string) => void;
+  onSend: () => void;
+  onCancel?: () => void;
+  /**
+   * A paste (or drop) carrying files rather than text. The seam PR #39's
+   * screenshot input plugs into: give it a handler and both the card and the
+   * reader accept pasted images, because they are literally this component.
+   */
+  onPasteFiles?: (files: File[]) => void;
+}) {
+  const grow = (el: HTMLTextAreaElement) => {
+    el.style.height = 'auto';
+    el.style.height = `${el.scrollHeight}px`;
+  };
+  const onPaste = (e: ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onPasteFiles || sending) return;
+    const files = Array.from(e.clipboardData?.files || []);
+    if (!files.length) return;
+    e.preventDefault();
+    onPasteFiles(files);
+  };
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Desktop: Enter sends, Shift+Enter newlines. Mobile keyboards cannot do
+    // Shift+Enter, so there Enter newlines and the button sends.
+    if (e.key === 'Enter' && !e.shiftKey && !isMobile) { e.preventDefault(); onSend(); }
+    if (e.key === 'Escape') { onChange(''); onCancel?.(); inputRef?.current?.blur(); }
+  };
+  return (
+    <>
+      {above}
+      <div className={`ov-live ${className}`.trim()}>
+      <span className="ov-p mono">❯</span>
+      <textarea
+        ref={inputRef}
+        rows={1}
+        value={draft}
+        disabled={sending}
+        placeholder={sending ? 'sending…' : 'reply…'}
+        autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false}
+        onChange={(e) => { onChange(e.target.value); grow(e.currentTarget); }}
+        onPaste={onPaste}
+        // iOS does not resize the layout for the keyboard — scroll the input
+        // into view once the keyboard has animated in.
+        onFocus={(e) => { const el = e.currentTarget; setTimeout(() => el.scrollIntoView({ block: 'center', behavior: 'smooth' }), 300); }}
+        onKeyDown={onKeyDown}
+      />
+        {draft.trim() && (
+          <button className="ov-send" title="Send" onClick={onSend} disabled={sending}><SendGlyph /></button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -22,7 +22,7 @@ import { recallReading, rememberReading } from './readingPosition';
 import { useDraft } from './useDraft';
 import { fmtTok, splitExchanges } from './exchanges';
 import ExchangeView from './Exchange';
-import { SendGlyph } from '../icons';
+import Composer from './Composer';
 
 const NEAR_TOP_PX = 300;   // start fetching older turns before the reader arrives
 
@@ -124,14 +124,21 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
   const send = async () => {
     const text = draft.trim();
     if (!text || sending) return;
+    // Optimistic, and it has to be: the prompt belongs on screen the moment you
+    // send it, not when the POST comes back. Waiting for the round trip left a
+    // beat where the box was still full and nothing had happened. If the send
+    // fails, the echo is withdrawn and the text goes back in the box.
     setSending(true); setFailed(false);
+    setDraft(''); setSent({ text, at: Date.now() });
+    if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
+    stick.current = true;
     try {
       await api.sendInput(session.id, text);
-      setDraft(''); setSent({ text, at: Date.now() });
-      if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
-      stick.current = true;
       loadNewer();
-    } catch { setFailed(true); window.setTimeout(() => setFailed(false), 4000); }
+    } catch {
+      setSent(null); setDraft(text); setFailed(true);
+      window.setTimeout(() => setFailed(false), 4000);
+    }
     setSending(false);
   };
   const q = query.trim().toLowerCase();
@@ -441,25 +448,15 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
       </div>
 
       {!readOnly && (
-        <div className="ov-live cxv-live">
-          <span className="ov-p mono">❯</span>
-          <textarea
-            ref={inputRef}
-            rows={1}
-            value={draft}
-            disabled={sending}
-            placeholder={sending ? 'sending…' : 'reply…'}
-            autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false}
-            onChange={(e) => { setDraft(e.target.value); e.currentTarget.style.height = 'auto'; e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`; }}
-            onKeyDown={(e) => {
-              // Desktop: Enter sends, Shift+Enter newlines. Mobile keyboards
-              // cannot do Shift+Enter, so there the button sends.
-              if (e.key === 'Enter' && !e.shiftKey && !isMobile) { e.preventDefault(); send(); }
-              if (e.key === 'Escape') { setDraft(''); inputRef.current?.blur(); }
-            }}
-          />
-          {draft.trim() && <button className="ov-send" title="Send" onClick={send} disabled={sending}><SendGlyph /></button>}
-        </div>
+        <Composer
+          className="cxv-live"
+          draft={draft}
+          sending={sending}
+          isMobile={isMobile}
+          inputRef={inputRef}
+          onChange={setDraft}
+          onSend={send}
+        />
       )}
       {failed && <div className="ov-note cxv-note">failed to reach the agent</div>}
 

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -227,6 +227,18 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    content would not show through a floating band, and over .cxv-body's --panel
    the base transparent tint composites to the same colour. */
 
+/* …and it spans the pane. Reaching into the left gutter but stopping at the
+   text column on the right made it read as a card floating over the answer
+   rather than as the head of it. Full bleed both sides, with the text inside
+   still on the column. */
+.cxv-col .cx-prompt { margin-right: -14px; padding-right: 14px; }
+.cxv-body > .cxv-col > .cx { padding-left: 16px; }
+
+/* Grouping: the meta row is the prompt's, not the answer's, so it sits tight
+   under the band — and one exchange ends well before the next begins. */
+.cxv-col .cx-prompt + .cx-meta { margin-top: -3px; }
+.cxv-col > .cx + .cx { margin-top: 15px; }
+
 /* ---------- phone ---------- */
 @media (max-width: 720px) {
   .cxv-body { padding: 4px 8px 24px; }
@@ -235,7 +247,12 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 
 /* ---------- reader mode inside a session pane ---------- */
 /* Drawn over the live terminal, which stays mounted underneath. */
-.pane-reader { position: absolute; inset: 0; z-index: 3; display: flex; background: var(--panel); }
+/* Above the terminal's own covers (.term-preview/.term-boot/.term-exit sit at
+   4), not just above the terminal. Those are gated off while reading, but the
+   overlay outranking anything the terminal can raise is the belt to that
+   brace: a cover winning here does not look like a bug, it looks like the
+   reader turning into a terminal. */
+.pane-reader { position: absolute; inset: 0; z-index: 6; display: flex; background: var(--panel); }
 .pane-reader > .cxv { flex: 1; min-width: 0; }
 /* The one thing the reader can render that is not inside .cxv — so it reads the
    base itself rather than inheriting a size from it. */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1047,7 +1047,7 @@ a.btn-ghost { text-decoration: none; }
 /* terminal zoom bar */
 .pane-foot { display: flex; align-items: center; gap: 4px; padding: 3px 8px; background: var(--panel); border-top: 1px solid var(--border); flex: none; }
 .pane-foot .spacer { flex: 1; }
-.zbtn { width: 22px; height: 20px; border: 1px solid var(--border); background: var(--panel-2); color: var(--muted); border-radius: var(--r-sm); cursor: pointer; font-size: 13px; line-height: 1; display: inline-flex; align-items: center; justify-content: center; }
+.zbtn { width: 22px; height: 22px; border: 1px solid var(--border); background: var(--panel-2); color: var(--muted); border-radius: var(--r-sm); cursor: pointer; font-size: 13px; line-height: 1; display: inline-flex; align-items: center; justify-content: center; }
 .zbtn:hover { color: var(--text); border-color: var(--border-strong); }
 .zlvl { min-width: 44px; background: none; border: none; color: var(--muted); font-size: 11px; cursor: pointer; font-variant-numeric: tabular-nums; }
 .zlvl:hover { color: var(--text); }
@@ -1145,9 +1145,10 @@ a.btn-ghost { text-decoration: none; }
 /* mobile stage top bar (back + agent chips) — rendered only on mobile */
 .mbar { display: flex; align-items: center; gap: 8px; padding: 0 0 8px; flex: none; }
 .mback { flex: none; font-size: 19px; padding-bottom: 3px; }
-/* Reading mode, in the zoom bar: the same weight as the controls beside it. */
-.modebar { flex: none; margin-right: 6px; }
-.modebar button { padding: 2px 8px; font-size: 10.5px; letter-spacing: 0.02em; }
+/* Reader mode, in the zoom bar: the same height as every control beside it —
+   the zoom keys and the layout picker are both 22px. */
+.modebar { flex: none; margin-right: 6px; align-self: stretch; }
+.modebar button { height: 22px; padding: 0 9px; font-size: 11px; line-height: 1; }
 
 .mtitle { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mchips { display: flex; gap: 6px; overflow-x: auto; flex: 1; padding: 2px; }


### PR DESCRIPTION
Rebased onto main after #59 and #61, which cover ground this branch also
touched. Theirs wins in both places: #61 made zoom ONE number for both ways of
reading a session (`--cx-base` on `.pane-reader`), so the branch's second path
— a `zoom` prop and `zoom: var(--cx-zoom)` on `.cxv-body` — is gone rather than
reintroduced; and #59 comes back to where you had got to, over a tail window
that already opens on the end, so the branch's own open-on-the-newest-turn
landing (reader and trace viewer both) is gone too. TracePane keeps main's
version entirely.

What is left is what main does not have:

- **The prompt band spans the pane.** Reaching into the left gutter but stopping
  at the text column on the right made it read as a card floating over the
  answer rather than as the head of it. Full bleed both sides; the meta row sits
  tight under the band it belongs to, and one exchange ends well before the next
  begins.
- **Nothing of the terminal's may paint over the reader.** Its covers —
  `restoring last view…`, `starting claude…`, `stopped · output preserved` — sit
  at `z-index: 4` and were drawn straight over the conversation, so a reconnect
  turned the reader into a terminal screen with a reader toolbar on top. They
  are gated off while reading, and the overlay now outranks anything the
  terminal can raise.
- **One `Composer` for the card and the reader.** A composer accretes features —
  paste-to-attach, history recall, a slash-command menu — and duplicated markup
  is how one surface quietly gets them and the other does not. `onPasteFiles`
  and `above` are the seam an attachment strip plugs into. The echo is now
  optimistic in both: the prompt appears before the POST returns, and a failed
  send withdraws it and puts the text back in the box.
- **The reader switch is the same height as the zoom keys** (22px, like the
  layout picker beside it).

Verified against a running instance with a fixture transcript: the reader
renders, the band bleeds to the right edge, an injected `.term-boot` cover
paints behind the overlay, the bottom bar is one height, a sent prompt echoes
before the POST returns, and main's zoom still scales the reader through
`--cx-base` with no second path in play. Server, web and UI suites green.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

