### PR TITLE
Get the committed node_modules symlinks out of main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-node_modules/
+# No trailing slash: `node_modules/` matches directories only, so a SYMLINK
+# named node_modules slips past it and gets committed as a blob. That is how
+# machine-local links to /app and /home/node/local reached main once already.
+node_modules
 dist/
 data/
 *.log

--- a/server/node_modules
+++ b/server/node_modules
@@ -1,1 +1,0 @@
-/app/server/node_modules

--- a/web/node_modules
+++ b/web/node_modules
@@ -1,1 +1,0 @@
-/home/node/local/am-web-deps/node_modules


### PR DESCRIPTION
Two machine-local `node_modules` symlinks are committed on `main`. They arrived together in `732aa4c8` and merged in #55.

```
120000 server/node_modules -> /app/server/node_modules
120000 web/node_modules    -> /home/node/local/am-web-deps/node_modules
```

## Why nothing caught it

`.gitignore` said `node_modules/`. **A trailing slash matches directories only**, and a symlink named `node_modules` is a blob — so `git add` staged both without a word. Deleting the files alone would leave the hole open, so this drops the slash as well.

## Why it matters

Both targets exist only inside one running Space, and `/home/node/local` does not survive a rebuild — so anywhere else they are dangling links.

- In a checkout where `node_modules` is a real directory, git refuses to replace a directory with a symlink and **switching branches fails outright**. That is how this surfaced.
- Anything that resolves `server/node_modules` writes into `/app/server/node_modules` — the **running image's** dependency tree.

## Not affected

The image build. `.dockerignore` already used `**/node_modules`, no trailing slash, which matches a symlink too — verified before writing this.

## Verified

Re-created a `web/node_modules` symlink in a clean clone of this branch and confirmed `git check-ignore -v` now matches it at `.gitignore:4`, and that `git status` no longer offers it. Confirmed the two entries are gone from the tree, and that `.dockerignore` needed no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
