### PR TITLE
web: put playwright in the lockfile so npm ci can run at all

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -46,6 +46,7 @@
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@vitejs/plugin-react": "^4.3.1",
+        "playwright": "^1.62.1",
         "typescript": "^5.5.3",
         "vite": "^5.4.0"
       }
@@ -2312,6 +2313,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.16",


### PR DESCRIPTION
`npm ci` has been impossible in `web/` since #37. This makes it work again.

## The bug

`85a08f0` (#37) added `playwright` to `web/package.json` without regenerating `web/package-lock.json`. `npm ci` installs *only* from the lock and refuses to run when the two disagree:

```
npm error `npm ci` can only install packages when your package.json and
npm error package-lock.json ... are in sync.
npm error Missing: playwright@1.62.1 from lock file
npm error Missing: playwright-core@1.62.1 from lock file
npm error Missing: fsevents@2.3.2 from lock file
```

So anyone doing a clean frontend install gets nothing, and falls back to borrowing a `node_modules` from elsewhere on the box — which is how two machine-local `node_modules` symlinks ended up committed to `main` and needed #64 to remove.

## The fix

`npm install --package-lock-only`: adds the three missing entries, moves no existing dependency version. Diff is the lock and nothing else.

## Verified after the change

- `npm ci` → exit 0
- `npm run typecheck` (`tsc --noEmit`) → **0 errors**. Worth noting: the 32 "cannot find module" errors people have been seeing were entirely an artefact of incomplete borrowed dependency trees, not the source.
- All five web suites pass: `exchanges`, `sessionTitle`, `overviewSort`, `drafts`, `traceWindows`.

## Related, NOT fixed here

`traceWindows` needs a Chromium that the image doesn't have. `Dockerfile:82` installs browsers with `npx -y playwright install --with-deps chromium` — **unpinned**, so it fetches whatever is newest at build time instead of the version `package.json` pins, and `|| echo "playwright chromium install failed"` swallows the failure silently. The running image has `chromium-1208`; playwright 1.62.1 wants build `1234`, so any browser test fails until someone installs it by hand.

I installed the matching build into `/opt/pw-browsers` on the live box so tests run now, but that is a patch on one machine and it will drift again on the next rebuild. The real fix is to install browsers using the project's own pinned playwright and to stop swallowing the error — deliberately left out of this PR, since changing the image build wants its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
