### PR TITLE
Don't fail the boot when rsync reports vanished source files

### DIFF
--- a/scripts/agent-state.sh
+++ b/scripts/agent-state.sh
@@ -53,6 +53,21 @@ mark_checkpoint_floor() {
   touch -d '2 seconds ago' "$1" 2>/dev/null || touch "$1"
 }
 
+# rsync exit 24 is "partial transfer due to vanished source files": between
+# building its file list and reading them, something deleted files the listing
+# still named. Both tree copies are exposed to it — a restore walks the bucket
+# for minutes while a harness prunes transcript scratch, and a checkpoint copies
+# a live tree the harnesses are still writing. What vanishes is the scratch
+# itself, so nothing durable is lost and the copy is otherwise complete.
+# Treating it as a failure once refused to boot the Space at all.
+# Single-file copies below keep the strict test: there, a vanished source is
+# exactly the file we were asked for.
+rsync_tree() {
+  rsync "$@"; _rs_rc=$?
+  [ "$_rs_rc" -eq 24 ] && _rs_rc=0
+  return "$_rs_rc"
+}
+
 restore_tree() {
   key="$1" durable="$2" live="$3"; shift 3
   mkdir -p "$durable" "$live"
@@ -63,7 +78,7 @@ restore_tree() {
   # --update matters for hot/dev restarts: local disk survives those and can be
   # newer than the last completed bucket checkpoint. A fresh container starts
   # with an empty destination, so the same command performs a full restore.
-  if rsync -a --update "$@" "$durable/" "$live/"; then
+  if rsync_tree -a --update "$@" "$durable/" "$live/"; then
     mkdir -p "$stamp_dir"
     if [ ! -e "$stamp" ]; then
       if [ "$had_local" = true ]; then
@@ -102,7 +117,7 @@ checkpoint_tree() {
     # the remote tree every 15 seconds — a critical property on the bucket
     # mount. Destination temporaries close before rename, retaining the prior
     # object if this process dies during transfer.
-    if ! rsync -a -r --from0 --files-from="$list" --delay-updates \
+    if ! rsync_tree -a -r --from0 --files-from="$list" --delay-updates \
       "$@" "$live/" "$durable/"; then
       rm -f "$next" "$list"
       return 1

--- a/server/state-checkpoint.test.mjs
+++ b/server/state-checkpoint.test.mjs
@@ -191,6 +191,47 @@ try {
   check('SQLite snapshot restores without stale WAL state',
     sql(path.join(env.OPENCODE_LIVE, 'opencode.db'), 'SELECT body FROM message ORDER BY id;') === openRowsBeforeCorruption
       && !fs.existsSync(path.join(env.OPENCODE_LIVE, 'opencode.db-wal')));
+  // rsync exit 24 = "partial transfer due to vanished source files". A restore
+  // walks the bucket for minutes while a harness prunes its transcript scratch,
+  // so the listing names files that are gone by the time they are read. This
+  // once aborted the boot outright. Exit code handling is pinned with a stub so
+  // the check does not depend on winning a race against a real transfer; a
+  // fresh DATA_DIR keeps the strict single-file SQLite copies out of the way.
+  const vanishRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'am-agent-state-24-'));
+  const stubDir = path.join(vanishRoot, 'bin');
+  const stubRsync = (code) => {
+    fs.mkdirSync(stubDir, { recursive: true });
+    fs.writeFileSync(path.join(stubDir, 'rsync'), [
+      '#!/bin/sh',
+      'echo \'file has vanished: "tool-results/toolu_01.txt"\' >&2',
+      `echo 'rsync warning: vanished/error stub (code ${code})' >&2`,
+      `exit ${code}`,
+    ].join('\n'));
+    fs.chmodSync(path.join(stubDir, 'rsync'), 0o755);
+  };
+  const restoreStatus = (code) => {
+    stubRsync(code);
+    const stubEnv = { ...env, PATH: `${stubDir}:${env.PATH}` };
+    for (const [key, value] of Object.entries(stubEnv)) {
+      if (typeof value === 'string' && value.startsWith(root)) {
+        stubEnv[key] = value.replace(root, vanishRoot);
+      }
+    }
+    try {
+      execFileSync('sh', [script, 'restore'], { env: stubEnv, encoding: 'utf8', stdio: 'pipe' });
+      return { status: 0, local: stubEnv.AM_LOCAL };
+    } catch (error) {
+      return { status: error.status ?? 1, local: stubEnv.AM_LOCAL };
+    }
+  };
+
+  const vanished = restoreStatus(24);
+  check('restore survives rsync vanished-source warning (exit 24)', vanished.status === 0);
+  check('a tolerated exit 24 still takes the restore success path',
+    fs.existsSync(path.join(vanished.local, 'agent-state-stamps/claude')));
+  check('restore still fails on a genuine rsync error (exit 23)',
+    restoreStatus(23).status === 1);
+  fs.rmSync(vanishRoot, { recursive: true, force: true });
 } catch (error) {
   check('no unexpected exception', false, error?.stack || String(error));
 } finally {


### PR DESCRIPTION
Upstreaming a hotfix applied directly to the prod Space during yesterday's deploy. `ce3c3bd` has been live and running since 2026-08-15 08:16 UTC; main has been behind prod since then. Authored by the agent that fixed it — commit carried over unmodified.

## The incident

The Space refused to start:

```
agent-state restore was incomplete; refusing to start agents against partial state
```

The restore's rsync had exited **24** — *partial transfer due to vanished source files*. Claude pruned tool-results scratch under `/data/state/claude` while the 9m38s bucket walk was still reading the listing that named them. 24 is a warning: what vanished was the harness's own scratch, and the rest of the tree copied fine. Treating it as an error took the whole Space down.

## The fix

A `rsync_tree()` wrapper that maps exit 24 to 0, applied to **both** tree copies:

- `restore_tree` — walks the bucket for minutes while a harness prunes transcript scratch underneath it
- `checkpoint_tree` — copies a live tree the harnesses are still writing

Single-file copies keep the strict test. I checked every remaining bare `rsync` call site (lines 166, 171–173, 240): all four are single closed files — a SQLite `.backup` staging file or its WAL/SHM companions. There, a vanished source *is* exactly the file we asked for, and failing is right. So the split the commit message describes holds precisely.

## Review notes

- `agent-state.sh` sets `set -u`, not `set -e`, so the `rsync "$@"; _rs_rc=$?` pattern captures the status reliably; it does not depend on both call sites happening to sit in `if` conditions.
- Worth naming, since it is the real cost of this change: tolerating 24 on the restore path means a restore that lost *genuinely durable* files to a mount-level race would now boot and stamp itself complete rather than refusing. The judgement is that what vanishes under these trees is scratch, and that a Space which will not boot is the worse failure. If that trade ever needs tightening, the place to do it is a post-restore check on the durable trees rather than re-arming the blanket exit-code test.

## Verification

Re-ran `server/state-checkpoint.test.mjs` on this commit just now — 20/20 pass, including the three new checks:

```
PASS  restore survives rsync vanished-source warning (exit 24)
PASS  a tolerated exit 24 still takes the restore success path
PASS  restore still fails on a genuine rsync error (exit 23)
```

The test stubs `rsync` on `PATH` rather than racing a real transfer, so it pins the exit-code contract deterministically, and the exit-23 case proves the tolerance is narrow.