### PR TITLE
Overview: hide a group you don't want to look at

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
-    "test": "node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/hidden.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/hidden.js
+++ b/server/src/hidden.js
@@ -1,0 +1,79 @@
+// Refs the operator has hidden from the Overview.
+//
+// A deliberate, standing choice — "I don't want to see the cats group when I'm
+// looking at my fleet" — and therefore NOT the same thing as archiving, which is
+// derived from how long a session has been quiet and expires by itself. Hiding
+// never expires, never depends on state, and hides a group whose agents are
+// working right now if that is what you asked for.
+//
+// It lives on the server rather than in localStorage because it is a fact about
+// the fleet, not about the browser looking at it: hide the group on the desktop
+// and it stays hidden on the phone. (Contrast the Overview's sort and view, which
+// are per-browser localStorage — those describe how you are looking, not what is
+// worth looking at.)
+//
+// Scope: the OVERVIEW only. The sidebar still lists everything, which is both the
+// way back to a hidden group and the reason hiding can never lose an agent.
+//
+// The stored values are the same refs `tree.order` speaks — `g:<id>` for a group,
+// `s:<id>` for a loose session — so one list covers "hide this whole group" and
+// "hide this one agent" without a second concept.
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR } from './config.js';
+
+const FILE = path.join(DATA_DIR, 'overview-hidden.json');
+let refs = new Set();
+
+const REF_RE = /^[gs]:[A-Za-z0-9._-]+$/;
+
+function persist() {
+  try {
+    const tmp = `${FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify([...refs], null, 2));
+    fs.renameSync(tmp, FILE);
+  } catch (e) {
+    console.error('[hidden.persist]', e && e.message);
+  }
+}
+
+export function init() {
+  try {
+    const p = JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    refs = new Set(Array.isArray(p) ? p.filter((r) => typeof r === 'string' && REF_RE.test(r)) : []);
+  } catch { refs = new Set(); }   // no file yet → nothing hidden
+}
+
+export const list = () => [...refs];
+export const has = (ref) => refs.has(ref);
+
+/** Hide or unhide one ref. Returns false for anything that isn't a ref. */
+export function set(ref, hidden) {
+  if (typeof ref !== 'string' || !REF_RE.test(ref)) return false;
+  if (hidden) refs.add(ref); else refs.delete(ref);
+  persist();
+  return true;
+}
+
+/**
+ * Drop refs that no longer name anything, given the live set.
+ *
+ * Self-cleaning on read rather than a hook on every delete path: a group can stop
+ * existing in more ways than the delete endpoint (an edited groups.json, a
+ * restore, a bucket that lost a write), and a stale ref that outlives its group
+ * would silently hide a NEW group that later reuses the id. Only persists when
+ * something actually went away.
+ *
+ * Feed it EVERY live group and session, not the refs `tree.order` happens to
+ * hold: order lists loose sessions only, so a hidden agent that gets dragged into
+ * a group would otherwise quietly un-hide itself. And feed it the unfiltered
+ * lists — under demo mode the visible tree is a subset, and pruning against that
+ * would erase the operator's choices for everything demo mode is covering up.
+ */
+export function retain(validRefs) {
+  const live = validRefs instanceof Set ? validRefs : new Set(validRefs);
+  let dropped = false;
+  for (const r of refs) if (!live.has(r)) { refs.delete(r); dropped = true; }
+  if (dropped) persist();
+  return dropped;
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -16,6 +16,7 @@ import * as store from './sessions.js';
 import * as groups from './groups.js';
 import * as order from './order.js';
 import * as demo from './demo.js';
+import * as hidden from './hidden.js';
 import {
   attach, agentInfo, deriveState, stop, stopAll, ensureRunning, sendInput, isRunning,
   capturePane, ghosttyReady, ghosttyError, installClaudeRepinHook, installOpencodeRepinPlugin,
@@ -42,6 +43,7 @@ store.init();
 groups.init();
 order.init();
 demo.init();
+hidden.init();
 // Lifecycle adapters report conversation resets (e.g. /clear) with the exact
 // id, so re-pin watchers can follow them even in shared folders where storage
 // discovery must refuse to guess. Both installers are non-fatal; the existing
@@ -1802,6 +1804,13 @@ app.get('/api/tree', (_req, res) => {
   ].sort((a, b) => (a.t < b.t ? 1 : a.t > b.t ? -1 : 0)); // newest first
   order.normalize(refsMeta.map((x) => x.ref));
   let orderList = order.list();
+  // Overview-hidden refs, pruned against everything that still exists — every
+  // group and EVERY session, before demo mode narrows the view (see hidden.js).
+  hidden.retain(new Set([
+    ...groupList.map((g) => `g:${g.id}`),
+    ...store.list().map((s) => `s:${s.id}`),
+  ]));
+  const hiddenRefs = hidden.list();
   // Demo mode hides the snapshotted sessions/groups from the view (sessions
   // created after activation aren't in the snapshot, so they show through).
   if (demo.active()) {
@@ -1813,7 +1822,27 @@ app.get('/api/tree', (_req, res) => {
     orderList = orderList.filter((ref) =>
       ref.startsWith('g:') ? !hg.has(ref.slice(2)) : !hs.has(ref.slice(2)));
   }
-  res.json({ order: orderList, groups: groupList, sessions });
+  res.json({ order: orderList, groups: groupList, sessions, hidden: hiddenRefs });
+});
+
+/**
+ * Hide (or unhide) a group or a single agent in the Overview.
+ *
+ * A view choice, but a persisted, cross-device one — so it is server state, and
+ * it takes `from` like every other mutating call so the operation log can say who
+ * asked. It deliberately does NOT touch the sidebar: that is the way back.
+ */
+app.post('/api/overview/hidden', (req, res) => {
+  const { ref, hidden: want } = req.body || {};
+  if (typeof ref !== 'string') return res.status(400).json({ error: 'bad ref' });
+  // Only HIDING has to name something real. Unhiding a ref whose group is already
+  // gone must keep working — that is how a stale entry gets cleared by hand.
+  if (want) {
+    const live = ref.startsWith('g:') ? groups.get(ref.slice(2)) : store.get(ref.slice(2));
+    if (!live) return res.status(404).json({ error: 'no such group or agent' });
+  }
+  if (!hidden.set(ref, !!want)) return res.status(400).json({ error: 'bad ref' });
+  res.json({ ok: true, hidden: hidden.list() });
 });
 
 // Backwards-compatible flat list (used by probes/tests).

--- a/server/test/hidden.test.mjs
+++ b/server/test/hidden.test.mjs
@@ -1,0 +1,70 @@
+// Refs hidden from the Overview: what survives a restart, and what gets pruned.
+//
+// The pruning is the part worth a test. Hidden refs outlive the things they name
+// — delete a group and its `g:<id>` is still on disk — and a ref that outlives its
+// target would hide whatever later takes that id. But pruning too eagerly is the
+// worse bug: prune against the refs `tree.order` holds and every hidden agent
+// un-hides itself the moment it is dragged into a group; prune against the tree
+// demo mode is showing and the operator's choices are erased for everything demo
+// mode is covering up.
+// Run with: node test/hidden.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'hidden-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const hidden = await import('../src/hidden.js');
+hidden.init();
+
+let pass = 0, fail = 0;
+const check = (name, got, want) => {
+  const ok = JSON.stringify(got) === JSON.stringify(want);
+  ok ? pass++ : fail++;
+  console.log(`  ${ok ? 'PASS' : 'FAIL'}  ${name}${ok ? '' : `\n          got ${JSON.stringify(got)}  want ${JSON.stringify(want)}`}`);
+};
+
+console.log('\nhiding and unhiding');
+check('nothing is hidden to start with', hidden.list(), []);
+check('a group ref is accepted', hidden.set('g:cats', true), true);
+check('an agent ref is accepted', hidden.set('s:kimi-cat-1', true), true);
+check('both are hidden', hidden.list().sort(), ['g:cats', 's:kimi-cat-1']);
+check('has() sees a hidden ref', hidden.has('g:cats'), true);
+check('has() is false for one that is not', hidden.has('g:Prose'), false);
+check('unhiding removes it', (hidden.set('g:cats', false), hidden.has('g:cats')), false);
+check('hiding twice is not two entries', (hidden.set('s:kimi-cat-1', true), hidden.list()), ['s:kimi-cat-1']);
+
+console.log('\nonly refs, so a client bug cannot write junk into the file');
+check('no prefix', hidden.set('cats', true), false);
+check('unknown prefix', hidden.set('x:cats', true), false);
+check('empty id', hidden.set('g:', true), false);
+check('a path traversal is not a ref', hidden.set('g:../../etc/passwd', true), false);
+check('not a string', hidden.set(null, true), false);
+check('the list is unchanged by all of that', hidden.list(), ['s:kimi-cat-1']);
+
+console.log('\nit survives a restart');
+hidden.set('g:cats', true);
+const before = hidden.list().sort();
+hidden.init();   // as if the server had just booted
+check('same refs after re-init', hidden.list().sort(), before);
+
+console.log('\npruning drops refs that no longer name anything');
+hidden.set('g:deleted-group', true);
+const live = new Set(['g:cats', 's:kimi-cat-1']);
+check('something was dropped', hidden.retain(live), true);
+check('the dead ref is gone', hidden.list().sort(), ['g:cats', 's:kimi-cat-1']);
+check('a second pass has nothing to do', hidden.retain(live), false);
+hidden.init();
+check('the prune was persisted, not just in memory', hidden.list().sort(), ['g:cats', 's:kimi-cat-1']);
+
+console.log('\npruning must be given every session, not just the loose ones');
+// `tree.order` lists loose sessions only. If retain() were fed those refs, an
+// agent hidden on its own would un-hide itself as soon as it joined a group.
+check('a grouped agent keeps its own hidden ref',
+  (hidden.retain(new Set(['g:cats', 's:kimi-cat-1'])), hidden.has('s:kimi-cat-1')), true);
+
+console.log(`\n${pass}/${pass + fail} passed`);
+fs.rmSync(TMP, { recursive: true, force: true });
+process.exit(fail ? 1 : 0);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,8 +16,9 @@ import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewChip, OverviewSort, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
+import { hiddenSessionIds } from './lib/overviewHidden';
 import { isPassive, isRemote } from './types';
-import { GridGlyph, ListGlyph, SortGlyph } from './components/icons';
+import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './components/icons';
 
 // `?vvdebug=1` — a phone has no devtools, and the keyboard layout is a guess
 // when the app is embedded cross-origin. Read once: it never changes mid-run,
@@ -90,7 +91,7 @@ const writeStored = (k: string, v: string | null) => {
 
 export default function App() {
   const [clis, setClis] = useState<Cli[]>([]);
-  const [tree, setTree] = useState<Tree>({ order: [], groups: [], sessions: [] });
+  const [tree, setTree] = useState<Tree>({ order: [], groups: [], sessions: [], hidden: [] });
   // Restored from the last visit, then re-validated against the tree once it
   // loads (the agent may be long gone). focusedId comes back too, so a group
   // reopens on the pane you were actually reading rather than its first.
@@ -128,6 +129,11 @@ export default function App() {
   // stored — flipping the setting instantly (un)archives.
   const [showArchived, setShowArchived] = useState(false);
   const [archiveAfter, setArchiveAfter] = useState<'week' | 'month' | 'never'>('month');
+  // Hiding a group from the Overview is a standing choice and lives on the server
+  // (tree.hidden). REVEALING it is a glance, so that half stays here and resets on
+  // reload — otherwise "show hidden" becomes a mode you forget you left on, and
+  // hiding reads as broken.
+  const [showHidden, setShowHidden] = useState(false);
   // How every pane is read — the terminal itself, or reader mode over the same
   // session. App-wide, like zoom, and remembered the same way.
   const [paneMode, setPaneMode] = useState(readPaneMode);
@@ -379,6 +385,18 @@ export default function App() {
     try { setTree(await api.getTree()); setTreeLoaded(true); } catch { /* offline */ }
   }, []);
 
+  // Hide/unhide a group (or one agent) in the Overview. Optimistic, because the
+  // tree poll is up to 2.5s away and a control that does nothing for two seconds
+  // reads as broken; the server's own list replaces this on the next poll.
+  const toggleOverviewHidden = (ref: string, hide: boolean) => {
+    setTree((t) => {
+      const next = new Set(t.hidden);
+      if (hide) next.add(ref); else next.delete(ref);
+      return { ...t, hidden: [...next] };
+    });
+    api.setOverviewHidden(ref, hide).then(refresh).catch(showErr('could not change what the overview shows'));
+  };
+
   useEffect(() => {
     api.getClis().then(setClis).catch(() => {});
     refresh();
@@ -445,6 +463,13 @@ export default function App() {
     }
     return out;
   }, [tree.sessions, ages, archiveAfter]);
+
+  // What the operator hid from the Overview, as refs (`g:<id>` / `s:<id>`). The
+  // server owns the list; this is just the shape the sidebar wants for a lookup.
+  const hiddenRefs = useMemo(() => new Set(tree.hidden), [tree.hidden]);
+  // The bar's button counts AGENTS, not refs: "1 hidden" for a six-agent group
+  // would understate what is missing from the feed.
+  const hiddenCount = useMemo(() => hiddenSessionIds(tree).size, [tree]);
 
   const cliMap = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c])), [clis]);
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
@@ -983,6 +1008,8 @@ export default function App() {
         archived={archivedIds}
         showArchived={showArchived}
         onToggleArchived={() => setShowArchived((v) => !v)}
+        overviewHidden={hiddenRefs}
+        onToggleOverviewHidden={toggleOverviewHidden}
       />
 
       <div className="main">
@@ -1024,6 +1051,7 @@ export default function App() {
               view={ovView}
               archived={archivedIds}
               showArchived={showArchived}
+              showHidden={showHidden}
               meta={meta}
               metaReady={metaReady}
               isMobile={isMobile}
@@ -1079,6 +1107,18 @@ export default function App() {
               <button className={ovView === 'tiles' ? 'on' : ''} title="Tiles" onClick={() => setOvView('tiles')}><GridGlyph /></button>
               <button className={ovView === 'list' ? 'on' : ''} title="List" onClick={() => setOvView('list')}><ListGlyph /></button>
             </div>
+            {/* The way back. It appears only once something IS hidden, so the bar
+                costs nothing until you use the feature — and it counts groups and
+                agents, never "1 waiting", because being told about the group you
+                hid is the thing you were trying to stop. */}
+            {hiddenCount > 0 && (
+              <button className={`zbtn ov-hidebtn${showHidden ? ' on' : ''}`}
+                title={showHidden ? 'Hide them again' : 'Show what you hid from the overview'}
+                onClick={() => setShowHidden((v) => !v)}>
+                {showHidden ? <EyeGlyph /> : <EyeOffGlyph />}
+                <span className="mono">{hiddenCount} hidden</span>
+              </button>
+            )}
           </div>
         )}
         {showZoom && (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -17,6 +17,11 @@ const json = (r: Response) => {
 export const getClis = (): Promise<Cli[]> => fetch('/api/clis').then(json);
 export const getTree = (): Promise<Tree> => fetch('/api/tree').then(json);
 
+// Hide a group (or one agent) from the Overview. `ref` is a tree ref — `g:<id>`
+// or `s:<id>`. Persisted server-side, so it holds on every device.
+export const setOverviewHidden = (ref: string, hidden: boolean): Promise<{ hidden: string[] }> =>
+  fetch('/api/overview/hidden', { method: 'POST', headers: HEADERS, body: JSON.stringify({ ref, hidden }) }).then(json);
+
 // path: '.' = the workspaces root; anything else is a workspace-relative dir.
 const normalizePath = (path?: string) => (path && path.trim() ? path : '.');
 // Quickstart: create at the workspaces root, boot the CLI, and type the prompt

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -6,6 +6,7 @@ import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionS
 import { chipBuckets, isPassive, isRemote } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
+import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
 import Logo from './Logo';
 import { SendGlyph } from './icons';
@@ -399,7 +400,7 @@ function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession; color
 /** Mission control: one reading column — group capsules with their agents as
  *  slabs, loose agents as standalone panels. Unless a sort is on, in which case
  *  it is one flat ranked column instead (see §"sorted feed" below). */
-export default function Overview({ clis, tree, chip, sort, view, archived, showArchived, meta, metaReady, isMobile, onOpen }: {
+export default function Overview({ clis, tree, chip, sort, view, archived, showArchived, showHidden, meta, metaReady, isMobile, onOpen }: {
   clis: Cli[];
   tree: Tree;
   chip: OverviewChip;     // controlled by the bottom bar in App
@@ -407,6 +408,10 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
   view: 'tiles' | 'list'; // controlled by the bottom bar in App
   archived: Set<string>;
   showArchived: boolean;
+  // Reveal what `tree.hidden` hides, for as long as you are looking. Transient by
+  // design — a persisted "show hidden" would be a mode you forget you are in, and
+  // hiding would then look broken.
+  showHidden: boolean;
   meta: Record<string, MetaSession>; // continuously polled in App; instant on open
   metaReady: boolean;                // false until the first poll lands
   isMobile: boolean;
@@ -430,11 +435,20 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
   // session is in `meta` (or genuinely has no digest).
   const pending = (id: string) => !metaReady && !meta[id];
 
+  // Hidden refs resolved down to session ids: a hidden GROUP hides its members,
+  // and `s:<id>` hides one agent wherever it sits. Doing it once here is what
+  // makes hiding hold in all three renderings and under every sort — including
+  // the ranked feed's pinned `running now` block, which is the case that matters:
+  // hide a group and its working agent must not float back to the top.
+  const hiddenIds = useMemo(() => hiddenSessionIds(tree), [tree]);
+
   // One chip can stand for several buckets ('started' is waiting AND working), so
   // this is set membership, not equality.
   const buckets = chipBuckets(chip);
   const visible = (s: MetaSession) =>
-    buckets.includes(bucket(s.state)) && (showArchived || !archived.has(s.id));
+    buckets.includes(bucket(s.state))
+    && (showArchived || !archived.has(s.id))
+    && (showHidden || !hiddenIds.has(s.id));
 
   // Which group each agent is in, by name. Only the sorted feed needs it: the
   // manual feed draws the group as a frame around its members and would be
@@ -490,7 +504,7 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
     if (!metaReady) return { running: [], dated: items, undated: [] };
     return rankSessions(items, sort);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived]);
+  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived, hiddenIds, showHidden]);
 
   // Collapse at constant velocity: duration follows the group's height.
   const toggleGroup = (gid: string, el: HTMLElement) => {
@@ -514,7 +528,9 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
   const tileFor = (s: Session) => {
     const m = dataFor(s);
     if (!visible(m)) return null;
-    return <Tile key={s.id} s={m} color={colorOf[s.cli]} dim={archived.has(s.id)} pending={pending(s.id)} onOpen={() => setOpenId(s.id)} />;
+    // Revealed-but-hidden reads the same as archived: present, and visibly not
+    // part of what you normally look at.
+    return <Tile key={s.id} s={m} color={colorOf[s.cli]} dim={archived.has(s.id) || hiddenIds.has(s.id)} pending={pending(s.id)} onOpen={() => setOpenId(s.id)} />;
   };
   const tileBlocks: ReactNode[] = [];
   let looseTiles: ReactNode[] = [];
@@ -586,7 +602,7 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
       );
       for (const { m } of b.rows as Row[]) {
         out.push(view === 'tiles'
-          ? <Tile key={m.id} s={m} color={colorOf[m.cli]} group={groupNameOf[m.id]} dim={archived.has(m.id)}
+          ? <Tile key={m.id} s={m} color={colorOf[m.cli]} group={groupNameOf[m.id]} dim={archived.has(m.id) || hiddenIds.has(m.id)}
               pending={pending(m.id)} onOpen={() => setOpenId(m.id)} />
           : <div key={m.id} className="ov-panel">
               <Card s={m} color={colorOf[m.cli]} group={groupNameOf[m.id]} pending={pending(m.id)} isMobile={isMobile} onOpen={onOpen} />
@@ -609,11 +625,16 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
     </div>
   );
 
-  // "nothing in this state" is still true of the chips that mean exactly one
-  // state; `started` means two, so it says what it actually looked for.
+  // An empty feed has more than one cause now, and guessing wrong is worse than
+  // saying nothing: "no agents yet" while a hidden group sits there working would
+  // be a lie the operator cannot see through. So hiding is named first, and
+  // counted, whenever it is what emptied the feed.
+  const hiddenCount = hiddenIds.size;
   const empty = (
     <div className="usage-msg mono">
-      {chip === 'all' ? 'no agents yet — shells and file panes don’t appear here.'
+      {!showHidden && hiddenCount > 0
+        ? `nothing to show — ${hiddenCount} hidden. reveal them from the bar below.`
+        : chip === 'all' ? 'no agents yet — shells and file panes don’t appear here.'
         : chip === 'started' ? 'nothing started — no agent is running or waiting on you.'
         : 'nothing in this state.'}
     </div>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
+import { hiddenSessionIds } from '../lib/overviewHidden';
 import Logo from './Logo';
 import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
-import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph } from './icons';
+import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
 
 type Zone = 'before' | 'after' | 'on';
 
@@ -30,6 +31,7 @@ export default function Sidebar({
   onActivate, onOpenSession, onNewSession, onNewGroup, onRenameGroup, onRenameSession, onDeleteGroup,
   onStopSession, onSetRemotePaused, onDeleteSession, onShareSession, onShareTrace, onTraceHandover, onOpenTrace, onOpenSharedTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
   archived, showArchived, onToggleArchived,
+  overviewHidden, onToggleOverviewHidden,
 }: {
   clis: Cli[];
   tree: Tree;
@@ -61,6 +63,11 @@ export default function Sidebar({
   archived: Set<string>;
   showArchived: boolean;
   onToggleArchived: () => void;
+  // Refs hidden from the OVERVIEW. The sidebar keeps showing them — it is where
+  // you hide a group and the only way back to one — so this only drives the
+  // per-group button and the overview row's count.
+  overviewHidden: Set<string>;
+  onToggleOverviewHidden: (ref: string, hidden: boolean) => void;
 }) {
   const [panel, setPanel] = useState<'none' | 'create' | 'quick'>('none');
   const [quickMode, setQuickMode] = useState<'agent' | 'group'>('agent');
@@ -99,7 +106,13 @@ export default function Sidebar({
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
   const groupById = useMemo(() => Object.fromEntries(tree.groups.map((g) => [g.id, g])), [tree.groups]);
   const colorOf = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c.color])), [clis]);
-  const waiting = tree.sessions.filter((s) => s.state === 'waiting').length;
+  // This badge sits ON the overview row, so it has to count what the overview
+  // would actually show: not a hidden group's agents (being told about the group
+  // you hid is exactly what you hid it to stop), and not archived ones either,
+  // which the feed has always dropped while this number quietly included them.
+  const hiddenIds = useMemo(() => hiddenSessionIds(tree), [tree]);
+  const waiting = tree.sessions.filter((s) =>
+    s.state === 'waiting' && !hiddenIds.has(s.id) && !archived.has(s.id)).length;
 
   const clearDrag = () => { setDragRef(null); setDrop(null); onDragState?.(null); };
   // Failures here are ordinary and specific (no access, not a share, no token) —
@@ -313,7 +326,14 @@ export default function Sidebar({
             <>
               <span className="name">{g.name}</span>
               {!open && <span className="count">{g.sessionIds.length}</span>}
+              {/* Hidden from the OVERVIEW, not from here: the sidebar row is
+                  both where you hide a group and how you get back to it. */}
+              {overviewHidden.has(ref) && <span className="ov-hidden-tag mono" title="Hidden from the overview">hidden</span>}
               <span className="row-actions">
+                <button className="mini-btn" title={overviewHidden.has(ref) ? 'Show in the overview' : 'Hide from the overview'}
+                  onClick={(e) => { e.stopPropagation(); onToggleOverviewHidden(ref, !overviewHidden.has(ref)); }}>
+                  {overviewHidden.has(ref) ? <EyeOffGlyph /> : <EyeGlyph />}
+                </button>
                 <button className="mini-btn" title="Rename" onClick={(e) => { e.stopPropagation(); startEdit(ref, g.name); }}><PencilGlyph /></button>
                 <button className="mini-btn" title="Delete group" onClick={(e) => { e.stopPropagation(); onDeleteGroup(g.id); }}><CloseGlyph /></button>
               </span>

--- a/web/src/components/icons.tsx
+++ b/web/src/components/icons.tsx
@@ -263,6 +263,21 @@ export const BellGlyph = ({ className }: { className?: string }) => (
   </G>
 );
 
+// Hiding a group from the Overview, and the button that shows it again.
+export const EyeGlyph = ({ className }: { className?: string }) => (
+  <G className={className}>
+    <path d="M1.4 8S3.8 3.8 8 3.8 14.6 8 14.6 8 12.2 12.2 8 12.2 1.4 8 1.4 8Z" />
+    <circle cx="8" cy="8" r="2.1" />
+  </G>
+);
+
+export const EyeOffGlyph = ({ className }: { className?: string }) => (
+  <G className={className}>
+    <path d="M6.3 4.2A6.6 6.6 0 0 1 8 4c4.2 0 6.6 4 6.6 4a12 12 0 0 1-2 2.4M4 5.3A12.4 12.4 0 0 0 1.4 8S3.8 12 8 12a6.9 6.9 0 0 0 2.1-.3" />
+    <path d="M6.6 6.7a2.1 2.1 0 0 0 2.9 2.9M2.6 2.6l10.8 10.8" />
+  </G>
+);
+
 export const InfoGlyph = ({ className }: { className?: string }) => (
   <G className={className}>
     <circle cx="8" cy="8" r="6.2" />

--- a/web/src/lib/overviewHidden.ts
+++ b/web/src/lib/overviewHidden.ts
@@ -1,0 +1,26 @@
+import type { Tree } from '../types';
+
+/**
+ * Which agents the operator has hidden from the Overview.
+ *
+ * `tree.hidden` holds REFS — `g:<id>` for a whole group, `s:<id>` for one agent —
+ * and every consumer needs the same thing from them: the set of session ids that
+ * should not appear. One function, because three of them ask:
+ *
+ *  · Overview's `visible()`, the single gate for tiles, list and the ranked feed;
+ *  · the sidebar's `N waiting` badge, which sits on the overview row and so must
+ *    count what the overview would actually show;
+ *  · the bottom bar's `N hidden` button, which counts AGENTS rather than refs —
+ *    "1 hidden" for a six-agent group would understate what is missing.
+ *
+ * Written independently in each place, those three would drift, and the badge
+ * disagreeing with the feed is the exact bug hiding is supposed to avoid.
+ */
+export function hiddenSessionIds(tree: Tree): Set<string> {
+  const ids = new Set<string>();
+  if (!tree.hidden?.length) return ids;
+  const refs = new Set(tree.hidden);
+  for (const g of tree.groups) if (refs.has(`g:${g.id}`)) for (const id of g.sessionIds) ids.add(id);
+  for (const s of tree.sessions) if (refs.has(`s:${s.id}`)) ids.add(s.id);
+  return ids;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -91,6 +91,20 @@ body {
 .ov-sortmark svg { width: 12px; height: 12px; display: block; }
 .ov-viewseg button { display: inline-flex; align-items: center; padding: 4.5px 9px; }
 .ov-viewseg svg { width: 13px; height: 13px; }
+/* "n hidden": present only when something is, and deliberately quiet — it is the
+   way back, not a notification. `on` = you are currently looking at them. */
+/* nowrap + no shrink: as the last item in a wrapping bar it would otherwise be
+   squeezed into the leftover sliver, break "2 hidden" over two lines and spill
+   out of the bar at phone widths. It has to take a new row instead. */
+/* `.zbtn.ov-hidebtn`, not `.ov-hidebtn`: .zbtn's own `width: 22px` is declared
+   further down this file, so a single-class rule here loses to it and the button
+   renders 22px wide with "2 hidden" spilling out past its border. */
+.zbtn.ov-hidebtn { width: auto; height: 22px; padding: 0 8px; gap: 5px; font-size: 11px; white-space: nowrap; flex: 0 0 auto; }
+.zbtn.ov-hidebtn svg { width: 12px; height: 12px; display: block; }
+.zbtn.ov-hidebtn.on { color: var(--text); border-color: var(--border-strong); background: var(--panel); }
+/* the sidebar's own mark on a group that the overview is not showing */
+.row.group-head .ov-hidden-tag { font-size: 9.5px; letter-spacing: 0.02em; color: var(--muted); opacity: 0.75; margin-left: 4px; }
+.row.group-head:hover .ov-hidden-tag { display: none; }
 
 /* transparent CLI logos; invert the mostly-black ones in dark mode */
 .cli-logo { flex: none; display: inline-flex; align-items: center; justify-content: center; }
@@ -1180,6 +1194,17 @@ a.btn-ghost { text-decoration: none; }
   .tree { padding-top: 6px; }
   .group { margin: 13px 0 5px; }
   .row .row-actions { opacity: 1; pointer-events: auto; position: static; transform: none; margin-left: 4px; background: transparent; }
+  /* A group's actions were hover-only, which a touch device can never satisfy:
+     on a phone they were simply unreachable. That was survivable while they were
+     rename/delete (both reachable other ways) and is not now that hiding a group
+     from the overview is offered here and nowhere else. The eye already shows the
+     state, so the `hidden` word gives up its space to the buttons. */
+  .row.group-head .row-actions { display: flex; }
+  .row.group-head .ov-hidden-tag { display: none; }
+  /* Four controls do not fit across 390px. The escape hatch takes the row it
+     needs instead of being wedged against the view toggle — it only exists while
+     something is hidden, so the extra row is never in the way otherwise. */
+  .zbtn.ov-hidebtn { flex: 0 0 100%; justify-content: center; }
   .row .cli-logo, .row .count { opacity: 1 !important; }
   .row .age { display: none; } /* actions are always visible on touch — no room */
   .g-add { opacity: 1; }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -44,6 +44,12 @@ export interface Tree {
   order: string[]; // refs: "g:<id>" | "s:<id>"
   groups: Group[];
   sessions: Session[];
+  // Refs the operator hid from the OVERVIEW — same vocabulary as `order`, so one
+  // list covers a whole group and a single agent. Server-side and deliberate:
+  // unlike archiving it never expires and does not care what state the agent is
+  // in. The sidebar ignores it entirely; that is the way back. See
+  // server/src/hidden.js.
+  hidden: string[];
 }
 
 export const STATE_LABEL: Record<SessionState, string> = {


### PR DESCRIPTION
Hide a group and it stops appearing in the Overview — **including while its agents are working**. The sidebar still lists it, which is both the way back and the reason hiding can't lose an agent.

> **Stacked on #60** (the `started` chip), so the diff here is just this commit. Base retargets to `main` automatically once #60 merges.

## The shape

**One concept.** `tree.hidden` is a list of the refs `tree.order` already speaks — `g:<id>` for a whole group, `s:<id>` for a single agent. Hiding one agent therefore needs no second feature later.

**One gate.** `hiddenSessionIds()` (`web/src/lib/overviewHidden.ts`) resolves refs → session ids, and `visible()` in `Overview.tsx` is the only place that consults it. That's what makes hiding hold across tiles, list **and** the ranked feed — and the ranked feed is the case that matters: without a single gate, a hidden group's working agent floats straight back to the top under `running now`. There's an explicit check for exactly that.

**One shared selector**, because three callers want the same answer and drift between them *is* the bug: the feed's gate, the sidebar's `N waiting` badge, and the bar's `n hidden` count.

## Decisions, and why

**Server-side** (`overview-hidden.json`), not localStorage. Hiding is a fact about the fleet, not about the browser looking at it — hide `cats` on the desktop and it stays hidden on the phone. Contrast `ovSort`/`ovView`, which stay per-browser: those describe *how* you're looking, not *what is worth looking at*. There's a test for surviving a restart, and a browser check for surviving a reload.

**Revealing is the opposite kind of thing** and stays in transient React state, so "show hidden" can never become a mode you forgot you left on. Verified: reveal does *not* survive a reload.

**Not folded into archiving.** Archiving is derived from quietness and expires by itself; hiding never expires and ignores state entirely. Sharing `showArchived` would mean that checkbox silently revealing manually-excluded projects, and an Overview preference leaking into the sidebar.

**The control is on the sidebar's group row** — the only place that exists under every sort and every view (a capsule header doesn't exist in the ranked feed). The `n hidden` button appears in the bar only once something is hidden, and it counts **agents, not refs**: "1 hidden" for a six-agent group would understate what's missing. It deliberately does **not** say "1 waiting" — being told about the group you hid is the thing you hid it to stop.

**Pruning is self-cleaning on read**, and the two ways to get it wrong are both tested: prune against `tree.order`'s refs and a hidden agent un-hides itself when dragged into a group; prune against the tree *demo mode* is showing and you erase the operator's choices for everything demo mode is covering up.

## Two pre-existing bugs this had to fix to work at all

1. **The `N waiting` badge lied.** It sits *on* the overview row but was `tree.sessions.filter(s => s.state === 'waiting')` across the whole tree — no eligibility, no archive rule — so it already disagreed with the feed, and would now have nagged about the very group you hid. It now counts what the Overview actually shows (excludes hidden **and** archived).
2. **A group's row-actions were hover-only**, so on a touch device they were unreachable — `.row.group-head .row-actions { display: none }` beat the mobile override on specificity. Survivable while they were rename/delete (reachable other ways); fatal now that hiding is offered there and nowhere else. Mobile now shows them, and the `hidden` word yields its space to the buttons since the eye already carries the state.

## What I verified by running

Fleet with server-derived states: a group `cats` holding a **working** agent (screen genuinely changing) and a **waiting** one, plus a loose **stopped** one. Headless Chromium at **1280×900** and **390×844**. **36/36 checks pass.** The same suite against unmodified `main` fails **22 of 32** — that's what says they aren't vacuous.

Highlights (each at both viewports):

- hiding the group removes **both** its agents, the working one included; `running` and `started` go empty
- the ranked feed grows **no** pinned `running now` block for a hidden working agent
- `2 hidden` appears, counting agents not refs; no such button before anything is hidden
- the badge stops counting the hidden waiting agent; the sidebar still lists the group
- still hidden **after a reload** (server-side); reveal **does not** survive a reload
- revealed agents are visibly marked as not-normally-shown
- unhiding from the sidebar restores everything

Also: `tsc --noEmit` clean, `server` 20/20 in the new `hidden.test.mjs`, `web` 11/11.

Two layout bugs the browser run caught that I'd otherwise have shipped: the `n hidden` button lost a CSS width fight to `.zbtn`'s `width: 22px` (declared later in the file) and rendered its label spilling outside its own border while still measuring as "inside the bar" — so the assertion now checks `scrollWidth <= clientWidth`; and at 390px four controls don't fit across, so it takes its own row (bar 38px desktop / 98px phone, only while something is hidden).

## What I only reasoned about

- **Demo mode interaction** is handled in code (pruning uses the unfiltered lists) and unit-tested, but not exercised through the browser with demo mode actually on.
- **Remote and archived sessions** inside a hidden group: they run through the same `visible()` gate, but the fixture fleet had neither.
- **Multi-operator semantics.** Server-side means hiding applies to anyone looking at this instance. Right for a single-operator app; if that ever changes, this is the decision to revisit.
- **No cap on the hidden list.** Hide 40 groups and the button says `n hidden` with no way to review them except revealing. A "manage hidden" surface can come later if it's ever needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)