### PR TITLE
Make the browser suites runnable, and stop crashing when storage is denied

### DIFF
--- a/scripts/test-chromium.mjs
+++ b/scripts/test-chromium.mjs
@@ -1,0 +1,74 @@
+// Which Chromium the browser-level tests should drive.
+//
+// `chromium.launch()` with no executablePath demands the EXACT build the
+// installed Playwright expects, and fails with "Looks like Playwright was just
+// installed or updated / npx playwright install" if the machine has any other
+// revision. That is a real failure mode here rather than a hypothetical: this
+// workspace ships a shared browser under PLAYWRIGHT_BROWSERS_PATH (rev 1208 at
+// the time of writing) while `playwright@^1.62` asks for 1234, so every browser
+// suite died before running a line of app code — and the message blames a missing
+// install rather than a mismatch, which sends you off to download 115MB you
+// already have.
+//
+// Order of preference:
+//   1. PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH — an explicit answer always wins.
+//   2. the newest chromium under PLAYWRIGHT_BROWSERS_PATH, whatever its revision.
+//   3. undefined — let Playwright resolve its own download, which is what CI and
+//      an ordinary dev machine want. The error, if any, stays Playwright's.
+//
+// Driving a revision Playwright wasn't built against is a deliberate trade: these
+// suites use long-stable APIs (newPage, setContent, addScriptTag, keyboard,
+// screenshots), and a browser that is one build off is worth far more than a
+// suite nobody can run.
+import fs from 'node:fs';
+import path from 'node:path';
+
+// Full chromium first: it can run headed as well as headless, where
+// chrome-headless-shell cannot. Both are accepted — the shell alone is enough for
+// the headless suites, and on some images it is all that was fetched.
+const FAMILIES = [
+  { dir: /^chromium-(\d+)$/, exe: ['chrome-linux64/chrome', 'chrome-linux/chrome', 'chrome-mac/Chromium.app/Contents/MacOS/Chromium'] },
+  { dir: /^chromium_headless_shell-(\d+)$/, exe: ['chrome-headless-shell-linux64/chrome-headless-shell', 'chrome-headless-shell-linux/chrome-headless-shell'] },
+];
+
+export function chromiumExecutablePath() {
+  const explicit = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+  if (explicit) return fs.existsSync(explicit) ? explicit : undefined;
+
+  const root = process.env.PLAYWRIGHT_BROWSERS_PATH;
+  if (!root || !fs.existsSync(root)) return undefined;
+
+  let entries;
+  try { entries = fs.readdirSync(root); } catch { return undefined; }
+  for (const family of FAMILIES) {
+    const found = entries
+      .map((name) => ({ name, rev: Number((family.dir.exec(name) || [])[1]) }))
+      .filter((e) => Number.isFinite(e.rev))
+      .sort((a, b) => b.rev - a.rev);                 // newest revision present
+    for (const { name } of found) {
+      for (const rel of family.exe) {
+        const p = path.join(root, name, rel);
+        if (fs.existsSync(p)) return p;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Launch options for a headless run. Spread into `chromium.launch({...})`.
+ *
+ * `--no-sandbox` because these suites run inside a container as a non-root user
+ * with no user namespaces, where Chromium's sandbox cannot initialise and the
+ * browser exits immediately. It is scoped to tests driving content this repo
+ * generated itself.
+ */
+export function chromiumLaunchOptions(extra = {}) {
+  const executablePath = chromiumExecutablePath();
+  return {
+    headless: true,
+    ...(executablePath ? { executablePath } : {}),
+    args: ['--no-sandbox', '--disable-dev-shm-usage', ...(extra.args || [])],
+    ...Object.fromEntries(Object.entries(extra).filter(([k]) => k !== 'args')),
+  };
+}

--- a/server/mobile.test.mjs
+++ b/server/mobile.test.mjs
@@ -12,6 +12,7 @@ import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../scripts/test-chromium.mjs';
 import { WebSocket } from 'ws';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -46,12 +47,19 @@ if (!process.env.MOBILE_PUBLIC_DIR) {
   }
 }
 
+// A test server must not publish skills — the same strip migration.test.mjs and
+// resize.test.mjs already do, and for the same reason: `SPACE_ID` is set when this
+// runs inside the Space itself, and skillTargetDirs() then fans this checkout's
+// skill templates into every live agent's skills dir. Those paths come from $HOME,
+// NOT from DATA_DIR, so a throwaway DATA_DIR does not contain the damage.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+
 const backend = spawn('node', ['src/index.js'], {
   cwd: HERE,
   // Do not inherit the production Space hostname: this backend is deliberately
   // reached through localhost, and the origin guard should validate it as such.
   env: {
-    ...process.env,
+    ...BASE_ENV,
     PORT: '7896', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1',
   },
   stdio: ['ignore', 'pipe', 'pipe'],
@@ -106,7 +114,7 @@ try {
   });
   if (!historyReady) throw new Error('history did not reach the terminal');
 
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch(chromiumLaunchOptions());
   const context = await browser.newContext({
     viewport: { width: 375, height: 667 },
     screen: { width: 375, height: 667 },
@@ -532,8 +540,14 @@ try {
   await embeddedFrame.locator('.sidebar .row').filter({ hasText: 'mobile-terminal-e2e' }).first().click();
   await embeddedFrame.locator('.tile-terminal:not(.tile-cached) .xterm-screen').waitFor({ state: 'visible' });
   await embeddedFrame.locator('.tile-terminal:not(.tile-cached) .term-host').click();
-  const embeddedFallback = await waitFor(() => embeddedFrame.evaluate(() =>
-    document.documentElement.dataset.keyboardLayout === 'focus-fallback'));
+  // 07ad947 "Mobile keyboard: stop estimating a height nobody can measure"
+  // deliberately DELETED the focus fallback: when the browser reports no keyboard
+  // geometry the app must not guess one, because the strip it hid behind an
+  // imagined keyboard was visibly abandoned. This check kept asserting the removed
+  // behaviour and could not pass — it went unnoticed because the suite could not
+  // launch a browser here at all. Same purpose, current contract: no guess.
+  const embeddedNoGuess = await waitFor(() => embeddedFrame.evaluate(() =>
+    !document.documentElement.dataset.keyboardLayout));
   const embeddedLayout = await embeddedFrame.locator('.app').evaluate((node) => {
     const app = node.getBoundingClientRect();
     const keybar = document.querySelector('.tile-terminal:not(.tile-cached) .term-keybar')
@@ -547,9 +561,11 @@ try {
       innerHeight: window.innerHeight,
     };
   });
-  check('Hub iframe uses a focus fallback when keyboard geometry is unavailable',
-    embeddedFallback
-      && Math.abs(embeddedLayout.height - 360) < 1
+  check('a Hub iframe with no keyboard geometry does not guess one',
+    embeddedNoGuess
+      // Full height: the app leaves the frame alone rather than shrinking to a
+      // made-up 54%, and the keybar stays inside it.
+      && Math.abs(embeddedLayout.height - 667) < 1
       && embeddedLayout.keybarBottom <= embeddedLayout.bottom
       && embeddedLayout.visualViewportHeight === 667
       && embeddedLayout.innerHeight === 667,
@@ -573,6 +589,11 @@ try {
   }, id), 5_000);
   await page.evaluate(() => localStorage.setItem('__am_test_offline_sockets', '1'));
   await page.reload({ waitUntil: 'domcontentloaded' });
+  // Coming back on a phone restores the pane you were reading, so `.app.m-stage`
+  // hides the sidebar and its rows are unclickable. Return to the list the way a
+  // user does. (The app gained that restore after this check was written.)
+  const backToList = page.locator('.mback');
+  if (await backToList.isVisible().catch(() => false)) await backToList.click();
   await page.locator('.sidebar .row').filter({ hasText: 'mobile-terminal-e2e' }).first().click();
   const previewVisible = await page.locator('.term-preview').filter({ hasText: 'MOBILE-HISTORY-0280' })
     .isVisible().catch(() => false);

--- a/server/package.json
+++ b/server/package.json
@@ -14,6 +14,7 @@
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
     "test:ui": "node terminal-ui.test.mjs",
+    "test:mobile": "node mobile.test.mjs",
     "test": "node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -14,6 +14,7 @@ import path from 'node:path';
 import { spawn, spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../scripts/test-chromium.mjs';
 import { WebSocket } from 'ws';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -102,7 +103,7 @@ try {
   }));
   await sleep(600);
 
-  browser = await chromium.launch({ headless: true });
+  browser = await chromium.launch(chromiumLaunchOptions());
   const context = await browser.newContext({
     viewport: { width: 1280, height: 800 },
     permissions: ['clipboard-read', 'clipboard-write'],

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -65,7 +65,7 @@ const OV_CHIPS: { chip: OverviewChip; title: string }[] = [
 ];
 
 function initialTheme(): 'light' | 'dark' {
-  const stored = localStorage.getItem('am-theme');
+  const stored = readStored('am-theme');
   if (stored === 'light' || stored === 'dark') return stored;
   return window.matchMedia?.('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
 }
@@ -78,8 +78,12 @@ function initialTheme(): 'light' | 'dark' {
 // to be storage.
 //
 // Storage can be denied outright — private mode, or a third-party iframe under
-// cross-site tracking prevention. That's a "don't remember" fallback to the
-// behaviour we already had, never a crash, so both sides swallow.
+// cross-site tracking prevention (the Hub embeds this Space in exactly such an
+// iframe). Reading it then THROWS rather than returning null, so every access in
+// this file goes through these two: a raw localStorage call in a useState
+// initializer took the whole app down to its error boundary — "Something broke in
+// the UI" — for a preference as incidental as which zoom you last used. A
+// "don't remember" fallback, never a crash, so both sides swallow.
 const readStored = (k: string): string | null => {
   try { return localStorage.getItem(k); } catch { return null; }
 };
@@ -114,17 +118,17 @@ export default function App() {
   const showErr = (msg: string) => (e: unknown) => { console.error(msg, e); setToast(msg); window.setTimeout(() => setToast(null), 4000); };
   // Overview presentation: tiles (default) or the classic list.
   const [ovView, setOvViewRaw] = useState<'tiles' | 'list'>(() =>
-    (localStorage.getItem('am-ov-view') === 'list' ? 'list' : 'tiles'));
-  const setOvView = (v: 'tiles' | 'list') => { setOvViewRaw(v); localStorage.setItem('am-ov-view', v); };
+    (readStored('am-ov-view') === 'list' ? 'list' : 'tiles'));
+  const setOvView = (v: 'tiles' | 'list') => { setOvViewRaw(v); writeStored('am-ov-view', v); };
   // Overview order: the tree's own arrangement (default) or ranked by a
   // timestamp. A view preference like the two above it — per browser, and it
   // survives a reload, because re-picking your order on every visit is the
   // thing that makes a sort control feel like a toy.
   const [ovSort, setOvSortRaw] = useState<OverviewSort>(() => {
-    const s = localStorage.getItem('am-ov-sort');
+    const s = readStored('am-ov-sort');
     return s === 'prompt' || s === 'answer' ? s : 'manual';
   });
-  const setOvSort = (v: OverviewSort) => { setOvSortRaw(v); localStorage.setItem('am-ov-sort', v); };
+  const setOvSort = (v: OverviewSort) => { setOvSortRaw(v); writeStored('am-ov-sort', v); };
   // Archiving: sessions quiet for longer than the configured window are hidden
   // from the sidebar and overview unless "archived" is checked. Derived, never
   // stored — flipping the setting instantly (un)archives.
@@ -144,13 +148,13 @@ export default function App() {
   useEffect(() => onPaneMode(setPaneMode), []);
   const showPaneMode = (m: 'terminal' | 'reader') => { setPaneMode(m); writePaneMode(m); };
   const [zoom, setZoom] = useState<number>(() => {
-    const z = parseInt(localStorage.getItem('am-zoom') || '100', 10);
+    const z = parseInt(readStored('am-zoom') || '100', 10);
     return Number.isFinite(z) ? z : 100;
   });
   const [info, setInfo] = useState<Awaited<ReturnType<typeof api.getInfo>> | null>(null);
   // Default location for the next agent = where the last one was created,
   // falling back to the workspaces root.
-  const [lastPath, setLastPath] = useState(() => normalizePath(localStorage.getItem('am-last-path')));
+  const [lastPath, setLastPath] = useState(() => normalizePath(readStored('am-last-path')));
   // Mobile navigation: false = the sidebar is the (full-screen) home view,
   // true = the selected session/group fills the screen. Desktop ignores this.
   const isMobile = useIsMobile();
@@ -164,12 +168,12 @@ export default function App() {
   const rememberPath = (p?: string | null) => {
     const next = normalizePath(p);
     setLastPath(next);
-    localStorage.setItem('am-last-path', next);
+    writeStored('am-last-path', next);
   };
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
-    localStorage.setItem('am-theme', theme);
+    writeStored('am-theme', theme);
   }, [theme]);
 
   // Write the selection through on every change rather than on unload: a phone
@@ -352,7 +356,7 @@ export default function App() {
     const t = setInterval(() => api.getInfo().then(setInfo).catch(() => {}), 15_000);
     return () => clearInterval(t);
   }, [info?.locked]);
-  useEffect(() => { localStorage.setItem('am-zoom', String(zoom)); }, [zoom]);
+  useEffect(() => { writeStored('am-zoom', String(zoom)); }, [zoom]);
 
   // Show the welcome once, when /api/info first loads: on first run (never seen)
   // or whenever demo mode is active (so the Space reads like a fresh install).

--- a/web/test/traceWindows.test.mjs
+++ b/web/test/traceWindows.test.mjs
@@ -8,6 +8,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { build } from 'esbuild';
 import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-windows-web-'));
@@ -89,13 +90,11 @@ await build({
 });
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-// CI normally uses Playwright's matching download. The development Space keeps
-// a shared Chromium revision instead, so allow that executable to be supplied
-// without baking an environment-specific path into the test.
-const browser = await chromium.launch({
-  headless: true,
-  executablePath: process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH,
-});
+// CI uses Playwright's matching download; this workspace keeps a shared Chromium
+// of a different revision. The helper resolves whichever is actually installed
+// (and still honours PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH) so neither environment
+// needs a path baked into the test.
+const browser = await chromium.launch(chromiumLaunchOptions());
 try {
   const page = await browser.newPage();
   await page.setContent('<div id="root"></div>');


### PR DESCRIPTION
`web/npm test` is red on `main`. The cause is one line of Playwright behaviour, but fixing it made three suites runnable for the first time in this workspace, and they immediately caught two real bugs.

## 1. Resolve whatever browser is installed (the actual ask)

`chromium.launch()` with no `executablePath` demands the **exact** build the installed Playwright expects. This image ships rev **1208**; `playwright@^1.62` wants **1234**. The failure is `Looks like Playwright was just installed or updated / npx playwright install` — which blames a missing install and sends you to download 115MB you already have.

`scripts/test-chromium.mjs` picks, in order:
1. `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` — an explicit answer always wins (traceWindows already honoured this; nothing set it, and the other two suites had no such hook).
2. the newest `chromium-*` under `PLAYWRIGHT_BROWSERS_PATH`, whatever its revision — falling back to `chromium_headless_shell-*`.
3. nothing, so CI and an ordinary dev machine keep using Playwright's own download and any error stays Playwright's.

It also passes `--no-sandbox`, without which Chromium exits immediately as a non-root user in a container.

Driving a revision Playwright wasn't built against is a deliberate trade, stated in the file: these suites use long-stable APIs, and a browser one build off is worth more than a suite nobody can run.

## 2. The app crashed whenever localStorage was denied

`App.tsx` defines `readStored`/`writeStored` and its comment names the exact scenario — *"a third-party iframe under cross-site tracking prevention"*, which is how the Hub serves a Space. It then read `am-theme`, `am-zoom`, `am-ov-view`, `am-ov-sort` and `am-last-path` **directly**.

Denied storage **throws** rather than returning null, and those reads sit in `useState` initializers — so the entire UI fell to its error boundary, *"Something broke in the UI"*, over which zoom you last used. Every access in the file now goes through the guards.

This is not hypothetical: `mobile.test.mjs` loads the app in an `about:blank`-parented iframe (third-party → storage blocked) and was timing out clicking a sidebar row **on a dead page**. Any real user with third-party cookies blocked would hit the same white screen.

## 3. mobile.test.mjs published skills into the live workspace

It spread `...process.env` into the server it spawns. With `SPACE_ID` set — as it is inside the Space — `skillTargetDirs()` fans *this checkout's* skill templates over **every live agent's** skills dir. Those paths derive from `$HOME`, not `DATA_DIR`, so its throwaway data dir contained nothing. `migration.test.mjs` and `resize.test.mjs` already strip `SPACE_ID` and `AM_DISTRIBUTE_SKILLS` with a comment explaining precisely this; `mobile` now matches.

I verified the strip end to end by running the suite with `SPACE_ID` still set and `HOME` pointed at a scratch dir: no `SKILL.md` written anywhere.

## 4. Two stale expectations, from deliberate app changes

Both were invisible because the suite could not launch. I changed assertions to match intent, not to go green — the reasoning is in the diff:

- **`07ad947` "stop estimating a height nobody can measure" deleted the keyboard focus fallback on purpose.** The test still asserted the removed behaviour (`dataset.keyboardLayout === 'focus-fallback'`, app shrunk to 54% of the frame) — an assertion that *cannot* pass, since `focus-fallback` no longer appears anywhere in `web/src`. It now asserts the contract that replaced it (no guess, full height), which is the **iframe twin of the direct-app check the same commit added** (`direct app does not guess a keyboard height without a browser signal`).
- **A mobile reload now restores the pane you were reading**, so `.app.m-stage` hides the sidebar and its rows can't be clicked. The test returns to the list first, as a user does.

Plus the `test:mobile` script that `mobile.test.mjs`'s own header already told you to run.

## Verified by running

| suite | result |
|---|---|
| `web` `npm test` | 11/11 + `trace-windows: ok` |
| `server` `npm test` | green end to end, **exit 0**, `migration` and `resize` included |
| `server` `test:ui` (terminal-ui) | all checks passed |
| `server` `test:mobile` | all checks passed |

The mobile suite is green on **both** rev 1208 (what the image ships) and rev 1234 (what Playwright wants) — I installed 1234 specifically to rule out a browser-version artifact before touching any assertion.

## Notes

- `server/package.json` declares `playwright` as a devDependency, but `/app/server/node_modules` has no `playwright`, so `test:ui`/`test:mobile` can't run against the deployed server's deps at all. I worked around it locally; installing server devDeps in the image would make these two runnable there.
- The right long-term fix for the revision drift is to install browsers matching the pinned Playwright in the image. This resolver stops the drift from being fatal either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)