### PR TITLE
Re-pin: follow a /clear that happens inside a worktree

### DIFF
--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -661,6 +661,31 @@ async function hydrateTraceHistory(session, host) {
   }
 }
 
+// ---------- whose folder is this conversation in? ----------
+// Every pin path asks the same question of a candidate conversation: was it
+// started by THIS pane? The answer is the folder it was born in — and a pane's
+// folder is a tree, not one directory.
+//
+// This used to be `cwd === workdir`, and that quietly broke every agent that
+// works in a git worktree. The PTY starts in the session's folder, the agent
+// then enters `.claude/worktrees/<name>` (or just cd's somewhere below), and the
+// conversation a later `/clear` starts records that DEEPER cwd. Equality
+// rejected it from both directions — the SessionStart crumb as 'cwd mismatch',
+// the transcript scan by skipping the file — so the pin stayed on the abandoned
+// conversation for the rest of the pane's life. The reader kept showing the
+// pre-/clear thread while the terminal showed the new one, and the next launch
+// would `--resume` the old id and discard everything since. Observed live:
+// session claude-code-4 pinned edbfc11f… while claude wrote b1e23587… in
+// /data/workspaces/Agent-manager/.claude/worktrees/session-sharing.
+//
+// Containment, not prefix matching: `/w/proj-a2` must not count as inside
+// `/w/proj-a`. Exported for server/test/repin.test.mjs.
+export function cwdUnderWorkdir(cwd, workdir) {
+  if (typeof cwd !== 'string' || !cwd || typeof workdir !== 'string' || !workdir) return false;
+  const rel = path.relative(path.resolve(workdir), path.resolve(cwd));
+  return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
+}
+
 // ---------- Codex conversation pinning ----------
 // Codex picks its own conversation id at launch and doesn't accept one up
 // front. The managed SessionStart hook below is the primary source of its exact
@@ -764,7 +789,7 @@ function tryCaptureCodexId(sessionId, workdir, sinceMs) {
     let meta;
     try { meta = JSON.parse(firstLine(c.p)); } catch { continue; }
     const mp = (meta && meta.payload) || {};
-    if (mp.cwd !== workdir) continue;
+    if (!cwdUnderWorkdir(mp.cwd, workdir)) continue;
     // A sibling's ongoing conversation in the same folder gets fresh writes
     // (mtime) during our capture window — require the rollout to have been
     // CREATED after this launch so we never claim someone else's thread.
@@ -948,8 +973,10 @@ export async function claudeCandidate(sessionId, workdir, sinceMs) {
     // in every real transcript measured. Reading line 1 made this check always
     // fail, so the re-pin could never actually claim anything.
     const head = await transcriptHeadCached(c.p);
-    // Only claim a conversation started in THIS session's folder.
-    if (!head || head.cwd !== workdir) continue;
+    // Only claim a conversation started in THIS session's folder — or in a
+    // directory below it, which is where an agent in a worktree lives (see
+    // cwdUnderWorkdir).
+    if (!head || !cwdUnderWorkdir(head.cwd, workdir)) continue;
     const start = Date.parse(head.timestamp || '') || 0;
     // Born in this launch window, or it's an older thread that merely received
     // writes — someone else's, or our own pre-relaunch one.
@@ -959,12 +986,22 @@ export async function claudeCandidate(sessionId, workdir, sinceMs) {
   return best;
 }
 
-// Another LIVE session of the same harness on the same folder makes a new
+// Another LIVE session of the same harness whose folder OVERLAPS ours makes a new
 // conversation there unattributable: we cannot tell whose /clear produced it.
 // Refuse to guess, the way share.js does when a folder has rivals.
+//
+// Overlap, not equality, because the scan now accepts a conversation born
+// anywhere below the folder (see cwdUnderWorkdir): a live sibling running in a
+// subdirectory of ours — or in a parent of it, which is what a session on the
+// workspaces root is — is exactly as ambiguous as one in the same directory.
+// Refusing here costs nothing where it fires: the breadcrumb path is unaffected,
+// and it is the mechanism now — the scan is its backstop.
 function folderIsShared(sessionId, workdir, cli) {
-  return list().some((s) => s.id !== sessionId && s.cli === cli
-    && path.join(WORKSPACES_DIR, s.path ?? s.id) === workdir && isRunning(s.id));
+  return list().some((s) => {
+    if (s.id === sessionId || s.cli !== cli || !isRunning(s.id)) return false;
+    const other = path.join(WORKSPACES_DIR, s.path ?? s.id);
+    return cwdUnderWorkdir(other, workdir) || cwdUnderWorkdir(workdir, other);
+  });
 }
 
 // Re-pinning is NOT a one-shot check, because the pin can go stale mid-session.
@@ -1086,8 +1123,10 @@ export function breadcrumbVerdict(crumb, sessionId, facts) {
   if (!CONVERSATION_ID[facts.cli]?.test(conversationId || ''))
     return { repin: null, why: 'no session_id' };
   // A crumb written before a pane was moved to another folder must not follow
-  // it there — same folder-scoping rule the transcript scan applies.
-  if (crumb.payload?.cwd !== facts.workdir) return { repin: null, why: 'cwd mismatch' };
+  // it there — same folder-scoping rule the transcript scan applies, and the
+  // same tree (a worktree under the folder is still this pane's work).
+  if (!cwdUnderWorkdir(crumb.payload?.cwd, facts.workdir))
+    return { repin: null, why: 'cwd outside the session folder' };
   // Every supported adapter inherits the pane markers into child processes.
   // Only the top-level agent process may speak for the pane; nested agents can
   // otherwise re-pin their parent's Overview, trace and next resume target.
@@ -1242,7 +1281,8 @@ function applyBreadcrumb(session, host, workdir, crumb) {
     const row = opencodeSessionInfo(crumb?.payload?.session_id);
     if (!row) return { repin: null, why: 'session missing from database', retry: true };
     if (row.parentId) return { repin: null, why: 'subagent session' };
-    if (row.directory !== workdir) return { repin: null, why: 'database cwd mismatch' };
+    if (!cwdUnderWorkdir(row.directory, workdir))
+      return { repin: null, why: 'database cwd outside the session folder' };
     patch = (id) => ({ opencodeSessionId: id });
   }
 

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -83,6 +83,34 @@ check('claimed uuid skipped', (await runner.claudeCandidate('s1', WORKDIR, SINCE
 console.log('\nnothing new in the window means no re-pin');
 check('no candidate', await runner.claudeCandidate('s1', path.join(cfg.WORKSPACES_DIR, 'empty'), SINCE), null);
 
+// ---------- the folder is a tree ----------
+// An agent that enters a git worktree is still the same pane in the same folder,
+// and the conversation its /clear starts records the DEEPER cwd. Equality here
+// meant the pin could never follow that — the reader kept showing the pre-/clear
+// thread while the terminal showed the new one, and the next launch would
+// `--resume` the abandoned id.
+console.log('\ncwdUnderWorkdir: the pane owns its whole tree, and nothing beside it');
+const WT = path.join(WORKDIR, '.claude', 'worktrees', 'wt-1');
+check('the folder itself', runner.cwdUnderWorkdir(WORKDIR, WORKDIR), true);
+check('a worktree below it', runner.cwdUnderWorkdir(WT, WORKDIR), true);
+check('a plain subdirectory', runner.cwdUnderWorkdir(path.join(WORKDIR, 'server'), WORKDIR), true);
+check('a sibling sharing a name prefix',
+  runner.cwdUnderWorkdir(`${WORKDIR}2`, WORKDIR), false);
+check('the parent folder', runner.cwdUnderWorkdir(cfg.WORKSPACES_DIR, WORKDIR), false);
+check('somewhere else entirely', runner.cwdUnderWorkdir('/elsewhere', WORKDIR), false);
+check('no cwd at all', runner.cwdUnderWorkdir(null, WORKDIR), false);
+check('no workdir at all', runner.cwdUnderWorkdir(WORKDIR, ''), false);
+
+console.log('\na /clear inside a worktree is followed');
+const F = 'ffffffff-0000-0000-0000-000000000006';
+transcript(F, { cwd: WT, startMs: NOW + 240_000, projDir: '-proj-a--claude-worktrees-wt-1' });
+check('worktree conversation claimed', (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, F);
+
+console.log('\na neighbouring folder whose name starts the same is still not ours');
+transcript('99999999-0000-0000-0000-000000000009',
+  { cwd: `${WORKDIR}2`, startMs: NOW + 300_000, projDir: '-proj-a2' });
+check('prefix neighbour ignored', (await runner.claudeCandidate('s1', WORKDIR, SINCE))?.uuid, F);
+
 // ---------- breadcrumbs: attribution the scan cannot do in shared folders ----------
 const E = 'eeeeeeee-0000-0000-0000-000000000005';
 const RUN = '11111111-2222-4333-8444-555555555555';
@@ -106,6 +134,15 @@ check('stale launch rejected', verdict(crumb({ runId: 'old-run' }), facts()).why
 check('wrong harness rejected', verdict(crumb({ cli: 'codex' }), facts()).why, 'cli mismatch');
 check('cwd mismatch rejected',
   verdict(crumb({ payload: { session_id: E, cwd: '/elsewhere', source: 'clear' } }), facts()).repin, null);
+check('a crumb from a parent folder rejected',
+  verdict(crumb({ payload: { session_id: E, cwd: cfg.WORKSPACES_DIR, source: 'clear' } }), facts()).why,
+  'cwd outside the session folder');
+check('a crumb from a prefix neighbour rejected',
+  verdict(crumb({ payload: { session_id: E, cwd: `${WORKDIR}2`, source: 'clear' } }), facts()).repin, null);
+
+console.log('\na /clear reported from a worktree below the folder is this pane speaking');
+check('worktree crumb accepted',
+  verdict(crumb({ payload: { session_id: E, cwd: WT, source: 'clear' } }), facts()).repin, E);
 
 console.log('\na nested claude -p cannot claim the pane (pid not under the pane root)');
 check('untrusted pid rejected', verdict(crumb(), facts({ pidTrusted: false })).repin, null);


### PR DESCRIPTION
## The symptom

A session's reader and its terminal showed two different conversations. Same
pane, same agent: the terminal was mid-conversation while the reader kept
rendering a thread that had ended hours earlier.

## Why

The reader reads `/api/trace/:id`, which resolves to `session.sessionUuid` — the
pin. `runner.js` keeps that pin honest with two mechanisms (a SessionStart
breadcrumb from the pane, and a transcript scan as its backstop), and **both
asked `cwd === workdir`** of a candidate conversation.

That equality quietly broke every agent that works in a git worktree. The PTY
starts in the session's folder; the agent enters `.claude/worktrees/<name>`; and
the conversation a later `/clear` starts records that *deeper* cwd. So the
breadcrumb was rejected as `cwd mismatch` and the scan skipped the file, and the
pin stayed on the abandoned conversation for the rest of the pane's life.

Observed live on this Space: a session pinned `edbfc11f…` while Claude was
writing `b1e23587…` under `.claude/worktrees/session-sharing`. `/tmp/am-repin`
showed a crumb written and consumed with the pin unmoved.

The wrong reader is the visible half. The other half is worse: the next launch
runs `--resume <pinned uuid>`, so a restart would restore the pre-`/clear`
thread and discard everything since — precisely the failure this watcher was
written to prevent (see the comment above `scheduleClaudeCapture`).

## The change

One helper, containment instead of equality:

```js
export function cwdUnderWorkdir(cwd, workdir) {
  const rel = path.relative(path.resolve(workdir), path.resolve(cwd));
  return rel === '' || (rel !== '..' && !rel.startsWith(`..${path.sep}`) && !path.isAbsolute(rel));
}
```

Containment rather than a prefix test, so `/w/proj-a2` is not inside `/w/proj-a`.

Applied at all four places that asked the same question, because the other three
harnesses carried the identical one-liner and Codex agents here work in worktrees
too:

| Path | Was |
|---|---|
| Claude transcript scan (`claudeCandidate`) | `head.cwd !== workdir` |
| Claude/Codex/OpenCode breadcrumb (`breadcrumbVerdict`) | `crumb.payload.cwd !== facts.workdir` |
| Codex rollout head (`tryCaptureCodexId`) | `mp.cwd !== workdir` |
| OpenCode database row (`applyBreadcrumb`) | `row.directory !== workdir` |

`folderIsShared` widens with it. Now that the scan reaches below the folder, a
live sibling of the same harness in a *subdirectory* — or in a *parent* of it,
which is what a session on the workspaces root is — is exactly as unattributable
as one in the same directory, and gets the same refusal to guess. That costs
nothing where it fires: breadcrumbs are the mechanism, and they carry their own
pane/run/pid attribution; the scan is only their backstop.

Attribution is not loosened anywhere else. A crumb still has to match `AM_ID`,
`AM_RUN_ID`, the harness, an unclaimed conversation id, and a pid that is the
pane root or its direct child — so a nested `claude -p` in a subdirectory still
cannot speak for the pane.

## What I verified

**A control first, because a test that passes both ways proves nothing.** With
the fix reverted, against the same fixtures the new tests use:

```
scan:       worktree conversation claimed -> null
breadcrumb: worktree crumb -> {"repin":null,"why":"cwd mismatch"}
```

With it applied, the scan claims the worktree conversation and the crumb
re-pins. Both cases, plus eight containment unit cases (the folder itself, a
worktree below it, a plain subdirectory, a prefix neighbour `proj-a2`, the
parent, elsewhere, and null inputs), are now in `server/test/repin.test.mjs`.

**Full server suite green, exit 0**: `spawn-group` 28, `repin` 67,
`opencode-resume` 32, plus `terminal-modes`, `trace-tail`, `migration` (which
boots a real server) and `resize`.

That run needs `@coder/libghostty-vt-node`, which a fresh worktree does not have
— from the worktree alone you get 65/67 (the two live-pane checks skip) and a
spurious `migration.test.mjs` failure that is only the missing dep. I ran the
suite from a clone with a real `node_modules` symlinked in to confirm it passes
with deps present.

**What I did NOT verify:** I did not drive a browser, and I did not watch this
fix repair a live pin end to end. The re-pin needs a conversation born inside a
launch window, so proving it live means restarting a pane on this build and
`/clear`-ing inside a worktree — the deployed server is still `main`. The
evidence here is the control-vs-fix pair on real transcript fixtures plus the
live diagnosis that produced the same `cwd mismatch` verdict.

**Not in scope:** `share.js:217` has the same equality in its cwd *fallback*.
It only runs when the pin matches nothing on disk, and a correct pin makes it
moot, so widening the share path's guesswork belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
