### PR TITLE
Space: full-screen chrome via `header: mini`, not `fullWidth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ colorFrom: gray
 colorTo: indigo
 sdk: docker
 app_port: 7860
-fullWidth: true
+header: mini
 pinned: false
 license: apache-2.0
 short_description: Private cloud manager for AI coding CLI sessions


### PR DESCRIPTION
Corrects #70, which was a no-op.

#70 added `fullWidth: true` on the assumption that the Hub renders a Space in a centered container by default. It does not — [the config reference](https://huggingface.co/docs/hub/spaces-config-reference) says `fullWidth` **defaults to `true`**. The flag I added was already the effective value, so the Space page looked exactly the same before and after. The card metadata parsed fine (`cardData.fullWidth == True` on both Spaces); it simply changed nothing.

The field that produces the requested behaviour is on the same page:

> **`header`**: _string_ — Can be either `mini` or `default`. If `header` is set to `mini` the space will be displayed full-screen with a mini floating header.

So this swaps `fullWidth: true` (redundant, it is the default) for `header: mini`. What was actually consuming the space is the Hub's default header chrome above the iframe, not the column width.

Both keys are outside the set `scripts/deploy-dev-space.sh` rewrites (`title`, `emoji`, `colorFrom`, `short_description`), so dev instances inherit this on their next deploy.

Card-only change: it takes effect per-Space when that Space's repo receives it, not on merge here. Direct `*.hf.space` URLs are unaffected either way — this only changes the Hub-hosted view.