### PR TITLE
Title a session by the group it belongs to

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/exchanges.test.mjs",
+    "test": "node test/exchanges.test.mjs && node test/sessionTitle.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewFilter, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
+import { groupLabel, sessionTitle } from './lib/sessionTitle';
 import { isPassive, isRemote } from './types';
 import { GridGlyph, ListGlyph } from './components/icons';
 
@@ -407,6 +408,15 @@ export default function App() {
   const cliMap = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c])), [clis]);
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
   const groupById = useMemo(() => Object.fromEntries(tree.groups.map((g) => [g.id, g])), [tree.groups]);
+  // Which group an agent belongs to, by name — the one fact every place that
+  // titles a single agent needs. It rides the tree poll, so renaming a group or
+  // dragging an agent into another one retitles its pane and the browser tab on
+  // the next refresh, with no reload and nothing to keep in sync by hand.
+  const groupNameOf = useMemo(() => {
+    const m: Record<string, string> = {};
+    for (const g of tree.groups) for (const id of g.sessionIds) m[id] = g.name;
+    return m;
+  }, [tree.groups]);
 
   // Keep a valid selection ('overview' is always valid).
   useEffect(() => {
@@ -436,6 +446,21 @@ export default function App() {
   const visibleSessions = activeGroup ? pageSessions : activeSingle ? [activeSingle] : [];
   const visibleIds = visibleSessions.map((s) => s.id).join(',');
   const showZoom = visibleSessions.length > 0;
+
+  // The browser tab names the agent you are actually in — `[Group] name`, the
+  // same reading as its pane header. A tab strip (or a phone's app switcher) is
+  // exactly where several Spaces and several `claude-code-N` look alike, so the
+  // group earns its place there; the app's own name is what gives way, since
+  // the favicon already says which app this is. Under a tiled group the title
+  // follows the focused pane, because that is the one taking your keystrokes.
+  const onStage = !isMobile || mobileStage;
+  const titleSession = onStage
+    ? visibleSessions.find((s) => s.id === focusedId) ?? visibleSessions[0] ?? null
+    : null;
+  const tabTitle = titleSession
+    ? sessionTitle(titleSession.name, groupNameOf[titleSession.id])
+    : 'Agent Manager';
+  useEffect(() => { document.title = tabTitle; }, [tabTitle]);
 
   // Keep a small working set of terminal panes alive across navigation. The
   // backend session already survives a viewer disconnect; retaining xterm and
@@ -739,6 +764,7 @@ export default function App() {
                 theme={theme}
                 zoom={zoom}
                 mode={paneMode}
+                groupName={groupNameOf[s.id]}
                 focused={shown && sessions.length > 1 && s.id === focusedId}
                 visible={shown && deckVisible}
                 active={shown && deckVisible && s.id === focusedId}
@@ -773,6 +799,7 @@ export default function App() {
               <RemotePane
                 session={s}
                 zoom={zoom}
+                groupName={groupNameOf[s.id]}
                 focused={visibleSessions.length > 1 && s.id === focusedId}
                 dragId={canDrag ? `p:${s.id}` : undefined}
                 onDragActive={setPaneDrag}
@@ -904,7 +931,19 @@ export default function App() {
                 ))}
               </div>
             ) : (
-              <span className="mtitle mono">{activeRef === 'overview' ? 'Overview' : activeSingle?.name}</span>
+              <span className="mtitle mono" title={activeSingle ? sessionTitle(activeSingle.name, groupNameOf[activeSingle.id]) : undefined}>
+                {activeRef === 'overview' ? 'Overview' : (
+                  <>
+                    {/* Same rule as the pane header: the group is a prefix that
+                        elides before the agent's name does. A loose agent — the
+                        usual case for this bar — shows a bare name. */}
+                    {activeSingle && groupLabel(groupNameOf[activeSingle.id]) && (
+                      <span className="ph-group">[{groupNameOf[activeSingle.id]}]</span>
+                    )}
+                    <span className="ph-name">{activeSingle?.name}</span>
+                  </>
+                )}
+              </span>
             )}
           </div>
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,6 @@ import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewFilter, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
-import { groupLabel, sessionTitle } from './lib/sessionTitle';
 import { isPassive, isRemote } from './types';
 import { GridGlyph, ListGlyph } from './components/icons';
 
@@ -446,21 +445,6 @@ export default function App() {
   const visibleSessions = activeGroup ? pageSessions : activeSingle ? [activeSingle] : [];
   const visibleIds = visibleSessions.map((s) => s.id).join(',');
   const showZoom = visibleSessions.length > 0;
-
-  // The browser tab names the agent you are actually in — `[Group] name`, the
-  // same reading as its pane header. A tab strip (or a phone's app switcher) is
-  // exactly where several Spaces and several `claude-code-N` look alike, so the
-  // group earns its place there; the app's own name is what gives way, since
-  // the favicon already says which app this is. Under a tiled group the title
-  // follows the focused pane, because that is the one taking your keystrokes.
-  const onStage = !isMobile || mobileStage;
-  const titleSession = onStage
-    ? visibleSessions.find((s) => s.id === focusedId) ?? visibleSessions[0] ?? null
-    : null;
-  const tabTitle = titleSession
-    ? sessionTitle(titleSession.name, groupNameOf[titleSession.id])
-    : 'Agent Manager';
-  useEffect(() => { document.title = tabTitle; }, [tabTitle]);
 
   // Keep a small working set of terminal panes alive across navigation. The
   // backend session already survives a viewer disconnect; retaining xterm and
@@ -931,19 +915,7 @@ export default function App() {
                 ))}
               </div>
             ) : (
-              <span className="mtitle mono" title={activeSingle ? sessionTitle(activeSingle.name, groupNameOf[activeSingle.id]) : undefined}>
-                {activeRef === 'overview' ? 'Overview' : (
-                  <>
-                    {/* Same rule as the pane header: the group is a prefix that
-                        elides before the agent's name does. A loose agent — the
-                        usual case for this bar — shows a bare name. */}
-                    {activeSingle && groupLabel(groupNameOf[activeSingle.id]) && (
-                      <span className="ph-group">[{groupNameOf[activeSingle.id]}]</span>
-                    )}
-                    <span className="ph-name">{activeSingle?.name}</span>
-                  </>
-                )}
-              </span>
+              <span className="mtitle mono">{activeRef === 'overview' ? 'Overview' : activeSingle?.name}</span>
             )}
           </div>
         )}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -407,10 +407,10 @@ export default function App() {
   const cliMap = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c])), [clis]);
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
   const groupById = useMemo(() => Object.fromEntries(tree.groups.map((g) => [g.id, g])), [tree.groups]);
-  // Which group an agent belongs to, by name — the one fact every place that
-  // titles a single agent needs. It rides the tree poll, so renaming a group or
-  // dragging an agent into another one retitles its pane and the browser tab on
-  // the next refresh, with no reload and nothing to keep in sync by hand.
+  // Which group an agent belongs to, by name — the one fact a pane header needs
+  // to title itself. It rides the tree poll, so renaming a group or dragging an
+  // agent into another one retitles its pane on the next refresh, with no
+  // reload and nothing to keep in sync by hand.
   const groupNameOf = useMemo(() => {
     const m: Record<string, string> = {};
     for (const g of tree.groups) for (const id of g.sessionIds) m[id] = g.name;

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -4,6 +4,7 @@ import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
+import { groupLabel, sessionTitle } from '../lib/sessionTitle';
 import { CloseGlyph, StopGlyph, PlayGlyph, ShareGlyph, AckGlyph } from './icons';
 
 // Looks like the terminal, is not one: no PTY, no xterm.js, no WebSocket. The
@@ -24,9 +25,10 @@ const fmtAgo = (ts?: number | null) => {
 };
 
 export default function RemotePane({
-  session, focused, zoom = 100, dragId, onDragActive, onFocus, onClose, onRename,
+  session, focused, zoom = 100, dragId, groupName, onDragActive, onFocus, onClose, onRename,
 }: {
   session: Session;
+  groupName?: string | null; // the group this pane belongs to, if any
   focused?: boolean;
   zoom?: number;
   dragId?: string;
@@ -36,6 +38,7 @@ export default function RemotePane({
   onRename?: (name: string) => void;
 }) {
   const name = session.remote?.name || '';
+  const group = groupLabel(groupName);
   const [info, setInfo] = useState<RemoteInfo | null>(null);
   const [messages, setMessages] = useState<RemoteMessage[]>([]);
   const [draft, setDraft] = useState('');
@@ -218,9 +221,12 @@ export default function RemotePane({
         ) : (
           <span
             className="ph-title"
-            title={onRename ? 'double-click to rename' : undefined}
+            title={`${sessionTitle(session.name, groupName)}${onRename ? ' · double-click to rename' : ''}`}
             onDoubleClick={onRename ? () => { setTitleDraft(session.name); setEditing(true); } : undefined}
-          >{session.name}</span>
+          >
+            {group && <span className="ph-group">[{group}]</span>}
+            <span className="ph-name">{session.name}</span>
+          </span>
         )}
         <div className="ph-right">
           <div className="rp-pop-wrap" ref={popRef}>

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -10,6 +10,7 @@ import Logo from './Logo';
 import ConversationView from './conversation/ConversationView';
 import { isPassive } from '../types';
 import type { PaneMode } from '../lib/paneMode';
+import { groupLabel, sessionTitle } from '../lib/sessionTitle';
 import { CloseGlyph, RefreshGlyph } from './icons';
 
 const THEMES: Record<'light' | 'dark', ITheme> = {
@@ -180,11 +181,12 @@ if (typeof window !== 'undefined') {
 }
 
 export default function TerminalPane({
-  session, cli, theme, focused, visible, active, zoom = 100, mode = 'terminal', dragId, isMobile, onDragActive, onFocus, onRename, onClose,
+  session, cli, theme, focused, visible, active, zoom = 100, mode = 'terminal', dragId, isMobile, groupName, onDragActive, onFocus, onRename, onClose,
 }: {
   session: Session;
   cli?: Cli;
   theme: 'light' | 'dark';
+  groupName?: string | null; // the group this pane belongs to, if any
   focused?: boolean;
   visible?: boolean;
   active?: boolean;
@@ -810,6 +812,7 @@ export default function TerminalPane({
   // Focused panes tint toward THEIR agent's brand color, not the app accent.
   const tint = cli?.color;
   const pathLabel = workspaceLabel(session.path);
+  const group = groupLabel(groupName);
   return (
     <div
       className={`slot${focused ? ' focused' : ''}`}
@@ -840,7 +843,17 @@ export default function TerminalPane({
             onKeyDown={(e) => { if (e.key === 'Enter') commitName(); if (e.key === 'Escape') setEditing(false); }}
           />
         ) : (
-          <span className="ph-title" title={`${pathLabel} · double-click to rename`} onDoubleClick={() => { setDraft(session.name); setEditing(true); }}>{session.name}</span>
+          // Two spans, not one string: the group is a prefix that must give way
+          // before the agent's own name does (see .ph-group in styles.css), and
+          // the rename below still edits the name alone.
+          <span
+            className="ph-title"
+            title={`${sessionTitle(session.name, groupName)} · ${pathLabel} · double-click to rename`}
+            onDoubleClick={() => { setDraft(session.name); setEditing(true); }}
+          >
+            {group && <span className="ph-group">[{group}]</span>}
+            <span className="ph-name">{session.name}</span>
+          </span>
         )}
         <div className="ph-right">
           <span className="ph-path" title={pathLabel}>{pathLabel}</span>

--- a/web/src/lib/sessionTitle.ts
+++ b/web/src/lib/sessionTitle.ts
@@ -1,0 +1,49 @@
+// What an agent is called when it is shown on its own: `[Group] name`.
+//
+// The sidebar and the Overview already draw the group as a frame around its
+// agents, so they say it once and leave the rows bare. The surfaces that show a
+// single agent with no such frame — a pane header in a tiled group, the phone's
+// title bar, the browser tab — have to spell the group out, or four panes named
+// `claude-code-1` are indistinguishable.
+//
+// One rule everywhere: the group is context and the name is the thing you are
+// looking for, so when there isn't room the group gives way first. A session
+// with no group is titled by its bare name — never `[None] foo` or `[] foo`.
+
+/**
+ * The group's display name, or null when the session sits loose in the tree.
+ *
+ * Ungrouped is an absence here, not a word: the tree simply has no group that
+ * lists the session, and `/api/agents` serialises that as `group: null`. So the
+ * empty cases all collapse to the same bare name — there is no `[None] foo`.
+ */
+export function groupLabel(name?: string | null): string | null {
+  const trimmed = (name ?? '').trim();
+  return trimmed ? trimmed : null;
+}
+
+// About what a browser shows of a tab title before it stops being readable.
+// Past this the prefix would be all you can see, which is the failure this
+// whole module exists to avoid.
+export const TAB_BUDGET = 42;
+
+// Shorter than "[abc…]" the prefix identifies nothing, so drop it instead.
+const MIN_GROUP = 4;
+
+/**
+ * `[Group] name` as a single string, for the places that can only take one: the
+ * browser tab and `title=` tooltips.
+ *
+ * Fits `budget` characters by shortening the group, then by dropping it. The
+ * name comes back whole even when it exceeds the budget by itself — cutting
+ * into the name is the one thing this must never do.
+ */
+export function sessionTitle(name: string, group?: string | null, budget = TAB_BUDGET): string {
+  const g = groupLabel(group);
+  if (!g) return name;
+  const full = `[${g}] ${name}`;
+  if (full.length <= budget) return full;
+  const room = budget - name.length - 3; // the brackets and the separating space
+  if (room < MIN_GROUP) return name;
+  return `[${g.slice(0, room - 1)}…] ${name}`;
+}

--- a/web/src/lib/sessionTitle.ts
+++ b/web/src/lib/sessionTitle.ts
@@ -1,14 +1,15 @@
 // What an agent is called when it is shown on its own: `[Group] name`.
 //
 // The sidebar and the Overview already draw the group as a frame around its
-// agents, so they say it once and leave the rows bare. The surfaces that show a
-// single agent with no such frame — a pane header in a tiled group, the phone's
-// title bar, the browser tab — have to spell the group out, or four panes named
-// `claude-code-1` are indistinguishable.
+// agents, so they say it once and leave the rows bare. A pane header has no
+// such frame — four tiles named `claude-code-N` are indistinguishable — so it
+// spells the group out.
 //
-// One rule everywhere: the group is context and the name is the thing you are
-// looking for, so when there isn't room the group gives way first. A session
-// with no group is titled by its bare name — never `[None] foo` or `[] foo`.
+// The prefix is context and the name is the thing you are looking for. Fitting
+// the two into a narrow header is CSS's job (`.ph-group` shrinks and then hides
+// before `.ph-name` gives up a pixel); what this module owns is the plain
+// string, which goes in the header's tooltip and is deliberately NOT shortened
+// — the tooltip is where you go when the header ran out of room.
 
 /**
  * The group's display name, or null when the session sits loose in the tree.
@@ -22,28 +23,8 @@ export function groupLabel(name?: string | null): string | null {
   return trimmed ? trimmed : null;
 }
 
-// About what a browser shows of a tab title before it stops being readable.
-// Past this the prefix would be all you can see, which is the failure this
-// whole module exists to avoid.
-export const TAB_BUDGET = 42;
-
-// Shorter than "[abc…]" the prefix identifies nothing, so drop it instead.
-const MIN_GROUP = 4;
-
-/**
- * `[Group] name` as a single string, for the places that can only take one: the
- * browser tab and `title=` tooltips.
- *
- * Fits `budget` characters by shortening the group, then by dropping it. The
- * name comes back whole even when it exceeds the budget by itself — cutting
- * into the name is the one thing this must never do.
- */
-export function sessionTitle(name: string, group?: string | null, budget = TAB_BUDGET): string {
+/** `[Group] name`, whole; a bare name when the session has no group. */
+export function sessionTitle(name: string, group?: string | null): string {
   const g = groupLabel(group);
-  if (!g) return name;
-  const full = `[${g}] ${name}`;
-  if (full.length <= budget) return full;
-  const room = budget - name.length - 3; // the brackets and the separating space
-  if (room < MIN_GROUP) return name;
-  return `[${g.slice(0, room - 1)}…] ${name}`;
+  return g ? `[${g}] ${name}` : name;
 }

--- a/web/src/lib/sessionTitle.ts
+++ b/web/src/lib/sessionTitle.ts
@@ -14,9 +14,11 @@
 /**
  * The group's display name, or null when the session sits loose in the tree.
  *
- * Ungrouped is an absence here, not a word: the tree simply has no group that
- * lists the session, and `/api/agents` serialises that as `group: null`. So the
- * empty cases all collapse to the same bare name — there is no `[None] foo`.
+ * Ungrouped is an absence here, not a word: `/api/tree` gives the app groups
+ * with their `sessionIds`, so a loose session is simply one no group lists and
+ * the caller has nothing to pass. Every empty shape collapses to the same bare
+ * name — there is no `[None] foo`. (The roster that agents read, `/api/agents`,
+ * spells the same absence as `group: null`.)
  */
 export function groupLabel(name?: string | null): string | null {
   const trimmed = (name ?? '').trim();

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -562,13 +562,25 @@ body {
 
 .pane-head { container-type: inline-size; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr); align-items: center; gap: 9px; padding: 7px 11px; background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; flex: none; }
 .pane-head .ph-left { grid-column: 1; justify-self: start; display: inline-flex; align-items: center; gap: 7px; }
-.pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; text-align: center; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; cursor: text; }
+.pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; display: inline-flex; align-items: baseline; justify-content: center; gap: 5px; text-align: center; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; cursor: text; }
+/* `[Group] name` is one title in two parts, and the group is the part that
+   gives way: it is weighted to shrink hundreds of times faster than the name,
+   so a tile too narrow for both truncates the context rather than the thing you
+   are looking for. Below a tile width where a clipped prefix would say nothing
+   anyway, it drops out entirely and the name gets the whole header. */
+.ph-group { flex: 0 500 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-weight: 500; }
+.ph-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pane-head .ph-right { grid-column: 3; min-width: 0; display: inline-flex; align-items: center; justify-self: end; gap: 6px; }
 .pane-head .ph-path { min-width: 0; max-width: min(24vw, 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; }
 .pane-head .ph-title-input { width: 100%; text-align: center; font: inherit; font-family: var(--font-mono); font-weight: 600; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
 .pane-head .ph-close { justify-self: end; }
 @container (max-width: 520px) {
   .pane-head .ph-path { display: none; }
+}
+/* Narrower than this a prefix could only ever be a sliver of itself, and a
+   header that reads "[A… name" is worse than one that just reads "name". */
+@container (max-width: 260px) {
+  .pane-head .ph-group { display: none; }
 }
 .slot { transition: border-color 0.15s ease-out, box-shadow 0.15s ease-out; }
 /* fallback focus tint (terminal panes override with their agent's color inline) */
@@ -1074,7 +1086,7 @@ a.btn-ghost { text-decoration: none; }
 .modebar { flex: none; margin-right: 6px; }
 .modebar button { padding: 2px 8px; font-size: 10.5px; letter-spacing: 0.02em; }
 
-.mtitle { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mtitle { display: inline-flex; align-items: baseline; gap: 5px; min-width: 0; font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mchips { display: flex; gap: 6px; overflow-x: auto; flex: 1; padding: 2px; }
 .mchip { display: inline-flex; align-items: center; gap: 7px; padding: 6px 10px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md); cursor: pointer; flex: none; }
 .mchip.on { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -568,8 +568,8 @@ body {
    so a tile too narrow for both truncates the context rather than the thing you
    are looking for. Below a tile width where a clipped prefix would say nothing
    anyway, it drops out entirely and the name gets the whole header. */
-.ph-group { flex: 0 500 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-weight: 500; }
-.ph-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pane-head .ph-group { flex: 0 500 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-weight: 500; }
+.pane-head .ph-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pane-head .ph-right { grid-column: 3; min-width: 0; display: inline-flex; align-items: center; justify-self: end; gap: 6px; }
 .pane-head .ph-path { min-width: 0; max-width: min(24vw, 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; }
 .pane-head .ph-title-input { width: 100%; text-align: center; font: inherit; font-family: var(--font-mono); font-weight: 600; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
@@ -1086,7 +1086,7 @@ a.btn-ghost { text-decoration: none; }
 .modebar { flex: none; margin-right: 6px; }
 .modebar button { padding: 2px 8px; font-size: 10.5px; letter-spacing: 0.02em; }
 
-.mtitle { display: inline-flex; align-items: baseline; gap: 5px; min-width: 0; font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.mtitle { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .mchips { display: flex; gap: 6px; overflow-x: auto; flex: 1; padding: 2px; }
 .mchip { display: inline-flex; align-items: center; gap: 7px; padding: 6px 10px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md); cursor: pointer; flex: none; }
 .mchip.on { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -560,16 +560,28 @@ body {
 .welcome-reopen { font-size: 11px; color: var(--muted); }
 .welcome-foot .btn-primary { flex: none; padding: 8px 18px; }
 
-.pane-head { container-type: inline-size; display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, auto) minmax(0, 1fr); align-items: center; gap: 9px; padding: 7px 11px; background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; flex: none; }
+/* The side columns keep a min-content floor. Without one the centre track is
+   sized to its max-content BEFORE the two `1fr` tracks get anything, so a wide
+   title takes its width out of its neighbours: the logo and the close button
+   keep their place in the flow but the title's box grows over them. That was
+   already reachable with a long enough agent name; putting the group in front
+   of the name made it reachable at ordinary ones. With the floor the title is
+   capped at what is actually free and ellipsises instead. */
+.pane-head { container-type: inline-size; display: grid; grid-template-columns: minmax(min-content, 1fr) minmax(0, auto) minmax(min-content, 1fr); align-items: center; gap: 9px; padding: 7px 11px; background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; flex: none; }
 .pane-head .ph-left { grid-column: 1; justify-self: start; display: inline-flex; align-items: center; gap: 7px; }
-.pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; display: inline-flex; align-items: baseline; justify-content: center; gap: 5px; text-align: center; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; cursor: text; }
-/* `[Group] name` is one title in two parts, and the group is the part that
-   gives way: it is weighted to shrink hundreds of times faster than the name,
-   so a tile too narrow for both truncates the context rather than the thing you
-   are looking for. Below a tile width where a clipped prefix would say nothing
-   anyway, it drops out entirely and the name gets the whole header. */
-.pane-head .ph-group { flex: 0 500 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-weight: 500; }
-.pane-head .ph-name { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 5px; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; cursor: text; }
+/* `[Group] name` is one title in two parts, and the group is the only part that
+   gives way: a tile too narrow for both truncates the context, never the thing
+   you are looking for. The squeeze passes through a band where the prefix reads
+   as a stub (`[Agent-man…`); below a tile width where that is all it could ever
+   be, it drops out entirely and the name has the header to itself. */
+.pane-head .ph-group { flex: 0 1 auto; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-weight: 500; }
+/* flex-shrink 0, not a small weight: shrinking is proportional, so ANY shared
+   deficit takes a sliver off the name too — and a name that misses by 0.03px
+   still renders an ellipsis. So the name never shrinks, and `max-width` is what
+   bounds it: it can fill the whole title but no more, which is what puts the
+   ellipsis on the name itself when the name alone is too long for the header. */
+.pane-head .ph-name { flex: 0 0 auto; min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pane-head .ph-right { grid-column: 3; min-width: 0; display: inline-flex; align-items: center; justify-self: end; gap: 6px; }
 .pane-head .ph-path { min-width: 0; max-width: min(24vw, 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; }
 .pane-head .ph-title-input { width: 100%; text-align: center; font: inherit; font-family: var(--font-mono); font-weight: 600; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
@@ -577,8 +589,8 @@ body {
 @container (max-width: 520px) {
   .pane-head .ph-path { display: none; }
 }
-/* Narrower than this a prefix could only ever be a sliver of itself, and a
-   header that reads "[A… name" is worse than one that just reads "name". */
+/* Narrower than this the prefix could only ever be a stub, and a header that
+   reads "[A… name" is worse than one that just reads "name". */
 @container (max-width: 260px) {
   .pane-head .ph-group { display: none; }
 }

--- a/web/test/sessionTitle.test.mjs
+++ b/web/test/sessionTitle.test.mjs
@@ -1,0 +1,70 @@
+// The length budget, which is the part of `[Group] name` that is easy to get
+// wrong: a prefix that pushes the agent's own name out of a browser tab has
+// made the title worse than it was before.
+//
+// Same shape as exchanges.test.mjs — no test runner, esbuild transpiles the
+// module and we import it. Run with:  node test/sessionTitle.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'title-')), 'sessionTitle.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/sessionTitle.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { groupLabel, sessionTitle, TAB_BUDGET } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+console.log('groupLabel');
+check('a real group is itself', () => assert.equal(groupLabel('Agent-manager'), 'Agent-manager'));
+check('no group is null, not a word', () => {
+  assert.equal(groupLabel(null), null);
+  assert.equal(groupLabel(undefined), null);
+  assert.equal(groupLabel(''), null);
+  assert.equal(groupLabel('   '), null);
+});
+
+console.log('sessionTitle');
+check('the example from the request', () => {
+  assert.equal(sessionTitle('claude-code-7', 'Agent-manager'), '[Agent-manager] claude-code-7');
+});
+check('ungrouped degrades to a bare name', () => {
+  for (const g of [null, undefined, '', '  ']) assert.equal(sessionTitle('claude-code-7', g), 'claude-code-7');
+});
+check('an over-budget pair keeps the name whole and elides the group', () => {
+  const t = sessionTitle('claude-code-7', 'a-very-long-group-name-that-will-not-fit', 30);
+  assert.ok(t.endsWith('claude-code-7'), `name survived: ${t}`);
+  assert.ok(t.startsWith('[') && t.includes('…]'), `group elided: ${t}`);
+  assert.ok(t.length <= 30, `within budget: ${t.length}`);
+});
+check('when the group can only show a stub, it is dropped instead', () => {
+  const t = sessionTitle('a-session-name-of-exactly-this-length', 'Agent-manager', 42);
+  assert.equal(t, 'a-session-name-of-exactly-this-length');
+});
+check('a name that blows the budget alone is still returned whole', () => {
+  const name = 'x'.repeat(80);
+  assert.equal(sessionTitle(name, 'Agent-manager', 42), name);
+});
+check('the budget is respected exactly at the boundary', () => {
+  // '[g] name' is 8 chars: fits a budget of 8, elides at 7.
+  assert.equal(sessionTitle('name', 'g', 8), '[g] name');
+  assert.equal(sessionTitle('name', 'group', 8), 'name');
+});
+check('the default budget fits a realistic pair', () => {
+  assert.ok(sessionTitle('claude-code-7', 'Agent-manager').length <= TAB_BUDGET);
+});
+
+console.log(failed ? `\n${failed} check(s) failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/sessionTitle.test.mjs
+++ b/web/test/sessionTitle.test.mjs
@@ -1,6 +1,5 @@
-// The length budget, which is the part of `[Group] name` that is easy to get
-// wrong: a prefix that pushes the agent's own name out of a browser tab has
-// made the title worse than it was before.
+// `[Group] name`, and the case that is easy to get wrong: an agent with no
+// group must read as a bare name, never `[None] foo` or `[] foo`.
 //
 // Same shape as exchanges.test.mjs — no test runner, esbuild transpiles the
 // module and we import it. Run with:  node test/sessionTitle.test.mjs
@@ -17,7 +16,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/lib/sessionTitle.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { groupLabel, sessionTitle, TAB_BUDGET } = await import(pathToFileURL(out).href);
+const { groupLabel, sessionTitle } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -29,6 +28,7 @@ const check = (what, fn) => {
 
 console.log('groupLabel');
 check('a real group is itself', () => assert.equal(groupLabel('Agent-manager'), 'Agent-manager'));
+check('a padded name is trimmed', () => assert.equal(groupLabel('  Agent-manager  '), 'Agent-manager'));
 check('no group is null, not a word', () => {
   assert.equal(groupLabel(null), null);
   assert.equal(groupLabel(undefined), null);
@@ -43,27 +43,10 @@ check('the example from the request', () => {
 check('ungrouped degrades to a bare name', () => {
   for (const g of [null, undefined, '', '  ']) assert.equal(sessionTitle('claude-code-7', g), 'claude-code-7');
 });
-check('an over-budget pair keeps the name whole and elides the group', () => {
-  const t = sessionTitle('claude-code-7', 'a-very-long-group-name-that-will-not-fit', 30);
-  assert.ok(t.endsWith('claude-code-7'), `name survived: ${t}`);
-  assert.ok(t.startsWith('[') && t.includes('…]'), `group elided: ${t}`);
-  assert.ok(t.length <= 30, `within budget: ${t.length}`);
-});
-check('when the group can only show a stub, it is dropped instead', () => {
-  const t = sessionTitle('a-session-name-of-exactly-this-length', 'Agent-manager', 42);
-  assert.equal(t, 'a-session-name-of-exactly-this-length');
-});
-check('a name that blows the budget alone is still returned whole', () => {
-  const name = 'x'.repeat(80);
-  assert.equal(sessionTitle(name, 'Agent-manager', 42), name);
-});
-check('the budget is respected exactly at the boundary', () => {
-  // '[g] name' is 8 chars: fits a budget of 8, elides at 7.
-  assert.equal(sessionTitle('name', 'g', 8), '[g] name');
-  assert.equal(sessionTitle('name', 'group', 8), 'name');
-});
-check('the default budget fits a realistic pair', () => {
-  assert.ok(sessionTitle('claude-code-7', 'Agent-manager').length <= TAB_BUDGET);
+check('nothing is ever shortened — this string is the tooltip', () => {
+  const group = 'a-very-long-group-name-that-nobody-would-choose';
+  const name = 'an-equally-unreasonable-agent-name';
+  assert.equal(sessionTitle(name, group), `[${group}] ${name}`);
 });
 
 console.log(failed ? `\n${failed} check(s) failed` : '\nall checks passed');


### PR DESCRIPTION
Four panes named `claude-code-N` don't tell you which fleet you're looking at. This puts the group in front of the name, in brackets, in the **pane header**:

`[Agent-manager] claude-code-7`

## Surfaces

**Changed** — the terminal pane header and the remote pane header. That's the tiled case this is for: several panes, one group, indistinguishable names, and no other label in sight.

**Deliberately left alone**

| Surface | Why |
|---|---|
| Browser tab | It has never named a session — it reads `Agent Manager` — and this PR does not change that. |
| Phone title bar (`.mtitle`) | It is only rendered for a session that is *not* in a group (a group swaps in the chip strip), so a prefix there would be dead code. The pane header directly beneath it carries the group on a phone. |
| Sidebar rows | Sessions are already nested inside their group's frame. |
| Overview (tiles and list) | Same — agents sit inside a labelled group capsule. |
| Files pane header | Titled by the folder it's showing, not by the session. |
| Trace pane header | Titled by the transcript's own recorded title (plus harness/model chips), not by the session. |
| Mobile chip strip | Chips only appear *inside* a group, so the group is already established. |
| Share dialog / exported dataset title | An artifact name produced server-side, not a window title. |

(An earlier revision of this branch also titled the browser tab and the phone bar. That was pulled back on review — the commits are in the history if the tab is wanted later.)

## Ungrouped

Bare name. In the web data model ungrouped is an *absence* — the tree simply has no group listing the session, and `/api/agents` serialises that as `group: null`. There is no `"None"` string anywhere in the frontend to leak into a title, so there is nothing to special-case: `groupLabel()` collapses null/undefined/empty/whitespace to `null` and the prefix element isn't rendered at all.

## Length budget

The prefix is context; the name is what you're looking for. So the group is the only part that gives way, and it does so in CSS, against the real pane width rather than a character count:

- `.ph-name` has `flex-shrink: 0` and is bounded by `max-width` instead. Shrinking is *proportional*, so any weighting — even 500:1 — still takes a sliver off the name, and a name that misses its natural width by 0.03px renders an ellipsis anyway. With shrink 0 the whole deficit lands on the group; `max-width` is what still puts an ellipsis on the name when the name **alone** is too long for the header.
- The header's side columns (`.ph-left`, `.ph-right`) now keep a `min-content` floor. The centre `auto` track is sized to max-content *before* the `1fr` side tracks get anything, so without a floor a wide title doesn't shrink — it grows over the logo and the close button. See "Review fixes" below.
- Below a 260px pane-head container the prefix hides outright, since a stub identifies nothing.
- The full, untruncated `[Group] name` is always in the header's `title=` tooltip. `sessionTitle()` deliberately does **not** shorten anything — the tooltip is where you go when the header ran out of room.

## Review fixes (second round)

A reviewer read this and found two real defects, both since reproduced in a browser, fixed, and re-measured:

1. **The title grew over the header's own furniture.** `.pane-head` is `minmax(0,1fr) minmax(0,auto) minmax(0,1fr)`; the `auto` centre track takes its max-content before the `fr` tracks are fed. At a 900px window in a 2×2, `[Agent-manager] claude-code-8` overlapped `.ph-left` by 4px; a 31-character name overlapped by 28px left and 16px right. **The long-name half of this is on `main` today** — the prefix just made it reachable at ordinary name lengths. Fixed with a `min-content` floor on the two side tracks, which also fixes the pre-existing case.
2. **Ordinary names were being ellipsised by 0.03px.** Proportional shrinking meant the name always took a sliver of the deficit, and that was enough: `claude-code-8` rendered as `claude-code…` in every tile of a 2×2 at 900px. Fixed by `flex-shrink: 0` + `max-width` on the name.

Both are now asserted in the browser run: every width also checks that `.ph-title` never overlaps `.ph-left`/`.ph-right`, and the name-width comparison against the no-prefix control is back to zero tolerance.

## Following the group

The group name is derived from the tree the app already polls, so a rename or a move retitles panes on the next poll — no reload, nothing to keep in sync by hand.

## What I verified

Unit tests (`web/test/sessionTitle.test.mjs`, wired into `npm test`) cover `groupLabel`/`sessionTitle`, including every empty-group shape and the fact that nothing is truncated. `tsc --noEmit` and `vite build` are clean; the existing `exchanges` test still passes.

**I drove a real browser** (Playwright/Chromium) against a throwaway server on a seeded data dir — two groups, one long-named group, one loose agent — and checked, live:

- all four panes of a group render `[Agent-manager] <name>`, and the tooltip carries the full title
- a loose agent renders a bare name
- the browser tab still reads `Agent Manager` in every one of those states, and the phone title bar still reads the bare name
- `PUT /api/groups/:id` (rename) → every pane header retitles with no reload; `POST /api/move` → the agent leaves one group's panes and arrives titled by the other
- at 1440/1100/1000/900/820/760px, with a control pass that re-measures the same panes with `.ph-group { display: none }` injected: **no name is clipped that wasn't already clipped without the prefix, no name gives up a pixel to it, and the title never overlaps the logo or the close button**
- sub-pixel truth where it matters: the name's text width via `Range.getBoundingClientRect()` (fractional) rather than integer `scrollWidth`, which is what hid defect 2 from the first round of checks
- double-click-to-rename in the header still opens with the bare name (`narrow-pane-4`), not the prefixed title

## What I did NOT verify

- **The pane rename flow end-to-end.** Under a synthetic Playwright `dblclick` the rename input opens and then closes within ~300ms (the header's mousedown hands focus back to the terminal, which blurs and commits). I ran the identical script against **unmodified main** built from `upstream/main` and got the same result, twice each — pre-existing, not a regression, left alone. So I confirmed the input's *initial value* is the bare name, but did not type a new name through the UI and watch the header update.
- **The remote pane rendered** — no remote agent was connected; its header change is the same two-span edit as the terminal pane, reviewed but not seen on screen.
- **Any other browser.** Chromium only. The layout leans on flex `text-overflow` and a `@container` query, both already used by `.ph-path` in the same header.
- **CI.** There isn't any — the repo has no workflows — so `npm test` is manual, and wiring the new file into it does not mean anything runs it on this PR.
- **No deploy.** Nothing was tested on a live Space; the running Space was untouched (throwaway servers, `env -u SPACE_ID`, separate data dirs).
- One cosmetic edge remains: an unusually long agent name in a mid-width pane can squeeze the prefix to a ~20px sliver before the 260px cutoff hides it. The name never loses width, and the tooltip still has the whole title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
