### PR TITLE
Type into a woken OpenCode pane, and stop two test servers publishing skills

### DIFF
--- a/server/migration.test.mjs
+++ b/server/migration.test.mjs
@@ -256,10 +256,30 @@ try {
   // OpenCode paints its stable welcome screen before its keyboard handler is
   // always ready. The first typed attempt is silently drained here; delivery
   // must wait for the composer to echo the real prompt before pressing Enter.
+  //
+  // The pane has to have run once before for that to be the path under test: a
+  // never-started pane whose CLI has `withPrompt` takes its first prompt as a
+  // launch ARGUMENT instead (deliver() in src/index.js), which never reaches the
+  // keyboard at all. So boot it, stop it, and type into the wake — which is also
+  // where an operator meets this: the pane they left running yesterday.
   const openCode = await (await fetch(`${base}/api/sessions`, {
     method: 'POST', headers: { 'content-type': 'application/json' },
     body: JSON.stringify({ cli: 'opencode', name: 'opencode-input-readiness', path: '.' }),
   })).json();
+  await fetch(`${base}/api/sessions/${openCode.id}/input`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text: 'opencode-launch-argument' }),
+  });
+  // Wait for the first boot to paint rather than sleeping a guess at it: the
+  // stop below has to land on a running pty for the wake to be a real wake.
+  let openCodeBooted = false;
+  for (let i = 0; i < 40 && !openCodeBooted; i++) {
+    const booting = await (await fetch(`${base}/api/agents/${openCode.id}/tail?lines=40`)).json();
+    openCodeBooted = (booting.text || '').includes('OPENCODE-SCREEN-READY');
+    if (!openCodeBooted) await sleep(150);
+  }
+  await fetch(`${base}/api/sessions/${openCode.id}/stop`, { method: 'POST' });
+  await sleep(600);
   const openCodeInput = 'opencode-delivery-survived';
   const openCodeDelivered = await fetch(`${base}/api/sessions/${openCode.id}/input`, {
     method: 'POST', headers: { 'content-type': 'application/json' },
@@ -269,9 +289,10 @@ try {
   const openCodeTail = await (await fetch(`${base}/api/agents/${openCode.id}/tail?lines=120`)).json();
   const executed = (openCodeTail.text || '').match(new RegExp(`OPENCODE-EXECUTED:${openCodeInput}`, 'g')) || [];
   check('OpenCode delivery waits for the real input handler after stable paint',
-    openCodeDelivered.ok
+    openCodeBooted
+      && openCodeDelivered.ok
       && executed.length === 1,
-    `${openCodeDelivered.status} ${JSON.stringify(openCodeTail.text || '')}`);
+    `booted=${openCodeBooted} ${openCodeDelivered.status} ${JSON.stringify(openCodeTail.text || '')}`);
   await fetch(`${base}/api/sessions/${openCode.id}`, { method: 'DELETE' }).catch(() => {});
 } catch (err) {
   check('no exceptions', false, String(err && err.message ? err.message : err));

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -61,10 +61,18 @@ if (!process.env.SCREENSHOT_PUBLIC_DIR) {
   if (build.status !== 0) throw new Error(`web build failed:\n${build.stdout}\n${build.stderr}`);
 }
 
+// A test server must not publish skills — the same strip migration.test.mjs,
+// resize.test.mjs and mobile.test.mjs do, for the same reason: `SPACE_ID` is set
+// when this runs inside the Space itself, and generateEnvSkill() then fans this
+// checkout's environment skill into every live agent's skills dir, over the
+// copies the running backend wrote. Those dirs come from $HOME, NOT from
+// DATA_DIR, so a throwaway DATA_DIR does not contain the damage.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+
 const backend = spawn('node', ['src/index.js'], {
   cwd: HERE,
   env: {
-    ...process.env,
+    ...BASE_ENV,
     PORT: '7896', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '',
     AM_ALLOW_MISSING_ORIGIN: '1',
     AM_TEST_REPAINT_CMD: 'bash --noprofile --norc',

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -48,9 +48,17 @@ if (!process.env.TERMUI_PUBLIC_DIR) {
   if (build.status !== 0) throw new Error(`web build failed:\n${build.stdout}\n${build.stderr}`);
 }
 
+// A test server must not publish skills — the same strip migration.test.mjs,
+// resize.test.mjs and mobile.test.mjs do, for the same reason: `SPACE_ID` is set
+// when this runs inside the Space itself, and generateEnvSkill() then fans this
+// checkout's environment skill into every live agent's skills dir, over the
+// copies the running backend wrote. Those dirs come from $HOME, NOT from
+// DATA_DIR, so a throwaway DATA_DIR does not contain the damage.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+
 const backend = spawn('node', ['src/index.js'], {
   cwd: HERE,
-  env: { ...process.env, PORT: '7897', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1' },
+  env: { ...BASE_ENV, PORT: '7897', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1' },
   stdio: ['ignore', 'pipe', 'pipe'],
 });
 let logs = '';


### PR DESCRIPTION
`npm test` has been red on `main` since #39 merged. This makes it green, and closes a hazard #39 reintroduced.

## The red test

```
FAIL  OpenCode delivery waits for the real input handler after stable paint  200 "OPENCODE-SCREEN-READY"
```

Reproducible 4/4. Bisected by running `migration.test.mjs` at three points: **green** at `1dfeefd` (#25, the commit that added this check), **green** at `95c7527` (#66), **red** at `16f6fd9` (#39).

**It is a stale test, not a product bug.** #25 added the check to prove delivery waits through OpenCode's startup drain before pressing Enter. #39 then added a short-circuit to `deliver()` (`server/src/index.js:338`): a pane that has *never started*, whose CLI has `withPrompt`, takes its first prompt as a **launch argument** rather than having it typed in — deliberately, since "typing into a half-booted TUI loses turns". The check created a fresh pane and typed into it, so after #39 its text went to `opencode --prompt …`, and the fake OpenCode (which echoes only stdin, ignoring argv) never printed `OPENCODE-EXECUTED`.

## The fix

The typed path is still the one an operator meets — on the pane they left running yesterday — so the check now goes there: boot the pane, wait for its first paint, stop it, then type into the wake. On that path `started` is true, so `confirmEcho` is on and #25's guard is genuinely exercised rather than skipped. The tail now reads:

```
OPENCODE-SCREEN-READY → OPENCODE-INPUT-READY → opencode-delivery-survived → OPENCODE-EXECUTED:opencode-delivery-survived
```

exactly once. The boot is waited for rather than slept at, and asserted, so a future failure says which half broke.

## The skills strip

Two test servers still spread `...process.env`: `terminal-ui.test.mjs` and `screenshot-input.test.mjs` (new in #39). With `SPACE_ID` set — as it is inside the Space — `generateEnvSkill()` fans this checkout's `environment` skill into **every live agent's skills dir**, over the copies the running backend wrote. Those paths come from `$HOME`, not `DATA_DIR`, so a throwaway `DATA_DIR` contains nothing. #66 fixed this in `mobile.test.mjs`; `migration.test.mjs` and `resize.test.mjs` already had it. Same three lines, same comment convention, now in the last two.

Nine agents are working in this Space, so this is not hypothetical: running `npm run test:ui` here would have rewritten all nine agents' `environment` skill.

## Verified

- `migration.test.mjs` alone: **3/3 green**, 28 checks (it has real timing, so it was run repeatedly rather than once).
- `server npm test`: **exit 0, 144 checks, 0 failures** — the whole chain, including `resize` which the old failure was cutting off.
- `npm run test:ui` (terminal-ui + screenshot-input): green, run with `SPACE_ID` **set** and `HOME`/`CLAUDE_CONFIG_DIR`/`OPENCLAW_HOME` redirected to a scratch dir — **nothing published**. Before the strip, the same experiment against `mobile.test.mjs` wrote four `SKILL.md` files, which is how the hazard was confirmed in the first place.
- `web`: `tsc --noEmit` clean, 11/11 + trace-windows (unchanged by this PR).
- `test:mobile`: green on `main` already and untouched here.

Test-only: no `src/` file is modified.