### PR TITLE
Come back from a restart with the sessions that were running

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ are pinned right after first launch (the id is captured from the rollout file
 Codex creates) — so agents sharing a folder never resume each other's
 conversations.
 
+A backend restart or sleep is survivable in practice. The server snapshots which
+sessions are alive — and which have a command or background job actually running
+in them — and on the next boot starts the ones that were still yours: those you
+prompted inside the configured window, plus any that had work in flight. Their
+scrollback comes back from the terminal history checkpoint, so a reopened pane
+reads as you left it. Settings → General → *Restart sessions after a reboot*
+sets the window (1 / 3 / 7 days, or off).
+
 ## Configuration (env)
 
 | Var | Default | Purpose |

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/spawn-group.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -34,6 +34,7 @@ import { startWatchdog } from './watchdog.js';
 import { shareSession, shareNamespace, findTrace, shareAccess, grantAccess, revokeAccess,
          importBundle, listBundles, SHAREABLE_CLIS } from './share.js';
 import * as backup from './backup.js';
+import * as runstate from './runstate.js';
 
 ensureDirs();
 refreshVersions();
@@ -270,6 +271,19 @@ async function deliver(session, text, from) {
   return started;
 }
 
+// When you last sent this session something. Typing in the pane is the only
+// signal a plain shell leaves — it has no transcript to read a prompt out of —
+// and it's what the boot-time revive uses to tell a session you're still working
+// in from one you abandoned months ago (see runstate.js). Throttled: this is
+// called per keystroke and each write lands on the FUSE bucket.
+const inputTouched = new Map(); // session id -> ms of the last recorded touch
+function touchInput(id) {
+  const now = Date.now();
+  if (now - (inputTouched.get(id) || 0) < 60_000) return;
+  inputTouched.set(id, now);
+  store.update(id, { lastInputAt: now });
+}
+
 // Type a prompt into a session's terminal from the Overview — no pane needed.
 // If the agent is stopped, start its backend PTY and give the resumed CLI a
 // moment to boot before the keystrokes land.
@@ -281,6 +295,7 @@ app.post('/api/sessions/:id/input', async (req, res) => {
   if (!text) return res.status(400).json({ error: 'empty' });
   try {
     const started = await deliver(s, text);
+    touchInput(s.id);
     res.json({ ok: true, started });
   } catch (e) {
     res.status(409).json({ error: String(e.message || e) });
@@ -913,6 +928,13 @@ function loadAmConfig() {
     archive: {
       after: ['week', 'month', 'never'].includes(saved.archive?.after) ? saved.archive.after : 'month',
     },
+    // After a restart, start the sessions that were running again — the ones you
+    // prompted within `days`, plus any that still had work in flight (see
+    // runstate.js). `days` is only read when enabled.
+    revive: {
+      enabled: saved.revive?.enabled !== false,
+      days: [1, 3, 7].includes(saved.revive?.days) ? saved.revive.days : 3,
+    },
     // How often the bucket is copied to private Hub storage. Off by default: it
     // copies this machine's contents — saved logins included — into another Hub
     // resource, which is the operator's call to make. docs/bucket-backup.md
@@ -937,6 +959,10 @@ app.put('/api/config', (req, res) => {
     },
     jobs: { askAboveUsd: Math.max(0, Number(b.jobs?.askAboveUsd) || 0) },
     archive: { after: ['week', 'month', 'never'].includes(b.archive?.after) ? b.archive.after : 'month' },
+    revive: {
+      enabled: !!(b.revive?.enabled ?? true),
+      days: [1, 3, 7].includes(b.revive?.days) ? b.revive.days : 3,
+    },
     backup: {
       every: backup.INTERVALS.includes(b.backup?.every) ? b.backup.every : 'never',
       dataset: typeof b.backup?.dataset === 'string' ? b.backup.dataset.trim() : '',
@@ -2256,7 +2282,7 @@ wss.on('connection', (ws, req) => {
   ws.on('message', (raw) => {
     let msg;
     try { msg = JSON.parse(raw.toString()); } catch { return; }
-    if (msg.t === 'i') handle.write(msg.d);
+    if (msg.t === 'i') { handle.write(msg.d); touchInput(session.id); }
     else if (msg.t === 'r') handle.resize(msg.cols, msg.rows);
     else if (msg.t === 'claim') handle.claim();
   });
@@ -2296,6 +2322,20 @@ backup.startBackupTimer(loadAmConfig);
 // Off-thread stall detector — must start early so it's watching before the
 // first heavy build. Logs any event-loop wedge to the run logs (see watchdog.js).
 startWatchdog();
+
+// Start the sessions that were running before this Space went down. init() must
+// read the previous snapshot BEFORE the watch starts overwriting it, so it
+// happens here, synchronously; the decision itself waits for the trace digests
+// it judges "recent" with.
+runstate.init();
+setTimeout(() => {
+  // A locked (public) Space serves no terminals, so it starts nothing — but it
+  // still records what's running, so the snapshot stays true for the next boot.
+  const done = isPublic()
+    ? Promise.resolve([])
+    : runstate.reviveOnBoot(loadAmConfig().revive).catch((e) => console.error('[revive]', e && e.message));
+  done.then(() => runstate.startRunstateWatch());
+}, 8000);
 
 server.listen(PORT, () => {
   console.log(`Agent Manager :${PORT}  engine=libghostty${ghosttyReady() ? '' : ' (UNAVAILABLE)'}  data=${DATA_DIR}`);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2282,7 +2282,13 @@ wss.on('connection', (ws, req) => {
   ws.on('message', (raw) => {
     let msg;
     try { msg = JSON.parse(raw.toString()); } catch { return; }
-    if (msg.t === 'i') { handle.write(msg.d); touchInput(session.id); }
+    if (msg.t === 'i') {
+      handle.write(msg.d);
+      // Not every frame on this channel is you: the emulator answers the TUI's
+      // device-attribute and cursor queries down the same path, instantly on
+      // attach. Opening a pane is not sending it something.
+      if (!runstate.isTerminalReply(msg.d)) touchInput(session.id);
+    }
     else if (msg.t === 'r') handle.resize(msg.cols, msg.rows);
     else if (msg.t === 'claim') handle.claim();
   });

--- a/server/src/runstate.js
+++ b/server/src/runstate.js
@@ -1,0 +1,195 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR, PASSIVE_CLIS, isRemote } from './config.js';
+import { list as listSessions, get as getSession } from './sessions.js';
+import { isRunning, paneRootPid, ensureRunning, ghosttyReady } from './runner.js';
+import { traceDigests } from './traces.js';
+
+// The server owns every PTY, so a Space sleep, a reboot, or a factory reset ends
+// all of them at once. Files and conversations survive on the bucket, but coming
+// back means clicking each agent again — and a shell that was running something
+// is simply gone, with nothing to show it ever mattered.
+//
+// So keep a RUNSTATE snapshot on the bucket: which sessions were alive, and
+// which had a process actually running in them. On the next boot that snapshot
+// is the record of what was up when the lights went out, and the sessions that
+// were still yours get started again — detached, each resuming its own pinned
+// conversation (runner.commandFor) with its scrollback replayed from the
+// terminal history checkpoint. Everything else stays stopped: a restart is not
+// an excuse to boot every agent you ever created.
+//
+// "revive", not "restore": in this codebase restore already means replaying a
+// terminal's serialized grid to a viewer, which is a different thing entirely.
+const RUNSTATE_FILE = path.join(DATA_DIR, 'runstate.json');
+
+// How often the snapshot is refreshed. Frequent enough that a sleep loses at
+// most half a minute of truth, rare enough to be invisible on the FUSE bucket.
+const SNAPSHOT_MS = 30_000;
+// A staggered boot: each revived session is a PTY plus a whole CLI booting, and
+// launching them in one burst is what would make a restart feel like a crash.
+const REVIVE_GAP_MS = 4000;
+// Reviving is meant to bring your workbench back, not to recreate a fleet.
+// Beyond this we start the most recently active ones and SAY so in the logs
+// rather than quietly pretending the rest weren't running.
+const MAX_REVIVE = 12;
+// A Space that has been down for a season shouldn't wake up mid-thought. The
+// recency rule bounds itself; this is the backstop for the work-in-flight one,
+// whose whole point is that it carries no clock.
+const STALE_SNAPSHOT_DAYS = 30;
+
+// The snapshot as it was when this process started — read once, before the
+// watch below starts overwriting it.
+let previous = null;
+let lastWritten = '';
+// Boot revivals are staggered, so the first new snapshot must wait for them:
+// writing at 30s would record a half-revived Space as the whole truth.
+let settleAt = 0;
+
+/** Load the previous boot's snapshot. Call once, before startRunstateWatch(). */
+export function init() {
+  try {
+    const j = JSON.parse(fs.readFileSync(RUNSTATE_FILE, 'utf8'));
+    previous = j && typeof j === 'object' && j.sessions ? j : null;
+  } catch { previous = null; }
+  return previous;
+}
+
+// Is anything running INSIDE this session — a foreground command, a `make &`
+// left in the background, an agent's tool call? The pane's root process is the
+// shell or the CLI itself; anything it started is a child of it, and Linux
+// hands us those directly. One small procfs read, no subprocess, no /proc walk.
+// This is the only signal a plain shell leaves that it was busy: it has no
+// transcript to read a prompt out of.
+function hasLiveChildren(pid) {
+  if (!pid) return false;
+  try { return fs.readFileSync(`/proc/${pid}/task/${pid}/children`, 'utf8').trim().length > 0; }
+  catch { return false; } // no procfs / process already gone
+}
+
+/** What is alive right now, and where something is actually running. */
+function snapshot() {
+  const sessions = {};
+  for (const s of listSessions()) {
+    // Passive panels are views, and a remote agent runs on someone's laptop —
+    // neither is a process this server could ever start.
+    if (PASSIVE_CLIS.includes(s.cli) || isRemote(s.cli)) continue;
+    if (!isRunning(s.id)) continue;
+    sessions[s.id] = { running: true, work: hasLiveChildren(paneRootPid(s.id)) };
+  }
+  return { at: new Date().toISOString(), sessions };
+}
+
+/**
+ * Write the snapshot now. Deliberately NOT hooked to SIGTERM: by the time a
+ * shutdown signal lands the PTYs may already be going down, so a final write is
+ * as likely to record an empty Space as a true one — and it would overwrite the
+ * good record with it. A 30s-stale truth beats a fresh lie.
+ */
+export function saveRunstate() {
+  const snap = snapshot();
+  // The set of live sessions changes rarely; don't rewrite the bucket for a
+  // timestamp nobody reads.
+  const body = JSON.stringify(snap.sessions);
+  if (body === lastWritten) return;
+  lastWritten = body;
+  try {
+    const tmp = `${RUNSTATE_FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(snap, null, 2));
+    fs.renameSync(tmp, RUNSTATE_FILE);
+  } catch (e) { console.error('[runstate]', e && e.message); }
+}
+
+/**
+ * Keep the on-disk snapshot current for the next boot to read. Deliberately
+ * writes nothing for the first cycle: until the boot revivals have finished, the
+ * old snapshot is a truer record of what was running than the new one, and a
+ * Space that crash-loops on boot must not erase it.
+ */
+export function startRunstateWatch() {
+  const t = setInterval(() => { if (Date.now() >= settleAt) saveRunstate(); }, SNAPSHOT_MS);
+  if (t.unref) t.unref();
+  return t;
+}
+
+/**
+ * Which of the snapshotted sessions deserve to come back, most recently used
+ * first. A session qualifies when it was alive in the snapshot AND either
+ *   - you sent it something within `days` (your keystrokes in the pane, the
+ *     Overview reply box, or a prompt in its transcript), or
+ *   - something was still running in it at snapshot time.
+ * The first rule is what keeps a working set alive across a reboot; the second
+ * is what a shell running a long job leaves behind.
+ *
+ * Pure, and separate from the starting below, because this is the part with
+ * rules in it: the arguments are all facts, the answer is just a list.
+ */
+export function selectRevivable({ snapshot: snap, sessions, digests, alive, days, now = Date.now() }) {
+  const cutoff = now - days * 864e5;
+  const byId = new Map(sessions.map((s) => [s.id, s]));
+  const plan = [];
+  for (const [id, rec] of Object.entries((snap && snap.sessions) || {})) {
+    if (!rec || !rec.running) continue;
+    const s = byId.get(id);
+    if (!s) continue;                                        // deleted since
+    if (PASSIVE_CLIS.includes(s.cli) || isRemote(s.cli)) continue;
+    if (alive.has(id)) continue;                             // already up somehow
+    // `lastInputAt` is what YOU typed (index.js records it); the digest covers
+    // prompts that arrived before we tracked that, and prompts from peers.
+    const d = digests.get(id);
+    const lastPrompt = Math.max(Number(s.lastInputAt) || 0, (d && d.lastPromptTs) || 0);
+    const recent = lastPrompt >= cutoff;
+    if (!recent && !rec.work) continue;
+    plan.push({ id, name: s.name, cli: s.cli, at: lastPrompt, why: recent ? 'prompted recently' : 'work in flight' });
+  }
+  return plan.sort((a, b) => b.at - a.at);
+}
+
+/** Start the sessions that were running when this Space last went down. */
+export async function reviveOnBoot({ enabled = true, days = 3 } = {}) {
+  if (!enabled) return [];
+  if (!previous || !previous.sessions) return [];
+  // No terminal engine means ensureRunning throws for every session; say it once
+  // instead of a dozen times.
+  if (!ghosttyReady()) {
+    console.warn('[revive] no terminal engine — starting nothing');
+    return [];
+  }
+  const age = Date.now() - (Date.parse(previous.at) || 0);
+  if (age > STALE_SNAPSHOT_DAYS * 864e5) {
+    console.log(`[revive] last snapshot is ${Math.round(age / 864e5)} days old — starting nothing`);
+    return [];
+  }
+
+  let digests = new Map();
+  try { digests = await traceDigests(); } catch { /* no transcripts is fine */ }
+  const sessions = listSessions();
+  const plan = selectRevivable({
+    snapshot: previous,
+    sessions,
+    digests,
+    alive: new Set(sessions.filter((s) => isRunning(s.id)).map((s) => s.id)),
+    days,
+  });
+  if (!plan.length) return [];
+
+  const start = plan.slice(0, MAX_REVIVE);
+  const skipped = plan.slice(MAX_REVIVE);
+  console.log(`[revive] ${start.length} session(s) were running at shutdown — starting them again`);
+  if (skipped.length) {
+    console.log(`[revive] NOT starting ${skipped.length} more (cap ${MAX_REVIVE}): ${skipped.map((p) => p.name).join(', ')}`);
+  }
+
+  settleAt = Date.now() + start.length * REVIVE_GAP_MS + 5000;
+  start.forEach((p, i) => {
+    const t = setTimeout(() => {
+      const s = getSession(p.id);
+      if (!s) return; // deleted between the plan and its turn
+      try {
+        ensureRunning(s);
+        console.log(`[revive] ${p.name} (${p.cli}) — ${p.why}`);
+      } catch (e) { console.error(`[revive] ${p.name}:`, e && e.message); }
+    }, i * REVIVE_GAP_MS);
+    if (t.unref) t.unref();
+  });
+  return start;
+}

--- a/server/src/runstate.js
+++ b/server/src/runstate.js
@@ -42,7 +42,10 @@ const STALE_SNAPSHOT_DAYS = 30;
 let previous = null;
 let lastWritten = '';
 // Boot revivals are staggered, so the first new snapshot must wait for them:
-// writing at 30s would record a half-revived Space as the whole truth.
+// writing at 30s would record a half-revived Space as the whole truth. Set in
+// init() so it holds on EVERY boot path — the ones that revive nothing because
+// something went wrong (no engine, Space locked) are exactly the ones where
+// erasing the record does the most damage.
 let settleAt = 0;
 
 /** Load the previous boot's snapshot. Call once, before startRunstateWatch(). */
@@ -51,19 +54,44 @@ export function init() {
     const j = JSON.parse(fs.readFileSync(RUNSTATE_FILE, 'utf8'));
     previous = j && typeof j === 'object' && j.sessions ? j : null;
   } catch { previous = null; }
+  // Hold the first write for a full cycle from here, whatever happens next. A
+  // boot that revives nothing — engine missing, Space still locked, revive
+  // switched off — must not answer by wiping the record of what was running:
+  // that record is the only reason the next boot can do better.
+  settleAt = Date.now() + SNAPSHOT_MS;
   return previous;
 }
 
-// Is anything running INSIDE this session — a foreground command, a `make &`
-// left in the background, an agent's tool call? The pane's root process is the
-// shell or the CLI itself; anything it started is a child of it, and Linux
-// hands us those directly. One small procfs read, no subprocess, no /proc walk.
-// This is the only signal a plain shell leaves that it was busy: it has no
-// transcript to read a prompt out of.
+// Is anything running INSIDE this shell — a foreground command, or a `make &`
+// left in the background? The pane's root process is the interactive bash, and
+// anything it started is a child of it, which Linux hands us directly. One small
+// procfs read, no subprocess, no /proc walk.
+//
+// SHELLS ONLY, on purpose. "Pane root == the thing you're talking to" is false
+// for most agent CLIs: `codex` is a `#!/usr/bin/env node` launcher that keeps
+// the native binary as a permanent child, and every `cont || exec run` launch
+// shape leaves bash as the pane root with the CLI as its child. Both report a
+// child forever, which would make the window mean nothing for those sessions —
+// they would revive on every restart regardless. Agents don't need this signal
+// anyway: they have a transcript, so the recency rule can see them. A shell has
+// nothing else, which is the whole reason this rule exists.
 function hasLiveChildren(pid) {
   if (!pid) return false;
   try { return fs.readFileSync(`/proc/${pid}/task/${pid}/children`, 'utf8').trim().length > 0; }
   catch { return false; } // no procfs / process already gone
+}
+
+// A terminal answers the TUI's questions by itself: on attach, xterm replies to
+// device-attribute and cursor-position queries, and those replies travel the
+// same socket frame as your keystrokes (the client sends all of onData; only its
+// own control-claiming path distinguishes real keys). Counting them would make
+// "you sent this session something" mean "a pane was open on it", which is not
+// the question the revive window asks. Match only the shapes a terminal EMITS in
+// reply — DA/CPR/window-report/DECRPM and DCS/OSC answers — never a key: arrow
+// keys and friends end in uppercase A-D or `~`, none of which appear here.
+const REPLY = /^(?:\x1b\[[?>!]?[0-9;]*\$?[cRty]|\x1bP[\s\S]*?\x1b\\|\x1b\][\s\S]*?(?:\x07|\x1b\\))+$/;
+export function isTerminalReply(d) {
+  return typeof d === 'string' && d.length > 0 && REPLY.test(d);
 }
 
 /** What is alive right now, and where something is actually running. */
@@ -74,7 +102,10 @@ function snapshot() {
     // neither is a process this server could ever start.
     if (PASSIVE_CLIS.includes(s.cli) || isRemote(s.cli)) continue;
     if (!isRunning(s.id)) continue;
-    sessions[s.id] = { running: true, work: hasLiveChildren(paneRootPid(s.id)) };
+    sessions[s.id] = {
+      running: true,
+      work: s.cli === 'shell' && hasLiveChildren(paneRootPid(s.id)),
+    };
   }
   return { at: new Date().toISOString(), sessions };
 }
@@ -91,11 +122,13 @@ export function saveRunstate() {
   // timestamp nobody reads.
   const body = JSON.stringify(snap.sessions);
   if (body === lastWritten) return;
-  lastWritten = body;
   try {
     const tmp = `${RUNSTATE_FILE}.tmp`;
     fs.writeFileSync(tmp, JSON.stringify(snap, null, 2));
     fs.renameSync(tmp, RUNSTATE_FILE);
+    // Only once it's actually on disk: a FUSE write that threw must be retried
+    // next cycle, not remembered as the state of the file.
+    lastWritten = body;
   } catch (e) { console.error('[runstate]', e && e.message); }
 }
 
@@ -105,8 +138,8 @@ export function saveRunstate() {
  * old snapshot is a truer record of what was running than the new one, and a
  * Space that crash-loops on boot must not erase it.
  */
-export function startRunstateWatch() {
-  const t = setInterval(() => { if (Date.now() >= settleAt) saveRunstate(); }, SNAPSHOT_MS);
+export function startRunstateWatch({ intervalMs = SNAPSHOT_MS } = {}) {
+  const t = setInterval(() => { if (Date.now() >= settleAt) saveRunstate(); }, intervalMs);
   if (t.unref) t.unref();
   return t;
 }
@@ -138,7 +171,11 @@ export function selectRevivable({ snapshot: snap, sessions, digests, alive, days
     const d = digests.get(id);
     const lastPrompt = Math.max(Number(s.lastInputAt) || 0, (d && d.lastPromptTs) || 0);
     const recent = lastPrompt >= cutoff;
-    if (!recent && !rec.work) continue;
+    // `work` is only meaningful for a shell (see hasLiveChildren). Re-checked
+    // here rather than trusted, so a snapshot written before that was true
+    // can't revive an agent on a signal that was never valid for it.
+    const busy = !!rec.work && s.cli === 'shell';
+    if (!recent && !busy) continue;
     plan.push({ id, name: s.name, cli: s.cli, at: lastPrompt, why: recent ? 'prompted recently' : 'work in flight' });
   }
   return plan.sort((a, b) => b.at - a.at);

--- a/server/test/revive.test.mjs
+++ b/server/test/revive.test.mjs
@@ -1,0 +1,92 @@
+// Which sessions come back after a restart.
+//
+// The server owns every PTY, so a sleep or reboot ends all of them. The runstate
+// snapshot records what was alive and what had work running in it; this is the
+// rule that reads it back. Two ways to qualify — you prompted it recently, or
+// something was still running in it — and everything else must stay stopped, so
+// a restart never boots every agent you ever created.
+// Run with: node test/revive.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'revive-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const { selectRevivable } = await import('../src/runstate.js');
+
+let pass = 0, fail = 0;
+const check = (name, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  ok ? pass++ : fail++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `\n          got ${JSON.stringify(got)}  want ${JSON.stringify(want)}`}`);
+};
+
+const NOW = Date.parse('2026-08-08T12:00:00Z');
+const ago = (days) => NOW - days * 864e5;
+
+const sessions = [
+  { id: 'typed-today', name: 'claude-1', cli: 'claude', lastInputAt: ago(0.5) },
+  { id: 'typed-5d', name: 'claude-2', cli: 'claude', lastInputAt: ago(5) },
+  { id: 'busy-shell', name: 'busy shell', cli: 'shell' },   // no clock of its own
+  { id: 'idle-shell', name: 'idle shell', cli: 'shell' },
+  { id: 'digest-2d', name: 'codex-1', cli: 'codex' },       // clock via its transcript
+  { id: 'panel', name: 'files', cli: 'files' },
+  { id: 'laptop', name: 'remote-agent-1', cli: 'remote', lastInputAt: ago(0.1) },
+  { id: 'was-stopped', name: 'stopped one', cli: 'claude', lastInputAt: ago(0.1) },
+  { id: 'still-up', name: 'survivor', cli: 'claude', lastInputAt: ago(0.1) },
+];
+// Only the digest-backed session has a transcript timestamp.
+const digests = new Map([['digest-2d', { lastPromptTs: ago(2) }]]);
+const snapshot = {
+  at: new Date(NOW - 3600e3).toISOString(),
+  sessions: {
+    'typed-today': { running: true },
+    'typed-5d': { running: true },
+    'busy-shell': { running: true, work: true },  // a background job outlived you
+    'idle-shell': { running: true },              // sitting at its prompt
+    'digest-2d': { running: true },
+    panel: { running: true },                     // a view, not a process
+    laptop: { running: true },                    // runs on someone's machine
+    'was-stopped': { running: false },            // you stopped it before the reboot
+    'still-up': { running: true },                // somehow already back
+    'deleted-since': { running: true },           // no session record any more
+  },
+};
+const ids = (days) => selectRevivable({
+  snapshot, sessions, digests, alive: new Set(['still-up']), days, now: NOW,
+}).map((p) => p.id);
+
+console.log('\nthe window decides who counts as still yours');
+check('3 days: today\'s agent, the busy shell, and the 2-day-old codex', ids(3),
+  ['typed-today', 'digest-2d', 'busy-shell']);
+check('1 day: the 2-day-old codex drops out, the busy shell does not', ids(1),
+  ['typed-today', 'busy-shell']);
+check('7 days: the 5-day-old agent joins, newest first', ids(7),
+  ['typed-today', 'digest-2d', 'typed-5d', 'busy-shell']);
+
+console.log('\nwork in flight qualifies on its own — a shell has no transcript');
+const plan = selectRevivable({ snapshot, sessions, digests, alive: new Set(['still-up']), days: 3, now: NOW });
+check('and it says so', plan.find((p) => p.id === 'busy-shell')?.why, 'work in flight');
+check('recency says so too', plan.find((p) => p.id === 'typed-today')?.why, 'prompted recently');
+check('an idle shell nobody touched stays down', ids(7).includes('idle-shell'), false);
+
+console.log('\nwhat is never started');
+check('a session stopped before the reboot', ids(7).includes('was-stopped'), false);
+check('a passive panel', ids(7).includes('panel'), false);
+check('a remote agent on its own machine', ids(7).includes('laptop'), false);
+check('one already running', ids(7).includes('still-up'), false);
+check('a session deleted since the snapshot', ids(7).includes('deleted-since'), false);
+
+console.log('\nnothing running at shutdown means nothing to start');
+check('an empty snapshot', selectRevivable({
+  snapshot: { at: snapshot.at, sessions: {} }, sessions, digests, alive: new Set(), days: 7, now: NOW,
+}), []);
+check('a missing snapshot', selectRevivable({
+  snapshot: null, sessions, digests, alive: new Set(), days: 7, now: NOW,
+}), []);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+fs.rmSync(TMP, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);

--- a/server/test/revive.test.mjs
+++ b/server/test/revive.test.mjs
@@ -14,7 +14,7 @@ const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'revive-'));
 process.env.DATA_DIR = path.join(TMP, 'data');
 fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
 
-const { selectRevivable } = await import('../src/runstate.js');
+const { selectRevivable, isTerminalReply } = await import('../src/runstate.js');
 
 let pass = 0, fail = 0;
 const check = (name, got, want) => {
@@ -32,10 +32,16 @@ const sessions = [
   { id: 'busy-shell', name: 'busy shell', cli: 'shell' },   // no clock of its own
   { id: 'idle-shell', name: 'idle shell', cli: 'shell' },
   { id: 'digest-2d', name: 'codex-1', cli: 'codex' },       // clock via its transcript
-  { id: 'panel', name: 'files', cli: 'files' },
+  // Given a fresh clock on purpose: without one it would be excluded by the
+  // window anyway, and the passive-panel guard would never be under test.
+  { id: 'panel', name: 'files', cli: 'files', lastInputAt: ago(0.1) },
   { id: 'laptop', name: 'remote-agent-1', cli: 'remote', lastInputAt: ago(0.1) },
   { id: 'was-stopped', name: 'stopped one', cli: 'claude', lastInputAt: ago(0.1) },
   { id: 'still-up', name: 'survivor', cli: 'claude', lastInputAt: ago(0.1) },
+  // A launcher-shaped CLI reports a child forever (codex is a node launcher;
+  // `cont || exec run` leaves bash as the pane root). An old snapshot may
+  // carry that as work — it must not resurrect a long-quiet agent.
+  { id: 'stale-work', name: 'quiet codex', cli: 'codex', lastInputAt: ago(40) },
 ];
 // Only the digest-backed session has a transcript timestamp.
 const digests = new Map([['digest-2d', { lastPromptTs: ago(2) }]]);
@@ -51,6 +57,7 @@ const snapshot = {
     laptop: { running: true },                    // runs on someone's machine
     'was-stopped': { running: false },            // you stopped it before the reboot
     'still-up': { running: true },                // somehow already back
+    'stale-work': { running: true, work: true },  // a flag that never meant anything here
     'deleted-since': { running: true },           // no session record any more
   },
 };
@@ -71,6 +78,8 @@ const plan = selectRevivable({ snapshot, sessions, digests, alive: new Set(['sti
 check('and it says so', plan.find((p) => p.id === 'busy-shell')?.why, 'work in flight');
 check('recency says so too', plan.find((p) => p.id === 'typed-today')?.why, 'prompted recently');
 check('an idle shell nobody touched stays down', ids(7).includes('idle-shell'), false);
+check('but only for a shell — an agent\'s "work" flag is not a reason',
+  ids(7).includes('stale-work'), false);
 
 console.log('\nwhat is never started');
 check('a session stopped before the reboot', ids(7).includes('was-stopped'), false);
@@ -78,6 +87,32 @@ check('a passive panel', ids(7).includes('panel'), false);
 check('a remote agent on its own machine', ids(7).includes('laptop'), false);
 check('one already running', ids(7).includes('still-up'), false);
 check('a session deleted since the snapshot', ids(7).includes('deleted-since'), false);
+
+console.log('\nthe window boundary is inclusive');
+check('exactly on the cutoff still counts', selectRevivable({
+  snapshot: { at: snapshot.at, sessions: { edge: { running: true } } },
+  sessions: [{ id: 'edge', name: 'edge', cli: 'claude', lastInputAt: ago(3) }],
+  digests: new Map(), alive: new Set(), days: 3, now: NOW,
+}).map((p) => p.id), ['edge']);
+check('a hair past it does not', selectRevivable({
+  snapshot: { at: snapshot.at, sessions: { edge: { running: true } } },
+  sessions: [{ id: 'edge', name: 'edge', cli: 'claude', lastInputAt: ago(3) - 1 }],
+  digests: new Map(), alive: new Set(), days: 3, now: NOW,
+}).map((p) => p.id), []);
+
+console.log('\nthe emulator answering the TUI is not you typing');
+check('device attributes', isTerminalReply('\x1b[?62;c'), true);
+check('cursor position report', isTerminalReply('\x1b[24;80R'), true);
+check('a DCS version answer', isTerminalReply('\x1bP>|xterm(1)\x1b\\'), true);
+check('several replies in one frame', isTerminalReply('\x1b[?62;c\x1b[24;80R'), true);
+check('a typed character is not', isTerminalReply('a'), false);
+check('a return is not', isTerminalReply('\\r'), false);
+check('an arrow key is not', isTerminalReply('\x1b[C'), false);
+check('ctrl-arrow is not', isTerminalReply('\x1b[1;5C'), false);
+check('a delete key is not', isTerminalReply('\x1b[3~'), false);
+check('ctrl-c is not', isTerminalReply('\x03'), false);
+check('a reply with typing after it counts as typing', isTerminalReply('\x1b[?62;chello'), false);
+check('an empty frame is not a reply', isTerminalReply(''), false);
 
 console.log('\nnothing running at shutdown means nothing to start');
 check('an empty snapshot', selectRevivable({

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -86,6 +86,9 @@ export interface AmConfig {
   artifacts: { enabled: boolean; space: string; visibility: 'public' | 'private' };
   jobs: { askAboveUsd: number };
   archive: { after: 'week' | 'month' | 'never' };
+  // After a restart, sessions that were running come back if you prompted them
+  // within `days` (or had work still in flight).
+  revive: { enabled: boolean; days: 1 | 3 | 7 };
   backup: { every: BackupEvery; dataset: string; exclude: string[] };
   defaultArtifactsSpace?: string;
 }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -591,6 +591,32 @@ export default function SettingsView({
 
                 <div className="setting-row">
                   <div>
+                    <div className="s-label">Restart sessions after a reboot</div>
+                    <div className="s-help">
+                      When the Space wakes or reboots, sessions that were running come back on their own: the ones
+                      you sent something to within this window, plus any that still had a command or background
+                      job running. Agents resume their own conversation and wait for you; nothing is re-sent.
+                    </div>
+                  </div>
+                  <span className="cfg-ctl">
+                    <div className="seg cfg-seg">
+                      {([1, 3, 7] as const).map((d) => (
+                        <button
+                          key={d}
+                          className={cfg.revive.enabled && cfg.revive.days === d ? 'on' : ''}
+                          onClick={() => setCfg({ ...cfg, revive: { enabled: true, days: d } })}
+                        >{d === 1 ? '1 day' : `${d} days`}</button>
+                      ))}
+                      <button
+                        className={!cfg.revive.enabled ? 'on' : ''}
+                        onClick={() => setCfg({ ...cfg, revive: { ...cfg.revive, enabled: false } })}
+                      >off</button>
+                    </div>
+                  </span>
+                </div>
+
+                <div className="setting-row">
+                  <div>
                     <div className="s-label">Archive inactive sessions</div>
                     <div className="s-help">Sessions with no activity beyond this window disappear from the sidebar and overview. Nothing is deleted; the "archived" checkbox in the sidebar brings them back.</div>
                   </div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
 import Logo from './Logo';
@@ -12,6 +12,9 @@ type Zone = 'before' | 'after' | 'on';
 // verbatim (mirrors SHAREABLE_CLIS in server/src/share.js). The others need
 // converters first, and a button that always fails is worse than no button.
 const SHAREABLE_CLIS = ['claude', 'codex', 'hermes', 'opencode', 'openclaw'];
+
+// Folded groups, remembered across reloads.
+const COLLAPSED_KEY = 'am-collapsed';
 
 const fmtAgo = (ts?: number) => {
   if (!ts) return '';
@@ -74,7 +77,18 @@ export default function Sidebar({
   const [cart, setCart] = useState<Record<string, number>>({});
   const [editRef, setEditRef] = useState<string | null>(null);
   const [editName, setEditName] = useState('');
-  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  // Which groups are folded. Kept per browser (like the theme and the zoom):
+  // it's how you've arranged THIS screen, and a phone and a desktop want
+  // different answers.
+  const [collapsed, setCollapsed] = useState<Set<string>>(() => {
+    try {
+      const saved = JSON.parse(localStorage.getItem(COLLAPSED_KEY) || '[]');
+      return new Set(Array.isArray(saved) ? saved.filter((x): x is string => typeof x === 'string') : []);
+    } catch { return new Set(); }
+  });
+  useEffect(() => {
+    try { localStorage.setItem(COLLAPSED_KEY, JSON.stringify([...collapsed])); } catch { /* private mode */ }
+  }, [collapsed]);
   const [dragRef, setDragRef] = useState<string | null>(null);
   const [drop, setDrop] = useState<{ ref: string; zone: Zone } | null>(null);
   // "Open a shared trace": paste a dataset id/URL, we pull it and show it.


### PR DESCRIPTION
A Space sleep, a reboot, or a factory reset ends every PTY at once — the server owns them all. Files and conversations survive on the bucket, but coming back means clicking each agent again, and a shell that was running something is simply gone with nothing to show it ever mattered.

This keeps a **runstate snapshot** on the bucket (refreshed every 30s): which sessions are alive, and which have a process actually running in them. On the next boot it starts again the ones that were still yours:

- **you prompted it inside the window** — your keystrokes in the pane, the Overview reply box, or a prompt in its transcript; or
- **something was still running in it** — a foreground command, a `make &` left in the background, an agent mid-tool-call.

The second rule is the only signal a plain shell leaves: it has no transcript to read a prompt out of. Scrollback comes back from the existing terminal-history checkpoint, so a reopened pane reads as you left it. Agents resume their own pinned conversation and wait — nothing is re-sent.

**Settings → General → _Restart sessions after a reboot_**: 1 day / 3 days / 7 days / off (default 3 days).

Also in here, since it is the same complaint: the sidebar's **folded groups persist** across reloads, per browser, alongside the theme and zoom.

## How "is anything running in there" works

One procfs read per live session, no process walk and no subprocess: the pane root is the shell or the CLI itself (`paneRootPid`), and anything it started is a direct child, which Linux hands us at `/proc/<pid>/task/<pid>/children`. Needs no new runner exports.

## Deliberate limits — all logged, none silent

- Revivals are **staggered 4s apart** and **capped at 12**, most recently active first. The ones over the cap are named in the logs rather than quietly treated as if they weren't running.
- A snapshot **older than 30 days** starts nothing. The recency rule bounds itself; this is the backstop for the work-in-flight rule, whose whole point is that it carries no clock.
- **No SIGTERM write.** At shutdown the PTYs may already be going down, so a final write is as likely to record an empty Space as a true one — and it would overwrite the good record with it. A 30s-stale truth beats a fresh lie.
- The first new snapshot **waits for the boot revivals to finish**, so a Space that crash-loops on boot can't erase the record of what was up.
- `lastInputAt` is throttled to one write per session per minute — it is recorded per keystroke and each write lands on the FUSE bucket.

**Never revived:** passive panels, remote agents (they run on their own machine), sessions you stopped before the reboot, and anything already up.

## Verification

- `server/test/revive.test.mjs` — 13 cases over the selection rule (each window, work-only, and every never-revive case), wired into `npm test`.
- Full `npm test` passes on this branch, with the engine installed: **all checks passed**.
- End-to-end against the real Ghostty engine, not committed: three shells (one given a real `sleep 300 &`, one idle, one typed into) → snapshot → `stopAll()` → revive. The snapshot recorded `work: true` for exactly the busy one, and exactly the busy and typed-in shells came back. With the setting off, nothing started.
- `tsc --noEmit` clean.

## Note for a follow-up

Settings still tells you a factory reboot is safe because "Sessions survive on the bucket", and the README said something similar. That stopped being true when tmux left; the README paragraph is updated here, but the Settings copy is left alone to keep this diff to one subject.