### PR TITLE
Overview: a `started` chip, without a second name for `working`

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,7 +14,7 @@ import Locked from './components/Locked';
 import BackupBanner from './components/BackupBanner';
 import Welcome from './components/Welcome';
 import * as api from './api';
-import type { Cli, GridSpec, MoveTarget, OverviewFilter, OverviewSort, Session, Tree } from './types';
+import type { Cli, GridSpec, MoveTarget, OverviewChip, OverviewSort, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
 import { isPassive, isRemote } from './types';
 import { GridGlyph, ListGlyph, SortGlyph } from './components/icons';
@@ -50,6 +50,17 @@ type SettingsPage = 'general' | 'usage' | 'skills';
 const ROOT_PATH = '.';
 const WARM_TERMINAL_LIMIT = 12;
 const normalizePath = (p?: string | null) => (p && p.trim() ? p : ROOT_PATH);
+// The Overview's filter chips. The label IS the chip, so there is no second
+// display string that can drift from the value; the tooltips carry the rest.
+// `started` is the union of the two before it, not a fifth state of its own —
+// see chipBuckets in types.ts.
+const OV_CHIPS: { chip: OverviewChip; title: string }[] = [
+  { chip: 'all', title: 'Every agent' },
+  { chip: 'done', title: 'Answered and waiting on you' },
+  { chip: 'running', title: 'Working right now' },
+  { chip: 'started', title: 'Anything still up — running or waiting on you' },
+  { chip: 'stopped', title: 'Not running' },
+];
 
 function initialTheme(): 'light' | 'dark' {
   const stored = localStorage.getItem('am-theme');
@@ -134,7 +145,11 @@ export default function App() {
   // true = the selected session/group fills the screen. Desktop ignores this.
   const isMobile = useIsMobile();
   const [mobileStage, setMobileStage] = useState(() => readStored('am-mobile-stage') === '1');
-  const [ovFilter, setOvFilter] = useState<OverviewFilter>('all');
+  // Which chip the Overview's bottom bar is on. A chip is coarser than a bucket
+  // (`started` = waiting or working) — see chipBuckets in types.ts. Not persisted,
+  // unlike the sort beside it: "show me only the stopped ones" is a thing you do
+  // for a moment, not a standing preference.
+  const [ovChip, setOvChip] = useState<OverviewChip>('all');
   const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
   const rememberPath = (p?: string | null) => {
     const next = normalizePath(p);
@@ -1004,7 +1019,7 @@ export default function App() {
             <Overview
               clis={clis}
               tree={tree}
-              filter={ovFilter}
+              chip={ovChip}
               sort={ovSort}
               view={ovView}
               archived={archivedIds}
@@ -1042,10 +1057,9 @@ export default function App() {
         {activeRef === 'overview' && (
           <div className="zoombar ov-bar">
             <div className="seg ov-seg">
-              {(['all', 'waiting', 'working', 'quiet'] as OverviewFilter[]).map((f) => (
-                <button key={f} className={ovFilter === f ? 'on' : ''} onClick={() => setOvFilter(f)}>
-                  {f === 'waiting' ? 'done' : f === 'working' ? 'running' : f === 'quiet' ? 'stopped' : 'all'}
-                </button>
+              {OV_CHIPS.map(({ chip, title }) => (
+                <button key={chip} className={ovChip === chip ? 'on' : ''} title={title}
+                  onClick={() => setOvChip(chip)}>{chip}</button>
               ))}
             </div>
             {/* Sort, independent of the filter beside it: one says WHICH agents

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } fr
 import type { CSSProperties, ReactNode } from 'react';
 import * as api from '../api';
 import type { MetaSession, TraceTurn } from '../api';
-import type { Cli, OverviewFilter, OverviewSort, Session, SessionState, Tree } from '../types';
-import { isPassive, isRemote } from '../types';
+import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionState, Tree } from '../types';
+import { chipBuckets, isPassive, isRemote } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
 import type { Rankable } from '../lib/overviewSort';
@@ -399,10 +399,10 @@ function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession; color
 /** Mission control: one reading column — group capsules with their agents as
  *  slabs, loose agents as standalone panels. Unless a sort is on, in which case
  *  it is one flat ranked column instead (see §"sorted feed" below). */
-export default function Overview({ clis, tree, filter, sort, view, archived, showArchived, meta, metaReady, isMobile, onOpen }: {
+export default function Overview({ clis, tree, chip, sort, view, archived, showArchived, meta, metaReady, isMobile, onOpen }: {
   clis: Cli[];
   tree: Tree;
-  filter: OverviewFilter; // controlled by the bottom bar in App
+  chip: OverviewChip;     // controlled by the bottom bar in App
   sort: OverviewSort;     // ditto, and independent of the filter
   view: 'tiles' | 'list'; // controlled by the bottom bar in App
   archived: Set<string>;
@@ -430,8 +430,11 @@ export default function Overview({ clis, tree, filter, sort, view, archived, sho
   // session is in `meta` (or genuinely has no digest).
   const pending = (id: string) => !metaReady && !meta[id];
 
+  // One chip can stand for several buckets ('started' is waiting AND working), so
+  // this is set membership, not equality.
+  const buckets = chipBuckets(chip);
   const visible = (s: MetaSession) =>
-    (filter === 'all' || bucket(s.state) === filter) && (showArchived || !archived.has(s.id));
+    buckets.includes(bucket(s.state)) && (showArchived || !archived.has(s.id));
 
   // Which group each agent is in, by name. Only the sorted feed needs it: the
   // manual feed draws the group as a frame around its members and would be
@@ -470,10 +473,14 @@ export default function Overview({ clis, tree, filter, sort, view, archived, sho
           m,
           lastPromptTs: m.digest?.lastPromptTs || 0,
           lastAssistantTs: m.digest?.lastAssistantTs || 0,
-          // Don't pin under the `running` filter: `visible()` has already kept
-          // ONLY working sessions, so pinning them all would empty the sorted
-          // block and make the sort a no-op that still looks selected.
-          running: filter !== 'working' && atWork(m),
+          // Don't pin when the chip has already kept ONLY working sessions
+          // (`running`): `visible()` has kept nothing else, so pinning them all
+          // would empty the sorted block and make the sort a no-op that still
+          // looks selected. Asked as a question about the BUCKET SET rather than
+          // about the chip's name, so a chip that merely includes working —
+          // `started`, `all` — still pins, and the working agents float to the top
+          // of the wider set instead of being lost in it.
+          running: !(buckets.length === 1 && buckets[0] === 'working') && atWork(m),
         });
       }
     }
@@ -483,7 +490,7 @@ export default function Overview({ clis, tree, filter, sort, view, archived, sho
     if (!metaReady) return { running: [], dated: items, undated: [] };
     return rankSessions(items, sort);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, filter, archived, showArchived]);
+  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived]);
 
   // Collapse at constant velocity: duration follows the group's height.
   const toggleGroup = (gid: string, el: HTMLElement) => {
@@ -602,7 +609,15 @@ export default function Overview({ clis, tree, filter, sort, view, archived, sho
     </div>
   );
 
-  const empty = <div className="usage-msg mono">{filter === 'all' ? 'no agents yet — shells and file panes don’t appear here.' : 'nothing in this state.'}</div>;
+  // "nothing in this state" is still true of the chips that mean exactly one
+  // state; `started` means two, so it says what it actually looked for.
+  const empty = (
+    <div className="usage-msg mono">
+      {chip === 'all' ? 'no agents yet — shells and file panes don’t appear here.'
+        : chip === 'started' ? 'nothing started — no agent is running or waiting on you.'
+        : 'nothing in this state.'}
+    </div>
+  );
 
   if (view === 'tiles') {
     const content = sorted ? rankedBlocks() : tileBlocks;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -101,7 +101,33 @@ export interface RemoteInfo {
   state: SessionState;
 }
 
+// Which bucket an agent falls in — one per meaningful state, plus `all`. This is
+// the granular representation and it stays granular: bucket() in
+// components/Overview.tsx puts a session in one, and the working/waiting split is
+// load-bearing well outside the filter (atWork(), the card's "running" line, the
+// sorted feed's pinned block).
 export type OverviewFilter = 'all' | 'waiting' | 'working' | 'quiet';
+
+// What the Overview's bottom bar OFFERS. A chip is something you can click; a
+// bucket is a state an agent can be in, and the two are NOT one-to-one: `started`
+// covers the same agents as `done` and `running` together, the way `all` covers
+// everything. Chips may overlap because exactly one is ever selected.
+//
+// Deliberately a separate type rather than two more OverviewFilter members: on
+// one type `started` and `working` would both be selectable spellings of an
+// overlapping set, and every consumer of the granular value (atWork(), the card's
+// "running" line, the pinned at-work block) would have to know which spelling it
+// was handed. Here the widening lives in one function and nothing downstream
+// changes.
+export type OverviewChip = 'all' | 'done' | 'running' | 'started' | 'stopped';
+
+// The buckets a chip covers. Pure, and the only place the widening happens.
+export const chipBuckets = (chip: OverviewChip): OverviewFilter[] =>
+  chip === 'done' ? ['waiting']
+  : chip === 'running' ? ['working']
+  : chip === 'started' ? ['waiting', 'working']
+  : chip === 'stopped' ? ['quiet']
+  : ['waiting', 'working', 'quiet'];
 
 // How the Overview is ordered. `manual` is the tree's own arrangement — groups
 // as capsules, agents where you put them; the other two flatten that and rank


### PR DESCRIPTION
The Overview's filter chips go from **(all, done, running, stopped)** to **(all, done, running, started, stopped)**. `started` is one click for "anything still up" — the union of `done` and `running`.

## How, because this isn't a rename

The chips and the buckets are now different types.

- `OverviewFilter` (`'all' | 'waiting' | 'working' | 'quiet'`) is **unchanged**. It is what `bucket()` returns and it stays granular, because the working/waiting distinction is load-bearing outside the filter: `atWork()`, the card's "running" line and the sorted feed's pinned at-work block all turn on it.
- New `OverviewChip` (`'all' | 'done' | 'running' | 'started' | 'stopped'`) is what the bar offers, plus one pure `chipBuckets(chip)` saying which buckets a chip covers. That function is the only place the widening happens.
- `visible()` goes from an equality test to set membership.

Adding a `started` member to `OverviewFilter` instead would have given the working bucket two selectable spellings of overlapping sets, and every consumer of the granular value would have had to know which one it was handed. Chips are allowed to overlap precisely because only one is ever selected; buckets are not. One source of truth each: `OverviewFilter` means "a bucket", `OverviewChip` means "a chip".

The chip's label **is** its value, so there is no second display string that can drift — that also removes the old `waiting → 'done'` / `working → 'running'` mapping rather than leaving orphaned label strings behind. The tooltips carry the rest, including what `started` includes.

## Things handled deliberately

**The pinned at-work block.** Was `filter !== 'working'`. It now asks the question about the bucket *set*, not the chip's name: `!(buckets.length === 1 && buckets[0] === 'working')`. The guard exists because under a working-only filter `visible()` has already kept nothing else, so pinning every row empties the sorted block and makes the sort a no-op that still looks selected. Under `started` the guard does not fire, so working agents pin to the top of the merged set — the granularity coming back as order. **Verified by running, not assumed** (see below).

**Empty-state copy.** `'nothing in this state.'` is still true of `done` / `running` / `stopped`, which each mean exactly one state, so they keep it. `started` means two and gets its own line: *"nothing started — no agent is running or waiting on you."* Verified by stopping every agent in a live server and reading what the feed printed.

**No stored value to migrate.** `ovChip` (was `ovFilter`) is plain `useState('all')`, not persisted. `ovSort` **is** persisted and is untouched.

## Copy point, raised rather than decided alone

`started` is a *lifecycle* framing sitting next to two *activity* framings. Two consequences worth a second opinion:

1. An agent merely waiting on the operator is included in `started`, which is accurate but may scan as "busy". The tooltip says "Anything still up — running or waiting on you" to blunt that; the chip label alone doesn't.
2. The five chips are no longer a partition — `done` and `running` are each subsets of `started` — so the row may read as five mutually exclusive states when it is really three states plus two roll-ups. I used the order you gave (`all, done, running, started, stopped`). Putting `started` right after `all` (`all, started, done, running, stopped`) would group the roll-ups together and read broad → narrow; easy to change if you prefer it.

## What I verified by running

A throwaway server (own `DATA_DIR`, `SPACE_ID` unset, killed by pid) with three agents whose states the server derives for itself — one looping so its screen keeps changing (`working`), one blocked on stdin (`waiting`), one that exited (`stopped`) — driven in headless Chromium at **1280×900** and **390×844**. **Unmodified `main` was run first as a control**, same harness, same fixtures.

| chip | agents shown (this branch) | control (`main`) |
|---|---|---|
| all | busy, quiet, dead | busy, quiet, dead |
| done | quiet | quiet |
| running | busy | busy |
| started | busy, quiet | *(chip does not exist)* |
| stopped | dead | dead |

- Every chip filters to the right set at both viewports; the four shared chips behave exactly as they do on `main`.
- Pinning, with `sort: prompt`: under `started` the feed renders `running now (1) → busy-agent`, then `nothing sent yet (1) → quiet-agent`. Under `running` there is **no** `running now` block — the guard still fires. `main` behaves identically for the chips it has.
- Layout: five chips still sit on **one row** at 390px, and the bar's height is unchanged from the control (38px desktop, 71px phone). No wrap, no overflow.
- Empty copy, after stopping every agent: `done` / `running` → "nothing in this state."; `started` → "nothing started — no agent is running or waiting on you."
- `tsc --noEmit` clean; `npm test` in `web/` 11/11.

## What I only reasoned about

- The `remote` and archived paths. `visible()`'s archived clause is unchanged and remote sessions reach `bucket()` through the same `state`, but no remote agent or archived session was in the fixture fleet.
- The `list` view was exercised only through the same `visible()` call as tiles; the screenshots above are the tiles view (the default). The filtering code is shared, the rendering is not.
- No test covers `chipBuckets()` directly — it is a five-branch pure function and the browser run exercises every branch, but there is no unit test pinning it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)