### PR TITLE
Render the Space full width

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ colorFrom: gray
 colorTo: indigo
 sdk: docker
 app_port: 7860
+fullWidth: true
 pinned: false
 license: apache-2.0
 short_description: Private cloud manager for AI coding CLI sessions


### PR DESCRIPTION
One line in the Space card: `fullWidth: true`.

Without it the Hub renders a Space inside a centered, padded container, so `huggingface.co/spaces/lvwerra/agent-manager` shows the manager letterboxed with dead margin on both sides. For a terminal manager that margin is expensive — it is width that panes, the sidebar and side-by-side group tiles would otherwise use.

Direct `*.hf.space` URLs are unaffected either way; this only changes the embedded view on the Hub page.

`scripts/deploy-dev-space.sh` rewrites `title`, `emoji`, `colorFrom` and `short_description` on a dev Space's card but preserves every other key, so dev instances inherit this too.

If "full screen" meant something else — the app's own layout rather than the Hub frame — say so and I will close this; the in-app equivalent is a different change.