### PR TITLE
Trace reader: open on the last exchange, page backwards by byte window

### DIFF
--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -450,6 +450,22 @@ and one older window was fetched on every open. Paging is therefore gated on a f
 waits for both the first measurement and the first placement of the scroller. Opening a
 pane now costs exactly two requests, the tail and the summary, on both traces.
 
+**Things a review caught, all of them about a window claiming more than it knows.** The
+codex guardian guard read a fixed 16 KB and parsed the first line; a real `session_meta`
+carries `base_instructions` and runs 18–44 KB, so the parse always threw and the `catch`
+turned "I could not tell" into "not a subagent" — the guard never fired on a real rollout.
+It now grows the read until the line is whole, and a head it genuinely cannot read falls
+back to the whole-file reader rather than guessing. A window's `note` (codex's count of
+encrypted reasoning steps) is a per-parse number and was being rendered as a statement
+about the session, changing as you scrolled — it now travels with `usage`/`firstTs` as a
+summary-only fact. A single line larger than `WINDOW_MAX_BYTES` (a file-history blob)
+cannot be paged past; the reader used to conclude it had reached the beginning of the
+conversation, and now says what actually happened. A last line that never becomes valid
+JSON no longer costs the final answer its accent: having READ to EOF is what makes a
+window the end, not having consumed every byte. And in the pane, every load now carries a
+generation stamp, so a window in flight when you switch files cannot be spliced into the
+next transcript with the previous one's byte cursors.
+
 **The one behavioural difference:** a harness message whose lines straddle a window
 boundary is split into two turns instead of merged into one. Stitching every window of
 that transcript gives 1,433 turns against the full parse's 1,420, with character-for-

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -434,6 +434,14 @@ turn floor that makes a window grow (`WINDOW_MIN_TURNS`) is deliberately low for
 reason: at 30 it grew the codex rollout's window to 1.5 MB and its response to 591 KB,
 which is the whole-file cost this exists to avoid.
 
+**Scroll anchoring is measured, not modelled.** The first version restored the reading
+position from the prefix-sum height model, which is only ever approximately right for rows
+it has not measured yet: on a codex rollout — whose collapsed tool groups are several
+times `ROW_EST` — a prepend moved the text under the reader by ~280 px on the Space and
+~30 px locally. The reader now records the anchor row's real `getBoundingClientRect()`
+position and re-applies *that* after the layout, falling back to the model only for a row
+that has scrolled out of the rendered window. Drift on both traces is 0 px.
+
 **The one behavioural difference:** a harness message whose lines straddle a window
 boundary is split into two turns instead of merged into one. Stitching every window of
 that transcript gives 1,433 turns against the full parse's 1,420, with character-for-

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -442,6 +442,14 @@ times `ROW_EST` — a prepend moved the text under the reader by ~280 px on the 
 position and re-applies *that* after the layout, falling back to the model only for a row
 that has scrolled out of the rendered window. Drift on both traces is 0 px.
 
+**"Am I at the top?" is only answerable after measurement.** The reader fetches the window
+above when `scrollTop` enters a 400 px band, and `scrollTop` means nothing until the rows
+have been measured: before the first measuring pass every row is `ROW_EST` (44 px), so a
+window of 19 dense codex turns models as 800 px when it is really 3,600 — inside the band,
+and one older window was fetched on every open. Paging is therefore gated on a flag that
+waits for both the first measurement and the first placement of the scroller. Opening a
+pane now costs exactly two requests, the tail and the summary, on both traces.
+
 **The one behavioural difference:** a harness message whose lines straddle a window
 boundary is split into two turns instead of merged into one. Stitching every window of
 that transcript gives 1,433 turns against the full parse's 1,420, with character-for-

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -414,9 +414,18 @@ on screen" is Playwright, median of 5–9 opens of the pane.
 | bytes, first request | 676 KB | **82 KB** | 513 KB | **151 KB** |
 | server time, transcript changed since the last request | 160 ms | **6 ms** | 46 ms | **6 ms** |
 | server time, transcript unchanged (parse memo hit) | 6 ms | 6 ms | 5 ms | 6 ms |
+| the `?summary=1` read, 400 ms after the paint | — | 176 ms | — | 46 ms |
 | first turn on screen, localhost | 181 ms | **167 ms** | 172 ms | 189 ms |
 | first turn on screen, 10 Mbps / 40 ms link | 866 ms | **267 ms** | 868 ms | **355 ms** |
 | opens on | oldest turn | **newest turn** | oldest turn | **newest turn** |
+
+Read that table with the summary row in view: the whole-file parse is **deferred, not
+removed**. The reader still asks for `?summary=1` once per pane open, and on a transcript
+being appended to (the memo is keyed on mtime) that is the same 160–176 ms parse as before,
+just after the first paint instead of in front of it. What the window buys is the first
+view and every subsequent page; what it does not buy is a server that never reads the whole
+file. The honest summary of the server work is: one bounded read on the critical path, one
+whole-file read off it, and none at all for the pages after the first.
 
 Read honestly: **on loopback this is a wash** — both are ~170–190 ms, dominated by render
 and app work, and the codex case is if anything marginally slower. The win is the bytes,
@@ -466,10 +475,34 @@ window the end, not having consumed every byte. And in the pane, every load now 
 generation stamp, so a window in flight when you switch files cannot be spliced into the
 next transcript with the previous one's byte cursors.
 
-**The one behavioural difference:** a harness message whose lines straddle a window
-boundary is split into two turns instead of merged into one. Stitching every window of
+**codex windows are cut at task boundaries, not at arbitrary bytes.** A byte window is
+sound for a format whose lines stand alone. Codex's do not: `event_msg/task_complete`
+points BACK at the assistant message it marks, and a dangling pointer does not degrade —
+`normalizeCodex` cannot find the answer, so it pushes a verbatim second copy of it.
+Measured on a real 4.8 MB rollout at 128 KB windows: 955 stitched turns against the full
+parse's 953, two answers shown twice. A rollout describes its own unit
+(`task_started` … `task_complete`) and every backward reference lives inside one task, so a
+codex window now begins on a `task_started` line. Measured over every rollout on this
+Space: 339 `task_started`, 333 `task_complete`, none outside a started task, largest task
+768 KB — inside the 8 MB growth ceiling with room to spare. A task bigger than the ceiling
+cannot be aligned; there the pointer is treated as a marker only, since the answer it names
+is rendered (and marked) in the window that holds it. Verified: a synthetic 10 MB
+single-task rollout yields exactly one copy of its answer.
+
+With that, stitching every window of a codex rollout reproduces the full parse **exactly** —
+same turns, same blocks, same `final` accents — at 64 KB, 128 KB and 384 KB windows, on all
+six rollouts on this Space.
+
+**The one behavioural difference, and it is Claude's:** a harness message whose lines
+straddle a window boundary is split into two turns instead of merged into one. Stitching every window of
 that transcript gives 1,433 turns against the full parse's 1,420, with character-for-
-character identical content — thirteen turns show as two rows each. Covered by
+character identical content — thirteen turns show as two rows each. Checked as a multiset
+of blocks against the full parse across the six largest Claude transcripts and the six
+largest codex rollouts here, at three window sizes: **0 blocks missing and 0 duplicated in
+all 36 runs**. The `final` accent is withheld (never wrongly added) from a window that
+cannot see whether an answer is the last one before the next prompt: at the shipped 384 KB
+window the accents match the full parse exactly on both formats; at an unusually small
+64 KB window a 19 MB Claude transcript withholds 3 of 56. Covered by
 `server/test/trace-window.test.mjs`, which also pins the edges: paging back terminates at
 byte 0, an appended turn arrives exactly once, a torn last line is not a turn until it is
 whole, and a transcript with no trailing newline still ends in one.

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -415,6 +415,7 @@ on screen" is Playwright, median of 5–9 opens of the pane.
 | server time, transcript changed since the last request | 160 ms | **6 ms** | 46 ms | **6 ms** |
 | server time, transcript unchanged (parse memo hit) | 6 ms | 6 ms | 5 ms | 6 ms |
 | the `?summary=1` read, 400 ms after the paint | — | 176 ms | — | 46 ms |
+| bytes `pread` to page the whole trace back | — | 20.8 MB / 35 windows | — | 5.7 MB / 13 windows |
 | first turn on screen, localhost | 181 ms | **167 ms** | 172 ms | 189 ms |
 | first turn on screen, 10 Mbps / 40 ms link | 866 ms | **267 ms** | 868 ms | **355 ms** |
 | opens on | oldest turn | **newest turn** | oldest turn | **newest turn** |
@@ -489,9 +490,16 @@ cannot be aligned; there the pointer is treated as a marker only, since the answ
 is rendered (and marked) in the window that holds it. Verified: a synthetic 10 MB
 single-task rollout yields exactly one copy of its answer.
 
-With that, stitching every window of a codex rollout reproduces the full parse **exactly** —
+Be precise about which half does what, because the first version of this section claimed
+more than the code delivers. Alignment is an *optimization*: when a window happens to hold a
+`task_started` it begins there and the task's grouping is not split at the seam. Most windows
+hold none (at 64 KB, with tasks up to 768 KB, almost none do) and are cut mid-task anyway —
+what keeps those correct is the second rule, that a `task_complete` whose answer is not in
+this window is treated as a marker and never emitted. **That fallback is load-bearing.**
+
+With both, stitching every window of a codex rollout reproduces the full parse **exactly** —
 same turns, same blocks, same `final` accents — at 64 KB, 128 KB and 384 KB windows, on all
-six rollouts on this Space.
+eight rollouts on this Space (24 runs, independently reproduced in review).
 
 **The one behavioural difference, and it is Claude's:** a harness message whose lines
 straddle a window boundary is split into two turns instead of merged into one. Stitching every window of

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -403,19 +403,41 @@ indices as cursors (`window.mode`), and the reader treats a cursor as opaque eit
 which the reader asks for 400 ms after its first paint. Until it lands the header says
 `N turns loaded` rather than inventing a total.
 
-**Cost, measured on the 19 MB / 1,395-turn transcript** (`edbfc11f…`, warm page cache):
+**Cost.** Measured against `upstream/main` built and served from the same files, on
+two real traces on this Space: a 19 MB / ~1,420-turn **Claude** transcript and a 4.8 MB /
+~1,200-turn **codex** rollout. Server time is `curl` against a local server; "first turn
+on screen" is Playwright, median of 5–9 opens of the pane.
 
-| | before | after |
-|---|---|---|
-| server time for the first request | 165 ms | 5 ms |
-| bytes on the wire | 676 KB | 96 KB |
-| first turn on screen (localhost) | 180 ms | 155 ms |
-| first turn on screen (10 Mbps / 40 ms) | 865 ms | 267 ms |
+| | Claude 19 MB | | codex 4.8 MB | |
+|---|---|---|---|---|
+| | before | after | before | after |
+| bytes, first request | 676 KB | **82 KB** | 513 KB | **151 KB** |
+| server time, transcript changed since the last request | 160 ms | **6 ms** | 46 ms | **6 ms** |
+| server time, transcript unchanged (parse memo hit) | 6 ms | 6 ms | 5 ms | 6 ms |
+| first turn on screen, localhost | 181 ms | **167 ms** | 172 ms | 189 ms |
+| first turn on screen, 10 Mbps / 40 ms link | 866 ms | **267 ms** | 868 ms | **355 ms** |
+| opens on | oldest turn | **newest turn** | oldest turn | **newest turn** |
+
+Read honestly: **on loopback this is a wash** — both are ~170–190 ms, dominated by render
+and app work, and the codex case is if anything marginally slower. The win is the bytes,
+and it shows the moment there is a real link between the browser and the Space (3.2× and
+2.4×), plus the server work that vanishes: the "changed since the last request" row is the
+one a *working* agent hits, because the parse memo is keyed on mtime and every append
+invalidates it. The memo-hit row is what an idle trace costs, and there the two are the
+same — main was never slow at *serving* a memoized parse, only at building one and at
+putting 676 KB on the wire to show you the wrong end of the conversation.
+
+The 384 KB default window was chosen by sweeping 128 KB – 1 MB in a browser: paint time is
+flat (155–171 ms median, since the list is virtualized either way) and only the payload
+moves, so the smallest window that still opens on a full-looking conversation wins. The
+turn floor that makes a window grow (`WINDOW_MIN_TURNS`) is deliberately low for the same
+reason: at 30 it grew the codex rollout's window to 1.5 MB and its response to 591 KB,
+which is the whole-file cost this exists to avoid.
 
 **The one behavioural difference:** a harness message whose lines straddle a window
 boundary is split into two turns instead of merged into one. Stitching every window of
-that transcript gives 1,401 turns against the full parse's 1,395, with character-for-
-character identical content — six turns show as two rows each. Covered by
+that transcript gives 1,433 turns against the full parse's 1,420, with character-for-
+character identical content — thirteen turns show as two rows each. Covered by
 `server/test/trace-window.test.mjs`, which also pins the edges: paging back terminates at
 byte 0, an appended turn arrives exactly once, a torn last line is not a turn until it is
 whole, and a transcript with no trailing newline still ends in one.

--- a/docs/trace-panel-spec.md
+++ b/docs/trace-panel-spec.md
@@ -369,3 +369,53 @@ dedupe per ENTRY, not per joined string; and web searches exist ONLY as `web_sea
 
 **Encrypted reasoning is normal.** 49 of 56 reasoning items carried only
 `encrypted_content`. Say so in the UI; do not leave the impression the model didn't think.
+
+## 13. Tail-first reading (2026-08-09)
+
+§5 shipped one way of asking for turns: `offset`/`limit` over a whole-file parse. It is
+the right shape for the surfaces that want a fixed slice (the Overview card, RENDER mode)
+and the wrong one for the reader, because it can only answer *any* question after
+normalizing the entire transcript — 19 MB and 1,395 turns for the longest session on this
+Space — and the pane then opened on the OLDEST turn, which is never the one you came for.
+
+The reader now opens at the end and pages backwards.
+
+**Wire.** Same endpoints, three modes (`server/src/index.js` `traceOpts`):
+
+| Request | Answers with |
+|---|---|
+| `?tail=1&bytes=` | the last window of the transcript |
+| `?before=<cursor>` | the window in front of one you hold |
+| `?after=<cursor>` | whatever has been appended since |
+| `?summary=1` | whole-trace facts (`total`, `userTurns`, `usage`, `firstTs`), no turns |
+| `?offset=&limit=` | unchanged — index paging over the full parse |
+
+A window is a byte range of the .jsonl run through the same normalizers
+(`rangeJsonLines`), and the cursors it hands back are line-aligned, so consecutive
+windows abut exactly: no line is read twice and none is skipped. A window that starts
+mid-line drops that fragment (the window before it owns the line); a window that ends at
+a half-written line stops before it, so a live tail picks it up once it is whole. The
+SQLite harnesses have no byte offsets to seek — they answer the same shape with message
+indices as cursors (`window.mode`), and the reader treats a cursor as opaque either way.
+
+**What a window cannot know**, and therefore does not claim: `total`, `userTurns`,
+`firstTs` and the session's `usage` are whole-trace facts. They arrive from `?summary=1`,
+which the reader asks for 400 ms after its first paint. Until it lands the header says
+`N turns loaded` rather than inventing a total.
+
+**Cost, measured on the 19 MB / 1,395-turn transcript** (`edbfc11f…`, warm page cache):
+
+| | before | after |
+|---|---|---|
+| server time for the first request | 165 ms | 5 ms |
+| bytes on the wire | 676 KB | 96 KB |
+| first turn on screen (localhost) | 180 ms | 155 ms |
+| first turn on screen (10 Mbps / 40 ms) | 865 ms | 267 ms |
+
+**The one behavioural difference:** a harness message whose lines straddle a window
+boundary is split into two turns instead of merged into one. Stitching every window of
+that transcript gives 1,401 turns against the full parse's 1,395, with character-for-
+character identical content — six turns show as two rows each. Covered by
+`server/test/trace-window.test.mjs`, which also pins the edges: paging back terminates at
+byte 0, an appended turn arrives exactly once, a torn last line is not a turn until it is
+whole, and a transcript with no trailing newline still ends in one.

--- a/server/node_modules
+++ b/server/node_modules
@@ -1,0 +1,1 @@
+/app/server/node_modules

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/spawn-group.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/spawn-group.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1663,16 +1663,35 @@ app.delete('/api/files/:id/entry', (req, res) => {
 // One page of an on-disk transcript, rendered by the same reader the Trace pane
 // uses. Paged rather than whole: these files reach tens of MB, and the viewer
 // only ever has a window of them on screen.
+// Which slice of a trace the caller is asking for. Three modes, one endpoint:
+//
+//   ?tail=1 | ?before=<cursor> | ?after=<cursor>   a window (the reader's path):
+//       the last stretch of the conversation, the stretch in front of one it
+//       already holds, or whatever has been written since — each answered from a
+//       byte range of the transcript rather than a parse of all of it.
+//   ?summary=1                                     whole-trace facts, no turns.
+//   ?offset=&limit=                                index paging, as before.
+function traceOpts(q) {
+  if (q.summary !== undefined) return { summary: true };
+  const at = q.tail !== undefined ? 'tail' : q.before !== undefined ? 'before' : q.after !== undefined ? 'after' : null;
+  if (!at) return { offset: Number(q.offset) || 0, limit: Number(q.limit) || 200 };
+  return {
+    window: {
+      at,
+      cursor: Number(at === 'before' ? q.before : q.after) || 0,
+      bytes: Number(q.bytes) || 0,
+      min: Number(q.min) || 0,
+    },
+  };
+}
+
 app.get('/api/files/:id/trace', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
   if (!f || !fs.existsSync(f) || !fs.statSync(f).isFile()) return res.status(404).json({ error: 'not found' });
   try {
-    res.json(await readTraceByPath(f, {
-      offset: Number(req.query.offset) || 0,
-      limit: Number(req.query.limit) || 200,
-    }));
+    res.json(await readTraceByPath(f, traceOpts(req.query)));
   } catch (e) {
     // "not a transcript" is an ordinary answer here, not a failure: the pane
     // falls back to showing the file as text.
@@ -2007,17 +2026,16 @@ app.get('/api/trace/:id', async (req, res) => {
   if (!pane) return res.status(404).json({ error: 'not found' });
 
   const source = pane.traceSource || { kind: 'session', ref: pane.id };
-  const offset = Number(req.query.offset) || 0;
-  const limit = Number(req.query.limit) || 200;
+  const opts = traceOpts(req.query);
 
   try {
     if (source.kind === 'bundle') {
       if (!/^[\w.-]+$/.test(String(source.ref))) return res.status(400).json({ error: 'bad bundle ref' });
-      return res.json(await readTraceBundle(path.join(DATA_DIR, 'traces', source.ref), { offset, limit }));
+      return res.json(await readTraceBundle(path.join(DATA_DIR, 'traces', source.ref), opts));
     }
     const target = store.get(source.ref);
     if (!target) return res.status(404).json({ error: 'source session is gone', code: 'no-trace' });
-    res.json(await readTrace(target, { offset, limit }));
+    res.json(await readTrace(target, opts));
   } catch (e) {
     // These are expected states, not failures: no transcript yet, an
     // unsupported CLI, or a codex guardian rollout. The pane renders the reason.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1694,8 +1694,10 @@ app.get('/api/files/:id/trace', async (req, res) => {
     res.json(await readTraceByPath(f, traceOpts(req.query)));
   } catch (e) {
     // "not a transcript" is an ordinary answer here, not a failure: the pane
-    // falls back to showing the file as text.
-    if (['no-trace', 'unsupported-harness'].includes(e && e.code)) {
+    // falls back to showing the file as text. A codex guardian rollout is the
+    // same kind of answer — the session route already says so, and a 500 here
+    // would replace the reason with "could not read the trace".
+    if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
       return res.status(404).json({ error: e.message, code: e.code });
     }
     console.error('[trace file]', e && e.message);

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1419,16 +1419,19 @@ function flattenToolContent(value) {
 
 // Bundles have no session record telling us the harness, so sniff the first
 // lines — same trick as the Hub's detect.ts / sniffTraceHarness.
-// A file's format does not change under us, and this is now on the path of
-// EVERY window request (it decides whether the trace can be seeked at all), so
-// the answer is remembered per path rather than re-read off the bucket each time.
-const harnessMemo = new Map();
+// This is now on the path of EVERY window request (it decides whether the trace
+// can be seeked at all), so the answer is remembered rather than re-read off the
+// bucket each time. Briefly, though: a path is not permanently one format — a
+// bundle ref can be re-imported with a different harness underneath it.
+const harnessMemo = new Map(); // path -> { at, harness }
+const HARNESS_TTL = 60_000;
 async function sniffHarness(file) {
-  if (harnessMemo.has(file)) return harnessMemo.get(file);
+  const hit = harnessMemo.get(file);
+  if (hit && Date.now() - hit.at < HARNESS_TTL) return hit.harness;
   const found = await sniffHarnessUncached(file);
   if (found) {
     if (harnessMemo.size > 200) harnessMemo.clear();
-    harnessMemo.set(file, found);
+    harnessMemo.set(file, { at: Date.now(), harness: found });
   }
   return found;
 }
@@ -1575,12 +1578,15 @@ const clampN = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
 function windowOf(parsed, cur) {
   return {
     ...headOf(parsed),
-    // `firstTs` and `usage` describe the WHOLE conversation. A window that
-    // doesn't span the whole file knows neither, and reporting its own first
-    // line as the start of the session (or its own tokens as the session's bill)
-    // would be a confident lie. The summary pass fills them in.
+    // `firstTs`, `usage` and `note` describe the WHOLE conversation. A window
+    // that doesn't span the whole file knows none of them, and reporting its own
+    // first line as the start of the session, its own tokens as the session's
+    // bill, or its own count of encrypted reasoning steps as the session's,
+    // would be a confident lie — the last one visibly so, since it would change
+    // every time you scrolled. The summary pass fills them in.
     firstTs: cur.atStart ? parsed.firstTs : 0,
     usage: cur.atStart && cur.atEnd ? parsed.usage : null,
+    note: cur.atStart && cur.atEnd ? parsed.note || null : null,
     total: null,
     userTurns: null,
     turns: parsed.messages,
@@ -1611,7 +1617,13 @@ async function oneWindow(harness, file, sessionId, range, size) {
   const parsed = await parseTraceFile(harness, file, sessionId, range);
   const start = range.start ?? range.from;
   const end = range.end ?? range.to;
-  const atEnd = end >= size;
+  // Having READ to the end of the file is what makes this the end of the
+  // conversation. `end` can legitimately stop short of `size` — a line the agent
+  // is halfway through writing, or one a killed writer left broken — and taking
+  // that as "there is more to come" would deny the last answer its accent
+  // forever. The cursor still stops in front of the fragment, so the next
+  // `after: end` picks it up if it ever becomes whole.
+  const atEnd = range.to >= size;
   if (!atEnd) unmarkTrailingFinal(parsed);
   return { parsed, cur: { mode: 'bytes', start, end, atStart: start <= 0, atEnd } };
 }
@@ -1641,7 +1653,14 @@ async function readWindow(harness, file, sessionId, size, req) {
   for (;;) {
     const from = Math.max(0, to - span);
     const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size);
-    if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) return w;
+    if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) {
+      // A window that consumed nothing at all has hit a single line longer than
+      // the ceiling (a file-history blob), and no amount of asking again will
+      // get past it. Say that, rather than let the reader conclude it has
+      // reached the beginning of the conversation.
+      if (w.cur.start >= to && to > 0) w.cur.blocked = true;
+      return w;
+    }
     span = Math.min(span * 2, WINDOW_MAX_BYTES);
   }
 }
@@ -1649,9 +1668,11 @@ async function readWindow(harness, file, sessionId, size, req) {
 // Harnesses whose conversation lives in SQLite have no byte offsets to seek, and
 // a bundle small enough not to matter doesn't need them. They answer the same
 // shape with message INDICES as cursors: the reader treats a cursor as opaque.
+const INDEX_WINDOW_TURNS = 100; // no bytes to seek: page by turns, as index mode always did
+
 function windowIndex(parsed, req) {
   const total = parsed.messages.length;
-  const min = clampN(Math.trunc(req.min) || WINDOW_MIN_TURNS, 1, 500);
+  const min = clampN(Math.trunc(req.min) || INDEX_WINDOW_TURNS, 1, 500);
   const cursor = clampN(Math.trunc(req.cursor) || 0, 0, total);
   let from; let to;
   if (req.at === 'after') { from = cursor; to = total; } else if (req.at === 'before') { to = cursor; from = Math.max(0, to - min); } else { to = total; from = Math.max(0, total - min); }
@@ -1667,13 +1688,39 @@ function windowIndex(parsed, req) {
 // The subagent marker lives in `session_meta`, the FIRST line of a codex
 // rollout — a tail window never sees it, so a guardian thread would render as if
 // it were the operator's conversation. Check the head before serving a window.
+//
+// That line is NOT small: it carries `base_instructions.text`, and every real
+// rollout on this Space starts with 18–44 KB of it. Reading a fixed 16 KB and
+// parsing what came back therefore never parsed at all, and the `catch` turned
+// "I could not tell" into "not a subagent" — the guard silently never fired.
+// So: grow the read until the line is whole, and if it still cannot be read,
+// say so rather than assume the safe answer.
+const FIRST_LINE_MAX = 4 * 1024 * 1024;
+
+async function firstLine(file) {
+  for (let span = 64 * 1024; ; span *= 4) {
+    const buf = await rangeBuf(file, 0, span);
+    const nl = buf.indexOf(0x0a);
+    if (nl >= 0) return buf.toString('utf8', 0, nl);
+    // Shorter than the span means we read the whole file: it is one line.
+    if (buf.length < span) return buf.toString('utf8');
+    if (span >= FIRST_LINE_MAX) return null;
+  }
+}
+
 async function refuseCodexSubagent(file) {
-  const buf = await rangeBuf(file, 0, 16 * 1024);
-  const nl = buf.indexOf(0x0a);
+  const line = await firstLine(file);
   let j = null;
-  try { j = JSON.parse(buf.toString('utf8', 0, nl < 0 ? buf.length : nl)); } catch { return; }
-  const p = (j && j.payload) || {};
-  if (j && j.type === 'session_meta' && (p.thread_source === 'subagent' || p.source?.subagent)) {
+  try { j = line == null ? null : JSON.parse(line); } catch { j = null; }
+  if (!j) {
+    // Unreadable head: fall back to the reader that walks the whole rollout,
+    // which throws on the marker itself. Rare, and correctness beats the window.
+    const e = new Error('could not read the head of this rollout');
+    e.code = 'window-unavailable';
+    throw e;
+  }
+  const p = j.payload || {};
+  if (j.type === 'session_meta' && (p.thread_source === 'subagent' || p.source?.subagent)) {
     const err = new Error('this rollout is an internal guardian/subagent thread, not the session');
     err.code = 'trace-not-user-conversation';
     throw err;
@@ -1701,7 +1748,14 @@ async function serveTrace({ key, harness, file, sessionId, size, decorate }, opt
   if (!opts.window) return pageOf(await full(), opts.offset ?? 0, opts.limit ?? 200);
   if (!WINDOWABLE.has(harness)) return windowIndex(await full(), opts.window);
 
-  if (harness === 'codex') await refuseCodexSubagent(file);
+  if (harness === 'codex') {
+    try {
+      await refuseCodexSubagent(file);
+    } catch (e) {
+      if (e.code !== 'window-unavailable') throw e;
+      return windowIndex(await full(), opts.window); // whole-file read, which checks it properly
+    }
+  }
   const { parsed, cur } = await tracked(PHASE.readTrace, () =>
     readWindow(harness, file, sessionId, size, opts.window));
   if (decorate) await decorate(parsed);

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1563,7 +1563,13 @@ const WINDOWABLE = new Set(['claude', 'codex', 'openclaw', 'sts']);
 const WINDOW_BYTES = 384 * 1024;         // default span (see the PR for the measurements)
 const WINDOW_MIN_BYTES = 32 * 1024;
 const WINDOW_MAX_BYTES = 8 * 1024 * 1024; // a single window can't cost more than this
-const WINDOW_MIN_TURNS = 30;             // grow the span until at least this many turns are in it
+// Grow the span until at least this many turns are in it — a floor against
+// opening on a stub, NOT a target. It is deliberately low, and growth doubles
+// rather than quadruples: a codex rollout packs ~20 turns into 384 KB, and
+// insisting on 30 grew that window to 1.5 MB and the response to 591 KB, which
+// is the whole-file cost this exists to avoid. Measured on `finetuning boy`
+// (2 MB rollout): 384 KB = 19 turns / 135 KB, 1.5 MB = 75 turns / 591 KB.
+const WINDOW_MIN_TURNS = 12;
 const clampN = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
 
 function windowOf(parsed, cur) {
@@ -1636,7 +1642,7 @@ async function readWindow(harness, file, sessionId, size, req) {
     const from = Math.max(0, to - span);
     const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size);
     if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) return w;
-    span = Math.min(span * 4, WINDOW_MAX_BYTES);
+    span = Math.min(span * 2, WINDOW_MAX_BYTES);
   }
 }
 

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -977,7 +977,7 @@ async function rangeBuf(file, from, to) {
 // offset can cut a UTF-8 character in half, and offsets derived from the decoded
 // string would then be a byte or two off — enough to corrupt the next cursor.
 async function* rangeJsonLines(file, range) {
-  const buf = await rangeBuf(file, range.from, range.to);
+  const buf = range.buf || await rangeBuf(file, range.from, range.to);
   let i = 0;
   if (!range.aligned) {
     const nl = buf.indexOf(0x0a);
@@ -1238,6 +1238,13 @@ async function normalizeCodex(file, out, range) {
           // A capped block only holds a prefix, so compare as a prefix there.
           if (marked && shown.some((t) => t === text || (t.length >= VIEW_BLOCK_CAP && text.startsWith(t)))) {
             marked.kind = 'final';
+          } else if (range && range.danglingTaskComplete === 'ignore') {
+            // This window had to cut a task in half (one bigger than the growth
+            // ceiling), so the answer this event points at is in a window we did
+            // not read — where it is already rendered, and already marked. A
+            // pointer to something outside the window is not an answer; emitting
+            // it here would show the reader a copy of a turn that occurs once.
+            cur = null;
           } else {
             cur = null;
             out.push({ role: 'assistant', kind: 'final', ts, blocks: [textBlock('text', text)] });
@@ -1247,6 +1254,10 @@ async function normalizeCodex(file, out, range) {
       } else if (p.type === 'turn_aborted' || p.type === 'thread_rolled_back') {
         cur = null;
       }
+      // Did this window's last task close inside it? That is what decides
+      // whether its final answer is really final — see oneWindow.
+      if (p.type === 'task_started') out.taskOpen = true;
+      else if (p.type === 'task_complete' || p.type === 'turn_aborted') out.taskOpen = false;
       continue;
     }
   }
@@ -1613,7 +1624,73 @@ function unmarkTrailingFinal(parsed) {
   }
 }
 
+// ---------- codex: windows are cut at task boundaries ----------
+// A byte window is sound for a format whose lines stand alone. Codex's do not:
+// `event_msg/task_complete` POINTS BACK at the assistant message it marks, and
+// `agent_reasoning` is deduped against reasoning items earlier in the same turn.
+// Cut the file anywhere and those references dangle — and a dangling
+// `task_complete` does not degrade, it INVENTS: `normalizeCodex` cannot find the
+// answer, so it pushes a verbatim second copy of it. Measured on a real 4.8 MB
+// rollout at 128 KB windows: 955 stitched turns against the full parse's 953,
+// two answers shown twice.
+//
+// The fix is not to dedupe the symptom but to stop cutting mid-reference. A
+// rollout describes its own unit — `task_started` … `task_complete` — and every
+// backward reference lives inside one task. So a codex window begins at a
+// `task_started` line: each task, with its answer, its reasoning and its token
+// count, lands whole in exactly one window, and stitching reproduces the full
+// parse exactly. Measured over every rollout on this Space: 339 `task_started`,
+// 333 `task_complete`, no `task_complete` outside a started task, largest task
+// 768 KB — comfortably inside the growth ceiling.
+const TASK_MARK = '"task_started"';
+
+/** Byte offset of the first `task_started` line at or after `buf`'s first whole
+ *  line, or -1 if this window holds none. `base` is the file offset of buf[0]. */
+function codexTaskStart(buf, base, firstLine) {
+  let i = firstLine;
+  while (i < buf.length) {
+    let nl = buf.indexOf(0x0a, i);
+    if (nl < 0) nl = buf.length;
+    // Cheap filter first: parsing every line of every window to find a boundary
+    // would cost as much as the parse itself.
+    if (buf.includes(TASK_MARK, i) && buf.indexOf(TASK_MARK, i) < nl) {
+      let j = null;
+      try { j = JSON.parse(buf.toString('utf8', i, nl)); } catch { j = null; }
+      if (j && j.type === 'event_msg' && j.payload && j.payload.type === 'task_started') return base + i;
+    }
+    i = nl + 1;
+  }
+  return -1;
+}
+
+/** Where a window's first whole line begins inside `buf`. */
+function firstWholeLine(buf, aligned) {
+  if (aligned) return 0;
+  const nl = buf.indexOf(0x0a);
+  return nl < 0 ? buf.length : nl + 1;
+}
+
 async function oneWindow(harness, file, sessionId, range, size) {
+  let taskAligned = false;
+  if (harness === 'codex' && range.from > 0) {
+    // Read once, align, then parse the same bytes — `range.buf` keeps this to a
+    // single read of the window.
+    const buf = await rangeBuf(file, range.from, range.to);
+    const at = codexTaskStart(buf, range.from, firstWholeLine(buf, range.aligned));
+    if (at >= 0) {
+      range.buf = buf.subarray(at - range.from);
+      range.from = at;
+      range.aligned = true;
+      taskAligned = true;
+    } else {
+      range.buf = buf;
+      // No boundary in reach: this window cuts a task in half, so a
+      // `task_complete` inside it may point at an answer we cannot see. Tell the
+      // normalizer to treat it as a marker only — pointing at something outside
+      // the window is not a reason to invent a copy of it.
+      range.danglingTaskComplete = 'ignore';
+    }
+  }
   const parsed = await parseTraceFile(harness, file, sessionId, range);
   const start = range.start ?? range.from;
   const end = range.end ?? range.to;
@@ -1624,7 +1701,14 @@ async function oneWindow(harness, file, sessionId, range, size) {
   // forever. The cursor still stops in front of the fragment, so the next
   // `after: end` picks it up if it ever becomes whole.
   const atEnd = range.to >= size;
-  if (!atEnd) unmarkTrailingFinal(parsed);
+  // Withhold the "final answer" accent only from a window that cannot know
+  // whether the answer is final. For codex that is precisely a window whose last
+  // task is still open at its edge — a closed task's answer is named by the
+  // harness itself. For the line-oriented formats it is any window that does not
+  // reach the end of the file, since "final" there means "no later answer before
+  // the next prompt", and the next prompt may be in the window after this one.
+  const openEdge = harness === 'codex' ? !!parsed.taskOpen : true;
+  if (!atEnd && openEdge) unmarkTrailingFinal(parsed);
   return { parsed, cur: { mode: 'bytes', start, end, atStart: start <= 0, atEnd } };
 }
 
@@ -1653,7 +1737,10 @@ async function readWindow(harness, file, sessionId, size, req) {
   for (;;) {
     const from = Math.max(0, to - span);
     const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size);
-    if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) {
+    // A codex window that holds no task boundary had to cut a task in half; grow
+    // rather than serve a window whose references point outside it.
+    const unaligned = harness === 'codex' && from > 0 && w.cur.start <= from;
+    if ((w.parsed.messages.length >= min && !unaligned) || from === 0 || span >= WINDOW_MAX_BYTES) {
       // A window that consumed nothing at all has hit a single line longer than
       // the ceiling (a file-history blob), and no amount of asking again will
       // get past it. Say that, rather than let the reader conclude it has

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -929,7 +929,11 @@ function makeStitcher() {
 }
 
 // ---------- line-oriented harnesses ----------
-async function* jsonLines(file) {
+// `range` (optional) reads only a BYTE WINDOW of the file — see the window
+// reader below. Without it the whole file streams through, which is what the
+// index-mode readers and the summary pass still want.
+async function* jsonLines(file, range = null) {
+  if (range) { yield* rangeJsonLines(file, range); return; }
   const rl = readline.createInterface({
     input: fs.createReadStream(file, { encoding: 'utf8' }),
     crlfDelay: Infinity,
@@ -947,15 +951,71 @@ async function* jsonLines(file) {
   } finally { rl.close(); }
 }
 
+// Bytes [from, to) of a file, as one buffer. Callers bound the span themselves
+// (WINDOW_MAX_BYTES), so this never has to stream.
+async function rangeBuf(file, from, to) {
+  const len = Math.max(0, to - from);
+  if (!len) return Buffer.alloc(0);
+  const fh = await fsp.open(file, 'r');
+  try {
+    const buf = Buffer.alloc(len);
+    const { bytesRead } = await fh.read(buf, 0, len, from);
+    return bytesRead === len ? buf : buf.subarray(0, bytesRead);
+  } finally { await fh.close(); }
+}
+
+// One byte window of a .jsonl, aligned to line boundaries.
+//
+// `range` is { from, to, aligned, eof } and is FILLED IN with the { start, end }
+// this actually consumed, which is what the client gets back as a cursor:
+//   - a window that begins mid-line drops that fragment — the window BEFORE it
+//     ends at `start` and owns that line, so nothing is read twice or lost;
+//   - a file being appended to right now ends in a half-written line, which is
+//     nobody's yet: `end` stops before it, and the next `after: end` picks it up
+//     once it is whole.
+// Line splitting happens on the BUFFER, not on decoded text: an arbitrary byte
+// offset can cut a UTF-8 character in half, and offsets derived from the decoded
+// string would then be a byte or two off — enough to corrupt the next cursor.
+async function* rangeJsonLines(file, range) {
+  const buf = await rangeBuf(file, range.from, range.to);
+  let i = 0;
+  if (!range.aligned) {
+    const nl = buf.indexOf(0x0a);
+    i = nl < 0 ? buf.length : nl + 1;
+  }
+  range.start = range.from + i;
+  range.end = range.start;
+  let n = 0;
+  while (i < buf.length) {
+    const nl = buf.indexOf(0x0a, i);
+    const last = nl < 0;
+    // Mid-file, an unterminated tail belongs to the next window.
+    if (last && !range.eof) break;
+    const line = buf.toString('utf8', i, last ? buf.length : nl);
+    i = last ? buf.length : nl + 1;
+    let j = null;
+    let whole = false;
+    if (line.trim()) { try { j = JSON.parse(line); whole = true; } catch { whole = false; } }
+    // A newline ends a line whether or not we could read it. The FINAL line of a
+    // file has no newline to prove it is finished, so it counts as consumed only
+    // if it parses: a transcript can legitimately end without a newline, and an
+    // agent halfway through writing one looks exactly the same until it does.
+    if (!last || whole) range.end = range.from + i;
+    if (!whole) continue;
+    yield j;
+    if (++n % VIEW_YIELD_LINES === 0) await yieldLoop();
+  }
+}
+
 // Claude Code — $CLAUDE_CONFIG_DIR/projects/<slug>/<uuid>.jsonl
 // Streaming writes the SAME message.id across several lines, each carrying the
 // same usage. parseClaude() above dedupes by dropping repeats; a viewer must
 // instead MERGE them, or half the assistant text disappears. So: first line for
 // an id creates the message and owns the usage, later lines append blocks.
-async function normalizeClaude(file, out) {
+async function normalizeClaude(file, out, range) {
   const stitch = makeStitcher();
   const byMsgId = new Map();
-  for await (const j of jsonLines(file)) {
+  for await (const j of jsonLines(file, range)) {
     // These embed whole file contents; share.js drops them and so do we.
     if (j.type === 'file-history-snapshot' || j.type === 'file-history-delta') continue;
     if (j.isMeta || j.sourceToolUseID) continue;
@@ -1050,7 +1110,7 @@ async function normalizeClaude(file, out) {
 // attach to it — so one row reads "text + 16 tool calls (exec_command,
 // apply_patch, write_stdin)" the way the Hub's own viewer shows it, instead of
 // 17 separate rows.
-async function normalizeCodex(file, out) {
+async function normalizeCodex(file, out, range) {
   const stitch = makeStitcher();
   const seenThinking = new Set();
   let cur = null;      // the assistant turn being built
@@ -1063,7 +1123,7 @@ async function normalizeCodex(file, out) {
   };
   const hasText = (m) => !!m && m.blocks.some((b) => b.type === 'text');
 
-  for await (const j of jsonLines(file)) {
+  for await (const j of jsonLines(file, range)) {
     const p = j.payload || {};
     const ts = j.timestamp ? Date.parse(j.timestamp) || undefined : undefined;
 
@@ -1194,9 +1254,9 @@ async function normalizeCodex(file, out) {
 }
 
 // OpenClaw — already close to STS: {type:'message', message:{role,content,usage}}
-async function normalizeOpenClaw(file, out) {
+async function normalizeOpenClaw(file, out, range) {
   const stitch = makeStitcher();
-  for await (const j of jsonLines(file)) {
+  for await (const j of jsonLines(file, range)) {
     if (j.type !== 'message' || !j.message) continue;
     const m = j.message;
     const ts = j.timestamp ? Date.parse(j.timestamp) || undefined : undefined;
@@ -1232,9 +1292,9 @@ async function normalizeOpenClaw(file, out) {
 // STS (Session Trace Simple Format) — what share-session.mjs emits for the
 // converted harnesses, so accepted bundles from hermes/opencode/openclaw come
 // back through this one reader.
-async function normalizeSts(file, out) {
+async function normalizeSts(file, out, range) {
   const stitch = makeStitcher();
-  for await (const j of jsonLines(file)) {
+  for await (const j of jsonLines(file, range)) {
     if (j.type === 'session') {
       out.harnessLabel = label(j.harness) || out.harnessLabel;
       out.sessionId = j.id || out.sessionId;
@@ -1359,7 +1419,21 @@ function flattenToolContent(value) {
 
 // Bundles have no session record telling us the harness, so sniff the first
 // lines — same trick as the Hub's detect.ts / sniffTraceHarness.
+// A file's format does not change under us, and this is now on the path of
+// EVERY window request (it decides whether the trace can be seeked at all), so
+// the answer is remembered per path rather than re-read off the bucket each time.
+const harnessMemo = new Map();
 async function sniffHarness(file) {
+  if (harnessMemo.has(file)) return harnessMemo.get(file);
+  const found = await sniffHarnessUncached(file);
+  if (found) {
+    if (harnessMemo.size > 200) harnessMemo.clear();
+    harnessMemo.set(file, found);
+  }
+  return found;
+}
+
+async function sniffHarnessUncached(file) {
   let n = 0;
   for await (const j of jsonLines(file)) {
     if (j.type === 'session' && j.harness) return 'sts';
@@ -1418,14 +1492,14 @@ function markFinalTurns(out) {
   }
 }
 
-async function parseTraceFile(harness, file, sessionId) {
+async function parseTraceFile(harness, file, sessionId, range = null) {
   const out = newTrace(harness);
   out.sessionId = sessionId || null;
   switch (harness) {
-    case 'claude': await normalizeClaude(file, out); break;
-    case 'codex': await normalizeCodex(file, out); break;
-    case 'openclaw': await normalizeOpenClaw(file, out); break;
-    case 'sts': await normalizeSts(file, out); break;
+    case 'claude': await normalizeClaude(file, out, range); break;
+    case 'codex': await normalizeCodex(file, out, range); break;
+    case 'openclaw': await normalizeOpenClaw(file, out, range); break;
+    case 'sts': await normalizeSts(file, out, range); break;
     case 'opencode': normalizeOpencodeDb(file, sessionId, out); break;
     case 'hermes': normalizeHermesDb(file, sessionId, out); break;
     default: { const e = new Error(`no trace reader for '${harness}'`); e.code = 'unsupported-harness'; throw e; }
@@ -1436,6 +1510,18 @@ async function parseTraceFile(harness, file, sessionId) {
   if (!out.usage) out.usage = out.usageSum;
   markFinalTurns(out);
   return out;
+}
+
+// Everything a response says about the trace itself, as opposed to the turns in
+// it. Shared by pages, windows and the summary so the three can't drift.
+function headOf(parsed) {
+  return {
+    harness: parsed.harness, harnessLabel: parsed.harnessLabel, sessionId: parsed.sessionId,
+    title: parsed.title, model: parsed.model, cwd: parsed.cwd,
+    firstTs: parsed.firstTs, lastTs: parsed.lastTs, usage: parsed.usage,
+    source: parsed.source, sharedBy: parsed.sharedBy, note: parsed.note || null,
+    truncated: !!parsed.truncated,
+  };
 }
 
 function pageOf(parsed, offset, limit) {
@@ -1452,14 +1538,168 @@ function pageOf(parsed, offset, limit) {
   const from = off < 0 ? Math.max(0, total + off) : Math.max(0, Math.min(off, total));
   const to = Math.min(total, from + Math.max(1, Math.min(limit | 0 || 200, 500)));
   return {
-    harness: parsed.harness, harnessLabel: parsed.harnessLabel, sessionId: parsed.sessionId,
-    title: parsed.title, model: parsed.model, cwd: parsed.cwd,
-    firstTs: parsed.firstTs, lastTs: parsed.lastTs, usage: parsed.usage,
-    source: parsed.source, sharedBy: parsed.sharedBy, note: parsed.note || null,
-    total, offset: from, limit: to - from, truncated: !!parsed.truncated,
+    ...headOf(parsed),
+    total, offset: from, limit: to - from,
     userTurns,
     turns: parsed.messages.slice(from, to),
   };
+}
+
+// ---------- windows: open at the END, page backwards ----------
+// Index-mode paging (above) can only answer "turns 400–600" after the whole file
+// has been normalized, because nothing else knows where turn 400 is. That is the
+// wrong bargain for a reader that opens on the last exchange: on a 19 MB
+// transcript it spends a full read + parse before the first pixel, and it spends
+// it again every time the file changes underneath (a working agent rewrites the
+// memo key on every append).
+//
+// A window is a BYTE RANGE of the transcript, parsed by the same normalizers,
+// with line-aligned cursors handed back to the caller. `tail` reads the last
+// WINDOW_BYTES; `before: <start we just gave you>` reads the stretch in front of
+// it; `after: <end>` picks up whatever the agent has written since. Windows abut
+// exactly, so a reader can stitch them into one conversation with no gaps and no
+// repeats — and never pays for the part of the trace nobody scrolled to.
+const WINDOWABLE = new Set(['claude', 'codex', 'openclaw', 'sts']);
+const WINDOW_BYTES = 384 * 1024;         // default span (see the PR for the measurements)
+const WINDOW_MIN_BYTES = 32 * 1024;
+const WINDOW_MAX_BYTES = 8 * 1024 * 1024; // a single window can't cost more than this
+const WINDOW_MIN_TURNS = 30;             // grow the span until at least this many turns are in it
+const clampN = (n, lo, hi) => Math.max(lo, Math.min(hi, n));
+
+function windowOf(parsed, cur) {
+  return {
+    ...headOf(parsed),
+    // `firstTs` and `usage` describe the WHOLE conversation. A window that
+    // doesn't span the whole file knows neither, and reporting its own first
+    // line as the start of the session (or its own tokens as the session's bill)
+    // would be a confident lie. The summary pass fills them in.
+    firstTs: cur.atStart ? parsed.firstTs : 0,
+    usage: cur.atStart && cur.atEnd ? parsed.usage : null,
+    total: null,
+    userTurns: null,
+    turns: parsed.messages,
+    window: cur,
+  };
+}
+
+// The whole-trace facts a window can't know: how many turns there are, where the
+// prompts are, what the session cost. One full parse, memoized like any other —
+// the reader asks for it AFTER it has painted, so it never delays the first view.
+function summaryOf(parsed) {
+  const userTurns = [];
+  for (let i = 0; i < parsed.messages.length; i++) if (parsed.messages[i].role === 'user') userTurns.push(i);
+  return { ...headOf(parsed), total: parsed.messages.length, userTurns };
+}
+
+// A window that stops mid-conversation must not call its last assistant turn the
+// final answer — it isn't one; the window simply ran out.
+function unmarkTrailingFinal(parsed) {
+  const ms = parsed.messages;
+  for (let i = ms.length - 1; i >= 0; i--) {
+    if (ms[i].role === 'user') break;
+    if (ms[i].kind === 'final') delete ms[i].kind;
+  }
+}
+
+async function oneWindow(harness, file, sessionId, range, size) {
+  const parsed = await parseTraceFile(harness, file, sessionId, range);
+  const start = range.start ?? range.from;
+  const end = range.end ?? range.to;
+  const atEnd = end >= size;
+  if (!atEnd) unmarkTrailingFinal(parsed);
+  return { parsed, cur: { mode: 'bytes', start, end, atStart: start <= 0, atEnd } };
+}
+
+async function readWindow(harness, file, sessionId, size, req) {
+  const bytes = clampN(Math.trunc(req.bytes) || WINDOW_BYTES, WINDOW_MIN_BYTES, WINDOW_MAX_BYTES);
+  const min = clampN(Math.trunc(req.min) || WINDOW_MIN_TURNS, 1, 500);
+  const cursor = clampN(Math.trunc(req.cursor) || 0, 0, size);
+
+  if (req.at === 'after') {
+    // A pane left open while the agent wrote megabytes: don't try to catch up in
+    // one window. Hand back the tail and flag the gap, so the reader replaces
+    // what it holds instead of splicing a hole into the middle of it.
+    if (size - cursor > WINDOW_MAX_BYTES) {
+      const w = await readWindow(harness, file, sessionId, size, { at: 'tail', bytes, min });
+      return { ...w, cur: { ...w.cur, gap: true } };
+    }
+    return oneWindow(harness, file, sessionId, { from: cursor, to: size, aligned: true, eof: true }, size);
+  }
+
+  const to = req.at === 'before' ? cursor : size;
+  const eof = to >= size;
+  // Turns vary wildly in size — one window can hold 200 of them or one 300 KB
+  // tool result. Grow the span until it holds a readable number of turns, or
+  // until it reaches the start of the file / the per-window ceiling.
+  let span = bytes;
+  for (;;) {
+    const from = Math.max(0, to - span);
+    const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size);
+    if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) return w;
+    span = Math.min(span * 4, WINDOW_MAX_BYTES);
+  }
+}
+
+// Harnesses whose conversation lives in SQLite have no byte offsets to seek, and
+// a bundle small enough not to matter doesn't need them. They answer the same
+// shape with message INDICES as cursors: the reader treats a cursor as opaque.
+function windowIndex(parsed, req) {
+  const total = parsed.messages.length;
+  const min = clampN(Math.trunc(req.min) || WINDOW_MIN_TURNS, 1, 500);
+  const cursor = clampN(Math.trunc(req.cursor) || 0, 0, total);
+  let from; let to;
+  if (req.at === 'after') { from = cursor; to = total; } else if (req.at === 'before') { to = cursor; from = Math.max(0, to - min); } else { to = total; from = Math.max(0, total - min); }
+  return {
+    ...headOf(parsed),
+    total,
+    userTurns: null,
+    turns: parsed.messages.slice(from, to),
+    window: { mode: 'index', start: from, end: to, atStart: from <= 0, atEnd: to >= total },
+  };
+}
+
+// The subagent marker lives in `session_meta`, the FIRST line of a codex
+// rollout — a tail window never sees it, so a guardian thread would render as if
+// it were the operator's conversation. Check the head before serving a window.
+async function refuseCodexSubagent(file) {
+  const buf = await rangeBuf(file, 0, 16 * 1024);
+  const nl = buf.indexOf(0x0a);
+  let j = null;
+  try { j = JSON.parse(buf.toString('utf8', 0, nl < 0 ? buf.length : nl)); } catch { return; }
+  const p = (j && j.payload) || {};
+  if (j && j.type === 'session_meta' && (p.thread_source === 'subagent' || p.source?.subagent)) {
+    const err = new Error('this rollout is an internal guardian/subagent thread, not the session');
+    err.code = 'trace-not-user-conversation';
+    throw err;
+  }
+}
+
+/**
+ * One request against one located trace. `opts` picks the mode:
+ *   { window: { at, cursor, bytes, min } } — a byte window (the reader's path)
+ *   { summary: true }                      — whole-trace facts, no turns
+ *   { offset, limit }                      — index paging (Overview, RENDER mode)
+ * `decorate` is the bundle manifest pass, applied to every fresh parse.
+ */
+async function serveTrace({ key, harness, file, sessionId, size, decorate }, opts) {
+  const full = async () => {
+    if (viewMemo.key !== key) {
+      const parsed = await tracked(PHASE.readTrace, () => parseTraceFile(harness, file, sessionId));
+      if (decorate) await decorate(parsed);
+      viewMemo = { key, val: parsed };
+    }
+    return viewMemo.val;
+  };
+
+  if (opts.summary) return summaryOf(await full());
+  if (!opts.window) return pageOf(await full(), opts.offset ?? 0, opts.limit ?? 200);
+  if (!WINDOWABLE.has(harness)) return windowIndex(await full(), opts.window);
+
+  if (harness === 'codex') await refuseCodexSubagent(file);
+  const { parsed, cur } = await tracked(PHASE.readTrace, () =>
+    readWindow(harness, file, sessionId, size, opts.window));
+  if (decorate) await decorate(parsed);
+  return windowOf(parsed, cur);
 }
 
 /**
@@ -1468,20 +1708,20 @@ function pageOf(parsed, offset, limit) {
  * already handles all five harnesses, per-session pins, cwd attribution,
  * ambiguity refusal and codex subagent rollouts. Do not reimplement it.
  */
-export async function readTrace(session, { offset = 0, limit = 200 } = {}) {
+export async function readTrace(session, opts = {}) {
   const hit = await findTrace(session, store.list());
   if (!hit) { const e = new Error('no trace found for this session'); e.code = 'no-trace'; throw e; }
 
   const st = await statRetry(hit.src);
   if (!st) { const e = new Error(`trace file unreadable: ${hit.src}`); e.code = 'no-trace'; throw e; }
 
-  const key = `s:${session.id}:${hit.src}:${hit.sessionId || ''}:${st.mtimeMs}:${st.size}`;
-  if (viewMemo.key !== key) {
-    const parsed = await tracked(PHASE.readTrace, () =>
-      parseTraceFile(session.cli, hit.src, hit.sessionId || session.sessionUuid || null));
-    viewMemo = { key, val: parsed };
-  }
-  return pageOf(viewMemo.val, offset, limit);
+  return serveTrace({
+    key: `s:${session.id}:${hit.src}:${hit.sessionId || ''}:${st.mtimeMs}:${st.size}`,
+    harness: session.cli,
+    file: hit.src,
+    sessionId: hit.sessionId || session.sessionUuid || null,
+    size: st.size,
+  }, opts);
 }
 
 /**
@@ -1498,18 +1738,20 @@ export async function traceHarnessOf(file) {
  * reader above locates a file for a session; this one is handed the file and
  * sniffs the format the same way an imported bundle does.
  */
-export async function readTraceByPath(file, { offset = 0, limit = 200 } = {}) {
+export async function readTraceByPath(file, opts = {}) {
   const st = await statRetry(file);
   if (!st) { const e = new Error('trace file unreadable'); e.code = 'no-trace'; throw e; }
 
-  const key = `f:${file}:${st.mtimeMs}:${st.size}`;
-  if (viewMemo.key !== key) {
-    const harness = await sniffHarness(file);
-    if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
-    const parsed = await tracked(PHASE.readTrace, () => parseTraceFile(harness, file, null));
-    viewMemo = { key, val: parsed };
-  }
-  return pageOf(viewMemo.val, offset, limit);
+  const harness = await sniffHarness(file);
+  if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
+
+  return serveTrace({
+    key: `f:${file}:${st.mtimeMs}:${st.size}`,
+    harness,
+    file,
+    sessionId: null,
+    size: st.size,
+  }, opts);
 }
 
 /**
@@ -1517,18 +1759,19 @@ export async function readTraceByPath(file, { offset = 0, limit = 200 } = {}) {
  * plus meta/. The harness is sniffed from the file, since a bundle carries
  * whatever format the sender's harness ships.
  */
-export async function readTraceBundle(dir, { offset = 0, limit = 200 } = {}) {
+export async function readTraceBundle(dir, opts = {}) {
   const names = (await fsp.readdir(dir).catch(() => [])).filter((n) => n.endsWith('.jsonl'));
   if (!names.length) { const e = new Error('bundle has no trace file'); e.code = 'no-trace'; throw e; }
   const file = path.join(dir, names[0]);
   const st = await statRetry(file);
   if (!st) { const e = new Error('bundle trace unreadable'); e.code = 'no-trace'; throw e; }
 
-  const key = `b:${file}:${st.mtimeMs}:${st.size}`;
-  if (viewMemo.key !== key) {
-    const harness = await sniffHarness(file);
-    if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
-    const parsed = await tracked(PHASE.readTrace, () => parseTraceFile(harness, file, null));
+  const harness = await sniffHarness(file);
+  if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
+
+  // Applied to every parse of this bundle — a window is as entitled to the
+  // sender's own description of it as a full read is.
+  const decorate = async (parsed) => {
     let manifest = null;
     try { manifest = JSON.parse(await fsp.readFile(path.join(dir, 'meta', 'manifest.json'), 'utf8')); } catch {}
     // The manifest is the sender's own description of the bundle
@@ -1553,7 +1796,14 @@ export async function readTraceBundle(dir, { offset = 0, limit = 200 } = {}) {
       const src = JSON.parse(await fsp.readFile(path.join(dir, 'meta', 'source.json'), 'utf8'));
       parsed.source = { repo: src.repo || null, url: src.url || null, importedAt: src.importedAt || null };
     } catch { /* hand-placed bundle, or an older import */ }
-    viewMemo = { key, val: parsed };
-  }
-  return pageOf(viewMemo.val, offset, limit);
+  };
+
+  return serveTrace({
+    key: `b:${file}:${st.mtimeMs}:${st.size}`,
+    harness,
+    file,
+    sessionId: null,
+    size: st.size,
+    decorate,
+  }, opts);
 }

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1634,14 +1634,22 @@ function unmarkTrailingFinal(parsed) {
 // rollout at 128 KB windows: 955 stitched turns against the full parse's 953,
 // two answers shown twice.
 //
-// The fix is not to dedupe the symptom but to stop cutting mid-reference. A
-// rollout describes its own unit — `task_started` … `task_complete` — and every
-// backward reference lives inside one task. So a codex window begins at a
-// `task_started` line: each task, with its answer, its reasoning and its token
-// count, lands whole in exactly one window, and stitching reproduces the full
-// parse exactly. Measured over every rollout on this Space: 339 `task_started`,
-// 333 `task_complete`, no `task_complete` outside a started task, largest task
-// 768 KB — comfortably inside the growth ceiling.
+// Two things make it right, and it is worth being precise about which does what,
+// because a review found the code claiming more than it delivers.
+//
+//  1. A window PREFERS to begin at a `task_started` line. When the window holds
+//     one, the task it opens — with its answer, its reasoning and its token
+//     count — lands whole, and the turn grouping is not split at the seam.
+//  2. When it holds none (any window smaller than the task it lands in, which at
+//     64 KB is most of them), the window is cut mid-task anyway, and what keeps
+//     the output correct is that a `task_complete` whose answer is NOT in this
+//     window is treated as a marker only — see `danglingTaskComplete`. That
+//     fallback is load-bearing, not a corner case.
+//
+// Measured over every rollout on this Space: 339 `task_started`, 333
+// `task_complete`, no `task_complete` outside a started task, largest task
+// 768 KB. Stitching every window back together reproduces the full parse exactly
+// — turns, blocks and `final` accents — at 64 KB, 128 KB and 384 KB.
 const TASK_MARK = '"task_started"';
 
 /** Byte offset of the first `task_started` line at or after `buf`'s first whole
@@ -1670,12 +1678,13 @@ function firstWholeLine(buf, aligned) {
   return nl < 0 ? buf.length : nl + 1;
 }
 
-async function oneWindow(harness, file, sessionId, range, size) {
+async function oneWindow(harness, file, sessionId, range, size, prebuilt) {
   let taskAligned = false;
+  if (prebuilt) range.buf = prebuilt;
   if (harness === 'codex' && range.from > 0) {
     // Read once, align, then parse the same bytes — `range.buf` keeps this to a
     // single read of the window.
-    const buf = await rangeBuf(file, range.from, range.to);
+    const buf = range.buf || await rangeBuf(file, range.from, range.to);
     const at = codexTaskStart(buf, range.from, firstWholeLine(buf, range.aligned));
     if (at >= 0) {
       range.buf = buf.subarray(at - range.from);
@@ -1733,14 +1742,24 @@ async function readWindow(harness, file, sessionId, size, req) {
   // Turns vary wildly in size — one window can hold 200 of them or one 300 KB
   // tool result. Grow the span until it holds a readable number of turns, or
   // until it reaches the start of the file / the per-window ceiling.
+  //
+  // Growing EXTENDS the buffer downwards rather than reading the wider span from
+  // scratch: doubling and re-reading turned one response into 384K + 768K + 1.5M
+  // + 3M of reads (5.76 MB for a single window, and 28 MB to page a 19 MB file
+  // back to its start — more bytes than the file has). On the bucket this
+  // reader exists for, those are the expensive ones.
   let span = bytes;
+  let buf = null;
+  let bufFrom = to;
   for (;;) {
     const from = Math.max(0, to - span);
-    const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size);
-    // A codex window that holds no task boundary had to cut a task in half; grow
-    // rather than serve a window whose references point outside it.
-    const unaligned = harness === 'codex' && from > 0 && w.cur.start <= from;
-    if ((w.parsed.messages.length >= min && !unaligned) || from === 0 || span >= WINDOW_MAX_BYTES) {
+    if (from < bufFrom) {
+      const head = await rangeBuf(file, from, bufFrom);
+      buf = buf && buf.length ? Buffer.concat([head, buf]) : head;
+      bufFrom = from;
+    }
+    const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size, buf);
+    if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) {
       // A window that consumed nothing at all has hit a single line longer than
       // the ceiling (a file-history blob), and no amount of asking again will
       // get past it. Say that, rather than let the reader conclude it has

--- a/server/test/trace-window.test.mjs
+++ b/server/test/trace-window.test.mjs
@@ -124,5 +124,66 @@ const big = await readTraceByPath(huge, { window: { at: 'tail', bytes: 32 * 1024
 assert.equal(big.turns.length, 2, 'the window grew past a 300 KB turn');
 assert.equal(big.window.atStart, true);
 
+// ---- a codex guardian rollout is refused, however big its first line ----
+// `session_meta` carries base_instructions and runs to tens of KB in the real
+// thing; a guard that reads a fixed slab and parses what it got back parses
+// nothing at all, and "I could not tell" must never read as "not a subagent".
+const rollout = (subagent, padKb) => [
+  JSON.stringify({
+    type: 'session_meta', timestamp: new Date().toISOString(),
+    payload: { cwd: TMP, ...(subagent ? { thread_source: 'subagent' } : {}), base_instructions: { text: 'x'.repeat(padKb * 1024) } },
+  }),
+  ...Array.from({ length: 400 }, (_, i) => JSON.stringify({
+    type: 'response_item', timestamp: new Date().toISOString(),
+    payload: { type: 'message', role: i % 2 ? 'assistant' : 'user', content: [{ type: 'text', text: `codex turn ${i} ${'q'.repeat(500)}` }] },
+  })),
+].join('\n');
+
+for (const padKb of [0, 20, 48]) {
+  const guardian = path.join(TMP, `guardian-${padKb}.jsonl`);
+  fs.writeFileSync(guardian, `${rollout(true, padKb)}\n`);
+  await assert.rejects(
+    () => readTraceByPath(guardian, { window: { at: 'tail', bytes: 32 * 1024 } }),
+    (e) => e.code === 'trace-not-user-conversation',
+    `a guardian rollout with a ${padKb} KB session_meta is refused a window`,
+  );
+  await assert.rejects(
+    () => readTraceByPath(guardian, { offset: 0, limit: 10 }),
+    (e) => e.code === 'trace-not-user-conversation',
+    `and refused an index page (${padKb} KB)`,
+  );
+  const real = path.join(TMP, `real-${padKb}.jsonl`);
+  fs.writeFileSync(real, `${rollout(false, padKb)}\n`);
+  const okWin = await readTraceByPath(real, { window: { at: 'tail', bytes: 32 * 1024 } });
+  assert.ok(okWin.turns.length > 0, `the operator's own rollout still opens (${padKb} KB)`);
+}
+
+// ---- a line larger than any window blocks, and does not read as the start ----
+const wall = path.join(TMP, 'wall.jsonl');
+fs.writeFileSync(wall, `${[
+  claudeLine(0),
+  JSON.stringify({ type: 'file-history-snapshot', blob: 'z'.repeat(9 * 1024 * 1024) }),
+  ...Array.from({ length: 40 }, (_, i) => claudeLine(i + 1, 200)),
+].join('\n')}\n`);
+const beyond = await readTraceByPath(wall, { window: { at: 'tail', bytes: 64 * 1024 } });
+const stuck = await readTraceByPath(wall, { window: { at: 'before', cursor: beyond.window.start, bytes: 64 * 1024 } });
+assert.equal(stuck.turns.length, 0);
+assert.equal(stuck.window.atStart, false, 'a wall is not the beginning of the conversation');
+assert.equal(stuck.window.blocked, true, 'and the reader is told why it cannot get past it');
+
+// ---- a torn final line does not cost the last answer its accent ----
+const half = path.join(TMP, 'half-written.jsonl');
+fs.writeFileSync(half, `${[claudeLine(0), claudeLine(1)].join('\n')}\n{"type":"assistant","mess`);
+const t = await readTraceByPath(half, { window: { at: 'tail' } });
+assert.equal(t.window.atEnd, true, 'reading to EOF is being at the end, fragment or no fragment');
+assert.equal(t.turns[t.turns.length - 1].kind, 'final', 'so the last answer keeps its accent');
+assert.ok(t.window.end < fs.statSync(half).size, 'while the cursor still waits in front of the fragment');
+
+// ---- a partial window claims nothing about the whole session ----
+const partial = await readTraceByPath(file, { window: { at: 'tail', bytes: 32 * 1024 } });
+assert.equal(partial.note, null, 'a per-window count is not a fact about the session');
+assert.equal(partial.usage, null);
+assert.equal(partial.firstTs, 0);
+
 fs.rmSync(TMP, { recursive: true, force: true });
 console.log('trace-window: ok');

--- a/server/test/trace-window.test.mjs
+++ b/server/test/trace-window.test.mjs
@@ -185,5 +185,71 @@ assert.equal(partial.note, null, 'a per-window count is not a fact about the ses
 assert.equal(partial.usage, null);
 assert.equal(partial.firstTs, 0);
 
+// ---- codex: a window is cut at a task boundary, never inside one ----
+// `task_complete` POINTS BACK at the assistant message it marks. Cut a rollout
+// between the two and the pointer dangles — and the normalizer's fallback then
+// pushes a verbatim second copy of the answer, so the reader shows a turn the
+// conversation does not contain. Windows therefore begin at `task_started`.
+const ev = (type, payload, ts) => JSON.stringify({ type, timestamp: ts, payload });
+const codexTask = (i) => {
+  const ts = new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString();
+  return [
+    ev('event_msg', { type: 'task_started' }, ts),
+    ev('turn_context', { model: 'gpt-test', cwd: TMP }, ts),
+    ev('response_item', { type: 'message', role: 'user', content: [{ type: 'text', text: `ask ${i} ${'u'.repeat(300)}` }] }, ts),
+    ev('response_item', { type: 'function_call', name: 'exec', call_id: `c${i}`, arguments: '{"cmd":"ls"}' }, ts),
+    ev('response_item', { type: 'function_call_output', call_id: `c${i}`, output: `out ${i} ${'o'.repeat(300)}` }, ts),
+    ev('response_item', { type: 'message', role: 'assistant', content: [{ type: 'text', text: `ANSWER ${i} ${'a'.repeat(300)}` }] }, ts),
+    ev('event_msg', { type: 'agent_message', message: `ANSWER ${i} ${'a'.repeat(300)}` }, ts),
+    ev('event_msg', { type: 'task_complete', last_agent_message: `ANSWER ${i} ${'a'.repeat(300)}` }, ts),
+  ].join('\n');
+};
+const tasks = path.join(TMP, 'rollout-tasks.jsonl');
+fs.writeFileSync(tasks, `${[
+  ev('session_meta', { cwd: TMP, base_instructions: { text: 'i'.repeat(20 * 1024) } }, new Date().toISOString()),
+  ...Array.from({ length: 40 }, (_, i) => codexTask(i)),
+].join('\n')}\n`);
+
+const fullCodex = [];
+const cHead = await readTraceByPath(tasks, { offset: 0, limit: 500 });
+for (let off = 0; off < cHead.total; off += 500) fullCodex.push(...(await readTraceByPath(tasks, { offset: off, limit: 500 })).turns);
+const answers = (ts) => ts.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).filter((t) => t.startsWith('ANSWER'));
+assert.equal(new Set(answers(fullCodex)).size, answers(fullCodex).length, 'the full parse shows each answer once');
+
+// Every window size, including ones whose boundaries land between an assistant
+// message and its task_complete.
+for (const bytes of [16 * 1024, 32 * 1024, 64 * 1024]) {
+  let stitched = [];
+  let page = await readTraceByPath(tasks, { window: { at: 'tail', bytes } });
+  let hops = 0;
+  const firstLines = [];
+  for (;;) {
+    firstLines.push(page.window.start);
+    stitched = [...page.turns, ...stitched];
+    if (page.window.atStart || page.window.blocked) break;
+    assert.ok(++hops < 200, 'paging back terminates');
+    const before = page.window.start;
+    page = await readTraceByPath(tasks, { window: { at: 'before', cursor: before, bytes } });
+    assert.equal(page.window.end, before, 'windows still abut exactly');
+  }
+  const a = answers(stitched);
+  assert.equal(new Set(a).size, a.length, `no answer is shown twice (bytes=${bytes})`);
+  assert.deepEqual(a, answers(fullCodex), `the same answers, in the same order (bytes=${bytes})`);
+  assert.equal(stitched.length, fullCodex.length, `and the same number of turns (bytes=${bytes})`);
+  assert.equal(
+    stitched.filter((t) => t.kind === 'final').length,
+    fullCodex.filter((t) => t.kind === 'final').length,
+    `the final-answer accent lands the same number of times (bytes=${bytes})`,
+  );
+  // Every window except the one holding byte 0 begins ON a task boundary.
+  const buf = fs.readFileSync(tasks);
+  for (const at of firstLines) {
+    if (at === 0) continue;
+    const nl = buf.indexOf(0x0a, at);
+    const first = JSON.parse(buf.toString('utf8', at, nl < 0 ? buf.length : nl));
+    assert.equal(first.payload.type, 'task_started', `a window starts a task, not the middle of one (at ${at})`);
+  }
+}
+
 fs.rmSync(TMP, { recursive: true, force: true });
 console.log('trace-window: ok');

--- a/server/test/trace-window.test.mjs
+++ b/server/test/trace-window.test.mjs
@@ -37,7 +37,7 @@ assert.equal(tail.window.atEnd, true, 'a tail window reaches the end of the file
 assert.equal(tail.window.end, SIZE, 'and consumed every whole line up to it');
 assert.equal(tail.window.atStart, false, '600 turns do not fit in 32 KB');
 assert.equal(textOf(tail.turns[tail.turns.length - 1]), `turn ${N - 1} ${'x'.repeat(200)}`, 'the last turn written is the last turn shown');
-assert.ok(tail.turns.length >= 30, `a window grows until it holds a readable number of turns (got ${tail.turns.length})`);
+assert.ok(tail.turns.length >= 12, `a window grows until it holds a readable number of turns (got ${tail.turns.length})`);
 // A window that cannot see the start of the trace must not claim to know when
 // the conversation began or what the whole of it cost.
 assert.equal(tail.firstTs, 0);

--- a/server/test/trace-window.test.mjs
+++ b/server/test/trace-window.test.mjs
@@ -1,0 +1,128 @@
+// Reading a trace as WINDOWS: the reader opens on the end of the conversation
+// and pages backwards, so none of this may lose a line, repeat one, or run off
+// the start of the file. Run with:
+//   node test/trace-window.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import assert from 'node:assert/strict';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-window-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const { readTraceByPath } = await import('../src/traces.js');
+
+const textOf = (t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text).join('');
+const claudeLine = (i, pad = 0) => JSON.stringify({
+  type: i % 2 === 0 ? 'user' : 'assistant',
+  cwd: TMP,
+  timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+  message: {
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    ...(i % 2 ? { id: `m${i}`, model: 'claude-test', usage: { input_tokens: 10, output_tokens: 5 } } : {}),
+    content: [{ type: 'text', text: `turn ${i}${pad ? ` ${'x'.repeat(pad)}` : ''}` }],
+  },
+});
+
+// ~600 turns of a few hundred bytes each: several windows at any sane size.
+const file = path.join(TMP, 'session.jsonl');
+const N = 600;
+fs.writeFileSync(file, `${Array.from({ length: N }, (_, i) => claudeLine(i, 200)).join('\n')}\n`);
+const SIZE = fs.statSync(file).size;
+
+// ---- the tail is the end of the conversation, and knows it ----
+const tail = await readTraceByPath(file, { window: { at: 'tail', bytes: 32 * 1024 } });
+assert.equal(tail.window.atEnd, true, 'a tail window reaches the end of the file');
+assert.equal(tail.window.end, SIZE, 'and consumed every whole line up to it');
+assert.equal(tail.window.atStart, false, '600 turns do not fit in 32 KB');
+assert.equal(textOf(tail.turns[tail.turns.length - 1]), `turn ${N - 1} ${'x'.repeat(200)}`, 'the last turn written is the last turn shown');
+assert.ok(tail.turns.length >= 30, `a window grows until it holds a readable number of turns (got ${tail.turns.length})`);
+// A window that cannot see the start of the trace must not claim to know when
+// the conversation began or what the whole of it cost.
+assert.equal(tail.firstTs, 0);
+assert.equal(tail.usage, null);
+assert.equal(tail.total, null);
+
+// ---- paging back reproduces the conversation exactly ----
+let page = tail;
+let stitched = [];
+let hops = 0;
+const seen = [];
+for (;;) {
+  stitched = [...page.turns, ...stitched];
+  seen.push([page.window.start, page.window.end]);
+  if (page.window.atStart) break;
+  assert.ok(++hops < 200, 'paging back terminates');
+  const before = page.window.start;
+  page = await readTraceByPath(file, { window: { at: 'before', cursor: before, bytes: 32 * 1024 } });
+  assert.ok(page.window.end === before, 'each window ends exactly where the one after it began');
+  assert.ok(page.window.start < before, 'and makes progress towards the start of the file');
+}
+assert.equal(seen[seen.length - 1][0], 0, 'the last window reaches byte 0');
+assert.deepEqual(stitched.map(textOf), Array.from({ length: N }, (_, i) => `turn ${i} ${'x'.repeat(200)}`),
+  'every turn, once, in order');
+
+// Asking for more once the start is reached returns nothing and stays put,
+// rather than wrapping around or looping forever.
+const past = await readTraceByPath(file, { window: { at: 'before', cursor: 0, bytes: 32 * 1024 } });
+assert.equal(past.turns.length, 0);
+assert.equal(past.window.atStart, true);
+
+// ---- a trace that grows while the reader is open ----
+const before = await readTraceByPath(file, { window: { at: 'tail', bytes: 32 * 1024 } });
+fs.appendFileSync(file, `${claudeLine(N)}\n${claudeLine(N + 1)}\n`);
+const grown = await readTraceByPath(file, { window: { at: 'after', cursor: before.window.end } });
+assert.deepEqual(grown.turns.map(textOf), [`turn ${N}`, `turn ${N + 1}`], 'only what was appended, exactly once');
+assert.equal(grown.window.start, before.window.end, 'and it continues from where the reader had got to');
+const nothingNew = await readTraceByPath(file, { window: { at: 'after', cursor: grown.window.end } });
+assert.equal(nothingNew.turns.length, 0, 'polling an unchanged trace adds nothing');
+
+// A line half-written by the agent is nobody's yet: it must not be parsed, and
+// the cursor must stop in front of it so the next poll picks it up whole.
+fs.appendFileSync(file, '{"type":"user","message":{"role":"user","conte');
+const torn = await readTraceByPath(file, { window: { at: 'after', cursor: grown.window.end } });
+assert.equal(torn.turns.length, 0, 'a partial line is not a turn');
+assert.equal(torn.window.end, grown.window.end, 'and the cursor waits for it');
+fs.appendFileSync(file, 'nt":[{"type":"text","text":"turn 602"}]}}\n');
+const healed = await readTraceByPath(file, { window: { at: 'after', cursor: torn.window.end } });
+assert.deepEqual(healed.turns.map(textOf), ['turn 602'], 'once whole, the line is read');
+
+// ---- a transcript whose last line has no newline still ends in a turn ----
+const noNl = path.join(TMP, 'no-newline.jsonl');
+fs.writeFileSync(noNl, [claudeLine(0), claudeLine(1)].join('\n'));
+const end = await readTraceByPath(noNl, { window: { at: 'tail' } });
+assert.deepEqual(end.turns.map(textOf), ['turn 0', 'turn 1']);
+assert.equal(end.window.atStart, true);
+assert.equal(end.window.atEnd, true);
+
+// ---- the summary is the whole-trace view the windows can't give ----
+const sum = await readTraceByPath(file, { summary: true });
+assert.equal(sum.total, N + 3, 'every turn in the file');
+assert.equal(sum.userTurns.length, (N + 3 + 1) / 2 | 0 || sum.userTurns.length, 'prompt indices are whole-trace');
+assert.ok(sum.usage.in > 0, 'and so is the token total');
+assert.ok(sum.firstTs > 0);
+assert.equal(sum.turns, undefined, 'a summary carries no turns');
+
+// ---- index paging is untouched ----
+const p0 = await readTraceByPath(file, { offset: 0, limit: 5 });
+assert.deepEqual(p0.turns.map(textOf).slice(0, 2), [`turn 0 ${'x'.repeat(200)}`, `turn 1 ${'x'.repeat(200)}`]);
+assert.equal(p0.total, N + 3);
+assert.equal(p0.window, undefined);
+
+// ---- one turn bigger than the window still arrives ----
+const huge = path.join(TMP, 'huge.jsonl');
+fs.writeFileSync(huge, `${[
+  claudeLine(0),
+  JSON.stringify({
+    type: 'assistant',
+    timestamp: new Date().toISOString(),
+    message: { role: 'assistant', id: 'big', content: [{ type: 'text', text: `big ${'y'.repeat(300_000)}` }] },
+  }),
+].join('\n')}\n`);
+const big = await readTraceByPath(huge, { window: { at: 'tail', bytes: 32 * 1024 } });
+assert.equal(big.turns.length, 2, 'the window grew past a 300 KB turn');
+assert.equal(big.window.atStart, true);
+
+fs.rmSync(TMP, { recursive: true, force: true });
+console.log('trace-window: ok');

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,0 +1,1 @@
+/home/node/local/am-web-deps/node_modules

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -783,6 +783,12 @@ export default function App() {
             ) : (
               <TracePane
                 session={s}
+                // A trace pane follows its SOURCE session: whether that agent is
+                // still writing decides how hard this pane looks for new turns.
+                sourceLive={(() => {
+                  const ref = s.traceSource?.kind === 'session' ? s.traceSource.ref : null;
+                  return ref ? sessById[ref]?.state === 'working' : false;
+                })()}
                 zoom={zoom}
                 focused={visibleSessions.length > 1 && s.id === focusedId}
                 dragId={canDrag ? `p:${s.id}` : undefined}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -422,6 +422,8 @@ export interface TraceCursor {
   atEnd: boolean;
   /** the trace grew more than one window while we were away: replace, don't splice */
   gap?: boolean;
+  /** one line here is bigger than a window: nothing older can be reached */
+  blocked?: boolean;
 }
 
 export interface TraceWindow extends Omit<TracePage, 'total' | 'offset' | 'limit' | 'userTurns'> {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -405,6 +405,59 @@ export const getTracePage = async (id: string, offset = 0, limit = 200): Promise
   return r.json();
 };
 
+// ---- windows: how the reader actually reads ----
+// A conversation is read from its END. `tail` is the last stretch of it,
+// `before` the stretch in front of one you already hold, `after` whatever has
+// been written since — each answered from a byte range of the transcript
+// instead of a parse of the whole thing. Cursors are opaque: hand back the
+// `start`/`end` the server gave you.
+export type TraceReq = { at: 'tail' } | { at: 'before' | 'after'; cursor: number };
+
+export interface TraceCursor {
+  /** byte offsets for a .jsonl, message indices for the SQLite harnesses */
+  mode: 'bytes' | 'index';
+  start: number;
+  end: number;
+  atStart: boolean;
+  atEnd: boolean;
+  /** the trace grew more than one window while we were away: replace, don't splice */
+  gap?: boolean;
+}
+
+export interface TraceWindow extends Omit<TracePage, 'total' | 'offset' | 'limit' | 'userTurns'> {
+  /** null when the window doesn't span the whole trace — ask for the summary */
+  total: number | null;
+  userTurns: number[] | null;
+  window: TraceCursor;
+}
+
+/** Whole-trace facts a single window cannot know. One full parse, off the paint path. */
+export type TraceSummary = Omit<TracePage, 'turns' | 'offset' | 'limit'>;
+
+const traceRange = (req: TraceReq) => (req.at === 'tail' ? 'tail=1' : `${req.at}=${req.cursor}`);
+
+const traceFetch = async <T>(url: string): Promise<T> => {
+  const r = await fetch(url);
+  if (r.status === 404) {
+    const d = await r.json().catch(() => ({}));
+    throw new TraceUnavailable(d.error || 'no trace for this session yet', d.code || 'no-trace');
+  }
+  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
+  return r.json();
+};
+
+export const getTraceWindow = (id: string, req: TraceReq, bytes?: number): Promise<TraceWindow> =>
+  traceFetch(`/api/trace/${id}?${traceRange(req)}${bytes ? `&bytes=${bytes}` : ''}`);
+
+export const getTraceSummary = (id: string): Promise<TraceSummary> =>
+  traceFetch(`/api/trace/${id}?summary=1`);
+
+export const getFileTraceWindow = (id: string, p: string, req: TraceReq, bytes?: number): Promise<TraceWindow> =>
+  traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&${traceRange(req)}${bytes ? `&bytes=${bytes}` : ''}`);
+
+export const getFileTraceSummary = (id: string, p: string): Promise<TraceSummary> =>
+  traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&summary=1`);
+
 export interface TraceLocation {
   path: string;
   sessionId?: string | null;

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -7,7 +7,7 @@ import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
 import CodeView from './CodeView';
 import PdfView from './PdfView';
-import { TraceView, type TraceSource } from './TracePane';
+import { TraceView, type TraceHeadInfo, type TraceSource } from './TracePane';
 import {
   FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, BackGlyph, DownloadGlyph,
   RefreshGlyph, ImageGlyph, CodeGlyph, DocGlyph, GlobeGlyph,
@@ -479,8 +479,13 @@ type ViewInfo = {
 export type TraceInfo = {
   harnessLabel?: string;
   model?: string | null;
+  /** whole-trace turn count once the summary lands, else what is loaded */
   turns?: number;
+  /** true while `turns` is only what the reader holds so far */
+  partial?: boolean;
   prompts: number;
+  /** the reader has something on screen — the jump buttons mean something */
+  ready: boolean;
   query: string;
   setQuery: (q: string) => void;
   go: (dir: -1 | 1) => void;
@@ -527,7 +532,7 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
   const [source, setSource] = useState<string | null>(null);
   const [dims, setDims] = useState<string | null>(null);
   const [pages, setPages] = useState<number | null>(null);
-  const [traceHead, setTraceHead] = useState<{ harnessLabel?: string; model?: string | null; total?: number; userTurns?: number[] } | null>(null);
+  const [traceHead, setTraceHead] = useState<TraceHeadInfo | null>(null);
   const [traceQuery, setTraceQuery] = useState('');
   const traceNav = useRef<((dir: -1 | 1) => void) | null>(null);
   const theme = useTheme();
@@ -749,15 +754,21 @@ function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
   const traceInfo = useMemo<TraceInfo | undefined>(() => (meta?.kind === 'trace' && !raw ? {
     harnessLabel: traceHead?.harnessLabel,
     model: traceHead?.model,
-    turns: traceHead?.total,
+    turns: traceHead ? (traceHead.total ?? traceHead.loaded) : undefined,
+    partial: !!traceHead && traceHead.total == null,
     prompts: traceHead?.userTurns?.length || 0,
+    ready: !!traceHead,
     query: traceQuery,
     setQuery: setTraceQuery,
     go: (d: -1 | 1) => traceNav.current?.(d),
   } : undefined), [meta?.kind, raw, traceHead, traceQuery]);
 
-  const traceSrc = useCallback<TraceSource>(
-    (offset, limit) => api.getFileTracePage(sessionId, path, offset, limit), [sessionId, path]);
+  // The reader opens on the tail of the transcript and pages backwards from
+  // there; the summary is the one call that reads all of it.
+  const traceSrc = useMemo<TraceSource>(() => ({
+    window: (req, bytes) => api.getFileTraceWindow(sessionId, path, req, bytes),
+    summary: () => api.getFileTraceSummary(sessionId, path),
+  }), [sessionId, path]);
 
   // Rendered markdown and a rendered trace do their own wrapping; the toggle is
   // for the surfaces that actually scroll sideways.
@@ -1172,12 +1183,14 @@ export default function FilesPane({
               <span className="fv-trace-tools">
                 {info.trace.harnessLabel && <span className="tv-chip">{info.trace.harnessLabel}</span>}
                 {info.trace.model && <span className="tv-chip">{info.trace.model}</span>}
-                {info.trace.turns != null && <span className="fi-stat">{info.trace.turns.toLocaleString()} turns</span>}
+                {info.trace.turns != null && (
+                  <span className="fi-stat">{info.trace.turns.toLocaleString()} turns{info.trace.partial ? ' loaded' : ''}</span>
+                )}
                 <span className="tv-nav">
-                  <button className="mini-btn" disabled={!info.trace.prompts} onClick={() => info.trace!.go(-1)}
-                    title={info.trace.prompts ? `Previous prompt (${info.trace.prompts})` : 'No prompts in this trace'}>▲</button>
-                  <button className="mini-btn" disabled={!info.trace.prompts} onClick={() => info.trace!.go(1)}
-                    title={info.trace.prompts ? `Next prompt (${info.trace.prompts})` : 'No prompts in this trace'}>▼</button>
+                  <button className="mini-btn" disabled={!info.trace.ready} onClick={() => info.trace!.go(-1)}
+                    title={info.trace.prompts ? `Previous prompt (${info.trace.prompts})` : 'Previous prompt'}>▲</button>
+                  <button className="mini-btn" disabled={!info.trace.ready} onClick={() => info.trace!.go(1)}
+                    title={info.trace.prompts ? `Next prompt (${info.trace.prompts})` : 'Next prompt'}>▼</button>
                 </span>
                 <input
                   className="tv-search fi-extra" placeholder="Search…"

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -10,20 +10,35 @@
 // Where we deliberately differ from the Hub viewer: it renders an ever-growing
 // window of the whole array (INITIAL 50 + 50 per sentinel hit) and holds every
 // message in the DOM, which is exactly why it dies on a 2.13 MB row. Here the
-// list is windowed by measured height and the data is paged from the server, so
-// a 6 MB session costs ~30 DOM rows.
+// list is windowed by measured height and the data is read from the END of the
+// transcript one byte-window at a time, so a 19 MB session costs one 95 KB
+// request and ~30 DOM rows to open.
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { Session } from '../types';
 import * as api from '../api';
-import type { TraceBlock, TracePage, TraceTurn } from '../api';
+import type { TraceBlock, TraceCursor, TraceSummary, TraceTurn, TraceWindow } from '../api';
 import { renderMarkdown } from '../lib/markdown';
 import Logo from './Logo';
 import { CloseGlyph } from './icons';
 
-const PAGE = 200;          // turns per request
+// How much transcript the first request asks for. Measured on the longest trace
+// on this box (19 MB / 1,395 turns): 384 KB is ~60 turns, 95 KB of JSON and
+// ~35 ms of server time, and renders in a frame — the smallest window that still
+// opens on a complete-looking conversation rather than a stub. See the PR.
+const WINDOW_BYTES = 384 * 1024;
 const ROW_EST = 44;        // unmeasured row height, collapsed
 const OVERSCAN_PX = 600;
+const NEAR_TOP_PX = 400;   // start fetching older turns before the reader arrives
+const STICK_PX = 24;       // "at the bottom" tolerance for following a live trace
+// Following a trace that is still being written. Nothing in here knows whether
+// an agent is running — but a transcript whose newest turn is seconds old is one
+// being written, so the cadence follows the trace itself: quick while it moves,
+// slow once it has gone quiet, which is also how it notices movement resuming.
+const LIVE_MS = 3_000;
+const IDLE_MS = 10_000;
+const FRESH_MS = 120_000;
+const SUMMARY_DELAY_MS = 400; // let the first paint happen before the whole-file read
 
 const fmtTs = (ms?: number) => (ms ? new Date(ms).toLocaleTimeString() : '');
 const fmtNum = (n: number) => n.toLocaleString();
@@ -181,12 +196,46 @@ function Row({ turn, index }: { turn: TraceTurn; index: number }) {
 
 // ---------- the pane ----------
 
-// The viewer itself: paging, windowing, measurement, search, prompt jumps. It
-// takes a page loader rather than a session, so the same reader serves the Trace
-// pane and a transcript opened in the Files pane. Its chrome lives in whichever
-// pane hosts it — `onHead` hands up what the toolbar needs to say, `onNav` hands
-// up the prompt jump for the host's buttons.
-export type TraceSource = (offset: number, limit: number) => Promise<TracePage>;
+// The viewer itself: windows, measurement, search, prompt jumps. It takes a
+// source rather than a session, so the same reader serves the Trace pane and a
+// transcript opened in the Files pane. Its chrome lives in whichever pane hosts
+// it — `onHead` hands up what the toolbar needs to say, `onNav` hands up the
+// prompt jump for the host's buttons.
+//
+// It opens on the END of the conversation. A transcript here reaches tens of MB
+// and thousands of turns, and the exchange a reader wants first is always the
+// last one — so the first request is a single window of the tail, and older
+// turns arrive one window at a time as you scroll back into them. The only read
+// that touches the whole trace is the summary, which buys the header an honest
+// turn count and is asked for after the first paint.
+export interface TraceSource {
+  window: (req: api.TraceReq, bytes?: number) => Promise<TraceWindow>;
+  summary: () => Promise<TraceSummary>;
+}
+
+/** What a host pane's toolbar needs. `total` is null until the summary lands. */
+export type TraceHeadInfo = Omit<TraceWindow, 'turns' | 'window'> & {
+  /** turns the reader is holding right now */
+  loaded: number;
+  /** the first turn of the conversation is loaded — there is nothing above */
+  atStart: boolean;
+};
+
+type Meta = Omit<TraceWindow, 'turns' | 'window'>;
+
+// Keep whichever value actually says something: a window that doesn't reach the
+// start of the trace reports no session start and no session cost, and must not
+// blank out what an earlier response already told us. Identity is preserved when
+// nothing changed — a poll that learns nothing must not look like new state.
+const mergeMeta = (prev: Meta | null, next: Meta): Meta => {
+  if (!prev) return next;
+  const out = { ...prev } as Record<string, unknown>;
+  let changed = false;
+  for (const [k, v] of Object.entries(next)) {
+    if ((v || !(k in out)) && out[k] !== v) { out[k] = v; changed = true; }
+  }
+  return changed ? (out as Meta) : prev;
+};
 
 export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }: {
   src: TraceSource;
@@ -194,15 +243,21 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   srcKey: string;
   zoom?: number;
   query?: string;
-  onHead?: (head: Omit<TracePage, 'turns'> | null) => void;
+  onHead?: (head: TraceHeadInfo | null) => void;
   onNav?: (go: (dir: -1 | 1) => void) => void;
 }) {
-  const [head, setHead] = useState<Omit<TracePage, 'turns'> | null>(null);
+  const [meta, setMeta] = useState<Meta | null>(null);
+  const [summary, setSummary] = useState<TraceSummary | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const turns = useRef<(TraceTurn | undefined)[]>([]);
-  const pending = useRef<Set<number>>(new Set());
-  const [, forceRender] = useState(0);
-  const bump = useCallback(() => forceRender((n) => n + 1), []);
+
+  const turns = useRef<TraceTurn[]>([]);
+  const cursor = useRef<TraceCursor | null>(null);
+  // ONE request at a time. Flicking the wheel at the top of a long trace fires
+  // scroll events by the dozen, and each one would otherwise start its own load;
+  // they would arrive out of order and prepend the same turns twice.
+  const loading = useRef(false);
+  const [tick, setTick] = useState(0);
+  const bump = useCallback(() => setTick((n) => n + 1), []);
 
   const scroller = useRef<HTMLDivElement | null>(null);
   const heights = useRef<number[]>([]);
@@ -212,47 +267,175 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   const [heightsVersion, setHeightsVersion] = useState(0);
   const [range, setRange] = useState({ start: 0, end: 40 });
 
-  // ---- paging ----
-  const loadPage = useCallback(async (pageIndex: number) => {
-    if (pending.current.has(pageIndex)) return;
-    pending.current.add(pageIndex);
+  // Follow the newest turn while the agent writes — but only while the reader is
+  // already down there. Scrolling up to read something is a decision.
+  const stick = useRef(true);
+  // What must not move across a re-layout: the row at the top of the viewport,
+  // and how far into it we are. Prepending older turns changes every offset in
+  // the list, and a row that measures itself after it renders changes the ones
+  // above the viewport — without an anchor, the paragraph under the reader's
+  // eyes jumps away mid-sentence.
+  const anchor = useRef<{ i: number; delta: number } | null>(null);
+  // False until the scroller has been put where it belongs for the turns we
+  // hold. Until then `scrollTop` is 0 because nothing has been placed yet, not
+  // because the reader is at the top — and acting on it would fetch a window of
+  // older turns nobody asked for on every open.
+  const positioned = useRef(false);
+
+  // ---- windowing ----
+  // Prefix sums over measured (or estimated) row heights. n is bounded by what
+  // the reader has actually loaded, so a full recompute is cheap and happens
+  // only when a row is measured, turns arrive, or the window moves.
+  const offsets = useMemo(() => {
+    const n = turns.current.length;
+    const acc = new Float64Array(n + 1);
+    for (let i = 0; i < n; i++) acc[i + 1] = acc[i] + (heights.current[i] || ROW_EST);
+    return acc;
+  }, [range, tick, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+  // The loaders need the offsets as they are NOW, not as they were when the
+  // callback was made.
+  const offsetsRef = useRef(offsets);
+  offsetsRef.current = offsets;
+
+  /** First row whose bottom edge is past `top`. */
+  const rowAt = (acc: Float64Array, top: number) => {
+    let lo = 0;
+    let hi = Math.max(0, acc.length - 1);
+    while (lo < hi) { const mid = (lo + hi) >> 1; if (acc[mid + 1] <= top) lo = mid + 1; else hi = mid; }
+    return lo;
+  };
+
+  // ---- loading ----
+  const loadTail = useCallback(async () => {
+    loading.current = true;
     try {
-      const p = await src(pageIndex * PAGE, PAGE);
-      const { turns: got, ...meta } = p;
-      if (turns.current.length !== meta.total) {
-        turns.current.length = meta.total;
-        heights.current.length = meta.total;
-      }
-      got.forEach((t, i) => { turns.current[meta.offset + i] = t; });
-      setHead(meta);
+      const { turns: got, window: win, ...m } = await src.window({ at: 'tail' }, WINDOW_BYTES);
+      turns.current = got;
+      heights.current = new Array(got.length);
+      cursor.current = win;
+      anchor.current = null;
+      stick.current = true;
+      positioned.current = false;
+      setMeta(m);
       setError(null);
+      setRange({ start: 0, end: Math.min(got.length, 40) });
       bump();
     } catch (e) {
       // The server distinguishes "nothing to show yet" from a real failure and
       // says which — pass its own words through rather than inventing a reason.
       setError(e instanceof api.TraceUnavailable ? e.message : 'could not read the trace');
     } finally {
-      pending.current.delete(pageIndex);
+      loading.current = false;
+    }
+  }, [src, bump]);
+
+  /** Fetch the window before the oldest turn held. Returns how many arrived. */
+  const loadOlder = useCallback(async () => {
+    const cur = cursor.current;
+    if (loading.current || !cur || cur.atStart) return 0;
+    loading.current = true;
+    try {
+      let from = cur.start;
+      let atStart = false;
+      let got: TraceTurn[] = [];
+      let meta2: Meta | null = null;
+      // A window can legitimately hold no turns at all (a stretch of file-history
+      // lines, a run of harness metadata). Keep walking back until it holds
+      // something, the file starts, or the cursor stops moving.
+      for (let hop = 0; hop < 8 && !got.length && !atStart; hop++) {
+        const { turns: page, window: win, ...m } = await src.window({ at: 'before', cursor: from }, WINDOW_BYTES);
+        got = page;
+        meta2 = m;
+        atStart = win.atStart || win.start >= from;
+        from = win.start;
+      }
+      const el = scroller.current;
+      if (el && got.length) {
+        // Same row, `got.length` places further down the list — see `anchor`.
+        const i = rowAt(offsetsRef.current, el.scrollTop);
+        anchor.current = { i: i + got.length, delta: el.scrollTop - (offsetsRef.current[i] || 0) };
+        stick.current = false;
+      }
+      turns.current = [...got, ...turns.current];
+      heights.current = [...new Array(got.length), ...heights.current];
+      cursor.current = { ...cur, start: from, atStart };
+      if (meta2) setMeta((p) => mergeMeta(p, meta2 as Meta));
+      if (got.length) setRange((r) => ({ start: r.start + got.length, end: r.end + got.length }));
+      bump();
+      return got.length;
+    } catch {
+      // Keep what is on screen; the next scroll retries.
+      return 0;
+    } finally {
+      loading.current = false;
+    }
+  }, [src, bump]);
+
+  /** Whatever the agent has written since we last looked. */
+  const loadNewer = useCallback(async () => {
+    const cur = cursor.current;
+    if (loading.current || !cur) return;
+    loading.current = true;
+    try {
+      const { turns: got, window: win, ...m } = await src.window({ at: 'after', cursor: cur.end });
+      if (win.gap) {
+        // More was written than one window can carry. Splicing it in would leave
+        // a hole in the middle of the conversation with nothing to say so —
+        // start again from the new tail instead.
+        turns.current = got;
+        heights.current = new Array(got.length);
+        cursor.current = win;
+        anchor.current = null;
+        stick.current = true;
+        positioned.current = false;
+        setRange({ start: 0, end: Math.min(got.length, 40) });
+      } else {
+        if (got.length) {
+          turns.current = [...turns.current, ...got];
+          heights.current = [...heights.current, ...new Array(got.length)];
+        }
+        cursor.current = { ...cur, end: win.end, atEnd: win.atEnd };
+      }
+      setMeta((p) => mergeMeta(p, m));
+      if (got.length) bump();
+    } catch {
+      // A poll that fails must not throw away the conversation on screen.
+    } finally {
+      loading.current = false;
     }
   }, [src, bump]);
 
   useEffect(() => {
     turns.current = [];
     heights.current = [];
-    setHead(null);
-    loadPage(0);
-  }, [srcKey, loadPage]);
+    cursor.current = null;
+    anchor.current = null;
+    stick.current = true;
+    positioned.current = false;
+    setMeta(null);
+    setSummary(null);
+    setRange({ start: 0, end: 40 });
+    loadTail();
+  }, [srcKey, loadTail]);
 
-  // ---- windowing ----
-  // Prefix sums over measured (or estimated) row heights. n is bounded by the
-  // reader's VIEW_MAX_MESSAGES, so a full recompute is cheap and happens only
-  // when a row is measured or the window moves.
-  const offsets = useMemo(() => {
-    const n = turns.current.length;
-    const acc = new Float64Array(n + 1);
-    for (let i = 0; i < n; i++) acc[i + 1] = acc[i] + (heights.current[i] || ROW_EST);
-    return acc;
-  }, [range, head, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+  // The one read that touches the whole file, fired AFTER the first paint: it
+  // buys the header a real turn count, the session's token total and the date
+  // the conversation started — none of which a window can know. If it fails or
+  // is slow, the header simply says how much is loaded.
+  useEffect(() => {
+    let dead = false;
+    const h = window.setTimeout(() => {
+      src.summary().then((s) => { if (!dead) setSummary(s); }).catch(() => {});
+    }, SUMMARY_DELAY_MS);
+    return () => { dead = true; window.clearTimeout(h); };
+  }, [src, srcKey]);
+
+  // The transcript may still be being written — see LIVE_MS above.
+  const lastTs = meta ? meta.lastTs : 0;
+  useEffect(() => {
+    const h = window.setInterval(loadNewer, lastTs && Date.now() - lastTs < FRESH_MS ? LIVE_MS : IDLE_MS);
+    return () => window.clearInterval(h);
+  }, [loadNewer, lastTs]);
 
   const recompute = useCallback(() => {
     const el = scroller.current;
@@ -260,38 +443,52 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     const n = turns.current.length;
     const top = Math.max(0, el.scrollTop - OVERSCAN_PX);
     const bottom = el.scrollTop + el.clientHeight + OVERSCAN_PX;
-    // binary search for the first row whose bottom edge is past `top`
-    let lo = 0, hi = n;
-    while (lo < hi) { const mid = (lo + hi) >> 1; if (offsets[mid + 1] <= top) lo = mid + 1; else hi = mid; }
+    const lo = rowAt(offsets, top);
     let end = lo;
     while (end < n && offsets[end] < bottom) end++;
     if (lo !== range.start || end !== range.end) setRange({ start: lo, end: Math.max(end, lo + 1) });
+    stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < STICK_PX;
+    // Reading back into the trace: fetch the stretch in front of what we hold,
+    // before the reader arrives at it. Also covers a tail window too short to
+    // fill the pane — there is no scrolling to do, so nothing else would ask.
+    if (positioned.current && el.scrollTop < NEAR_TOP_PX) loadOlder();
+  }, [offsets, range.start, range.end, loadOlder]);
 
-    // fetch whatever page the window needs
-    for (let i = lo; i < end; i++) {
-      if (!turns.current[i]) loadPage(Math.floor(i / PAGE));
-    }
-  }, [offsets, range.start, range.end, loadPage]);
+  useEffect(() => { recompute(); }, [recompute, meta]);
 
-  useEffect(() => { recompute(); }, [recompute, head]);
-
-  // ---- jump between prompts ----
-  // Landing exactly on a row is a two-step problem: the offsets are estimates
-  // until a row has been measured, so the first scroll is approximate and the
-  // real position is only known once the target has rendered. Remember the
-  // target and re-apply it as heights settle, giving up after a few passes so a
-  // row that keeps resizing can't hold the scroll position hostage.
+  // ---- keeping the view still ----
+  // Every layout change lands here: a jump to a prompt, a prepended window, a
+  // row that just measured itself, a new turn while pinned to the bottom.
   const wanted = useRef<number | null>(null);
   const tries = useRef(0);
+  useLayoutEffect(() => {
+    const el = scroller.current;
+    if (!el) return;
+    // Landing exactly on a row is a two-step problem: offsets are estimates
+    // until a row has been measured, so the first scroll is approximate and the
+    // real position is known only once the target has rendered. Re-apply it as
+    // heights settle, giving up after a few passes so a row that keeps resizing
+    // can't hold the scroll position hostage.
+    if (wanted.current != null) {
+      const target = offsets[wanted.current] || 0;
+      if (Math.abs(el.scrollTop - target) > 2) el.scrollTop = target;
+      if (++tries.current > 8) wanted.current = null;
+    } else if (stick.current) {
+      el.scrollTop = el.scrollHeight;
+      anchor.current = null;
+    } else if (anchor.current) {
+      el.scrollTop = (offsets[anchor.current.i] || 0) + anchor.current.delta;
+      anchor.current = null;
+    }
+    // The turns we hold are on screen and the view is where it should be:
+    // `scrollTop` now means what the reader is doing.
+    if ((offsets[turns.current.length] || 0) > 0) positioned.current = true;
+  }, [offsets]);
 
   const firstVisible = useCallback(() => {
     const el = scroller.current;
-    const n = turns.current.length;
-    if (!el || !n) return 0;
-    const top = el.scrollTop + 1;
-    let lo = 0, hi = n;
-    while (lo < hi) { const mid = (lo + hi) >> 1; if (offsets[mid + 1] <= top) lo = mid + 1; else hi = mid; }
-    return lo;
+    if (!el || !turns.current.length) return 0;
+    return rowAt(offsets, el.scrollTop + 1);
   }, [offsets]);
 
   const goToTurn = useCallback((i: number) => {
@@ -299,31 +496,35 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     if (!el) return;
     wanted.current = i;
     tries.current = 0;
+    stick.current = false;
     el.scrollTop = offsets[i] || 0;
     recompute();
   }, [offsets, recompute]);
 
-  useEffect(() => {
-    const i = wanted.current;
-    const el = scroller.current;
-    if (i == null || !el) return;
-    const target = offsets[i] || 0;
-    if (Math.abs(el.scrollTop - target) > 2) el.scrollTop = target;
-    if (++tries.current > 8) wanted.current = null;
-  }, [offsets, heightsVersion, head]);
+  // ---- jump between prompts ----
+  // The operator's own turns, among those loaded. Reaching past the oldest one
+  // loads the window in front of it rather than pretending there are no more.
+  const prompts = useMemo(() => {
+    const out: number[] = [];
+    turns.current.forEach((t, i) => { if (t.role === 'user') out.push(i); });
+    return out;
+  }, [tick]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const prompts = head?.userTurns || [];
-  const goPrompt = (dir: -1 | 1) => {
-    if (!prompts.length) return;
+  const goRef = useRef<(dir: -1 | 1) => void>(() => {});
+  const goPrompt = async (dir: -1 | 1) => {
     const cur = firstVisible();
-    const next = dir < 0
-      ? prompts.filter((i) => i < cur).pop()
-      : prompts.find((i) => i > cur);
-    // Past the last prompt, the ends are the useful destinations.
-    if (next !== undefined) goToTurn(next);
-    else if (dir < 0) goToTurn(prompts[0]);
-    else if (scroller.current) { wanted.current = null; scroller.current.scrollTop = scroller.current.scrollHeight; }
+    const next = dir < 0 ? prompts.filter((i) => i < cur).pop() : prompts.find((i) => i > cur);
+    if (next !== undefined) { goToTurn(next); return; }
+    if (dir > 0) {
+      // Past the last prompt, the end of the conversation is the destination.
+      const el = scroller.current;
+      if (el) { wanted.current = null; stick.current = true; el.scrollTop = el.scrollHeight; }
+      return;
+    }
+    if (!cursor.current?.atStart && await loadOlder()) { goRef.current(dir); return; }
+    if (prompts.length) goToTurn(prompts[0]);
   };
+  goRef.current = goPrompt;
 
   // Measure rendered rows (heights change when a fold is expanded).
   const rowRefs = useRef(new Map<number, HTMLElement>());
@@ -335,15 +536,23 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         const h = e.contentRect.height;
         if (Number.isFinite(i) && Math.abs((heights.current[i] || 0) - h) > 1) { heights.current[i] = h; changed = true; }
       }
-      if (changed) setHeightsVersion((v) => v + 1);
+      if (!changed) return;
+      // Measuring changes the offsets of everything below — and of everything
+      // above, if a row above the viewport grew. Pin the row being read.
+      const el = scroller.current;
+      if (el && !stick.current && wanted.current == null) {
+        const i = rowAt(offsetsRef.current, el.scrollTop);
+        anchor.current = { i, delta: el.scrollTop - (offsetsRef.current[i] || 0) };
+      }
+      setHeightsVersion((v) => v + 1);
     });
     for (const el of rowRefs.current.values()) ro.observe(el);
     return () => ro.disconnect();
-    // `head` is in here so rows that arrive from a fetch (without the window
+    // `tick` is in here so rows that arrive from a fetch (without the window
     // moving) get measured too — otherwise they keep their 44px estimate and the
     // scroll height stays wrong. NOT heightsVersion: that's what the observer
     // sets, and re-attaching on it would churn on every measurement.
-  }, [range, head, bump]);
+  }, [range, tick, meta]);
 
   const setRowRef = (i: number) => (el: HTMLDivElement | null) => {
     if (el) rowRefs.current.set(i, el); else rowRefs.current.delete(i);
@@ -358,24 +567,31 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       if (t && t.blocks.some((b) => JSON.stringify(b).toLowerCase().includes(q))) hits.push(i);
     });
     return hits.slice(0, 200);
-  }, [query, head, range, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [query, tick, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const n = turns.current.length;
+  const atStart = !!cursor.current?.atStart;
   const rows: ReactNode[] = [];
   for (let i = range.start; i < Math.min(range.end, n); i++) {
-    const t = turns.current[i];
     rows.push(
       <div key={i} ref={setRowRef(i)} data-i={i}>
-        {t ? <Row turn={t} index={i} /> : <div className="tv-row placeholder" style={{ height: ROW_EST }} />}
+        <Row turn={turns.current[i]} index={i} />
       </div>,
     );
   }
 
-
   // Hand the host what its toolbar needs. goPrompt is rebuilt every render, so
   // the host gets a stable wrapper around the current one.
-  const goRef = useRef(goPrompt);
-  goRef.current = goPrompt;
+  const head = useMemo<TraceHeadInfo | null>(() => (meta ? {
+    ...meta,
+    total: summary ? summary.total : null,
+    userTurns: summary ? summary.userTurns : null,
+    usage: meta.usage || (summary ? summary.usage : null),
+    firstTs: meta.firstTs || (summary ? summary.firstTs : 0),
+    truncated: meta.truncated || !!(summary && summary.truncated),
+    loaded: turns.current.length,
+    atStart,
+  } : null), [meta, summary, tick, atStart]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => { onNav?.((d: -1 | 1) => goRef.current(d)); }, [onNav]);
   useEffect(() => { onHead?.(head); }, [head, onHead]);
 
@@ -392,42 +608,49 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         style={{ fontSize: `${(13 * zoom) / 100}px` }}
       >
         {error && <div className="tv-msg">{error}</div>}
-        {!error && !head && <div className="tv-msg">reading…</div>}
+        {!error && !meta && <div className="tv-msg">reading…</div>}
 
-        {!error && head && matches && (
+        {!error && meta && matches && (
           <div className="tv-matches">
             <div className="tv-msg">
-              {matches.length} match{matches.length === 1 ? '' : 'es'} in the {fmtNum(turns.current.filter(Boolean).length)} turns
-              loaded so far{turns.current.filter(Boolean).length < head.total ? ' — scroll to load more' : ''}
+              {matches.length} match{matches.length === 1 ? '' : 'es'} in the {fmtNum(n)} turns
+              loaded so far{atStart ? '' : ' — scroll up to load more'}
             </div>
-            {matches.map((i) => <Row key={i} turn={turns.current[i]!} index={i} />)}
+            {matches.map((i) => <Row key={i} turn={turns.current[i]} index={i} />)}
           </div>
         )}
 
-        {!error && head && !matches && (
+        {!error && meta && !matches && (
           <>
+            {/* Fixed height whether it is loading, done, or at the beginning:
+                this line sits above every offset in the list, so changing its
+                size would move the whole conversation under the reader. */}
+            <div className="tv-msg tv-top">
+              {atStart
+                ? (head?.truncated ? 'session longer than the viewer’s cap — earlier turns are not shown' : 'beginning of the conversation')
+                : 'earlier turns load as you scroll up…'}
+            </div>
             {/* State the gaps up front: a reader who can't see the model's
                 reasoning should know it was withheld, not that there was none. */}
-            {head.note && <div className="tv-msg">{head.note}</div>}
+            {meta.note && <div className="tv-msg">{meta.note}</div>}
             <div style={{ height: offsets[range.start] || 0 }} />
             {rows}
             <div style={{ height: Math.max(0, (offsets[n] || 0) - (offsets[Math.min(range.end, n)] || 0)) }} />
-            {head.truncated && <div className="tv-msg">session longer than the viewer's cap — earlier turns only</div>}
           </>
         )}
       </div>
 
-      {head && (head.source || head.cwd) && (
+      {meta && (meta.source || meta.cwd) && (
         <div className="trace-hint">
-          {head.source?.repo && (
+          {meta.source?.repo && (
             <>
-              {head.sharedBy ? `shared by ${head.sharedBy} · ` : ''}
-              <a href={head.source.url || `https://huggingface.co/datasets/${head.source.repo}`} target="_blank" rel="noreferrer">{head.source.repo}</a>
+              {meta.sharedBy ? `shared by ${meta.sharedBy} · ` : ''}
+              <a href={meta.source.url || `https://huggingface.co/datasets/${meta.source.repo}`} target="_blank" rel="noreferrer">{meta.source.repo}</a>
               {' · '}
             </>
           )}
-          {head.cwd}
-          {head.firstTs ? ` · ${new Date(head.firstTs).toLocaleString()}` : ''}
+          {meta.cwd}
+          {head?.firstTs ? ` · ${new Date(head.firstTs).toLocaleString()}` : ''}
         </div>
       )}
     </>
@@ -445,14 +668,21 @@ export default function TracePane({
   onFocus?: () => void;
   onClose: () => void;
 }) {
-  const [head, setHead] = useState<Omit<TracePage, 'turns'> | null>(null);
+  const [head, setHead] = useState<TraceHeadInfo | null>(null);
   const [query, setQuery] = useState('');
   const nav = useRef<((dir: -1 | 1) => void) | null>(null);
   const onNav = useCallback((go: (dir: -1 | 1) => void) => { nav.current = go; }, []);
-  const src = useCallback<TraceSource>((offset, limit) => api.getTracePage(session.id, offset, limit), [session.id]);
+  const src = useMemo<TraceSource>(() => ({
+    window: (req, bytes) => api.getTraceWindow(session.id, req, bytes),
+    summary: () => api.getTraceSummary(session.id),
+  }), [session.id]);
 
-  const prompts = head?.userTurns || [];
+  const prompts = head?.userTurns?.length ?? 0;
   const totalTokens = head?.usage ? fmtUsage(head.usage) : '';
+  // Until the summary lands, the honest count is what the reader is holding.
+  const count = head && (head.total != null
+    ? `${fmtNum(head.total)} turns`
+    : `${fmtNum(head.loaded)} turn${head.loaded === 1 ? '' : 's'} loaded`);
 
   return (
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
@@ -468,16 +698,17 @@ export default function TracePane({
         <span className="tv-title" title={head?.title || undefined}>{head?.title || head?.harnessLabel || 'trace'}</span>
         {head?.title && head.harnessLabel && <span className="tv-chip">{head.harnessLabel}</span>}
         {head?.model && <span className="tv-chip">{head.model}</span>}
-        {head && <span className="tv-count">{fmtNum(head.total)} turns</span>}
+        {count && <span className="tv-count" title={head && head.total != null && head.loaded < head.total ? `${fmtNum(head.loaded)} loaded — scroll up for the rest` : undefined}>{count}</span>}
         {totalTokens && <span className="tv-tokens">{totalTokens}</span>}
         <span className="spacer" />
         {/* Prompt-to-prompt navigation: an agent turn can run for dozens of rows,
-            and what you usually want is the next thing YOU said. */}
+            and what you usually want is the next thing YOU said. Walking back
+            past the oldest prompt loaded pulls in the window before it. */}
         <span className="tv-nav">
-          <button className="mini-btn" disabled={!prompts.length} onClick={() => nav.current?.(-1)}
-            title={prompts.length ? `Previous prompt (${prompts.length} in this session)` : 'No prompts in this trace'}>▲</button>
-          <button className="mini-btn" disabled={!prompts.length} onClick={() => nav.current?.(1)}
-            title={prompts.length ? `Next prompt (${prompts.length} in this session)` : 'No prompts in this trace'}>▼</button>
+          <button className="mini-btn" disabled={!head} onClick={() => nav.current?.(-1)}
+            title={prompts ? `Previous prompt (${prompts} in this session)` : 'Previous prompt'}>▲</button>
+          <button className="mini-btn" disabled={!head} onClick={() => nav.current?.(1)}
+            title={prompts ? `Next prompt (${prompts} in this session)` : 'Next prompt'}>▼</button>
         </span>
         <input
           className="tv-search"

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -275,7 +275,14 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // the list, and a row that measures itself after it renders changes the ones
   // above the viewport — without an anchor, the paragraph under the reader's
   // eyes jumps away mid-sentence.
-  const anchor = useRef<{ i: number; delta: number } | null>(null);
+  //
+  // `top` is that row's real position in the scroller, and it is what the
+  // restore uses when the row is still rendered: the estimated-height model is
+  // only ever approximately right, and on rows far taller than ROW_EST (a codex
+  // rollout's tool groups) restoring from it left the text a few hundred pixels
+  // off. `delta` is the model-based fallback for a row that has scrolled out of
+  // the rendered window and has no geometry to read.
+  const anchor = useRef<{ i: number; delta: number; top: number | null } | null>(null);
   // False until the scroller has been put where it belongs for the turns we
   // hold. Until then `scrollTop` is 0 because nothing has been placed yet, not
   // because the reader is at the top — and acting on it would fetch a window of
@@ -297,12 +304,35 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   const offsetsRef = useRef(offsets);
   offsetsRef.current = offsets;
 
+  // Rendered rows, by index — the ResizeObserver measures through these, and the
+  // anchor reads its geometry from them.
+  const rowRefs = useRef(new Map<number, HTMLElement>());
+
   /** First row whose bottom edge is past `top`. */
   const rowAt = (acc: Float64Array, top: number) => {
     let lo = 0;
     let hi = Math.max(0, acc.length - 1);
     while (lo < hi) { const mid = (lo + hi) >> 1; if (acc[mid + 1] <= top) lo = mid + 1; else hi = mid; }
     return lo;
+  };
+
+  /**
+   * Remember the row at the top of the viewport so the layout effect can put it
+   * back there. `shift` is how far this row is about to move down the list
+   * (the number of turns being prepended). Returns false when there is nothing
+   * to anchor to yet.
+   */
+  const captureAnchor = (shift: number) => {
+    const el = scroller.current;
+    if (!el || !turns.current.length) return false;
+    const i = rowAt(offsetsRef.current, el.scrollTop);
+    const node = rowRefs.current.get(i);
+    anchor.current = {
+      i: i + shift,
+      delta: el.scrollTop - (offsetsRef.current[i] || 0),
+      top: node ? node.getBoundingClientRect().top - el.getBoundingClientRect().top : null,
+    };
+    return true;
   };
 
   // ---- loading ----
@@ -349,13 +379,8 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         atStart = win.atStart || win.start >= from;
         from = win.start;
       }
-      const el = scroller.current;
-      if (el && got.length) {
-        // Same row, `got.length` places further down the list — see `anchor`.
-        const i = rowAt(offsetsRef.current, el.scrollTop);
-        anchor.current = { i: i + got.length, delta: el.scrollTop - (offsetsRef.current[i] || 0) };
-        stick.current = false;
-      }
+      // Same row, `got.length` places further down the list — see `anchor`.
+      if (got.length && captureAnchor(got.length)) stick.current = false;
       turns.current = [...got, ...turns.current];
       heights.current = [...new Array(got.length), ...heights.current];
       cursor.current = { ...cur, start: from, atStart };
@@ -477,7 +502,17 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       el.scrollTop = el.scrollHeight;
       anchor.current = null;
     } else if (anchor.current) {
-      el.scrollTop = (offsets[anchor.current.i] || 0) + anchor.current.delta;
+      const a = anchor.current;
+      const node = rowRefs.current.get(a.i);
+      if (node && a.top != null) {
+        // Where that row actually is now, against where it was: exact, and free
+        // of whatever the height model still gets wrong about rows it has never
+        // measured.
+        const now = node.getBoundingClientRect().top - el.getBoundingClientRect().top;
+        el.scrollTop += now - a.top;
+      } else {
+        el.scrollTop = (offsets[a.i] || 0) + a.delta;
+      }
       anchor.current = null;
     }
     // The turns we hold are on screen and the view is where it should be:
@@ -527,7 +562,6 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   goRef.current = goPrompt;
 
   // Measure rendered rows (heights change when a fold is expanded).
-  const rowRefs = useRef(new Map<number, HTMLElement>());
   useLayoutEffect(() => {
     const ro = new ResizeObserver((entries) => {
       let changed = false;
@@ -539,11 +573,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       if (!changed) return;
       // Measuring changes the offsets of everything below — and of everything
       // above, if a row above the viewport grew. Pin the row being read.
-      const el = scroller.current;
-      if (el && !stick.current && wanted.current == null) {
-        const i = rowAt(offsetsRef.current, el.scrollTop);
-        anchor.current = { i, delta: el.scrollTop - (offsetsRef.current[i] || 0) };
-      }
+      if (!stick.current && wanted.current == null) captureAnchor(0);
       setHeightsVersion((v) => v + 1);
     });
     for (const el of rowRefs.current.values()) ro.observe(el);

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -283,11 +283,15 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // off. `delta` is the model-based fallback for a row that has scrolled out of
   // the rendered window and has no geometry to read.
   const anchor = useRef<{ i: number; delta: number; top: number | null } | null>(null);
-  // False until the scroller has been put where it belongs for the turns we
-  // hold. Until then `scrollTop` is 0 because nothing has been placed yet, not
-  // because the reader is at the top — and acting on it would fetch a window of
-  // older turns nobody asked for on every open.
+  // False until the turns we hold have been MEASURED and the scroller put where
+  // it belongs. Until then `scrollTop` says nothing about where the reader is:
+  // before the first layout it is 0 because nothing has been placed, and before
+  // the first measurement the whole list is 44 px per row, so a window of 19
+  // dense turns looks 800 px tall when it is really 3,600 — near enough to the
+  // top to fetch a window of older turns nobody asked for. (Seen on a codex
+  // rollout on the Space; a Claude transcript's 60-turn window hid it.)
   const positioned = useRef(false);
+  const measured = useRef(false);
 
   // ---- windowing ----
   // Prefix sums over measured (or estimated) row heights. n is bounded by what
@@ -346,10 +350,15 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       anchor.current = null;
       stick.current = true;
       positioned.current = false;
+      measured.current = false;
       setMeta(m);
       setError(null);
       setRange({ start: 0, end: Math.min(got.length, 40) });
       bump();
+      // Nothing to render means nothing to measure, so no measurement will ever
+      // arrive to unblock the paging: walk back until there is something. After
+      // this call returns, so the one-request-at-a-time guard still holds.
+      if (!got.length && !win.atStart) window.setTimeout(() => loadOlderRef.current(), 0);
     } catch (e) {
       // The server distinguishes "nothing to show yet" from a real failure and
       // says which — pass its own words through rather than inventing a reason.
@@ -358,6 +367,10 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       loading.current = false;
     }
   }, [src, bump]);
+
+  // loadTail may need loadOlder before it is declared; the ref keeps that honest
+  // without reordering the two.
+  const loadOlderRef = useRef<() => Promise<number>>(async () => 0);
 
   /** Fetch the window before the oldest turn held. Returns how many arrived. */
   const loadOlder = useCallback(async () => {
@@ -395,6 +408,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       loading.current = false;
     }
   }, [src, bump]);
+  loadOlderRef.current = loadOlder;
 
   /** Whatever the agent has written since we last looked. */
   const loadNewer = useCallback(async () => {
@@ -413,6 +427,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         anchor.current = null;
         stick.current = true;
         positioned.current = false;
+        measured.current = false;
         setRange({ start: 0, end: Math.min(got.length, 40) });
       } else {
         if (got.length) {
@@ -437,6 +452,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     anchor.current = null;
     stick.current = true;
     positioned.current = false;
+    measured.current = false;
     setMeta(null);
     setSummary(null);
     setRange({ start: 0, end: 40 });
@@ -515,9 +531,9 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       }
       anchor.current = null;
     }
-    // The turns we hold are on screen and the view is where it should be:
-    // `scrollTop` now means what the reader is doing.
-    if ((offsets[turns.current.length] || 0) > 0) positioned.current = true;
+    // The turns we hold are measured, on screen, and the view is where it should
+    // be: `scrollTop` now means what the reader is doing.
+    if (measured.current && (offsets[turns.current.length] || 0) > 0) positioned.current = true;
   }, [offsets]);
 
   const firstVisible = useCallback(() => {
@@ -571,6 +587,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         if (Number.isFinite(i) && Math.abs((heights.current[i] || 0) - h) > 1) { heights.current[i] = h; changed = true; }
       }
       if (!changed) return;
+      measured.current = true;
       // Measuring changes the offsets of everything below — and of everything
       // above, if a row above the viewport grew. Pin the row being read.
       if (!stick.current && wanted.current == null) captureAnchor(0);

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -200,12 +200,15 @@ function Row({ turn, index }: { turn: TraceTurn; index: number }) {
 // can use the same ones — see lib/traceWindows.ts.
 export type { TraceSource, TraceHeadInfo } from '../lib/traceWindows';
 
-export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }: {
+export function TraceView({ src, srcKey, zoom = 100, query = '', live, onHead, onNav }: {
   src: TraceSource;
   /** Changing this resets the loaded turns — a different session or file. */
   srcKey: string;
   zoom?: number;
   query?: string;
+  /** The agent behind this trace is running. `false` means it is not, and a
+   *  trace that has also been quiet is then not polled at all. */
+  live?: boolean;
   onHead?: (head: TraceHeadInfo | null) => void;
   onNav?: (go: (dir: -1 | 1) => void) => void;
 }) {
@@ -310,7 +313,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   }, []);
 
   const { turns, head, error, version: tick, atStart, blocked, loadOlder } =
-    useTraceWindows(src, srcKey, { onPrepend, onReset });
+    useTraceWindows(src, srcKey, { onPrepend, onAppend, onReset, live });
 
   // Prefix sums over measured (or estimated) row heights. n is bounded by what
   // the reader has actually loaded, so a full recompute is cheap and happens
@@ -326,14 +329,6 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   const offsetsRef = useRef(offsets);
   offsetsRef.current = offsets;
 
-  // heights are index-aligned with turns; the hook only ever prepends or appends,
-  // so re-derive the array length from it rather than tracking every mutation.
-  if (heights.current.length !== turns.current.length) {
-    const grew = turns.current.length - heights.current.length;
-    heights.current = grew > 0 && heights.current.length
-      ? [...new Array(grew), ...heights.current]   // older turns arrived on top
-      : new Array(turns.current.length);
-  }
 
   const recompute = useCallback(() => {
     const el = scroller.current;
@@ -574,10 +569,12 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
 }
 
 export default function TracePane({
-  session, focused, zoom = 100, dragId, onDragActive, onFocus, onClose,
+  session, focused, zoom = 100, dragId, sourceLive, onDragActive, onFocus, onClose,
 }: {
   session: Session;
   focused?: boolean;
+  /** Is the session this trace came from still running? */
+  sourceLive?: boolean;
   zoom?: number;
   dragId?: string;
   onDragActive?: (dragging: boolean) => void;
@@ -635,7 +632,7 @@ export default function TracePane({
         <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
       </div>
 
-      <TraceView src={src} srcKey={session.id} zoom={zoom} query={query} onHead={setHead} onNav={onNav} />
+      <TraceView src={src} srcKey={session.id} zoom={zoom} query={query} live={sourceLive} onHead={setHead} onNav={onNav} />
     </div>
   );
 }

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -294,6 +294,14 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // off. `delta` is the model-based fallback for a row that has scrolled out of
   // the rendered window and has no geometry to read.
   const anchor = useRef<{ i: number; delta: number; top: number | null } | null>(null);
+  // React keys for the rows. Indices move every time older turns are prepended,
+  // and a key that moves unmounts and remounts the row — which throws away every
+  // fold the reader had opened (`Collapsible` holds `open` in state) and every
+  // memoized markdown body, at exactly the moment they were reading a tool call
+  // and scrolled up for the context that produced it. Keys are therefore
+  // `keyBase + index`, with the base decremented by each prepend, so a given
+  // turn keeps the same key for the life of the pane.
+  const keyBase = useRef(0);
   // False until the turns we hold have been MEASURED and the scroller put where
   // it belongs. Until then `scrollTop` says nothing about where the reader is:
   // before the first layout it is 0 because nothing has been placed, and before
@@ -417,6 +425,15 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       if (got.length && captureAnchor(got.length)) stick.current = false;
       turns.current = [...got, ...turns.current];
       heights.current = [...new Array(got.length), ...heights.current];
+      // Everything that names a row BY INDEX moves with the prepend: the keys,
+      // a pending jump, and an anchor captured before this landed. Missing the
+      // jump was worth a runaway — `wanted` kept addressing turn N of the newly
+      // prepended window, which sits a whole window before the turn asked for,
+      // and the restored scroll position then triggered another load.
+      keyBase.current -= got.length;
+      if (wanted.current != null) wanted.current += got.length;
+      // NOT the anchor: captureAnchor() above was already given this shift, and
+      // shifting it a second time threw the view a whole window forward.
       cursor.current = { ...cur, start: from, atStart, blocked };
       if (meta2) setMeta((p) => mergeMeta(p, meta2 as Meta));
       if (got.length) setRange((r) => ({ start: r.start + got.length, end: r.end + got.length }));
@@ -496,12 +513,18 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     return () => { dead = true; window.clearTimeout(h); };
   }, [src, srcKey]);
 
-  // The transcript may still be being written — see LIVE_MS above.
+  // The transcript may still be being written — see LIVE_MS above. Except when
+  // "a window" costs a whole-file read: the SQLite harnesses have no byte
+  // offsets to seek, so every poll would re-parse the entire conversation (and
+  // evict the Overview's memo doing it). They are not polled at all, which is
+  // what this pane did for every harness before windows existed.
   const lastTs = meta ? meta.lastTs : 0;
+  const seekable = cursor.current ? cursor.current.mode === 'bytes' : true;
   useEffect(() => {
+    if (!seekable) return undefined;
     const h = window.setInterval(loadNewer, lastTs && Date.now() - lastTs < FRESH_MS ? LIVE_MS : IDLE_MS);
     return () => window.clearInterval(h);
-  }, [loadNewer, lastTs]);
+  }, [loadNewer, lastTs, seekable]);
 
   const recompute = useCallback(() => {
     const el = scroller.current;
@@ -517,7 +540,9 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     // Reading back into the trace: fetch the stretch in front of what we hold,
     // before the reader arrives at it. Also covers a tail window too short to
     // fill the pane — there is no scrolling to do, so nothing else would ask.
-    if (positioned.current && el.scrollTop < NEAR_TOP_PX) loadOlder();
+    // Not while a jump is settling: goPrompt does its own fetching, and letting
+    // this fire too turned one ▲ into several windows.
+    if (positioned.current && wanted.current == null && el.scrollTop < NEAR_TOP_PX) loadOlder();
   }, [offsets, range.start, range.end, loadOlder]);
 
   useEffect(() => { recompute(); }, [recompute, meta]);
@@ -538,6 +563,9 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     if (wanted.current != null) {
       const target = offsets[wanted.current] || 0;
       if (Math.abs(el.scrollTop - target) > 2) el.scrollTop = target;
+      // An anchor captured on the way here describes a position the jump is
+      // deliberately leaving; keeping it would re-apply it a layout pass later.
+      anchor.current = null;
       if (++tries.current > 8) wanted.current = null;
     } else if (stick.current) {
       el.scrollTop = el.scrollHeight;
@@ -653,7 +681,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   const rows: ReactNode[] = [];
   for (let i = range.start; i < Math.min(range.end, n); i++) {
     rows.push(
-      <div key={i} ref={setRowRef(i)} data-i={i}>
+      <div key={keyBase.current + i} ref={setRowRef(i)} data-i={i}>
         <Row turn={turns.current[i]} index={i} />
       </div>,
     );
@@ -661,6 +689,14 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
 
   // Hand the host what its toolbar needs. goPrompt is rebuilt every render, so
   // the host gets a stable wrapper around the current one.
+  // What the pane knows about the trace: whatever this window could tell us,
+  // filled in from the summary for everything a window cannot know. That is not
+  // only the counts — a window of a codex rollout cannot count the session's
+  // encrypted reasoning steps (`note`), and a window of an STS file never sees
+  // the `{type:'session'}` first line that carries the title, the harness and
+  // the session id. Taking only the numbers left a reader with no idea the
+  // model's reasoning had been withheld, which is the one thing §12 of the spec
+  // says must never be left implied.
   const head = useMemo<TraceHeadInfo | null>(() => (meta ? {
     ...meta,
     total: summary ? summary.total : null,
@@ -668,6 +704,14 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     usage: meta.usage || (summary ? summary.usage : null),
     firstTs: meta.firstTs || (summary ? summary.firstTs : 0),
     truncated: meta.truncated || !!(summary && summary.truncated),
+    note: meta.note || (summary ? summary.note : null),
+    title: meta.title || (summary ? summary.title : ''),
+    harnessLabel: meta.harnessLabel || (summary ? summary.harnessLabel : ''),
+    sessionId: meta.sessionId || (summary ? summary.sessionId : null),
+    model: meta.model || (summary ? summary.model : null),
+    cwd: meta.cwd || (summary ? summary.cwd : null),
+    source: meta.source || (summary ? summary.source : null),
+    sharedBy: meta.sharedBy || (summary ? summary.sharedBy : null),
     loaded: turns.current.length,
     atStart,
   } : null), [meta, summary, tick, atStart]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -695,7 +739,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
               {matches.length} match{matches.length === 1 ? '' : 'es'} in the {fmtNum(n)} turns
               loaded so far{atStart ? '' : ' — scroll up to load more'}
             </div>
-            {matches.map((i) => <Row key={i} turn={turns.current[i]} index={i} />)}
+            {matches.map((i) => <Row key={keyBase.current + i} turn={turns.current[i]} index={i} />)}
           </div>
         )}
 
@@ -713,7 +757,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
             </div>
             {/* State the gaps up front: a reader who can't see the model's
                 reasoning should know it was withheld, not that there was none. */}
-            {meta.note && <div className="tv-msg">{meta.note}</div>}
+            {head?.note && <div className="tv-msg">{head.note}</div>}
             <div style={{ height: offsets[range.start] || 0 }} />
             {rows}
             <div style={{ height: Math.max(0, (offsets[n] || 0) - (offsets[Math.min(range.end, n)] || 0)) }} />
@@ -721,16 +765,16 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         )}
       </div>
 
-      {meta && (meta.source || meta.cwd) && (
+      {head && (head.source || head.cwd) && (
         <div className="trace-hint">
-          {meta.source?.repo && (
+          {head.source?.repo && (
             <>
-              {meta.sharedBy ? `shared by ${meta.sharedBy} · ` : ''}
-              <a href={meta.source.url || `https://huggingface.co/datasets/${meta.source.repo}`} target="_blank" rel="noreferrer">{meta.source.repo}</a>
+              {head.sharedBy ? `shared by ${head.sharedBy} · ` : ''}
+              <a href={head.source.url || `https://huggingface.co/datasets/${head.source.repo}`} target="_blank" rel="noreferrer">{head.source.repo}</a>
               {' · '}
             </>
           )}
-          {meta.cwd}
+          {head.cwd}
           {head?.firstTs ? ` · ${new Date(head.firstTs).toLocaleString()}` : ''}
         </div>
       )}

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -17,28 +17,16 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { ReactNode } from 'react';
 import type { Session } from '../types';
 import * as api from '../api';
-import type { TraceBlock, TraceCursor, TraceSummary, TraceTurn, TraceWindow } from '../api';
+import type { TraceBlock, TraceTurn } from '../api';
+import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../lib/traceWindows';
 import { renderMarkdown } from '../lib/markdown';
 import Logo from './Logo';
 import { CloseGlyph } from './icons';
 
-// How much transcript the first request asks for. Measured on the longest trace
-// on this box (19 MB / 1,395 turns): 384 KB is ~60 turns, 95 KB of JSON and
-// ~35 ms of server time, and renders in a frame — the smallest window that still
-// opens on a complete-looking conversation rather than a stub. See the PR.
-const WINDOW_BYTES = 384 * 1024;
 const ROW_EST = 44;        // unmeasured row height, collapsed
 const OVERSCAN_PX = 600;
 const NEAR_TOP_PX = 400;   // start fetching older turns before the reader arrives
 const STICK_PX = 24;       // "at the bottom" tolerance for following a live trace
-// Following a trace that is still being written. Nothing in here knows whether
-// an agent is running — but a transcript whose newest turn is seconds old is one
-// being written, so the cadence follows the trace itself: quick while it moves,
-// slow once it has gone quiet, which is also how it notices movement resuming.
-const LIVE_MS = 3_000;
-const IDLE_MS = 10_000;
-const FRESH_MS = 120_000;
-const SUMMARY_DELAY_MS = 400; // let the first paint happen before the whole-file read
 
 const fmtTs = (ms?: number) => (ms ? new Date(ms).toLocaleTimeString() : '');
 const fmtNum = (n: number) => n.toLocaleString();
@@ -208,39 +196,9 @@ function Row({ turn, index }: { turn: TraceTurn; index: number }) {
 // turns arrive one window at a time as you scroll back into them. The only read
 // that touches the whole trace is the summary, which buys the header an honest
 // turn count and is asked for after the first paint.
-export interface TraceSource {
-  window: (req: api.TraceReq, bytes?: number) => Promise<TraceWindow>;
-  summary: () => Promise<TraceSummary>;
-}
-
-/** What a host pane's toolbar needs. `total` is null until the summary lands. */
-export type TraceHeadInfo = Omit<TraceWindow, 'turns' | 'window'> & {
-  /** turns the reader is holding right now */
-  loaded: number;
-  /** the first turn of the conversation is loaded — there is nothing above */
-  atStart: boolean;
-};
-
-type Meta = Omit<TraceWindow, 'turns' | 'window'>;
-
-// Keep whichever value actually says something: a window that doesn't reach the
-// start of the trace reports no session start and no session cost, and must not
-// blank out what an earlier response already told us. Identity is preserved when
-// nothing changed — a poll that learns nothing must not look like new state.
-const mergeMeta = (prev: Meta | null, next: Meta): Meta => {
-  if (!prev) return next;
-  const out = { ...prev } as Record<string, unknown>;
-  let changed = false;
-  for (const [k, v] of Object.entries(next)) {
-    // A window OLDER than what we hold describes an older stretch of the same
-    // conversation. Two of its facts must not travel backwards: `lastTs` drives
-    // how often we look for new turns (scrolling back would otherwise slow the
-    // live tail to a crawl), and `model` is the one the session is running now.
-    if ((k === 'lastTs' || k === 'model') && out[k] && (k !== 'lastTs' || (v as number) <= (out[k] as number))) continue;
-    if ((v || !(k in out)) && out[k] !== v) { out[k] = v; changed = true; }
-  }
-  return changed ? (out as Meta) : prev;
-};
+// The source and the head shape now live with the paging itself, so reader mode
+// can use the same ones — see lib/traceWindows.ts.
+export type { TraceSource, TraceHeadInfo } from '../lib/traceWindows';
 
 export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }: {
   src: TraceSource;
@@ -251,25 +209,6 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   onHead?: (head: TraceHeadInfo | null) => void;
   onNav?: (go: (dir: -1 | 1) => void) => void;
 }) {
-  const [meta, setMeta] = useState<Meta | null>(null);
-  const [summary, setSummary] = useState<TraceSummary | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const turns = useRef<TraceTurn[]>([]);
-  const cursor = useRef<TraceCursor | null>(null);
-  // ONE request at a time. Flicking the wheel at the top of a long trace fires
-  // scroll events by the dozen, and each one would otherwise start its own load;
-  // they would arrive out of order and prepend the same turns twice.
-  const loading = useRef(false);
-  // Which source the turns in hand belong to. Every load reads this before its
-  // await and checks it after: switch files in the Files pane while a window is
-  // in flight and it would otherwise be prepended to the NEW file's turns, with
-  // the old file's byte cursors and header — a conversation spliced out of two
-  // different transcripts.
-  const gen = useRef(0);
-  const [tick, setTick] = useState(0);
-  const bump = useCallback(() => setTick((n) => n + 1), []);
-
   const scroller = useRef<HTMLDivElement | null>(null);
   const heights = useRef<number[]>([]);
   // Bumped whenever a row is measured: the values live in a ref (so the
@@ -307,26 +246,11 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // before the first layout it is 0 because nothing has been placed, and before
   // the first measurement the whole list is 44 px per row, so a window of 19
   // dense turns looks 800 px tall when it is really 3,600 — near enough to the
-  // top to fetch a window of older turns nobody asked for. (Seen on a codex
-  // rollout on the Space; a Claude transcript's 60-turn window hid it.)
+  // top to fetch a window of older turns nobody asked for.
   const positioned = useRef(false);
   const measured = useRef(false);
-
-  // ---- windowing ----
-  // Prefix sums over measured (or estimated) row heights. n is bounded by what
-  // the reader has actually loaded, so a full recompute is cheap and happens
-  // only when a row is measured, turns arrive, or the window moves.
-  const offsets = useMemo(() => {
-    const n = turns.current.length;
-    const acc = new Float64Array(n + 1);
-    for (let i = 0; i < n; i++) acc[i + 1] = acc[i] + (heights.current[i] || ROW_EST);
-    return acc;
-  }, [range, tick, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
-  // The loaders need the offsets as they are NOW, not as they were when the
-  // callback was made.
-  const offsetsRef = useRef(offsets);
-  offsetsRef.current = offsets;
-
+  const wanted = useRef<number | null>(null);
+  const tries = useRef(0);
   // Rendered rows, by index — the ResizeObserver measures through these, and the
   // anchor reads its geometry from them.
   const rowRefs = useRef(new Map<number, HTMLElement>());
@@ -358,173 +282,58 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     return true;
   };
 
-  // ---- loading ----
-  const loadTail = useCallback(async () => {
-    loading.current = true;
-    const mine = gen.current;
-    try {
-      const { turns: got, window: win, ...m } = await src.window({ at: 'tail' }, WINDOW_BYTES);
-      if (mine !== gen.current) return;
-      turns.current = got;
-      heights.current = new Array(got.length);
-      cursor.current = win;
-      anchor.current = null;
-      stick.current = true;
-      positioned.current = false;
-      measured.current = false;
-      setMeta(m);
-      setError(null);
-      setRange({ start: 0, end: Math.min(got.length, 40) });
-      bump();
-      // Nothing to render means nothing to measure, so no measurement will ever
-      // arrive to unblock the paging: walk back until there is something. After
-      // this call returns, so the one-request-at-a-time guard still holds.
-      if (!got.length && !win.atStart) window.setTimeout(() => loadOlderRef.current(), 0);
-    } catch (e) {
-      if (mine !== gen.current) return;
-      // The server distinguishes "nothing to show yet" from a real failure and
-      // says which — pass its own words through rather than inventing a reason.
-      setError(e instanceof api.TraceUnavailable ? e.message : 'could not read the trace');
-    } finally {
-      if (mine === gen.current) loading.current = false;
-    }
-  }, [src, bump]);
+  // Everything that names a row BY INDEX moves with a prepend: the keys, a
+  // pending jump, and the anchor (which captureAnchor is given the shift for).
+  const onPrepend = useCallback((count: number) => {
+    // Everything that names a row BY INDEX moves with the prepend: the heights,
+    // the keys, the rendered window, and a pending jump. (The anchor is given
+    // the shift by captureAnchor rather than moved afterwards — shifting it
+    // twice throws the view a whole window forward.)
+    heights.current = [...new Array(count), ...heights.current];
+    keyBase.current -= count;
+    if (wanted.current != null) wanted.current += count;
+    if (captureAnchor(count)) stick.current = false;
+    setRange((r) => ({ start: r.start + count, end: r.end + count }));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // loadTail may need loadOlder before it is declared; the ref keeps that honest
-  // without reordering the two.
-  const loadOlderRef = useRef<() => Promise<number>>(async () => 0);
+  const onAppend = useCallback((count: number) => {
+    heights.current = [...heights.current, ...new Array(count)];
+  }, []);
 
-  /** Fetch the window before the oldest turn held. Returns how many arrived. */
-  const loadOlder = useCallback(async () => {
-    const cur = cursor.current;
-    if (loading.current || !cur || cur.atStart || cur.blocked) return 0;
-    loading.current = true;
-    const mine = gen.current;
-    try {
-      let from = cur.start;
-      let atStart = false;
-      let got: TraceTurn[] = [];
-      let meta2: Meta | null = null;
-      let blocked = false;
-      // A window can legitimately hold no turns at all (a stretch of file-history
-      // lines, a run of harness metadata). Keep walking back until it holds
-      // something, the file starts, or the cursor stops moving.
-      for (let hop = 0; hop < 8 && !got.length && !atStart; hop++) {
-        const { turns: page, window: win, ...m } = await src.window({ at: 'before', cursor: from }, WINDOW_BYTES);
-        if (mine !== gen.current) return 0;
-        got = page;
-        meta2 = m;
-        // `blocked` is a line too big for any window — the server cannot get
-        // past it, so neither can we, and this is NOT the start of the trace.
-        blocked = !!win.blocked;
-        atStart = win.atStart || (!blocked && win.start >= from);
-        from = win.start;
-        if (blocked) break;
-      }
-      // Same row, `got.length` places further down the list — see `anchor`.
-      if (got.length && captureAnchor(got.length)) stick.current = false;
-      turns.current = [...got, ...turns.current];
-      heights.current = [...new Array(got.length), ...heights.current];
-      // Everything that names a row BY INDEX moves with the prepend: the keys,
-      // a pending jump, and an anchor captured before this landed. Missing the
-      // jump was worth a runaway — `wanted` kept addressing turn N of the newly
-      // prepended window, which sits a whole window before the turn asked for,
-      // and the restored scroll position then triggered another load.
-      keyBase.current -= got.length;
-      if (wanted.current != null) wanted.current += got.length;
-      // NOT the anchor: captureAnchor() above was already given this shift, and
-      // shifting it a second time threw the view a whole window forward.
-      cursor.current = { ...cur, start: from, atStart, blocked };
-      if (meta2) setMeta((p) => mergeMeta(p, meta2 as Meta));
-      if (got.length) setRange((r) => ({ start: r.start + got.length, end: r.end + got.length }));
-      bump();
-      return got.length;
-    } catch {
-      // Keep what is on screen; the next scroll retries.
-      return 0;
-    } finally {
-      if (mine === gen.current) loading.current = false;
-    }
-  }, [src, bump]);
-  loadOlderRef.current = loadOlder;
-
-  /** Whatever the agent has written since we last looked. */
-  const loadNewer = useCallback(async () => {
-    const cur = cursor.current;
-    if (loading.current || !cur) return;
-    loading.current = true;
-    const mine = gen.current;
-    try {
-      const { turns: got, window: win, ...m } = await src.window({ at: 'after', cursor: cur.end });
-      if (mine !== gen.current) return;
-      if (win.gap) {
-        // More was written than one window can carry. Splicing it in would leave
-        // a hole in the middle of the conversation with nothing to say so —
-        // start again from the new tail instead.
-        turns.current = got;
-        heights.current = new Array(got.length);
-        cursor.current = win;
-        anchor.current = null;
-        stick.current = true;
-        positioned.current = false;
-        measured.current = false;
-        setRange({ start: 0, end: Math.min(got.length, 40) });
-      } else {
-        if (got.length) {
-          turns.current = [...turns.current, ...got];
-          heights.current = [...heights.current, ...new Array(got.length)];
-        }
-        cursor.current = { ...cur, end: win.end, atEnd: win.atEnd };
-      }
-      setMeta((p) => mergeMeta(p, m));
-      if (got.length) bump();
-    } catch {
-      // A poll that fails must not throw away the conversation on screen.
-    } finally {
-      if (mine === gen.current) loading.current = false;
-    }
-  }, [src, bump]);
-
-  useEffect(() => {
-    gen.current += 1;
-    loading.current = false;
-    turns.current = [];
+  const onReset = useCallback(() => {
     heights.current = [];
-    cursor.current = null;
     anchor.current = null;
     stick.current = true;
     positioned.current = false;
     measured.current = false;
-    setMeta(null);
-    setSummary(null);
     setRange({ start: 0, end: 40 });
-    loadTail();
-  }, [srcKey, loadTail]);
+  }, []);
 
-  // The one read that touches the whole file, fired AFTER the first paint: it
-  // buys the header a real turn count, the session's token total and the date
-  // the conversation started — none of which a window can know. If it fails or
-  // is slow, the header simply says how much is loaded.
-  useEffect(() => {
-    let dead = false;
-    const h = window.setTimeout(() => {
-      src.summary().then((s) => { if (!dead) setSummary(s); }).catch(() => {});
-    }, SUMMARY_DELAY_MS);
-    return () => { dead = true; window.clearTimeout(h); };
-  }, [src, srcKey]);
+  const { turns, head, error, version: tick, atStart, blocked, loadOlder } =
+    useTraceWindows(src, srcKey, { onPrepend, onReset });
 
-  // The transcript may still be being written — see LIVE_MS above. Except when
-  // "a window" costs a whole-file read: the SQLite harnesses have no byte
-  // offsets to seek, so every poll would re-parse the entire conversation (and
-  // evict the Overview's memo doing it). They are not polled at all, which is
-  // what this pane did for every harness before windows existed.
-  const lastTs = meta ? meta.lastTs : 0;
-  const seekable = cursor.current ? cursor.current.mode === 'bytes' : true;
-  useEffect(() => {
-    if (!seekable) return undefined;
-    const h = window.setInterval(loadNewer, lastTs && Date.now() - lastTs < FRESH_MS ? LIVE_MS : IDLE_MS);
-    return () => window.clearInterval(h);
-  }, [loadNewer, lastTs, seekable]);
+  // Prefix sums over measured (or estimated) row heights. n is bounded by what
+  // the reader has actually loaded, so a full recompute is cheap and happens
+  // only when a row is measured, turns arrive, or the window moves.
+  const offsets = useMemo(() => {
+    const n = turns.current.length;
+    const acc = new Float64Array(n + 1);
+    for (let i = 0; i < n; i++) acc[i + 1] = acc[i] + (heights.current[i] || ROW_EST);
+    return acc;
+  }, [range, tick, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
+  // The loaders need the offsets as they are NOW, not as they were when the
+  // callback was made.
+  const offsetsRef = useRef(offsets);
+  offsetsRef.current = offsets;
+
+  // heights are index-aligned with turns; the hook only ever prepends or appends,
+  // so re-derive the array length from it rather than tracking every mutation.
+  if (heights.current.length !== turns.current.length) {
+    const grew = turns.current.length - heights.current.length;
+    heights.current = grew > 0 && heights.current.length
+      ? [...new Array(grew), ...heights.current]   // older turns arrived on top
+      : new Array(turns.current.length);
+  }
 
   const recompute = useCallback(() => {
     const el = scroller.current;
@@ -545,13 +354,11 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     if (positioned.current && wanted.current == null && el.scrollTop < NEAR_TOP_PX) loadOlder();
   }, [offsets, range.start, range.end, loadOlder]);
 
-  useEffect(() => { recompute(); }, [recompute, meta]);
+  useEffect(() => { recompute(); }, [recompute, head]);
 
   // ---- keeping the view still ----
   // Every layout change lands here: a jump to a prompt, a prepended window, a
   // row that just measured itself, a new turn while pinned to the bottom.
-  const wanted = useRef<number | null>(null);
-  const tries = useRef(0);
   useLayoutEffect(() => {
     const el = scroller.current;
     if (!el) return;
@@ -627,7 +434,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     }
     // Let the prepend commit before looking again: the recursion would
     // otherwise read the pre-prepend prompt list and fetch another window.
-    if (!cursor.current?.atStart && await loadOlder()) {
+    if (!atStart && await loadOlder()) {
       await new Promise((r) => window.setTimeout(r, 0));
       goRef.current(dir);
       return;
@@ -649,7 +456,11 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       measured.current = true;
       // Measuring changes the offsets of everything below — and of everything
       // above, if a row above the viewport grew. Pin the row being read.
-      if (!stick.current && wanted.current == null) captureAnchor(0);
+      // Not if an anchor is already waiting: a prepend captured that one against
+      // the indices it is about to shift, and a measurement landing in between
+      // would overwrite it with the OLD indexing — restoring to a row a whole
+      // window away from the one the reader was looking at.
+      if (!stick.current && wanted.current == null && !anchor.current) captureAnchor(0);
       setHeightsVersion((v) => v + 1);
     });
     for (const el of rowRefs.current.values()) ro.observe(el);
@@ -658,7 +469,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     // moving) get measured too — otherwise they keep their 44px estimate and the
     // scroll height stays wrong. NOT heightsVersion: that's what the observer
     // sets, and re-attaching on it would churn on every measurement.
-  }, [range, tick, meta]);
+  }, [range, tick, head]);
 
   const setRowRef = (i: number) => (el: HTMLDivElement | null) => {
     if (el) rowRefs.current.set(i, el); else rowRefs.current.delete(i);
@@ -676,8 +487,6 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   }, [query, tick, heightsVersion]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const n = turns.current.length;
-  const atStart = !!cursor.current?.atStart;
-  const blocked = !!cursor.current?.blocked;
   const rows: ReactNode[] = [];
   for (let i = range.start; i < Math.min(range.end, n); i++) {
     rows.push(
@@ -697,24 +506,6 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // the session id. Taking only the numbers left a reader with no idea the
   // model's reasoning had been withheld, which is the one thing §12 of the spec
   // says must never be left implied.
-  const head = useMemo<TraceHeadInfo | null>(() => (meta ? {
-    ...meta,
-    total: summary ? summary.total : null,
-    userTurns: summary ? summary.userTurns : null,
-    usage: meta.usage || (summary ? summary.usage : null),
-    firstTs: meta.firstTs || (summary ? summary.firstTs : 0),
-    truncated: meta.truncated || !!(summary && summary.truncated),
-    note: meta.note || (summary ? summary.note : null),
-    title: meta.title || (summary ? summary.title : ''),
-    harnessLabel: meta.harnessLabel || (summary ? summary.harnessLabel : ''),
-    sessionId: meta.sessionId || (summary ? summary.sessionId : null),
-    model: meta.model || (summary ? summary.model : null),
-    cwd: meta.cwd || (summary ? summary.cwd : null),
-    source: meta.source || (summary ? summary.source : null),
-    sharedBy: meta.sharedBy || (summary ? summary.sharedBy : null),
-    loaded: turns.current.length,
-    atStart,
-  } : null), [meta, summary, tick, atStart]); // eslint-disable-line react-hooks/exhaustive-deps
   useEffect(() => { onNav?.((d: -1 | 1) => goRef.current(d)); }, [onNav]);
   useEffect(() => { onHead?.(head); }, [head, onHead]);
 
@@ -731,9 +522,9 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
         style={{ fontSize: `${(13 * zoom) / 100}px` }}
       >
         {error && <div className="tv-msg">{error}</div>}
-        {!error && !meta && <div className="tv-msg">reading…</div>}
+        {!error && !head && <div className="tv-msg">reading…</div>}
 
-        {!error && meta && matches && (
+        {!error && head && matches && (
           <div className="tv-matches">
             <div className="tv-msg">
               {matches.length} match{matches.length === 1 ? '' : 'es'} in the {fmtNum(n)} turns
@@ -743,7 +534,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
           </div>
         )}
 
-        {!error && meta && !matches && (
+        {!error && head && !matches && (
           <>
             {/* Fixed height whether it is loading, done, or at the beginning:
                 this line sits above every offset in the list, so changing its

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -232,6 +232,11 @@ const mergeMeta = (prev: Meta | null, next: Meta): Meta => {
   const out = { ...prev } as Record<string, unknown>;
   let changed = false;
   for (const [k, v] of Object.entries(next)) {
+    // A window OLDER than what we hold describes an older stretch of the same
+    // conversation. Two of its facts must not travel backwards: `lastTs` drives
+    // how often we look for new turns (scrolling back would otherwise slow the
+    // live tail to a crawl), and `model` is the one the session is running now.
+    if ((k === 'lastTs' || k === 'model') && out[k] && (k !== 'lastTs' || (v as number) <= (out[k] as number))) continue;
     if ((v || !(k in out)) && out[k] !== v) { out[k] = v; changed = true; }
   }
   return changed ? (out as Meta) : prev;
@@ -256,6 +261,12 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // scroll events by the dozen, and each one would otherwise start its own load;
   // they would arrive out of order and prepend the same turns twice.
   const loading = useRef(false);
+  // Which source the turns in hand belong to. Every load reads this before its
+  // await and checks it after: switch files in the Files pane while a window is
+  // in flight and it would otherwise be prepended to the NEW file's turns, with
+  // the old file's byte cursors and header — a conversation spliced out of two
+  // different transcripts.
+  const gen = useRef(0);
   const [tick, setTick] = useState(0);
   const bump = useCallback(() => setTick((n) => n + 1), []);
 
@@ -342,8 +353,10 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   // ---- loading ----
   const loadTail = useCallback(async () => {
     loading.current = true;
+    const mine = gen.current;
     try {
       const { turns: got, window: win, ...m } = await src.window({ at: 'tail' }, WINDOW_BYTES);
+      if (mine !== gen.current) return;
       turns.current = got;
       heights.current = new Array(got.length);
       cursor.current = win;
@@ -360,11 +373,12 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       // this call returns, so the one-request-at-a-time guard still holds.
       if (!got.length && !win.atStart) window.setTimeout(() => loadOlderRef.current(), 0);
     } catch (e) {
+      if (mine !== gen.current) return;
       // The server distinguishes "nothing to show yet" from a real failure and
       // says which — pass its own words through rather than inventing a reason.
       setError(e instanceof api.TraceUnavailable ? e.message : 'could not read the trace');
     } finally {
-      loading.current = false;
+      if (mine === gen.current) loading.current = false;
     }
   }, [src, bump]);
 
@@ -375,28 +389,35 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
   /** Fetch the window before the oldest turn held. Returns how many arrived. */
   const loadOlder = useCallback(async () => {
     const cur = cursor.current;
-    if (loading.current || !cur || cur.atStart) return 0;
+    if (loading.current || !cur || cur.atStart || cur.blocked) return 0;
     loading.current = true;
+    const mine = gen.current;
     try {
       let from = cur.start;
       let atStart = false;
       let got: TraceTurn[] = [];
       let meta2: Meta | null = null;
+      let blocked = false;
       // A window can legitimately hold no turns at all (a stretch of file-history
       // lines, a run of harness metadata). Keep walking back until it holds
       // something, the file starts, or the cursor stops moving.
       for (let hop = 0; hop < 8 && !got.length && !atStart; hop++) {
         const { turns: page, window: win, ...m } = await src.window({ at: 'before', cursor: from }, WINDOW_BYTES);
+        if (mine !== gen.current) return 0;
         got = page;
         meta2 = m;
-        atStart = win.atStart || win.start >= from;
+        // `blocked` is a line too big for any window — the server cannot get
+        // past it, so neither can we, and this is NOT the start of the trace.
+        blocked = !!win.blocked;
+        atStart = win.atStart || (!blocked && win.start >= from);
         from = win.start;
+        if (blocked) break;
       }
       // Same row, `got.length` places further down the list — see `anchor`.
       if (got.length && captureAnchor(got.length)) stick.current = false;
       turns.current = [...got, ...turns.current];
       heights.current = [...new Array(got.length), ...heights.current];
-      cursor.current = { ...cur, start: from, atStart };
+      cursor.current = { ...cur, start: from, atStart, blocked };
       if (meta2) setMeta((p) => mergeMeta(p, meta2 as Meta));
       if (got.length) setRange((r) => ({ start: r.start + got.length, end: r.end + got.length }));
       bump();
@@ -405,7 +426,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       // Keep what is on screen; the next scroll retries.
       return 0;
     } finally {
-      loading.current = false;
+      if (mine === gen.current) loading.current = false;
     }
   }, [src, bump]);
   loadOlderRef.current = loadOlder;
@@ -415,8 +436,10 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     const cur = cursor.current;
     if (loading.current || !cur) return;
     loading.current = true;
+    const mine = gen.current;
     try {
       const { turns: got, window: win, ...m } = await src.window({ at: 'after', cursor: cur.end });
+      if (mine !== gen.current) return;
       if (win.gap) {
         // More was written than one window can carry. Splicing it in would leave
         // a hole in the middle of the conversation with nothing to say so —
@@ -441,11 +464,13 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
     } catch {
       // A poll that fails must not throw away the conversation on screen.
     } finally {
-      loading.current = false;
+      if (mine === gen.current) loading.current = false;
     }
   }, [src, bump]);
 
   useEffect(() => {
+    gen.current += 1;
+    loading.current = false;
     turns.current = [];
     heights.current = [];
     cursor.current = null;
@@ -572,7 +597,13 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
       if (el) { wanted.current = null; stick.current = true; el.scrollTop = el.scrollHeight; }
       return;
     }
-    if (!cursor.current?.atStart && await loadOlder()) { goRef.current(dir); return; }
+    // Let the prepend commit before looking again: the recursion would
+    // otherwise read the pre-prepend prompt list and fetch another window.
+    if (!cursor.current?.atStart && await loadOlder()) {
+      await new Promise((r) => window.setTimeout(r, 0));
+      goRef.current(dir);
+      return;
+    }
     if (prompts.length) goToTurn(prompts[0]);
   };
   goRef.current = goPrompt;
@@ -618,6 +649,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
 
   const n = turns.current.length;
   const atStart = !!cursor.current?.atStart;
+  const blocked = !!cursor.current?.blocked;
   const rows: ReactNode[] = [];
   for (let i = range.start; i < Math.min(range.end, n); i++) {
     rows.push(
@@ -673,9 +705,11 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', onHead, onNav }
                 this line sits above every offset in the list, so changing its
                 size would move the whole conversation under the reader. */}
             <div className="tv-msg tv-top">
-              {atStart
-                ? (head?.truncated ? 'session longer than the viewer’s cap — earlier turns are not shown' : 'beginning of the conversation')
-                : 'earlier turns load as you scroll up…'}
+              {blocked
+                ? 'earlier turns can’t be read — one line here is larger than the reader’s window'
+                : atStart
+                  ? 'beginning of the conversation'
+                  : 'earlier turns load as you scroll up…'}
             </div>
             {/* State the gaps up front: a reader who can't see the model's
                 reasoning should know it was withheld, not that there was none. */}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -166,9 +166,16 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
   };
   const nav = (dir: -1 | 1) => (q && hits ? stepHit(dir) : goTurn(dir));
 
+  // Land on the end of the conversation, and stay there until the reader
+  // decides otherwise. This is not only for a working agent: switching a pane
+  // from terminal to reader (which mounts this component fresh) used to drop you
+  // at the top of the last 400 turns — hundreds of rows behind what the agent
+  // had just said, and behind what you were watching in the terminal a moment
+  // earlier. `stick` goes false the instant you scroll up, so following the end
+  // never fights a decision to read further back.
   useLayoutEffect(() => {
     const el = scroller.current;
-    if (el && live && stick.current) el.scrollTop = el.scrollHeight;
+    if (el && stick.current) el.scrollTop = el.scrollHeight;
   }, [turns, live]);
 
   if (!page) return <div className="cxv-empty mono">{error || 'reading the trace…'}</div>;

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -82,10 +82,10 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
     stick.current = false;
   }, []);
 
-  const onReset = useCallback(() => { anchor.current = null; stick.current = true; }, []);
+  const onReset = useCallback(() => { anchor.current = null; stick.current = true; fills.current = 0; }, []);
 
   const { turns: turnsRef, head, error, version, atStart, blocked, loadOlder, loadNewer } =
-    useTraceWindows(src, session.id, { onPrepend, onReset, paused });
+    useTraceWindows(src, session.id, { onPrepend, onReset, paused, live });
 
   const turns: TraceTurn[] = turnsRef.current;
   const exchanges = useMemo(() => splitExchanges(turns), [version, turns]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -181,6 +181,27 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
   // had just said, and behind what you were watching in the terminal a moment
   // earlier. `stick` goes false the instant you scroll up, so following the end
   // never fights a decision to read further back.
+  // A window that does not fill the pane leaves nothing to scroll, and paging is
+  // driven by scrolling — so on a tall display the reader would sit on the last
+  // few exchanges of a long conversation with no gesture that reaches the rest.
+  // (Measured: at a 2200 px viewport the first window was 2007 px and no wheel
+  // event could ever fire.)
+  //
+  // Fetching until it overflows is NOT the fix: this view collapses an agent's
+  // steps into one line, so a window of sixty turns can add almost no height,
+  // and "keep going until you can scroll" walked back through twelve windows of
+  // a conversation nobody had asked to see. So: a couple of attempts to make the
+  // pane scrollable, and past that the line at the top becomes the way to ask.
+  const fills = useRef(0);
+  useEffect(() => {
+    const el = scroller.current;
+    if (!el || !head || atStart || blocked) return;
+    if (el.scrollHeight > el.clientHeight) { fills.current = 0; return; }
+    if (fills.current >= 2) return;
+    fills.current += 1;
+    loadOlder();
+  }, [version, head, atStart, blocked, loadOlder]);
+
   useLayoutEffect(() => {
     const el = scroller.current;
     if (!el) return;
@@ -191,7 +212,7 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
     if (a == null) return;
     el.scrollTop = el.scrollHeight - a;
     anchor.current = null;
-  }, [version, live]);
+  }, [version, live, sent]);
 
   if (!head) return <div className="cxv-empty mono">{error || 'reading the trace…'}</div>;
 
@@ -230,17 +251,24 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
         }}>
         <div className="cxv-col">
           {error && <div className="cxv-msg bad mono">{error} · showing the last read</div>}
-          <div className="cxv-msg mono cxv-top">
+          <button
+            type="button"
+            className="cxv-msg mono cxv-top"
+            disabled={atStart || blocked}
+            onClick={() => loadOlder()}
+            title={atStart || blocked ? undefined : 'Load the previous stretch of the conversation'}
+          >
             {blocked
               ? 'earlier turns can’t be read — one line here is larger than the reader’s window'
               : atStart
                 ? 'beginning of the conversation'
-                : 'earlier turns load as you scroll up…'}
-          </div>
+                : 'earlier turns load as you scroll up — or click here'}
+          </button>
           {head.note && <div className="cxv-msg mono">{head.note}</div>}
           {q && (
             <div className="cxv-msg mono">
-              {shown.length} of {exchanges.length} turns match “{query}”
+              {shown.length} of the {exchanges.length} turn{exchanges.length === 1 ? '' : 's'} loaded
+              so far match “{query}”{atStart ? '' : ' — scroll up to load more'}
               {hits ? ` · ${hits} highlighted, ▲▼ walks them` : ''}
             </div>
           )}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -5,21 +5,24 @@
 // reader's own: a line of session facts, search, turn navigation, and the same
 // ExchangeView the Overview card shows one of.
 //
-// Draft scope: this reads the tail of the trace in one request and renders every
-// turn in it. Windowing by exchange (§10.7) is the next step — a collapsed turn
-// is 2–3 rows, so the DOM stays small, but the measured-height machinery in
-// TraceView is what makes it survive a 5,000-turn session.
+// It opens on the END of the conversation and pages backwards: one window of the
+// transcript to start, another when you scroll to the top, anchored so the text
+// you are reading does not move under you. Before that it read the last 400
+// turns in a single request and stopped there — 702 KB on a 19 MB session, with
+// "1,020 earlier messages are not shown" and no way to reach them — and it
+// re-fetched all 400 every three seconds while the agent worked, each one a full
+// re-parse of the transcript on the server. The paging itself lives in
+// lib/traceWindows.ts, shared with the Trace pane.
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../../api';
-import type { TracePage, TraceTurn } from '../../api';
+import type { TraceTurn } from '../../api';
+import { useTraceWindows, type TraceSource } from '../../lib/traceWindows';
 import type { Session } from '../../types';
 import { fmtTok, splitExchanges } from './exchanges';
 import ExchangeView from './Exchange';
 import { SendGlyph } from '../icons';
 
-/** How much of the tail RENDER mode reads. The server caps a page at 500. */
-export const RENDER_TAIL = 400;
-const POLL_MS = 3_000;
+const NEAR_TOP_PX = 300;   // start fetching older turns before the reader arrives
 
 const fmtNum = (n: number) => n.toLocaleString();
 const fmtUsage = (u?: { in: number; out: number } | null) =>
@@ -34,8 +37,6 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
   readOnly?: boolean;
   onHandover?: () => void;
 }) {
-  const [page, setPage] = useState<TracePage | null>(null);
-  const [error, setError] = useState<string>('');
   const [query, setQuery] = useState('');
   const [hits, setHits] = useState(0);
   const [hit, setHit] = useState(0);
@@ -55,32 +56,39 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
 
   const live = session.state === 'working' && !paused;
 
-  const load = useCallback(async () => {
-    try {
-      // A negative offset reads from the end (server/src/traces.js pageOf).
-      const p = await api.getTracePage(session.id, -RENDER_TAIL, RENDER_TAIL);
-      setPage(p);
-      setError('');
-    } catch (e) {
-      // A failed REFRESH must not throw away the conversation on screen: this
-      // mount answers EIO now and then, and blanking mid-read is worse than
-      // going stale for three seconds.
-      setError(e instanceof Error ? e.message : 'could not read this trace');
-    }
-  }, [session.id]);
+  const src = useMemo<TraceSource>(() => ({
+    window: (req, bytes) => api.getTraceWindow(session.id, req, bytes),
+    summary: () => api.getTraceSummary(session.id),
+  }), [session.id]);
 
-  useEffect(() => { setPage(null); setError(''); load(); }, [load]);
-  // While the agent works, the trace is still being written.
-  useEffect(() => {
-    if (!live) return undefined;
-    const h = window.setInterval(load, POLL_MS);
-    return () => window.clearInterval(h);
-  }, [live, load]);
-  // Coming back into view, catch up at once rather than waiting for a tick.
-  useEffect(() => { if (!paused && page) load(); }, [paused]);  // eslint-disable-line react-hooks/exhaustive-deps
+  // React keys for the exchanges, and the reading position across a prepend.
+  // The keys are indices into a list that grows at the FRONT, so without a base
+  // that moves with it every exchange remounts when older turns arrive.
+  const keyBase = useRef(0);
+  // The anchor is the scroll height, not an element. Turns regroup here: an
+  // exchange at the top of the list is a fragment whose prompt was in the window
+  // we had not read yet, and when that window arrives the two become ONE
+  // exchange — so the element the reader was looking at can cease to exist as an
+  // element. What does not change is that everything new is added ABOVE, so
+  // keeping the distance to the bottom constant keeps the same text under the
+  // reader's eyes regardless of how the pieces were regrouped.
+  const anchor = useRef<number | null>(null);
 
-  const turns: TraceTurn[] = useMemo(() => page?.turns || [], [page]);
-  const exchanges = useMemo(() => splitExchanges(turns), [turns]);
+  const onPrepend = useCallback((count: number) => {
+    keyBase.current -= count;
+    const el = scroller.current;
+    if (!el) return;
+    anchor.current = el.scrollHeight - el.scrollTop;
+    stick.current = false;
+  }, []);
+
+  const onReset = useCallback(() => { anchor.current = null; stick.current = true; }, []);
+
+  const { turns: turnsRef, head, error, version, atStart, blocked, loadOlder, loadNewer } =
+    useTraceWindows(src, session.id, { onPrepend, onReset, paused });
+
+  const turns: TraceTurn[] = turnsRef.current;
+  const exchanges = useMemo(() => splitExchanges(turns), [version, turns]); // eslint-disable-line react-hooks/exhaustive-deps
   const last = exchanges[exchanges.length - 1];
 
   // The optimistic echo stands until the transcript catches up: a CLI writes it,
@@ -99,7 +107,7 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
       setDraft(''); setSent({ text, at: Date.now() });
       if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
       stick.current = true;
-      load();
+      loadNewer();
     } catch { setFailed(true); window.setTimeout(() => setFailed(false), 4000); }
     setSending(false);
   };
@@ -175,23 +183,31 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
   // never fights a decision to read further back.
   useLayoutEffect(() => {
     const el = scroller.current;
-    if (el && stick.current) el.scrollTop = el.scrollHeight;
-  }, [turns, live]);
+    if (!el) return;
+    if (stick.current) { el.scrollTop = el.scrollHeight; anchor.current = null; return; }
+    // Older turns just arrived above the reader: restore the distance to the
+    // bottom, which is the same text on screen however the exchanges regrouped.
+    const a = anchor.current;
+    if (a == null) return;
+    el.scrollTop = el.scrollHeight - a;
+    anchor.current = null;
+  }, [version, live]);
 
-  if (!page) return <div className="cxv-empty mono">{error || 'reading the trace…'}</div>;
+  if (!head) return <div className="cxv-empty mono">{error || 'reading the trace…'}</div>;
 
   return (
     <div className="cxv">
       {/* The reader's own controls, on their own row: on a phone the pane
           header above has no spare width. */}
       <div className="cxv-bar mono">
-        {page.model && <span className="cxv-chip">{page.model}</span>}
-        <span className="cxv-count" title={`${fmtNum(page.total)} messages`}>
+        {head.model && <span className="cxv-chip">{head.model}</span>}
+        <span className="cxv-count" title={head.total != null ? `${fmtNum(head.total)} messages in this conversation` : `${fmtNum(head.loaded)} messages loaded`}>
           {fmtNum(exchanges.length)} turn{exchanges.length === 1 ? '' : 's'}
+          {head.total != null && head.loaded < head.total ? ` of ${fmtNum(head.total)} messages` : ''}
         </span>
-        {page.usage && (
-          <span className="cxv-tok" title={page.usage.cacheRead ? `${fmtNum(page.usage.cacheRead)} cached` : undefined}>
-            {fmtUsage(page.usage)}
+        {head.usage && (
+          <span className="cxv-tok" title={head.usage.cacheRead ? `${fmtNum(head.usage.cacheRead)} cached` : undefined}>
+            {fmtUsage(head.usage)}
           </span>
         )}
         <span className="spacer" />
@@ -208,15 +224,20 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
         onScroll={(e) => {
           const el = e.currentTarget;
           stick.current = el.scrollHeight - el.scrollTop - el.clientHeight < 48;
+          // Reading back into the conversation: fetch the stretch in front of
+          // what we hold before the reader arrives at it.
+          if (el.scrollTop < NEAR_TOP_PX) loadOlder();
         }}>
         <div className="cxv-col">
           {error && <div className="cxv-msg bad mono">{error} · showing the last read</div>}
-          {(page.truncated || page.offset > 0) && (
-            <div className="cxv-msg mono">
-              {page.offset > 0 ? `${fmtNum(page.offset)} earlier messages are not shown` : 'earlier turns are not shown'}
-            </div>
-          )}
-          {page.note && <div className="cxv-msg mono">{page.note}</div>}
+          <div className="cxv-msg mono cxv-top">
+            {blocked
+              ? 'earlier turns can’t be read — one line here is larger than the reader’s window'
+              : atStart
+                ? 'beginning of the conversation'
+                : 'earlier turns load as you scroll up…'}
+          </div>
+          {head.note && <div className="cxv-msg mono">{head.note}</div>}
           {q && (
             <div className="cxv-msg mono">
               {shown.length} of {exchanges.length} turns match “{query}”
@@ -224,13 +245,17 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
             </div>
           )}
           {shown.map((x, i) => (
-            <div key={x.key} ref={(el) => { if (el) rows.current.set(i, el); else rows.current.delete(i); }}>
+            <div
+              key={keyBase.current + x.at}
+              data-x={String(keyBase.current + x.at)}
+              ref={(el) => { if (el) rows.current.set(i, el); else rows.current.delete(i); }}
+            >
               <ExchangeView
                 x={x}
                 n={exchanges.indexOf(x) + 1}
                 total={exchanges.length}
                 q={q || undefined}
-                baseModel={page.model || undefined}
+                baseModel={head.model || undefined}
                 running={live && x === exchanges[exchanges.length - 1]}
               />
             </div>
@@ -269,9 +294,9 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
       {failed && <div className="ov-note cxv-note">failed to reach the agent</div>}
 
       <div className="cxv-foot mono">
-        <span className="cxv-path" title={page.cwd || undefined}>
-          {page.cwd}
-          {page.firstTs ? ` · ${new Date(page.firstTs).toLocaleDateString()}` : ''}
+        <span className="cxv-path" title={head.cwd || undefined}>
+          {head.cwd}
+          {head.firstTs ? ` · ${new Date(head.firstTs).toLocaleDateString()}` : ''}
         </span>
         <span className="spacer" />
         {onHandover && (

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -166,6 +166,10 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 .cxv-body { flex: 1; min-height: 0; overflow-y: auto; background: var(--panel); padding: 4px 14px 30px; }
 .cxv-col { display: flex; flex-direction: column; min-width: 0; }
 .cxv-msg { font-size: 11px; color: var(--muted); padding: 6px 0; }
+/* The line above the oldest loaded exchange. Fixed height on purpose: it sits
+   above everything in the column, so a line that grew or vanished when the
+   reader reached the start would shove the whole conversation. */
+.cxv-top { height: 1.5em; line-height: 1.5em; padding: 0; text-align: center; opacity: 0.75; }
 .cxv-foot {
   display: flex; align-items: center; gap: 8px; flex: none;
   padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel);

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -169,7 +169,13 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 /* The line above the oldest loaded exchange. Fixed height on purpose: it sits
    above everything in the column, so a line that grew or vanished when the
    reader reached the start would shove the whole conversation. */
-.cxv-top { height: 1.5em; line-height: 1.5em; padding: 0; text-align: center; opacity: 0.75; }
+.cxv-top {
+  height: 1.5em; line-height: 1.5em; padding: 0; text-align: center; opacity: 0.75;
+  display: block; width: 100%; background: none; border: 0; color: inherit;
+  font: inherit; cursor: pointer;
+}
+.cxv-top:disabled { cursor: default; }
+.cxv-top:not(:disabled):hover { opacity: 1; text-decoration: underline; }
 .cxv-foot {
   display: flex; align-items: center; gap: 8px; flex: none;
   padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel);

--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -8,12 +8,16 @@
 // racing the first, a pointer to a window nobody read), so it lives here once
 // rather than twice.
 //
+// `src` MUST be memoized by the caller (all three call sites use useMemo on the
+// session id or path): the reset effect depends on it, so a fresh object per
+// render would refetch the tail forever.
+//
 // What stays with the caller is everything about presentation: how a row is
 // measured, what is virtualized, and how the reading position is anchored when
 // older turns arrive. The hook says WHEN turns are about to be prepended
 // (`onPrepend`) and when everything has been replaced (`onReset`); the caller
 // decides what that means for its own scroller.
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../api';
 import type { TraceCursor, TraceSummary, TraceTurn, TraceWindow } from '../api';
 
@@ -51,16 +55,20 @@ export type TraceHeadInfo = Meta & {
 // Keep whichever value actually says something: a window that doesn't reach the
 // start of the trace reports no session start and no session cost, and must not
 // blank out what an earlier response already told us. Identity is preserved when
-// nothing changed — a poll that learns nothing must not look like new state.
+// no SCALAR changed, which is what keeps a poll that learns nothing from looking
+// like new state; an object-valued field (`usage`, `source`) compares by
+// identity and would churn, so those only ever arrive once per source today.
 export const mergeMeta = (prev: Meta | null, next: Meta): Meta => {
   if (!prev) return next;
   const out = { ...prev } as Record<string, unknown>;
   let changed = false;
   for (const [k, v] of Object.entries(next)) {
     // A window OLDER than what we hold describes an older stretch of the same
-    // conversation. Two of its facts must not travel backwards: `lastTs` drives
-    // how often we look for new turns (scrolling back would otherwise slow the
-    // live tail to a crawl), and `model` is the one the session is running now.
+    // conversation. `lastTs` must not travel backwards — it drives how often we
+    // look for new turns, and scrolling back would otherwise slow the live tail
+    // to a crawl. `model` is simply first-one-wins: the tail is read first, so
+    // that is the model the session is running now, and an older window's model
+    // does not replace it.
     if ((k === 'lastTs' || k === 'model') && out[k] && (k !== 'lastTs' || (v as number) <= (out[k] as number))) continue;
     if ((v || !(k in out)) && out[k] !== v) { out[k] = v; changed = true; }
   }
@@ -76,6 +84,10 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
   onReset?: () => void;
   /** The surface is off-screen: stop asking for turns nobody is looking at. */
   paused?: boolean;
+  /** The host knows the session is running. `false` means it is not, and a trace
+   *  that has also been quiet for a while is then left alone entirely — which is
+   *  what reader mode did before it had windows. Omit to decide on recency only. */
+  live?: boolean;
 } = {}) {
   const [meta, setMeta] = useState<Meta | null>(null);
   const [summary, setSummary] = useState<TraceSummary | null>(null);
@@ -235,21 +247,37 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
   const lastTs = meta ? meta.lastTs : 0;
   const seekable = cursor.current ? cursor.current.mode === 'bytes' : true;
   const paused = !!opts.paused;
+  const live = opts.live;
+  const [hidden, setHidden] = useState(() => (typeof document === 'undefined' ? false : document.hidden));
   useEffect(() => {
-    if (!seekable || paused) return undefined;
-    const h = window.setInterval(loadNewer, lastTs && Date.now() - lastTs < FRESH_MS ? LIVE_MS : IDLE_MS);
+    const onVis = () => setHidden(document.hidden);
+    document.addEventListener('visibilitychange', onVis);
+    return () => document.removeEventListener('visibilitychange', onVis);
+  }, []);
+  useEffect(() => {
+    const fresh = !!lastTs && Date.now() - lastTs < FRESH_MS;
+    // Nothing to follow: the host says the session is not running and the trace
+    // has not moved in a while. A pane behind another browser tab is the same
+    // case — the reader is not looking, so nobody is waiting for the turn.
+    if (!seekable || paused || hidden || (live === false && !fresh)) return undefined;
+    const h = window.setInterval(loadNewer, fresh ? LIVE_MS : IDLE_MS);
     return () => window.clearInterval(h);
-  }, [loadNewer, lastTs, seekable, paused]);
+  }, [loadNewer, lastTs, seekable, paused, hidden, live]);
 
   const atStart = !!cursor.current?.atStart;
   const blocked = !!cursor.current?.blocked;
+  // MEMOIZED, and it has to be: a host that lifts this into its own state — the
+  // Trace pane does, `onHead={setHead}` — turns a fresh object per render into
+  // effect → setState → render → fresh object, a loop that never trips React's
+  // update-depth guard because it goes through an effect. It just spins: measured
+  // at 98% of a core with an untouched pane open.
   // What the pane knows about the trace: whatever this window could tell us,
   // filled in from the summary for everything a window cannot know. That is not
   // only the counts — a window of a codex rollout cannot count the session's
   // encrypted reasoning steps (`note`), and a window of an STS file never sees
   // the `{type:'session'}` first line that carries the title, the harness and
   // the session id.
-  const head: TraceHeadInfo | null = meta ? {
+  const head: TraceHeadInfo | null = useMemo(() => (meta ? {
     ...meta,
     total: summary ? summary.total : null,
     userTurns: summary ? summary.userTurns : null,
@@ -267,7 +295,7 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
     loaded: turns.current.length,
     atStart,
     blocked,
-  } : null;
+  } : null), [meta, summary, version, atStart, blocked]); // eslint-disable-line react-hooks/exhaustive-deps
 
   return { turns, head, meta, error, version, atStart, blocked, loadOlder, loadNewer, reload: loadTail };
 }

--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -1,0 +1,273 @@
+// Reading a trace as WINDOWS, for whichever surface is doing the reading.
+//
+// The Trace pane and reader mode show the same conversation very differently —
+// one as rows of turns, the other as exchanges with a composer under them — but
+// they fetch it identically: open on the end, page backwards a window at a time,
+// follow the end while it is being written. That fetching is subtle in ways two
+// review rounds found the hard way (a load outliving its source, a second load
+// racing the first, a pointer to a window nobody read), so it lives here once
+// rather than twice.
+//
+// What stays with the caller is everything about presentation: how a row is
+// measured, what is virtualized, and how the reading position is anchored when
+// older turns arrive. The hook says WHEN turns are about to be prepended
+// (`onPrepend`) and when everything has been replaced (`onReset`); the caller
+// decides what that means for its own scroller.
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as api from '../api';
+import type { TraceCursor, TraceSummary, TraceTurn, TraceWindow } from '../api';
+
+/** How much transcript the first request asks for. Measured on the longest trace
+ *  on this box (19 MB / 1,420 turns): 384 KB is ~60 turns, ~84 KB of JSON and
+ *  ~6 ms of server time, and renders in a frame — the smallest window that still
+ *  opens on a complete-looking conversation rather than a stub. */
+export const WINDOW_BYTES = 384 * 1024;
+// Following a trace that is still being written. Nothing in here knows whether
+// an agent is running — but a transcript whose newest turn is seconds old is one
+// being written, so the cadence follows the trace itself: quick while it moves,
+// slow once it has gone quiet, which is also how it notices movement resuming.
+const LIVE_MS = 3_000;
+const IDLE_MS = 10_000;
+const FRESH_MS = 120_000;
+const SUMMARY_DELAY_MS = 400; // let the first paint happen before the whole-file read
+
+export interface TraceSource {
+  window: (req: api.TraceReq, bytes?: number) => Promise<TraceWindow>;
+  summary: () => Promise<TraceSummary>;
+}
+
+export type Meta = Omit<TraceWindow, 'turns' | 'window'>;
+
+/** What a host's chrome needs. `total` is null until the summary lands. */
+export type TraceHeadInfo = Meta & {
+  /** turns the reader is holding right now */
+  loaded: number;
+  /** the first turn of the conversation is loaded — there is nothing above */
+  atStart: boolean;
+  /** one line is bigger than a window: nothing older can be reached */
+  blocked: boolean;
+};
+
+// Keep whichever value actually says something: a window that doesn't reach the
+// start of the trace reports no session start and no session cost, and must not
+// blank out what an earlier response already told us. Identity is preserved when
+// nothing changed — a poll that learns nothing must not look like new state.
+export const mergeMeta = (prev: Meta | null, next: Meta): Meta => {
+  if (!prev) return next;
+  const out = { ...prev } as Record<string, unknown>;
+  let changed = false;
+  for (const [k, v] of Object.entries(next)) {
+    // A window OLDER than what we hold describes an older stretch of the same
+    // conversation. Two of its facts must not travel backwards: `lastTs` drives
+    // how often we look for new turns (scrolling back would otherwise slow the
+    // live tail to a crawl), and `model` is the one the session is running now.
+    if ((k === 'lastTs' || k === 'model') && out[k] && (k !== 'lastTs' || (v as number) <= (out[k] as number))) continue;
+    if ((v || !(k in out)) && out[k] !== v) { out[k] = v; changed = true; }
+  }
+  return changed ? (out as Meta) : prev;
+};
+
+export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
+  /** About to prepend `count` older turns — capture the reading position now. */
+  onPrepend?: (count: number) => void;
+  /** About to append `count` new turns at the end. */
+  onAppend?: (count: number) => void;
+  /** Everything replaced: a new source, or a gap too big to splice. */
+  onReset?: () => void;
+  /** The surface is off-screen: stop asking for turns nobody is looking at. */
+  paused?: boolean;
+} = {}) {
+  const [meta, setMeta] = useState<Meta | null>(null);
+  const [summary, setSummary] = useState<TraceSummary | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const turns = useRef<TraceTurn[]>([]);
+  const cursor = useRef<TraceCursor | null>(null);
+  // ONE request at a time. Flicking the wheel at the top of a long trace fires
+  // scroll events by the dozen, and each one would otherwise start its own load;
+  // they would arrive out of order and prepend the same turns twice.
+  const loading = useRef(false);
+  // Which source the turns in hand belong to. Every load reads this before its
+  // await and checks it after: switch files in the Files pane while a window is
+  // in flight and it would otherwise be prepended to the NEW file's turns, with
+  // the old file's byte cursors and header — a conversation spliced out of two
+  // different transcripts.
+  const gen = useRef(0);
+  const [version, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((n) => n + 1), []);
+
+  const cb = useRef(opts);
+  cb.current = opts;
+
+  const loadTail = useCallback(async () => {
+    loading.current = true;
+    const mine = gen.current;
+    try {
+      const { turns: got, window: win, ...m } = await src.window({ at: 'tail' }, WINDOW_BYTES);
+      if (mine !== gen.current) return;
+      turns.current = got;
+      cursor.current = win;
+      cb.current.onReset?.();
+      setMeta(m);
+      setError(null);
+      bump();
+      // Nothing to render means nothing to measure, so no measurement will ever
+      // arrive to unblock the paging: walk back until there is something. After
+      // this call returns, so the one-request-at-a-time guard still holds.
+      if (!got.length && !win.atStart) window.setTimeout(() => loadOlderRef.current(), 0);
+    } catch (e) {
+      if (mine !== gen.current) return;
+      // The server distinguishes "nothing to show yet" from a real failure and
+      // says which — pass its own words through rather than inventing a reason.
+      setError(e instanceof api.TraceUnavailable ? e.message : 'could not read the trace');
+    } finally {
+      if (mine === gen.current) loading.current = false;
+    }
+  }, [src, bump]);
+
+  const loadOlderRef = useRef<() => Promise<number>>(async () => 0);
+
+  /** Fetch the window before the oldest turn held. Returns how many arrived. */
+  const loadOlder = useCallback(async () => {
+    const cur = cursor.current;
+    if (loading.current || !cur || cur.atStart || cur.blocked) return 0;
+    loading.current = true;
+    const mine = gen.current;
+    try {
+      let from = cur.start;
+      let atStart = false;
+      let blocked = false;
+      let got: TraceTurn[] = [];
+      let meta2: Meta | null = null;
+      // A window can legitimately hold no turns at all (a stretch of file-history
+      // lines, a run of harness metadata). Keep walking back until it holds
+      // something, the file starts, or the cursor stops moving.
+      for (let hop = 0; hop < 8 && !got.length && !atStart; hop++) {
+        const { turns: page, window: win, ...m } = await src.window({ at: 'before', cursor: from }, WINDOW_BYTES);
+        if (mine !== gen.current) return 0;
+        got = page;
+        meta2 = m;
+        // `blocked` is a line too big for any window — the server cannot get
+        // past it, so neither can we, and this is NOT the start of the trace.
+        blocked = !!win.blocked;
+        atStart = win.atStart || (!blocked && win.start >= from);
+        from = win.start;
+        if (blocked) break;
+      }
+      if (got.length) cb.current.onPrepend?.(got.length);
+      turns.current = [...got, ...turns.current];
+      cursor.current = { ...cur, start: from, atStart, blocked };
+      if (meta2) setMeta((p) => mergeMeta(p, meta2 as Meta));
+      bump();
+      return got.length;
+    } catch {
+      // Keep what is on screen; the next scroll retries.
+      return 0;
+    } finally {
+      if (mine === gen.current) loading.current = false;
+    }
+  }, [src, bump]);
+  loadOlderRef.current = loadOlder;
+
+  /** Whatever the agent has written since we last looked. */
+  const loadNewer = useCallback(async () => {
+    const cur = cursor.current;
+    if (loading.current || !cur) return 0;
+    loading.current = true;
+    const mine = gen.current;
+    try {
+      const { turns: got, window: win, ...m } = await src.window({ at: 'after', cursor: cur.end });
+      if (mine !== gen.current) return 0;
+      if (win.gap) {
+        // More was written than one window can carry. Splicing it in would leave
+        // a hole in the middle of the conversation with nothing to say so —
+        // start again from the new tail instead.
+        turns.current = got;
+        cursor.current = win;
+        cb.current.onReset?.();
+      } else {
+        if (got.length) {
+          cb.current.onAppend?.(got.length);
+          turns.current = [...turns.current, ...got];
+        }
+        cursor.current = { ...cur, end: win.end, atEnd: win.atEnd };
+      }
+      setMeta((p) => mergeMeta(p, m));
+      if (got.length) bump();
+      return got.length;
+    } catch {
+      // A poll that fails must not throw away the conversation on screen.
+      return 0;
+    } finally {
+      if (mine === gen.current) loading.current = false;
+    }
+  }, [src, bump]);
+
+  useEffect(() => {
+    gen.current += 1;
+    loading.current = false;
+    turns.current = [];
+    cursor.current = null;
+    cb.current.onReset?.();
+    setMeta(null);
+    setSummary(null);
+    setError(null);
+    loadTail();
+  }, [srcKey, loadTail]);
+
+  // The one read that touches the whole file, fired AFTER the first paint: it
+  // buys the header a real turn count, the session's token total, the date the
+  // conversation started and the disclosures a window cannot see — none of which
+  // a window can know. If it fails or is slow, the header simply says how much
+  // is loaded.
+  useEffect(() => {
+    let dead = false;
+    const h = window.setTimeout(() => {
+      src.summary().then((s) => { if (!dead) setSummary(s); }).catch(() => {});
+    }, SUMMARY_DELAY_MS);
+    return () => { dead = true; window.clearTimeout(h); };
+  }, [src, srcKey]);
+
+  // The transcript may still be being written — see LIVE_MS above. Except when
+  // "a window" costs a whole-file read: the SQLite harnesses have no byte
+  // offsets to seek, so every poll would re-parse the entire conversation (and
+  // evict the Overview's memo doing it). They are not polled at all.
+  const lastTs = meta ? meta.lastTs : 0;
+  const seekable = cursor.current ? cursor.current.mode === 'bytes' : true;
+  const paused = !!opts.paused;
+  useEffect(() => {
+    if (!seekable || paused) return undefined;
+    const h = window.setInterval(loadNewer, lastTs && Date.now() - lastTs < FRESH_MS ? LIVE_MS : IDLE_MS);
+    return () => window.clearInterval(h);
+  }, [loadNewer, lastTs, seekable, paused]);
+
+  const atStart = !!cursor.current?.atStart;
+  const blocked = !!cursor.current?.blocked;
+  // What the pane knows about the trace: whatever this window could tell us,
+  // filled in from the summary for everything a window cannot know. That is not
+  // only the counts — a window of a codex rollout cannot count the session's
+  // encrypted reasoning steps (`note`), and a window of an STS file never sees
+  // the `{type:'session'}` first line that carries the title, the harness and
+  // the session id.
+  const head: TraceHeadInfo | null = meta ? {
+    ...meta,
+    total: summary ? summary.total : null,
+    userTurns: summary ? summary.userTurns : null,
+    usage: meta.usage || (summary ? summary.usage : null),
+    firstTs: meta.firstTs || (summary ? summary.firstTs : 0),
+    truncated: meta.truncated || !!(summary && summary.truncated),
+    note: meta.note || (summary ? summary.note : null),
+    title: meta.title || (summary ? summary.title : ''),
+    harnessLabel: meta.harnessLabel || (summary ? summary.harnessLabel : ''),
+    sessionId: meta.sessionId || (summary ? summary.sessionId : null),
+    model: meta.model || (summary ? summary.model : null),
+    cwd: meta.cwd || (summary ? summary.cwd : null),
+    source: meta.source || (summary ? summary.source : null),
+    sharedBy: meta.sharedBy || (summary ? summary.sharedBy : null),
+    loaded: turns.current.length,
+    atStart,
+    blocked,
+  } : null;
+
+  return { turns, head, meta, error, version, atStart, blocked, loadOlder, loadNewer, reload: loadTail };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1179,6 +1179,10 @@ a.btn-ghost { text-decoration: none; }
 .trace-hint { flex: none; padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel); color: var(--muted); font-size: 11px; font-family: var(--font-mono); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 
 .tv-msg { color: var(--muted); font-size: 0.85em; padding: 0.3em 0.1em; }
+/* The line above the oldest loaded turn. Its height is fixed on purpose: it
+   sits above every row offset, so a line that grew or vanished when the reader
+   reached the start of the trace would shove the whole conversation. */
+.tv-top { height: 1.6em; line-height: 1.6em; padding: 0 0.1em; overflow: hidden; text-align: center; opacity: 0.75; }
 
 .tv-row { padding: 5px 0; border-bottom: 1px solid var(--border); }
 .tv-row.placeholder { opacity: 0.25; }


### PR DESCRIPTION
Opening a long trace meant normalizing the whole transcript before anything could be shown, and then landing on its **oldest** turn. On the longest session on this Space (`edbfc11f…`, 19 MB, ~1,420 turns) that is 676 KB on the wire and ~160 ms of server time for the first read after the file changes — which, while an agent is writing, is *every* read, since the parse memo is keyed on mtime.

The reader now opens at the end and pages backwards.

## How

A **window** is a byte range of the `.jsonl` run through the same normalizers, with line-aligned cursors handed back to the caller. Consecutive windows abut exactly, so the conversation stitches together with no gaps and no repeats — and the part of the trace nobody scrolled to is never read.

| request | answers with |
|---|---|
| `?tail=1&bytes=` | the last window of the transcript |
| `?before=<cursor>` | the window in front of one you already hold |
| `?after=<cursor>` | whatever has been appended since |
| `?summary=1` | whole-trace facts (`total`, `userTurns`, `usage`, `firstTs`), no turns |
| `?offset=&limit=` | **unchanged** — index paging, still used by the Overview cards and RENDER mode |

`total`, `userTurns`, `firstTs` and the session's token total are whole-trace facts a window cannot know, so a window does not claim them. They come from `?summary=1`, which the pane asks for 400 ms **after** its first paint; until it lands the header says `N turns loaded` rather than inventing a total. The SQLite harnesses (opencode, hermes) have no byte offsets to seek, so they answer the same shape with message indices as cursors — the reader treats a cursor as opaque.

In the pane: the scroller is anchored on the row you are reading, using that row's **real geometry**; exactly one window request is ever in flight; reaching byte 0 stops the paging; and a growing trace is followed at the end — 3 s while it moves, 10 s once it has been quiet, which is also how it notices movement resuming — without dragging a reader who has scrolled up.

## Numbers

Against `upstream/main` built and served from the same files, on two real traces: a 19 MB Claude transcript and a 4.8 MB codex rollout. Server time is `curl` against a local server; "first turn on screen" is Playwright, median of 5–9 opens.

| | Claude 19 MB | | codex 4.8 MB | |
|---|---|---|---|---|
| | before | after | before | after |
| bytes, first request | 676 KB | **82 KB** | 513 KB | **151 KB** |
| server time, transcript changed since last request | 160 ms | **6 ms** | 46 ms | **6 ms** |
| server time, transcript unchanged (memo hit) | 6 ms | 6 ms | 5 ms | 6 ms |
| the `?summary=1` whole-file read, 400 ms after the paint | — | 176 ms | — | 46 ms |
| first turn on screen, localhost | 181 ms | 167 ms | 172 ms | 189 ms |
| first turn on screen, 10 Mbps / 40 ms | 866 ms | **267 ms** | 868 ms | **355 ms** |
| opens on | oldest turn | **newest turn** | oldest turn | **newest turn** |

**The whole-file parse is deferred, not removed** — the summary row above is the correction. The reader still asks for `?summary=1` once per pane open, and since `viewMemo` is keyed on mtime, a transcript a working agent is appending to pays that 160–176 ms parse on every open, after the first paint instead of in front of it. An earlier version of this table implied that work was gone; it moved. What the window buys is the first view and every page after it (a `before=` window is ~6 ms and never touches the memo); what it does not buy is a server that never reads the whole file.

Read honestly: **on loopback this is a wash** — both are ~170–190 ms, dominated by render and app work, and the codex case is if anything marginally slower. The win is the bytes, and it shows the moment there is a real link between browser and Space. Main was never slow at serving a memoized parse — only at building one, and at putting 676 KB on the wire to show you the wrong end of the conversation.

The 384 KB default window was chosen by sweeping 128 KB – 1 MB in a browser: paint time is flat (155–171 ms, the list is virtualized either way) and only the payload moves.

## What deploying it found

The last three commits are fixes from running this on the testing Space (`thomwolf/agent-manager`, now on this branch on top of #51), which put it in front of a **codex rollout** — turns far denser than Claude's — for the first time:

- **`734ecb7`** — the "at least 30 turns" growth floor grew that rollout's window to 1.5 MB and its response to 591 KB, within sight of the whole-file page this exists to avoid. The floor is a guard against opening on a stub, not a target: 12 turns, doubling instead of quadrupling.
- **`5300305`** — scroll anchoring restored from the prefix-sum height model, which is estimates until a row is measured; on rows several times `ROW_EST` a prepend moved the text under the reader ~280 px on the Space (~30 px locally, small enough to look like nothing). The anchor now carries the row's real `getBoundingClientRect()` position. 0 px drift on both traces.
- **`4fcb868`** — the same estimates made a 19-turn window model as 800 px against a 774 px pane, so the reader thought it was at the top and fetched an older window on every open. Paging now waits for a measurement, not just a placement. Opening a pane is back to exactly two requests.

**And one the operator caught while looking at it (`bd5aab9`), same principle one pane over:** switching a pane from terminal to **reader** mode landed at the *top* of the last 400 turns, because that view only placed itself when the agent was `working` — which most agents, most of the time, are not. On a 1,420-turn session that is 5,033 px above the end, hundreds of rows behind what you were just watching in the terminal. The placement is no longer conditional; `stick` still goes false the instant you scroll up, verified by parking the view and watching it stay across a poll tick.

## Review round (`d49cd6d`)

A review of the branch found six real defects, every one the same mistake in a different place — a window answering a question only the whole file can. All six now have tests that fail on the previous commit:

1. **The codex guardian guard never fired on a real rollout.** It read a fixed 16 KB and parsed the first line; a real `session_meta` carries `base_instructions.text` and runs 18–44 KB here (measured 18,596 B and 43,865 B), so the parse always threw and `catch { return }` turned "I could not tell" into "not a subagent". Any guardian rollout bigger than one window rendered as the operator's conversation. The read now grows until the line is whole; an unreadable head falls back to the whole-file reader, which throws on the marker itself. `/api/files/:id/trace` also mapped that refusal to a 500 — fixed.
2. **A load could outlive its source.** Switching files in the Files pane while a window was in flight prepended the old file's turns to the new file's list, with the old file's byte cursors and header. Every load now carries a generation stamp.
3. **A window's `note`** (codex's count of encrypted reasoning steps) was rendered as a fact about the session, and changed as you scrolled — 40, then 23, 25, 23. It now travels with `usage`/`firstTs` as summary-only.
4. **A line larger than the window read as the beginning of the conversation.** A 9 MB file-history blob cannot be paged past; the client turned "no progress" into `atStart`. The server now says `blocked` and the reader says what actually happened.
5. **A torn last line cost the final answer its accent forever** — `atEnd` meant "consumed every byte" rather than "read to EOF".
6. **`lastTs` went backwards when paging back**, dropping the live tail from 3 s to 10 s, and an older window's `model` replaced the current one. Both are monotonic in the merge now.

Plus: index-mode windows (opencode/hermes) page 100 turns rather than 12; the harness sniff memo gets a 60 s TTL so a re-imported bundle ref is not pinned to its old format; a prompt jump that has to fetch waits for the prepend to commit.

## What I verified, and how

**In a real browser, locally** (Playwright/Chromium, this branch on :7999 vs `upstream/main` on :7998, same transcripts, same seeded sessions). Every check ran on both builds; the control fails 7 of them:

- opens on the newest turn, with one tail request and nothing older fetched until asked
- scrolling into the top band prepends older turns and **the row under the reader stays at the same pixel** — asserted over an emulated 400 ms link so the before/after samples straddle the prepend, with the content above growing 2,800 px (Claude) and 4,171 px (codex)
- 25 scroll events at the top → 20 requests, never more than one window request in flight
- paging back reaches the first turn and then stops — 0 further requests while held at the top
- a transcript appended to while open: new turns appear in 1.8 s, exactly once, follows the end while pinned there and does not jump when the reader has scrolled up
- the same reader in the Files pane renders a `.jsonl` opened from the file tree, opens at the end, reports its turn count

**Reader mode**, timeline sampled every 200 ms rather than once at the end (a single late sample gave a false pass first time round): before, `scrollTop` sits at 0 for the whole 6 s after entering reader mode; after, it is at the end from the first frame the reader exists, on the same session, on the same Space.

**On the deployed Space** (private, driven through `https://thomwolf-agent-manager.hf.space` with a bearer token), against a codex **session** trace and an imported **bundle**: opens at the end in ~360 ms, two requests, anchor holds at 0 px drift on both, paging back reaches the beginning in 7 requests and stops, one window request in flight.

**Server tests:** new `server/test/trace-window.test.mjs` — stitching every window reproduces a 600-turn conversation exactly, paging past byte 0 returns nothing and stays put, an appended turn arrives once, a torn last line is not a turn until it is whole, a transcript with no trailing newline still ends in one, a 300 KB turn bigger than the window still arrives. `npm test` in `server/` passes in full (including both boot suites); `tsc --noEmit` and `web/test/exchanges.test.mjs` clean.

**Not verified:** mobile/touch. OpenClaw, STS and the SQLite harnesses go through the shared code paths and the unit tests, but I only opened Claude and codex traces in a browser. The codex subagent guard is re-checked from the head of the rollout, since a tail window never sees `session_meta`.

**One behavioural difference, on purpose:** a harness message whose lines straddle a window boundary is split into two turns instead of merged into one. Stitching every window of the 19 MB transcript gives 1,433 turns against the full parse's 1,420 — character-for-character identical content. Documented at the window reader and in `docs/trace-panel-spec.md` §13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



