### PR TITLE
Read the trace again when the operator comes back to the tab

### DIFF
--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -269,6 +269,10 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
   // a window can know. If it fails or is slow, the header simply says how much
   // is loaded.
   const summaryReady = !!meta;
+  // Bumped when a return to the foreground abandons a summary that was in
+  // flight. `summaryStarted` is a ref, so clearing it alone would not re-run the
+  // effect below — nothing else in its deps changes when a tab comes back.
+  const [summaryEpoch, setSummaryEpoch] = useState(0);
   useEffect(() => {
     // `meta` is set by the tail response and this effect runs after that render
     // commits. Starting the clock on mount let a slow tail lose a race to every
@@ -287,7 +291,7 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
         .finally(() => { if (summaryAbort.current === abort) summaryAbort.current = null; });
     }, SUMMARY_DELAY_MS);
     return () => { dead = true; window.clearTimeout(h); };
-  }, [src, srcKey, paused, summaryReady, summary]);
+  }, [src, srcKey, paused, summaryReady, summary, summaryEpoch]);
 
   // The transcript may still be being written — see LIVE_MS above. Except when
   // "a window" costs a whole-file read: the SQLite harnesses have no byte
@@ -339,6 +343,18 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
         outstanding.abort();
       }
       loading.current = false;
+      // The whole-file summary can be the frozen request instead of a window.
+      // It is single-flight through `summaryStarted`, which nothing else clears,
+      // so the header would keep its "loaded so far" counts — no turn total, no
+      // user turns, no session cost — for the life of this source, while the
+      // turns below it updated normally on every return.
+      const outstandingSummary = summaryAbort.current;
+      if (outstandingSummary) {
+        summaryAbort.current = null;
+        summaryStarted.current = false;
+        outstandingSummary.abort();
+        setSummaryEpoch((epoch) => epoch + 1);
+      }
       void (cursor.current ? loadNewer() : loadTail());
     };
     const onVisible = () => { if (!document.hidden) resync(); };

--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -312,6 +312,49 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
     return () => window.clearInterval(h);
   }, [loadNewer, lastTs, seekable, paused, hidden, live]);
 
+  // Coming back from another app has to show what happened while away, and none
+  // of the loop above survives the trip. The interval is cleared while hidden,
+  // and the effect that would restore it schedules NOTHING when the host says
+  // the session stopped and the trace has been quiet — so a reader left on a
+  // finished session shows the turns from before the operator switched away,
+  // for as long as they keep looking at it. Even when a poll is scheduled, an
+  // interval's first tick is one whole interval late.
+  //
+  // A frozen request makes it worse. iOS Safari suspends a backgrounded tab, so
+  // a window request that was in flight when the operator left may never settle
+  // — and `loading` is released only in that request's `finally`, so every later
+  // read returns early against a latch nothing will ever release. That is a
+  // reader which stays stale even once polling resumes.
+  //
+  // So a return reads immediately: abandon whatever was outstanding (bumping the
+  // generation, which is what makes its response and its `finally` no longer
+  // ours), release the latch, and ask for the turns written while away.
+  useEffect(() => {
+    const resync = () => {
+      if (document.hidden || cb.current.paused) return;
+      const outstanding = windowAbort.current;
+      if (outstanding) {
+        gen.current += 1;
+        windowAbort.current = null;
+        outstanding.abort();
+      }
+      loading.current = false;
+      void (cursor.current ? loadNewer() : loadTail());
+    };
+    const onVisible = () => { if (!document.hidden) resync(); };
+    // Restoring a page from the back/forward cache fires no visibilitychange:
+    // the tab was never hidden, the whole page was frozen and thawed. Safari
+    // leans on this hard — a swipe back, or an app switch that outlived the
+    // renderer, comes back this way.
+    const onShow = (e: PageTransitionEvent) => { if (e.persisted) resync(); };
+    document.addEventListener('visibilitychange', onVisible);
+    window.addEventListener('pageshow', onShow);
+    return () => {
+      document.removeEventListener('visibilitychange', onVisible);
+      window.removeEventListener('pageshow', onShow);
+    };
+  }, [loadNewer, loadTail]);
+
   const atStart = !!cursor.current?.atStart;
   const blocked = !!cursor.current?.blocked;
   // MEMOIZED, and it has to be: a host that lifts this into its own state — the

--- a/web/test/traceWindows.test.mjs
+++ b/web/test/traceWindows.test.mjs
@@ -26,9 +26,14 @@ await build({
 
       const calls = [];
       const tails = [];
-      const page = (turns, end = 20) => ({
+      // What the agent has written since the reader last looked, and a switch
+      // that leaves such a request outstanding forever: a connection frozen
+      // along with the tab, which is what iOS Safari does to a backgrounded one.
+      let pending = [];
+      let freeze = false;
+      const page = (turns, end = 20, lastTs = Date.now()) => ({
         harness: 'claude', harnessLabel: 'Claude Code', sessionId: 's',
-        title: '', model: null, cwd: null, firstTs: 0, lastTs: Date.now(),
+        title: '', model: null, cwd: null, firstTs: 0, lastTs,
         usage: null, source: null, sharedBy: null, note: null, truncated: false,
         total: null, userTurns: null, turns,
         window: { mode: 'bytes', start: 10, end, atStart: false, atEnd: true },
@@ -38,7 +43,14 @@ await build({
           const call = { kind: 'window', req, bytes, min, at: performance.now(), aborted: false };
           calls.push(call);
           signal?.addEventListener('abort', () => { call.aborted = true; }, { once: true });
-          if (req.at === 'after') return Promise.resolve(page([], req.cursor + 1));
+          if (req.at === 'after') {
+            if (freeze) return new Promise(() => {});
+            const got = pending;
+            pending = [];
+            // Written a while ago: a returning reader must not depend on the
+            // trace looking recent, which is exactly when polling is off.
+            return Promise.resolve(page(got, req.cursor + 1, Date.now() - 10 * 60_000));
+          }
           return new Promise((resolve) => tails.push({ resolve, call }));
         },
         summary(signal) {
@@ -71,6 +83,13 @@ await build({
         calls,
         setPaused(next) { paused = next; render(); },
         setSurface(next) { surfaceKey = next; render(); },
+        /** Turns the agent writes while the operator is looking at another app. */
+        writeWhileAway(count) {
+          pending = Array.from({ length: count }, (_, i) => (
+            { role: 'assistant', ts: 100 + i, blocks: [{ type: 'text', text: 'away-' + i }] }
+          ));
+        },
+        setFrozen(next) { freeze = next; },
         resolveTail() {
           const pending = [...tails].reverse().find((x) => !x.call.aborted);
           pending?.resolve(page([
@@ -158,6 +177,74 @@ try {
 
   await page.evaluate(() => window.__traceHarness.setPaused(true));
   await page.waitForFunction(() => window.__traceHarness.calls.find((c) => c.kind === 'summary').aborted);
+
+  // --- switching to another app and coming back ----------------------------
+  // Chromium cannot be genuinely backgrounded in this container: headless
+  // reports every page visible, and headed has no window manager to minimise or
+  // occlude one (both were tried, along with CDP lifecycle states, a sibling
+  // tab, and WebKit, which will not launch here). So the document's own
+  // visibility is overridden and the real event dispatched through the DOM. The
+  // hook reads `document.hidden` and nothing else, so this is the same code path
+  // a true app switch takes; what it does not prove is that the browser fires
+  // the event, which is the browser's guarantee rather than this app's.
+  const setVisibility = (state) => page.evaluate((s) => {
+    Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => s });
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => s === 'hidden' });
+    document.dispatchEvent(new Event('visibilitychange'));
+  }, state);
+  const windowCalls = () => page.evaluate(() =>
+    window.__traceHarness.calls.filter((c) => c.kind === 'window').length);
+
+  await page.evaluate(() => window.__traceHarness.setPaused(false));
+  await page.evaluate(() => window.__traceHarness.resolveTail());
+  await page.waitForFunction(() => document.getElementById('head').textContent === '2');
+
+  await setVisibility('hidden');
+  const whileAway = await windowCalls();
+  await sleep(1200);
+  assert.equal(await windowCalls(), whileAway, 'a reader nobody is looking at asks for nothing');
+
+  // The agent writes three turns while the operator is in another app, and the
+  // trace comes back ten minutes stale. `live: false` on a trace that old is
+  // exactly the case the scheduler leaves alone: no interval will ever cover
+  // this reader, so the return itself has to do the reading.
+  await page.evaluate(() => window.__traceHarness.writeWhileAway(3));
+  const returnedAt = Date.now();
+  await setVisibility('visible');
+  await page.waitForFunction(() => document.getElementById('head').textContent === '5', null, { timeout: 2_000 });
+  assert.ok(Date.now() - returnedAt < 2_000,
+    'what was written while away is on screen on return, not an interval later');
+  const caughtUp = await page.evaluate(() =>
+    window.__traceHarness.calls.filter((c) => c.kind === 'window').pop());
+  assert.equal(caughtUp.req.at, 'after', 'the reader asks for what it missed, not for the whole tail again');
+
+  // A request in flight when the tab went away can be frozen with it: it never
+  // resolves and never rejects. The one-request-at-a-time latch is released only
+  // in that request's `finally`, so a returning reader that waits for it is
+  // stuck for good — every later read returns early against a latch nothing will
+  // release.
+  await page.evaluate(() => window.__traceHarness.setFrozen(true));
+  const frozenIndex = await page.evaluate(() => window.__traceHarness.calls.length);
+  // Deliberately not awaited in the page: this is the request that never settles.
+  await page.evaluate(() => { void window.__loadNewer(); });
+  await page.waitForFunction((n) => window.__traceHarness.calls.length > n, frozenIndex);
+  await setVisibility('hidden');
+  await page.evaluate(() => {
+    window.__traceHarness.setFrozen(false);
+    window.__traceHarness.writeWhileAway(2);
+  });
+  await setVisibility('visible');
+  await page.waitForFunction(() => document.getElementById('head').textContent === '7', null, { timeout: 2_000 });
+  const frozen = await page.evaluate((n) => window.__traceHarness.calls[n], frozenIndex);
+  assert.ok(frozen.aborted, 'the request frozen with the tab is abandoned, not waited on');
+
+  // Restoring from the back/forward cache fires no visibilitychange — the page
+  // was frozen whole, not hidden. Chromium under automation refuses to put a
+  // page in that cache (verified: `persisted` is false even over http with the
+  // feature forced on), so the event a restore delivers is dispatched directly.
+  await page.evaluate(() => window.__traceHarness.writeWhileAway(1));
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true })));
+  await page.waitForFunction(() => document.getElementById('head').textContent === '8', null, { timeout: 2_000 });
 } finally {
   await browser.close();
   fs.rmSync(tmp, { recursive: true, force: true });

--- a/web/test/traceWindows.test.mjs
+++ b/web/test/traceWindows.test.mjs
@@ -26,6 +26,7 @@ await build({
 
       const calls = [];
       const tails = [];
+      const summaries = [];
       // What the agent has written since the reader last looked, and a switch
       // that leaves such a request outstanding forever: a connection frozen
       // along with the tab, which is what iOS Safari does to a backgrounded one.
@@ -57,7 +58,9 @@ await build({
           const call = { kind: 'summary', at: performance.now(), aborted: false };
           calls.push(call);
           signal?.addEventListener('abort', () => { call.aborted = true; }, { once: true });
-          return new Promise(() => {});
+          // Unresolved by default — the whole-file read is slow by nature, and
+          // several checks depend on it still being outstanding.
+          return new Promise((resolve) => summaries.push({ resolve, call }));
         },
       };
 
@@ -90,6 +93,15 @@ await build({
           ));
         },
         setFrozen(next) { freeze = next; },
+        /** Answer the newest live whole-file read, the way a server would. */
+        resolveSummary(total) {
+          const pending = [...summaries].reverse().find((x) => !x.call.aborted);
+          pending?.resolve({
+            total, userTurns: 3, usage: null, firstTs: 1, truncated: false,
+            note: null, title: '', harnessLabel: 'Claude Code', sessionId: 's',
+            model: null, cwd: null, source: null, sharedBy: null,
+          });
+        },
         resolveTail() {
           const pending = [...tails].reverse().find((x) => !x.call.aborted);
           pending?.resolve(page([
@@ -245,6 +257,25 @@ try {
   await page.evaluate(() => window.__traceHarness.writeWhileAway(1));
   await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true })));
   await page.waitForFunction(() => document.getElementById('head').textContent === '8', null, { timeout: 2_000 });
+
+  // The frozen request can be the whole-file summary rather than a window. That
+  // read is single-flight through a ref, so if it is the one the app switch
+  // killed, the header keeps its partial counts for the life of this source —
+  // turns arriving on every return, but never a turn total or a session cost.
+  await page.waitForFunction(() =>
+    window.__traceHarness.calls.some((c) => c.kind === 'summary' && !c.aborted), null, { timeout: 3_000 });
+  const summaryIndex = await page.evaluate(() =>
+    window.__traceHarness.calls.findIndex((c) => c.kind === 'summary' && !c.aborted));
+  assert.equal(await page.evaluate(() => window.__traceHead?.total ?? null), null,
+    'the header has no whole-file counts while that read is outstanding');
+  await setVisibility('hidden');
+  await setVisibility('visible');
+  await page.waitForFunction((n) => window.__traceHarness.calls[n].aborted, summaryIndex, { timeout: 2_000 });
+  await page.waitForFunction((n) => window.__traceHarness.calls
+    .some((call, index) => index > n && call.kind === 'summary'), summaryIndex, { timeout: 3_000 });
+  // And the retry is a real one: answering it fills the header in.
+  await page.evaluate(() => window.__traceHarness.resolveSummary(41));
+  await page.waitForFunction(() => window.__traceHead?.total === 41, null, { timeout: 3_000 });
 } finally {
   await browser.close();
   fs.rmSync(tmp, { recursive: true, force: true });


### PR DESCRIPTION
Switch to another app with the reader open, come back, and it is still showing the turns from when you left. This makes the return itself do a read.

## What is actually wrong

Not a dead socket — the reader has no socket. It follows a trace by polling `loadNewer` on an interval, and two things about that interval break a return from the background:

1. **On a quiet session nothing is scheduled at all.** `web/src/lib/traceWindows.ts` gates the interval on `if (!seekable || paused || hidden || (live === false && !fresh)) return undefined`. `ConversationView` passes `live = session.state === 'working' && !paused`, and `fresh` means the trace moved within `FRESH_MS` (2 min). A reader left open on a session that finished while the operator was away is `live === false` **and** stale, so no interval is created on return, and nothing reads the trace again for as long as they keep looking at it.
2. **When one IS scheduled, its first tick is a whole interval late** — `setInterval` does not fire immediately. That is 3s on a live trace, 10s on a quiet one, staring at content you know is out of date.

There is a third failure that only bites on a phone, which is where this was reported. iOS Safari suspends a backgrounded page, so a window request that was in flight when the operator switched apps **may never settle**. `loading` is the reader's one-request-at-a-time latch and it is released only in that request's `finally` — which never runs. Every later read then returns early against a latch nothing will ever release, so the reader stays stale even once polling resumes.

## The fix

One effect. On `visibilitychange` back to visible — and on `pageshow` with `persisted`, since a back/forward-cache restore fires no visibilitychange and Safari leans on that path — abandon whatever request was outstanding, release the latch, and read immediately:

- Abandoning bumps `gen`, which is what makes the old request's response *and* its `finally` no longer ours. Bumping rather than only aborting matters: the aborted request's `finally` would otherwise clear `loading` out from under the fresh read that replaced it.
- `cursor.current ? loadNewer() : loadTail()` — if the initial tail never landed (frozen with the tab), the return retries the tail instead of paging from a cursor that does not exist.
- A paused (off-screen) pane is skipped: it reloads on unpause already.

Unchanged: a hidden reader still asks for nothing, and the interval's own gating is untouched. This only adds one read at the moment of return. For the non-seekable SQLite harnesses — deliberately never polled, because a window costs a whole-file re-parse — that is one read per return to the foreground, not a poll loop.

## Verified

In a real browser (`web/test/traceWindows.test.mjs`, the existing React/Chromium harness), and **every new check fails without the fix** — confirmed by stashing the source change and re-running:

- turns written while the tab was hidden are on screen **within 2s of the return**, which is under both poll intervals, so it cannot be a tick that did it;
- the returning reader asks `{at: 'after'}` for what it missed rather than re-reading the whole tail;
- a request left frozen across the switch is **abandoned** (`aborted`), and the turns still land — the latch cannot strand the reader;
- a `pageshow` restore refreshes the same way;
- the existing invariant still holds: a hidden reader issues no requests at all (asserted over 1.2s of real time).

The stale case is the one the operator hit, so the fake source returns a trace whose `lastTs` is ten minutes old — `live: false` plus a stale trace is precisely the combination that schedules no interval.

Also: `web` typecheck clean, `web npm test` 11/11 + trace-windows, production build clean, and `server/screenshot-input.test.mjs` — the suite that opens the rendered reader in a browser — passes 20/20 against a build with this change.

### One honest limit on the verification

Chromium cannot be genuinely backgrounded in this container, so the browser's own occlusion is not what drives the test. I tried, and none of these produce a hidden page here: `bringToFront()` with a sibling page (headless and headed), CDP `Browser.setWindowBounds` minimised, CDP `Page.setWebLifecycleState`, a same-window tab via `Target.createTarget`, headed Chromium on Xvfb (Linux Chrome has no occlusion tracking, and there is no window manager to minimise a window), and WebKit, which will not launch without host libs this container lacks. Real bfcache is unavailable too: Chromium under automation refuses to cache the page, `persisted` staying false even over http with the feature forced on.

So the tests override `document.visibilityState`/`hidden` and dispatch the real events through the DOM. The hook reads `document.hidden` and nothing else, so this is the same code path a true app switch takes; what it does not prove is that the browser fires the event, which is the browser's guarantee rather than this app's. Someone with a phone can settle that in ten seconds, and it is worth doing before this is trusted on iOS.

## Note for whoever reviews next

`server/screenshot-input.test.mjs` failed twice for me on its hardcoded port 7896, with two different symptoms (a duplicate `.ovt-tile` strict-mode violation, then a wrong rejection reason). It fails the same way on unmodified `main`, and passes on a unique port with this change applied — so it is cross-talk between agents running suites concurrently, not a regression. The fixed test ports (7893, 7896, 7897) are worth making collision-proof in their own PR.