### PR TITLE
Upload attachments immediately with progress

### DIFF
--- a/docs/screenshot-input.md
+++ b/docs/screenshot-input.md
@@ -121,14 +121,17 @@ same paste/drop behavior:
   for several) as its text. Image-only server delivery retains the more specific
   `screenshot` wording.
 - At most five files may be attached to one prompt.
-- The send button is disabled while an upload is active.
-- A failed upload leaves the draft and pending files intact and names the
-  failure next to the affected chip.
+- Choosing, pasting, or dropping a file starts its upload immediately. Each
+  chip shows transferred bytes, percentage, and server-confirmed success.
+- The send button is disabled until every upload has succeeded.
+- A failed upload leaves the draft and pending files intact, names the exact
+  server/connection failure next to the affected chip, and offers retry when
+  retrying the same bytes can help.
 
-Pending files remain browser `File` objects until the operator submits. This
-means abandoning or editing a draft does not create server-side orphan files.
-`URL.createObjectURL()` supplies local previews and is revoked when a chip is
-removed or the component unmounts.
+Pending files remain browser `File` objects for retry even after the server has
+stored them. `URL.createObjectURL()` supplies local previews and is revoked when
+a chip is removed or the component unmounts. Successful files are session-owned
+and follow that session's existing deletion/pruning lifecycle.
 
 ### 5.2 Rendered terminal reader
 
@@ -149,7 +152,8 @@ xterm owns the visible composer, so Agent Manager cannot reliably place its own
 persistent attachment chips inside it. File paste/drop therefore behaves as a
 short transaction:
 
-1. Show `uploading file…` over the bottom of the pane.
+1. Show `uploading file · 0%` over the bottom of the pane and update it as bytes
+   transfer.
 2. Upload the file without sending a prompt.
 3. On success, attach it through the harness adapter or paste a formatted path
    reference into the CLI composer.
@@ -235,9 +239,11 @@ session's own directory, and never join an arbitrary browser-supplied filename.
 
 ### 6.3 Lifecycle
 
-- Composer files are uploaded only on submit.
-- Terminal files are uploaded immediately because xterm needs a server path to
-  insert.
+- Composer and terminal files are uploaded immediately on attachment. Prompt
+  delivery only reuses server-confirmed attachment ids; it never starts an
+  upload.
+- Quick creation first allocates a stopped session because attachment ids are
+  session-scoped, then immediately uploads into it without launching the CLI.
 - Successful attachments remain while the session exists, including while it
   is stopped.
 - Deleting a session removes its managed attachment directory. It does not
@@ -415,13 +421,14 @@ file.
 ### 8.3 First prompt without a boot race
 
 The quickstart path currently places an initial prompt on the CLI launch command
-because typing into a booting TUI could lose it. Attachment quickstart needs a
-two-step browser flow—create the session, then upload to its attachment scope—so
-`deliver()` must preserve that property:
+because typing into a booting TUI could lose it. On the first attachment it uses
+a two-step browser flow—create a stopped session, then upload to its attachment
+scope—so `deliver()` must preserve that property:
 
 1. `POST /api/sessions` without a prompt creates a stopped session.
-2. Upload all pending files to the returned session id.
-3. `POST /api/sessions/:id/input` with text and attachment ids.
+2. Upload each file immediately to the returned session id, with byte progress.
+3. When the operator launches, `POST /api/sessions/:id/input` with text and the
+   already-uploaded attachment ids.
 4. If the session has never started and its CLI has `withPrompt`, store the
    fully formatted prompt as `pendingPrompt`; for Codex, also retain the
    validated image paths as `pendingImagePaths`; then call `ensureRunning()`.
@@ -467,7 +474,7 @@ Add a small module, `web/src/lib/attachments.ts`, containing:
 - `transferMayContainFile(DataTransfer)`;
 - duplicate suppression across `items` and `files`;
 - local preview creation/revocation; and
-- sequential or bounded-concurrency upload helpers.
+- sequential upload helpers that report progress and preserve per-file errors.
 
 Use sequential uploads initially. Five files is the maximum, bucket writes are
 the bottleneck, and simpler ordering makes chip status deterministic.
@@ -479,10 +486,10 @@ Expected file changes:
 
 | File | Change |
 |---|---|
-| `web/src/api.ts` | attachment types, upload, preview URL, `sendInput(..., attachmentIds)` |
+| `web/src/api.ts` | attachment types, progress-aware XHR upload, preview URL, `sendInput(..., attachmentIds)` |
 | `web/src/lib/attachments.ts` | clipboard/drop extraction and pending-file lifecycle |
 | `web/src/components/Attachments.tsx` | image previews, file badges, picker, progress/error states |
-| `web/src/components/Sidebar.tsx` | quickstart paste/drop and two-step submit |
+| `web/src/components/Sidebar.tsx` | quickstart paste/drop, stopped-target creation, and immediate upload |
 | `web/src/components/Overview.tsx` | reply attachments and file-only send |
 | `web/src/components/TerminalPane.tsx` | capture-phase file paste/drop and mobile file paste |
 | `web/src/components/conversation/ConversationView.tsx` | rendered-reader attachments and structured send |
@@ -568,7 +575,8 @@ Markdown logs, and needlessly injects binary material into traces.
 |---|---|---|
 | clipboard contains no file | ordinary text paste continues, or no-op | no |
 | file larger than limit | chip says `too large (100 MB max)` | no |
-| network/write failure | chip or terminal overlay says upload failed | no |
+| interrupted/offline connection | chip or terminal overlay names the connection failure and offers retry | no |
+| non-JSON proxy rejection | chip classifies the HTTP status (including proxy `413`) | no |
 | one of several uploads fails | successful files remain, all chips stay for retry | no |
 | attachment id missing at send | `attachment no longer exists`; retain draft | no |
 | terminal socket closes after upload | say file was saved but not inserted; offer retry | no |
@@ -576,8 +584,8 @@ Markdown logs, and needlessly injects binary material into traces.
 | CLI cannot inspect path | agent sees explicit path and can report the limitation | yes |
 
 For multi-file composer sends, atomicity applies to delivery, not storage: files
-may upload one by one, but `/input` runs only after all have succeeded. A retry
-may reuse already uploaded ids while uploading only failed files.
+start uploading when attached, but `/input` runs only after all have succeeded.
+A retry reuses already uploaded ids and transfers only failed files.
 
 ## 13. Testing
 
@@ -607,8 +615,12 @@ may reuse already uploaded ids while uploading only failed files.
   chip.
 - Plain-text paste is unchanged.
 - Removing a chip revokes its preview and excludes it from upload.
-- A multi-file submission waits for every upload before `/input`.
-- Every chip mutation remains disabled for the complete multi-file send.
+- Upload starts when a file is attached, before `/input` or launch.
+- Progress exposes transferred bytes/percentage and waits for server confirmation
+  at 100%.
+- Interrupted connections and non-JSON proxy errors remain actionable at the
+  affected chip, with retry where appropriate.
+- A multi-file submission remains disabled until every upload succeeds.
 - Terminal paste receives a server acknowledgement and inserts without Return.
 - A terminal stopped after upload reports saved-but-not-inserted, disables new
   attachments, and can retry the stored attachment after restart.

--- a/docs/screenshot-input.md
+++ b/docs/screenshot-input.md
@@ -112,8 +112,10 @@ same paste/drop behavior:
   into the textarea.
 - Dropping files over the composer shows a restrained dashed highlight and
   adds the same chips.
-- Overview, rendered reader, and live terminal views expose a file button with
-  an unrestricted `<input type="file" multiple>`; quick creation intentionally
+- Overview exposes a file button in its reply row. Reader and live-terminal
+  views share the pane header's attachment button; it targets the reader draft
+  or terminal insertion flow according to the visible mode. Each uses an
+  unrestricted `<input type="file" multiple>`. Quick creation intentionally
   stays prompt-first and accepts paste/drop without another picker.
 - Image chips show thumbnails; other files show a compact extension badge.
 - The prompt may contain text plus files or files alone.
@@ -139,11 +141,14 @@ and follow that session's existing deletion/pruning lifecycle.
 ### 5.2 Rendered terminal reader
 
 Reader mode covers a still-mounted terminal with a structured conversation and
-its own reply composer. While that overlay is visible, its composer owns file
-pick, paste, drop, chips, upload, and structured `/input` delivery. The terminal
-header's attachment button, terminal upload status, mobile key bar, and fallback
-paste sheet stay hidden. Otherwise a file chosen while reading would be inserted
-into the invisible xterm prompt instead of being part of the visible reply.
+its own reply composer. The pane header keeps one attachment button in both
+views; while the reader is visible it opens the reader's hidden picker instead
+of the terminal's. The resulting chips, byte progress, failure reason, Cancel,
+and Retry stay above the fixed composer because they belong to—and gate—that
+draft. Paste, drop, upload, and structured `/input` delivery use the same queue.
+Terminal upload status, the mobile key bar, and fallback paste sheet stay hidden.
+Otherwise a file chosen while reading would be inserted into the invisible
+xterm prompt instead of being part of the visible reply.
 
 The rendered reader and Overview both permit text-plus-file and file-only turns,
 preserve the text draft behavior introduced by the reader, and keep failed
@@ -166,6 +171,11 @@ short transaction:
 The upload status includes a Cancel action while bytes are transferring. A
 saved-but-not-inserted file offers both Retry and Remove, so an insertion failure
 does not trap the terminal attachment affordance.
+
+The pane header's attachment button starts that transaction. Progress and
+recovery remain in the terminal overlay rather than competing with the header's
+compact attach/search/info/close cluster; unlike the reader, xterm has no visible
+Agent Manager draft queue to hold chips.
 
 An upload must never auto-submit the agent's prompt. Inserting the attachment and
 submitting are separate actions, matching native TUI image paste behavior.
@@ -654,8 +664,9 @@ A retry reuses already uploaded ids and transfers only failed files.
 - A terminal stopped after upload reports saved-but-not-inserted, disables new
   attachments, and can retry the stored attachment after restart.
 - Remote live composers explain that Space-local files are unavailable.
-- Reader mode owns its visible attachment picker and never inserts into the
-  covered terminal.
+- Reader mode owns the pane header's one attachment button, opens its hidden
+  picker, and keeps progress/error/retry chips in the visible composer rather
+  than inserting into the covered terminal.
 - Reader and Overview image-only replies send attachment ids through the same
   structured `/input` route.
 - Terminal file drop does not trigger pane movement.

--- a/docs/screenshot-input.md
+++ b/docs/screenshot-input.md
@@ -127,6 +127,9 @@ same paste/drop behavior:
 - A failed upload leaves the draft and pending files intact, names the exact
   server/connection failure next to the affected chip, and offers retry when
   retrying the same bytes can help.
+- The chip's × remains available during transfer. It aborts an in-flight upload;
+  removing a server-confirmed but unsent chip also deletes that stored file and
+  immediately lets the remaining text/files send.
 
 Pending files remain browser `File` objects for retry even after the server has
 stored them. `URL.createObjectURL()` supplies local previews and is revoked when
@@ -159,6 +162,10 @@ short transaction:
    reference into the CLI composer.
 4. Return focus to xterm. The operator can keep typing and presses Enter when
    ready.
+
+The upload status includes a Cancel action while bytes are transferring. A
+saved-but-not-inserted file offers both Retry and Remove, so an insertion failure
+does not trap the terminal attachment affordance.
 
 An upload must never auto-submit the agent's prompt. Inserting the attachment and
 submitting are separate actions, matching native TUI image paste behavior.
@@ -244,6 +251,13 @@ session's own directory, and never join an arbitrary browser-supplied filename.
   upload.
 - Quick creation first allocates a stopped session because attachment ids are
   session-scoped, then immediately uploads into it without launching the CLI.
+- Closing quick creation aborts its transfers and conditionally deletes that
+  placeholder session. The server refuses the conditional delete once the
+  session has ever started, so a target the operator deliberately opened is
+  retained. An invalid/restored selection falls back to Overview rather than to
+  the new placeholder, preventing its terminal pane from mounting implicitly.
+- Removing a successful unsent chip, or unmounting its composer, deletes the
+  stored file. A successful send deliberately keeps it for the session.
 - Successful attachments remain while the session exists, including while it
   is stopped.
 - Deleting a session removes its managed attachment directory. It does not
@@ -344,6 +358,17 @@ Attachments may contain sensitive material, so use `Cache-Control: no-store` in
 the first version. If bucket reads become measurable, a short private cache can
 be evaluated later without making year-long browser retention the default.
 
+### 7.3 Remove unsent state
+
+```http
+DELETE /api/sessions/:id/attachments/:attachmentId
+DELETE /api/sessions/:id?ifNeverStarted=1
+```
+
+The first route removes one canceled/unsent stored file. The second is the quick
+creation cleanup guard: it returns `409` rather than deleting a session whose
+`everStarted` flag is true. Ordinary session deletion remains unchanged.
+
 ### 7.3 Send a structured prompt
 
 Extend the existing route without breaking text-only callers:
@@ -437,7 +462,8 @@ scope—so `deliver()` must preserve that property:
 
 Only resumed or already-started sessions use the existing boot-then-type path.
 If attachment upload fails after session creation, keep the stopped session and
-the browser draft. Automatically deleting it would make recovery surprising.
+the browser draft while the dialog remains open so Retry can reuse it. Closing
+the dialog abandons that work and conditionally deletes the never-started target.
 
 ### 8.4 Terminal insertion
 
@@ -576,6 +602,7 @@ Markdown logs, and needlessly injects binary material into traces.
 | clipboard contains no file | ordinary text paste continues, or no-op | no |
 | file larger than limit | chip says `too large (100 MB max)` | no |
 | interrupted/offline connection | chip or terminal overlay names the connection failure and offers retry | no |
+| operator cancels an upload | abort transfer, remove its chip, and unblock the remaining draft | no |
 | non-JSON proxy rejection | chip classifies the HTTP status (including proxy `413`) | no |
 | one of several uploads fails | successful files remain, all chips stay for retry | no |
 | attachment id missing at send | `attachment no longer exists`; retain draft | no |
@@ -615,6 +642,8 @@ A retry reuses already uploaded ids and transfers only failed files.
   chip.
 - Plain-text paste is unchanged.
 - Removing a chip revokes its preview and excludes it from upload.
+- Canceling a held upload removes its chip and immediately re-enables sending;
+  removing an uploaded unsent chip deletes the server file.
 - Upload starts when a file is attached, before `/input` or launch.
 - Progress exposes transferred bytes/percentage and waits for server confirmation
   at 100%.
@@ -634,6 +663,9 @@ A retry reuses already uploaded ids and transfers only failed files.
 - The mobile fallback textarea handles both file and text paste.
 - Clipboard API denial reaches the fallback sheet.
 - Upload failure preserves the draft and shows the server's reason.
+- On a fresh visit, quick attachment creation stays stopped on Overview; Escape
+  removes the placeholder across reload, while conditional cleanup retains a
+  target that has actually started.
 
 `server/terminal-ui.test.mjs` already supplies a Chromium/xterm harness and
 clipboard permissions; extend it for the live-terminal cases. Add a focused

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -194,7 +194,9 @@ try {
   await page.locator('.pane-head .image-file-input').setInputFiles({
     name: 'disconnect.png', mimeType: 'image/png', buffer: png,
   });
-  const retryStatus = page.locator('.term-image-status.has-action');
+  const retryStatus = page.locator('.term-image-status.has-action').filter({
+    has: page.getByRole('button', { name: 'retry' }),
+  });
   await retryStatus.waitFor({ state: 'visible' });
   const failedText = await retryStatus.textContent();
   check('a stopped terminal reports saved-but-not-inserted, never success',
@@ -206,7 +208,7 @@ try {
 
   await page.locator('.term-exit .tx-btn').click();
   await waitFor(() => page.locator('.pane-head .ph-image').isEnabled(), 20_000);
-  const retry = retryStatus.locator('button');
+  const retry = retryStatus.getByRole('button', { name: 'retry' });
   await retry.click();
   await page.locator('.term-image-status.success').waitFor({ state: 'visible' });
   const successText = await page.locator('.term-image-status.success').textContent();
@@ -230,7 +232,7 @@ try {
   await watcher.goto(API, { waitUntil: 'domcontentloaded' });
   await watcher.locator('.sidebar .row[title^="screenshot-e2e"]').first().click();
   await watcher.locator('.pane-head .ph-image').waitFor({ state: 'visible' });
-  await waitFor(() => watcher.locator('.pane-head .ph-image').isDisabled());
+  await waitFor(async () => (await watcher.locator('.pane-head .ph-image').getAttribute('title'))?.includes('take control'));
   const watcherPickerDisabled = await watcher.locator('.pane-head .ph-image').isDisabled();
   const watcherPickerTitle = await watcher.locator('.pane-head .ph-image').getAttribute('title');
   check('a shared-terminal watcher cannot inject into the controller composer',
@@ -275,6 +277,38 @@ try {
       && await page.locator('.pane-reader .image-pick').count() === 0
       && await page.locator('.pane-reader .image-file-input').count() === 1);
 
+  // Keep the request outside the server until the operator cancels it. The
+  // composer must become usable immediately; it cannot be held hostage by a
+  // slow transfer that the operator no longer wants to send.
+  let releaseCanceledUpload;
+  let sawCanceledUpload;
+  const canceledUploadReached = new Promise((resolve) => { sawCanceledUpload = resolve; });
+  const canceledUploadHold = new Promise((resolve) => { releaseCanceledUpload = resolve; });
+  await page.route(`**/api/sessions/${id}/attachments`, async (route) => {
+    sawCanceledUpload();
+    await canceledUploadHold;
+    await route.continue().catch(() => {});
+  }, { times: 1 });
+  await readerPicker.setInputFiles({
+    name: 'cancel-me.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(512 * 1024),
+  });
+  await Promise.race([
+    canceledUploadReached,
+    sleep(10_000).then(() => { throw new Error('cancel fixture upload did not start'); }),
+  ]);
+  const canceledChip = page.locator('.pane-reader .image-chip', { hasText: 'cancel-me.bin' });
+  const cancelUpload = canceledChip.getByRole('button', { name: 'Cancel upload cancel-me.bin' });
+  await cancelUpload.waitFor({ state: 'visible' });
+  const cancelWasEnabled = await cancelUpload.isEnabled();
+  await cancelUpload.click();
+  releaseCanceledUpload();
+  await canceledChip.waitFor({ state: 'detached' });
+  const readerReply = page.locator('.pane-reader .ov-live textarea');
+  await readerReply.fill('send without the canceled upload');
+  check('an in-flight upload can be canceled and no longer blocks Send',
+    cancelWasEnabled && await page.locator('.pane-reader .ov-send').isVisible());
+  await readerReply.fill('');
+
   // The failure that motivated immediate uploads: once the HTTP connection is
   // cut, fetch used to surface only "Failed to fetch" after Send. The XHR
   // transport must classify it at attachment time and keep a retry beside it.
@@ -291,7 +325,13 @@ try {
     JSON.stringify({ interruptedText }));
   await interruptedChip.locator('.image-chip-retry').click();
   await interruptedChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  const attachmentDir = path.join(DATA_DIR, 'state', 'attachments', id);
+  const interruptedStored = await waitFor(() => fs.readdirSync(attachmentDir)
+    .some((name) => name.endsWith('-interrupted.bin')));
   await interruptedChip.getByRole('button', { name: 'Remove interrupted.bin' }).click();
+  const interruptedRemoved = await waitFor(() => !fs.existsSync(attachmentDir)
+    || !fs.readdirSync(attachmentDir).some((name) => name.endsWith('-interrupted.bin')));
+  check('removing a successful unsent chip deletes its stored file', interruptedStored && interruptedRemoved);
 
   // Hugging Face's ingress may answer before Express with an HTML error page.
   // Preserve the status as a useful diagnosis instead of reducing it to "413".
@@ -370,7 +410,7 @@ try {
   await page.locator('.sidebar .ov-row').click();
   await page.locator('.ovt-tile').filter({
     has: page.locator('.ovt-name', { hasText: /^screenshot-e2e$/ }),
-  }).last().click();
+  }).click();
   const overviewPicker = page.locator('.ovw-win .image-file-input');
   await overviewPicker.waitFor({ state: 'attached' });
   await overviewPicker.setInputFiles({ name: 'overview.png', mimeType: 'image/png', buffer: png });
@@ -461,13 +501,68 @@ try {
   check('quick creation uploads before launch and shows progress while pending',
     uploadCount === 2
       && await quickChips.nth(1).locator('.image-chip-progress').isVisible()
-      && await quickChips.nth(1).getByRole('button', { name: 'Remove requirements.docx' }).isDisabled());
+      && await quickChips.nth(1).getByRole('button', { name: 'Cancel upload requirements.docx' }).isEnabled());
   releaseSecond();
   await quickChips.nth(1).filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
   const uploadsBeforeLaunch = uploadCount;
   await page.locator('.quick-prompt').press('Enter');
   await page.locator('.controls').waitFor({ state: 'hidden', timeout: 30_000 });
   check('launch reuses already-uploaded attachment ids', uploadCount === uploadsBeforeLaunch);
+
+  // Reproduce the blocking review case from a truly fresh browser: before the
+  // fix, the attachment-created target became tree.order[0], its pane mounted,
+  // and Escape left that running target (and its file) behind after reload.
+  await page.close();
+  const existing = await (await fetch(`${API}/api/sessions`)).json();
+  for (const session of existing) {
+    await fetch(`${API}/api/sessions/${session.id}`, { method: 'DELETE' });
+  }
+  const freshContext = await browser.newContext({ viewport: { width: 390, height: 844 } });
+  const fresh = await freshContext.newPage();
+  await fresh.goto(API, { waitUntil: 'domcontentloaded' });
+  await fresh.locator('.bolt-btn').click();
+  await fresh.locator('.quick-cli[title="Repaint fixture"]').click();
+  await fresh.locator('.quick-prompt').evaluate((element, bytes) => {
+    const raw = atob(bytes);
+    const data = Uint8Array.from(raw, (character) => character.charCodeAt(0));
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([data], 'abandon.png', { type: 'image/png' }));
+    element.dispatchEvent(new ClipboardEvent('paste', {
+      bubbles: true, cancelable: true, clipboardData: transfer,
+    }));
+  }, png.toString('base64'));
+  const abandonChip = fresh.locator('.quick .image-chip', { hasText: 'abandon.png' });
+  await abandonChip.filter({ has: fresh.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  const stagedSessions = await (await fetch(`${API}/api/sessions`)).json();
+  check('fresh-visit attachment creates only a stopped target and keeps Overview selected',
+    stagedSessions.length === 1
+      && stagedSessions[0].everStarted === false
+      && stagedSessions[0].running === false
+      && await fresh.locator('.sidebar .ov-row').getAttribute('class').then((value) => value?.includes('active'))
+      && await fresh.locator('.tile-terminal').count() === 0,
+    JSON.stringify(stagedSessions.map((session) => ({ id: session.id, running: session.running, everStarted: session.everStarted }))));
+  await fresh.locator('.quick-prompt').press('Escape');
+  const abandonedRemoved = await waitFor(async () => (await (await fetch(`${API}/api/sessions`)).json()).length === 0);
+  await fresh.reload({ waitUntil: 'domcontentloaded' });
+  const afterReload = await (await fetch(`${API}/api/sessions`)).json();
+  check('Escape discards the unlaunched target and its upload across reload',
+    abandonedRemoved && afterReload.length === 0);
+
+  const retained = await apiJson('/api/sessions', {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ cli: 'test-repaint', name: 'retain-started', path: '.' }),
+  });
+  await apiJson(`/api/sessions/${retained.body.id}/input`, {
+    method: 'POST', headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ text: 'start it' }),
+  });
+  const conditionalDelete = await apiJson(`/api/sessions/${retained.body.id}?ifNeverStarted=1`, { method: 'DELETE' });
+  const afterConditionalDelete = await (await fetch(`${API}/api/sessions`)).json();
+  check('conditional cleanup cannot delete a target that has started',
+    conditionalDelete.response.status === 409
+      && afterConditionalDelete.some((session) => session.id === retained.body.id));
+  await fetch(`${API}/api/sessions/${retained.body.id}`, { method: 'DELETE' });
+  await freshContext.close();
 } finally {
   try { await browser?.close(); } catch {}
   backend.kill('SIGKILL');

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -7,6 +7,7 @@
  *   - attachment chips cannot mutate an in-flight send;
  *   - one clipboard image stays one chip across browser DataTransfer views;
  *   - document files stay inert downloads and can be sent beside images;
+ *   - attachment-time uploads expose progress and actionable transport errors;
  *   - both rendered reader and Overview composers send structured attachments;
  *   - the creation dialog has no redundant file picker.
  *
@@ -24,7 +25,8 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.dirname(HERE);
 const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'am-screenshot-ui-'));
 const PUBLIC_DIR = process.env.SCREENSHOT_PUBLIC_DIR || path.join(DATA_DIR, 'public');
-const API = 'http://127.0.0.1:7896';
+const PORT = process.env.SCREENSHOT_PORT || '7896';
+const API = `http://127.0.0.1:${PORT}`;
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 const png = Buffer.alloc(45);
@@ -32,6 +34,9 @@ Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]).copy(png);
 png.writeUInt32BE(13, 8); Buffer.from('IHDR').copy(png, 12);
 png.writeUInt32BE(1, 16); png.writeUInt32BE(1, 20);
 Buffer.from('IEND').copy(png, 37);
+const progressPng = Buffer.alloc(2 * 1024 * 1024);
+png.subarray(0, png.length - 12).copy(progressPng);
+png.subarray(png.length - 12).copy(progressPng, progressPng.length - 12);
 const pdf = Buffer.from('%PDF-1.7\nopaque pdf data');
 const docx = Buffer.from('PK\x03\x04opaque office data');
 
@@ -73,7 +78,7 @@ const backend = spawn('node', ['src/index.js'], {
   cwd: HERE,
   env: {
     ...BASE_ENV,
-    PORT: '7896', DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '',
+    PORT, DATA_DIR, PUBLIC_DIR, AM_BASHRC: '/nonexistent', SPACE_HOST: '',
     AM_ALLOW_MISSING_ORIGIN: '1',
     AM_TEST_REPAINT_CMD: 'bash --noprofile --norc',
   },
@@ -226,9 +231,11 @@ try {
   await watcher.locator('.sidebar .row[title^="screenshot-e2e"]').first().click();
   await watcher.locator('.pane-head .ph-image').waitFor({ state: 'visible' });
   await waitFor(() => watcher.locator('.pane-head .ph-image').isDisabled());
+  const watcherPickerDisabled = await watcher.locator('.pane-head .ph-image').isDisabled();
+  const watcherPickerTitle = await watcher.locator('.pane-head .ph-image').getAttribute('title');
   check('a shared-terminal watcher cannot inject into the controller composer',
-    await watcher.locator('.pane-head .ph-image').isDisabled()
-      && (await watcher.locator('.pane-head .ph-image').getAttribute('title'))?.includes('take control'));
+    watcherPickerDisabled && !!watcherPickerTitle?.includes('take control'),
+    JSON.stringify({ watcherPickerDisabled, watcherPickerTitle }));
   await watcher.close();
 
   // Reader mode is an overlay above the mounted terminal. Its own composer must
@@ -267,8 +274,80 @@ try {
     await page.locator('.pane-head .ph-image').isVisible()
       && await page.locator('.pane-reader .image-pick').count() === 0
       && await page.locator('.pane-reader .image-file-input').count() === 1);
-  await readerPicker.setInputFiles({ name: 'reader.png', mimeType: 'image/png', buffer: png });
-  await page.locator('.pane-reader .image-chip').waitFor({ state: 'visible' });
+
+  // The failure that motivated immediate uploads: once the HTTP connection is
+  // cut, fetch used to surface only "Failed to fetch" after Send. The XHR
+  // transport must classify it at attachment time and keep a retry beside it.
+  await page.route(`**/api/sessions/${id}/attachments`, (route) => route.abort('connectionreset'), { times: 1 });
+  await readerPicker.setInputFiles({
+    name: 'interrupted.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(256 * 1024),
+  });
+  const interruptedChip = page.locator('.pane-reader .image-chip', { hasText: 'interrupted.bin' });
+  await interruptedChip.filter({ has: page.locator('.image-chip-retry') }).waitFor({ state: 'visible' });
+  const interruptedText = await interruptedChip.locator('.image-chip-meta').textContent();
+  check('an interrupted upload fails immediately with a reason and retry',
+    !!interruptedText?.includes('connection was interrupted')
+      && await interruptedChip.locator('.image-chip-retry').isVisible(),
+    JSON.stringify({ interruptedText }));
+  await interruptedChip.locator('.image-chip-retry').click();
+  await interruptedChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  await interruptedChip.getByRole('button', { name: 'Remove interrupted.bin' }).click();
+
+  // Hugging Face's ingress may answer before Express with an HTML error page.
+  // Preserve the status as a useful diagnosis instead of reducing it to "413".
+  await page.route(`**/api/sessions/${id}/attachments`, (route) => route.fulfill({
+    status: 413, contentType: 'text/html', body: '<h1>Payload Too Large</h1>',
+  }), { times: 1 });
+  await readerPicker.setInputFiles({
+    name: 'proxy-limit.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(1024),
+  });
+  const proxyChip = page.locator('.pane-reader .image-chip', { hasText: 'proxy-limit.bin' });
+  await proxyChip.filter({ has: page.locator('.image-chip-retry') }).waitFor();
+  const proxyText = await proxyChip.locator('.image-chip-meta').textContent();
+  check('a non-JSON proxy rejection keeps an actionable HTTP reason',
+    !!proxyText?.includes('proxy rejected this file as too large') && proxyText.includes('HTTP 413'),
+    JSON.stringify({ proxyText }));
+  await proxyChip.getByRole('button', { name: 'Remove proxy-limit.bin' }).click();
+
+  // Client-side size rejection happens at attachment time and never offers a
+  // futile retry. The server separately exercises its streaming 100 MiB cap.
+  const tooLargePath = path.join(DATA_DIR, 'too-large.bin');
+  fs.writeFileSync(tooLargePath, '');
+  fs.truncateSync(tooLargePath, 101 * 1024 * 1024);
+  await readerPicker.setInputFiles(tooLargePath);
+  const tooLargeChip = page.locator('.pane-reader .image-chip', { hasText: 'too-large.bin' });
+  await tooLargeChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'too large' }) }).waitFor();
+  check('a large file is rejected before upload with its 100 MB limit',
+    (await tooLargeChip.locator('.image-chip-meta').textContent())?.includes('100 MB max')
+      && await tooLargeChip.locator('.image-chip-retry').count() === 0);
+  await tooLargeChip.getByRole('button', { name: 'Remove too-large.bin' }).click();
+
+  // Hold the intercepted request lifecycle so the progress surface can be
+  // inspected before the response changes the chip to server-confirmed success.
+  let releaseReaderUpload;
+  let sawReaderUpload;
+  const readerUploadReached = new Promise((resolve) => { sawReaderUpload = resolve; });
+  const readerUploadHold = new Promise((resolve) => { releaseReaderUpload = resolve; });
+  await page.route(`**/api/sessions/${id}/attachments`, async (route) => {
+    const response = await route.fetch();
+    sawReaderUpload();
+    await readerUploadHold;
+    await route.fulfill({ response });
+  }, { times: 1 });
+  await readerPicker.setInputFiles({ name: 'reader.png', mimeType: 'image/png', buffer: progressPng });
+  await Promise.race([
+    readerUploadReached,
+    sleep(10_000).then(() => { throw new Error('reader upload did not start on attachment'); }),
+  ]);
+  const readerChip = page.locator('.pane-reader .image-chip', { hasText: 'reader.png' });
+  await readerChip.locator('.image-chip-progress').waitFor({ state: 'visible' });
+  const readerProgress = await readerChip.locator('.image-chip-progress').getAttribute('aria-valuenow');
+  const readerProgressText = await readerChip.locator('.image-chip-meta').textContent();
+  check('reader upload starts before Send and reports byte progress',
+    readerProgress != null && !!readerProgressText?.includes('%') && readerProgressText.includes('/'),
+    JSON.stringify({ readerProgress, readerProgressText }));
+  releaseReaderUpload();
+  await readerChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
   let readerInput;
   let sawReaderInput;
   const readerInputReached = new Promise((resolve) => { sawReaderInput = resolve; });
@@ -291,11 +370,13 @@ try {
   await page.locator('.sidebar .ov-row').click();
   await page.locator('.ovt-tile').filter({
     has: page.locator('.ovt-name', { hasText: /^screenshot-e2e$/ }),
-  }).click();
+  }).last().click();
   const overviewPicker = page.locator('.ovw-win .image-file-input');
   await overviewPicker.waitFor({ state: 'attached' });
   await overviewPicker.setInputFiles({ name: 'overview.png', mimeType: 'image/png', buffer: png });
-  await page.locator('.ovw-win .image-chip').waitFor({ state: 'visible' });
+  const overviewChip = page.locator('.ovw-win .image-chip', { hasText: 'overview.png' });
+  await overviewChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  check('Overview uploads a file when attached, before Send', await overviewChip.isVisible());
   let overviewInput;
   let sawOverviewInput;
   const overviewInputReached = new Promise((resolve) => { sawOverviewInput = resolve; });
@@ -322,9 +403,22 @@ try {
       && await page.locator('.quick .image-file-input').count() === 0);
   await page.locator('.quick-cli[title="Repaint fixture"]').click();
 
-  // Hold the second upload. Once the first
-  // chip says uploaded, every attachment mutation must remain disabled until
-  // the single logical send transaction finishes.
+  // Quick creation has to allocate its stopped session first, but attachment
+  // selection still starts both uploads before the operator launches it. Hold
+  // the second request to make that ordering and the progress lock observable.
+  let releaseSecond;
+  let sawSecond;
+  const secondReached = new Promise((resolve) => { sawSecond = resolve; });
+  const secondHold = new Promise((resolve) => { releaseSecond = resolve; });
+  let uploadCount = 0;
+  await page.route('**/api/sessions/*/attachments', async (route) => {
+    uploadCount += 1;
+    if (uploadCount === 2) {
+      sawSecond();
+      await secondHold;
+    }
+    await route.continue();
+  });
   await page.locator('.quick-prompt').fill('inspect both files');
   await page.locator('.quick-prompt').evaluate((element, bytes) => {
     const raw = atob(bytes);
@@ -358,30 +452,22 @@ try {
   check('DOCX paste creates a generic file chip beside the image',
     await page.locator('.quick .image-chip').count() === 2
       && await page.locator('.quick .image-chip-placeholder', { hasText: 'DOCX' }).count() === 1);
-  let releaseSecond;
-  let sawSecond;
-  const secondReached = new Promise((resolve) => { sawSecond = resolve; });
-  const secondHold = new Promise((resolve) => { releaseSecond = resolve; });
-  let uploadCount = 0;
-  await page.route('**/api/sessions/*/attachments', async (route) => {
-    uploadCount += 1;
-    if (uploadCount === 2) {
-      sawSecond();
-      await secondHold;
-    }
-    await route.continue();
-  });
-  await page.locator('.quick-prompt').press('Enter');
   await Promise.race([
     secondReached,
-    sleep(20_000).then(() => { throw new Error('second upload did not start'); }),
+    sleep(20_000).then(() => { throw new Error('second upload did not start on attachment'); }),
   ]);
-  const removeButtons = page.locator('.quick .image-chip > button');
-  check('attachment removal stays locked for the full send transaction',
-    await removeButtons.nth(0).isDisabled()
-      && await removeButtons.nth(1).isDisabled());
+  const quickChips = page.locator('.quick .image-chip');
+  await quickChips.nth(0).filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  check('quick creation uploads before launch and shows progress while pending',
+    uploadCount === 2
+      && await quickChips.nth(1).locator('.image-chip-progress').isVisible()
+      && await quickChips.nth(1).getByRole('button', { name: 'Remove requirements.docx' }).isDisabled());
   releaseSecond();
+  await quickChips.nth(1).filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  const uploadsBeforeLaunch = uploadCount;
+  await page.locator('.quick-prompt').press('Enter');
   await page.locator('.controls').waitFor({ state: 'hidden', timeout: 30_000 });
+  check('launch reuses already-uploaded attachment ids', uploadCount === uploadsBeforeLaunch);
 } finally {
   try { await browser?.close(); } catch {}
   backend.kill('SIGKILL');

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -272,10 +272,17 @@ try {
   // The pane header owns ONE paperclip in both views now (2026-08-18): in the
   // reader it opens the composer's own picker, which is the input used below, so
   // the files still land in the draft. The composer no longer draws its own.
+  const [readerChooser] = await Promise.all([
+    page.waitForEvent('filechooser'),
+    page.locator('.pane-head .ph-image').click(),
+  ]);
+  const readerChooserIsInComposer = await readerChooser.element().evaluate((element) =>
+    !!element.closest('.pane-reader'));
   check('one paperclip, in the header, wired to the reader composer',
     await page.locator('.pane-head .ph-image').isVisible()
       && await page.locator('.pane-reader .image-pick').count() === 0
-      && await page.locator('.pane-reader .image-file-input').count() === 1);
+      && await page.locator('.pane-reader .image-file-input').count() === 1
+      && readerChooserIsInComposer);
 
   // Keep the request outside the server until the operator cancels it. The
   // composer must become usable immediately; it cannot be held hostage by a
@@ -296,7 +303,7 @@ try {
     canceledUploadReached,
     sleep(10_000).then(() => { throw new Error('cancel fixture upload did not start'); }),
   ]);
-  const canceledChip = page.locator('.pane-reader .image-chip', { hasText: 'cancel-me.bin' });
+  const canceledChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'cancel-me.bin' });
   const cancelUpload = canceledChip.getByRole('button', { name: 'Cancel upload cancel-me.bin' });
   await cancelUpload.waitFor({ state: 'visible' });
   const cancelWasEnabled = await cancelUpload.isEnabled();
@@ -316,7 +323,7 @@ try {
   await readerPicker.setInputFiles({
     name: 'interrupted.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(256 * 1024),
   });
-  const interruptedChip = page.locator('.pane-reader .image-chip', { hasText: 'interrupted.bin' });
+  const interruptedChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'interrupted.bin' });
   await interruptedChip.filter({ has: page.locator('.image-chip-retry') }).waitFor({ state: 'visible' });
   const interruptedText = await interruptedChip.locator('.image-chip-meta').textContent();
   check('an interrupted upload fails immediately with a reason and retry',
@@ -341,7 +348,7 @@ try {
   await readerPicker.setInputFiles({
     name: 'proxy-limit.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(1024),
   });
-  const proxyChip = page.locator('.pane-reader .image-chip', { hasText: 'proxy-limit.bin' });
+  const proxyChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'proxy-limit.bin' });
   await proxyChip.filter({ has: page.locator('.image-chip-retry') }).waitFor();
   const proxyText = await proxyChip.locator('.image-chip-meta').textContent();
   check('a non-JSON proxy rejection keeps an actionable HTTP reason',
@@ -355,7 +362,7 @@ try {
   fs.writeFileSync(tooLargePath, '');
   fs.truncateSync(tooLargePath, 101 * 1024 * 1024);
   await readerPicker.setInputFiles(tooLargePath);
-  const tooLargeChip = page.locator('.pane-reader .image-chip', { hasText: 'too-large.bin' });
+  const tooLargeChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'too-large.bin' });
   await tooLargeChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'too large' }) }).waitFor();
   check('a large file is rejected before upload with its 100 MB limit',
     (await tooLargeChip.locator('.image-chip-meta').textContent())?.includes('100 MB max')
@@ -379,7 +386,7 @@ try {
     readerUploadReached,
     sleep(10_000).then(() => { throw new Error('reader upload did not start on attachment'); }),
   ]);
-  const readerChip = page.locator('.pane-reader .image-chip', { hasText: 'reader.png' });
+  const readerChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'reader.png' });
   await readerChip.locator('.image-chip-progress').waitFor({ state: 'visible' });
   const readerProgress = await readerChip.locator('.image-chip-progress').getAttribute('aria-valuenow');
   const readerProgressText = await readerChip.locator('.image-chip-meta').textContent();

--- a/server/src/attachments.js
+++ b/server/src/attachments.js
@@ -325,6 +325,15 @@ export function resolveAttachments(sessionId, attachmentIds) {
   return attachmentIds.map((id) => resolveAttachment(sessionId, id));
 }
 
+/** Remove one unsent attachment without disturbing files the session still uses. */
+export async function removeAttachment(sessionId, attachmentId) {
+  return withUploadLock(sessionId, async () => {
+    const attachment = resolveAttachment(sessionId, attachmentId);
+    await fs.promises.unlink(attachment.path);
+    return attachment;
+  });
+}
+
 export async function removeSessionAttachments(sessionId) {
   uploadWindows.delete(sessionId);
   await withUploadLock(sessionId, () => fs.promises.rm(sessionDir(sessionId), { recursive: true, force: true }));

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -37,7 +37,8 @@ import { shareSession, shareNamespace, findTrace, shareAccess, grantAccess, revo
          importBundle, listBundles, SHAREABLE_CLIS } from './share.js';
 import * as backup from './backup.js';
 import {
-  formatAttachmentDelivery, formatAttachmentPrelude, pruneAttachmentDirs, receiveAttachment, removeSessionAttachments,
+  formatAttachmentDelivery, formatAttachmentPrelude, pruneAttachmentDirs, receiveAttachment, removeAttachment,
+  removeSessionAttachments,
   resolveAttachment, resolveAttachments,
 } from './attachments.js';
 import * as runstate from './runstate.js';
@@ -457,6 +458,17 @@ app.post('/api/sessions/:id/attachments/insert', async (req, res) => {
     return res.json({ ok: true, mode });
   } catch (e) {
     return res.status(e.statusCode || 409).json({ error: String(e.message || e) });
+  }
+});
+
+app.delete('/api/sessions/:id/attachments/:attachmentId', async (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  try {
+    await removeAttachment(s.id, req.params.attachmentId);
+    return res.json({ ok: true });
+  } catch (e) {
+    return res.status(e.statusCode || 500).json({ error: String(e.message || e) });
   }
 });
 
@@ -2415,6 +2427,9 @@ app.put('/api/trace/:id/source', (req, res) => {
 app.delete('/api/sessions/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
+  if (req.query.ifNeverStarted === '1' && s.everStarted) {
+    return res.status(409).json({ error: 'session has already started' });
+  }
   stop(s.id);
   // Close the agent's poll and drop the in-memory log, so a pane later created
   // with the same name reads the folder fresh instead of inheriting a ghost.

--- a/server/test/attachments.test.mjs
+++ b/server/test/attachments.test.mjs
@@ -9,7 +9,7 @@ process.env.DATA_DIR = root;
 
 const {
   ATTACHMENT_LIMIT, SESSION_ATTACHMENT_LIMIT, detectImageMime, formatAttachmentDelivery,
-  formatAttachmentPrelude, pruneAttachmentDirs, receiveAttachment, removeSessionAttachments,
+  formatAttachmentPrelude, pruneAttachmentDirs, receiveAttachment, removeAttachment, removeSessionAttachments,
   resolveAttachment, resolveAttachments,
 } = await import('../src/attachments.js');
 const { cliById } = await import('../src/config.js');
@@ -87,6 +87,10 @@ try {
     'application/x-custom-format', 'model.blend');
   assert.equal(opaque.kind, 'file');
   assert.equal(opaque.mime, 'application/octet-stream');
+  const discarded = await receive(Buffer.from('discard me'), 'discard-123abc',
+    'application/octet-stream', 'discard.bin');
+  await removeAttachment('discard-123abc', discarded.id);
+  assert.throws(() => resolveAttachment('discard-123abc', discarded.id), /not found/);
   await assert.rejects(
     receive(png.subarray(0, 24), 'codex-123abc', 'image/png', 'broken.png'),
     (error) => error.statusCode === 415 && /malformed/.test(error.message),

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,7 +22,6 @@ import { useReaderBatch } from './lib/readerBatch';
 import { paneOwnsBack } from './lib/mobileBack';
 import { isPassive, isRemote, isShareable } from './types';
 import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './components/icons';
-import { uploadPendingAttachments } from './lib/attachments';
 
 // `?vvdebug=1` — a phone has no devtools, and the keyboard layout is a guess
 // when the app is embedded cross-origin. Read once: it never changes mid-run,
@@ -628,28 +627,32 @@ export default function App() {
   };
   // Quickstart: server boots the agent and types the prompt; we jump straight
   // to the new pane so you watch it happen.
+  const prepareQuickStart = async (cli: string, name = '', path = '.') => {
+    const created = await api.createSession(name, cli, undefined, path);
+    rememberPath(created.path);
+    await refresh();
+    return created;
+  };
   const quickStart = async (cli: string, prompt: string, name = '', path = '.', attachmentOptions?: QuickStartAttachmentOptions) => {
     try {
       let sessionId: string;
       let sessionPath: string | null = path;
-      if (attachmentOptions?.attachments.length) {
+      if (attachmentOptions && (attachmentOptions.sessionId || attachmentOptions.attachments.length)) {
         if (attachmentOptions.sessionId) {
           sessionId = attachmentOptions.sessionId;
         } else {
-          // Attachments are session-scoped, so create the stopped session first,
-          // then upload. If an upload fails the session remains visible and the
-          // sidebar retains its id for a retry.
-          const created = await api.createSession(name, cli, undefined, path);
+          // Defensive fallback for a submit racing the target-creation render.
+          // Normal attachment uploads create this stopped target immediately.
+          const created = await prepareQuickStart(cli, name, path);
           sessionId = created.id;
           sessionPath = created.path;
           attachmentOptions.onSessionCreated(created.id);
-          rememberPath(created.path);
-          await refresh();
         }
-        const attachments = await uploadPendingAttachments(
-          sessionId, attachmentOptions.attachments, attachmentOptions.onAttachmentUpdate,
-        );
-        await api.sendInput(sessionId, prompt, attachments.map((image) => image.id));
+        if (attachmentOptions.attachments.some((attachment) => !attachment.attachment)) {
+          throw new Error('Wait for every file to finish uploading, or retry/remove the failed file.');
+        }
+        await api.sendInput(sessionId, prompt,
+          attachmentOptions.attachments.map((attachment) => attachment.attachment!.id));
       } else {
         const created = await api.quickStart(cli, prompt, name, path);
         sessionId = created.id;
@@ -1066,6 +1069,7 @@ export default function App() {
         theme={theme}
         onToggleTheme={toggleTheme}
         onQuickStart={quickStart}
+        onPrepareQuickStart={prepareQuickStart}
         archived={archivedIds}
         showArchived={showArchived}
         onToggleArchived={() => setShowArchived((v) => !v)}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -502,7 +502,7 @@ export default function App() {
     const ok = activeRef && (activeRef === 'overview'
       || (activeRef.startsWith('g:') ? groupById[activeRef.slice(2)] : sessById[activeRef.slice(2)]));
     if (!ok) {
-      setActiveRef(tree.order[0] ?? null);
+      setActiveRef('overview');
       // The remembered agent is gone (deleted, or a different Space). Land on
       // the list rather than full-screening whichever agent happens to be first.
       setMobileStage(false);
@@ -632,6 +632,22 @@ export default function App() {
     rememberPath(created.path);
     await refresh();
     return created;
+  };
+  const abandonQuickStart = async (id: string) => {
+    try {
+      await api.discardUnstartedSession(id);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      // A target the operator deliberately opened is no longer placeholder
+      // state. The conditional DELETE makes that decision atomically server-side.
+      if (detail.includes('session has already started') || detail === 'not found') return;
+      console.error('Couldn’t discard the unstarted agent', error);
+      setToast(`Couldn’t discard the unstarted agent: ${detail}`);
+      window.setTimeout(() => setToast(null), 5000);
+      throw error;
+    } finally {
+      await refresh();
+    }
   };
   const quickStart = async (cli: string, prompt: string, name = '', path = '.', attachmentOptions?: QuickStartAttachmentOptions) => {
     try {
@@ -1070,6 +1086,7 @@ export default function App() {
         onToggleTheme={toggleTheme}
         onQuickStart={quickStart}
         onPrepareQuickStart={prepareQuickStart}
+        onAbandonQuickStart={abandonQuickStart}
         archived={archivedIds}
         showArchived={showArchived}
         onToggleArchived={() => setShowArchived((v) => !v)}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -207,18 +207,62 @@ export interface Attachment {
   insertText: string;
 }
 
-export const uploadAttachment = async (id: string, file: File): Promise<Attachment> => {
-  const headers: Record<string, string> = {
-    'x-file-name': encodeURIComponent(file.name || 'Attachment'),
-  };
-  if (file.type) headers['content-type'] = file.type;
-  const response = await fetch(`/api/sessions/${id}/attachments`, {
-    method: 'POST',
-    headers,
-    body: file,
-  });
-  return jsonOrError(response);
+export interface AttachmentUploadProgress { loaded: number; total: number }
+
+const attachmentUploadError = (request: XMLHttpRequest) => {
+  let detail = '';
+  try {
+    const body = JSON.parse(request.responseText || '{}');
+    if (typeof body?.error === 'string') detail = body.error;
+  } catch { /* An ingress/proxy error can be HTML. Classify it by status below. */ }
+  if (detail) return detail;
+  if (request.status === 413) return 'The server or its proxy rejected this file as too large (HTTP 413). Try a smaller file.';
+  if (request.status === 408 || request.status === 504) return `The upload timed out (HTTP ${request.status}). Check the connection and retry.`;
+  if (request.status === 429) return 'Too many uploads at once (HTTP 429). Wait a minute, then retry.';
+  if (request.status >= 500) return `The upload server failed (HTTP ${request.status}). Retry in a moment.`;
+  return `Upload failed (HTTP ${request.status}${request.statusText ? ` ${request.statusText}` : ''}).`;
 };
+
+/** XMLHttpRequest is intentional: fetch has no browser upload-progress API. */
+export const uploadAttachment = (
+  id: string,
+  file: File,
+  onProgress?: (progress: AttachmentUploadProgress) => void,
+): Promise<Attachment> => new Promise((resolve, reject) => {
+  const request = new XMLHttpRequest();
+  request.open('POST', `/api/sessions/${encodeURIComponent(id)}/attachments`);
+  request.setRequestHeader('x-am-origin', 'operator');
+  request.setRequestHeader('x-file-name', encodeURIComponent(file.name || 'Attachment'));
+  if (file.type) request.setRequestHeader('content-type', file.type);
+  request.upload.onprogress = (event) => onProgress?.({
+    loaded: event.loaded,
+    total: event.lengthComputable && event.total ? event.total : file.size,
+  });
+  // Some browsers coalesce every progress event for a fast/small body. The
+  // upload-side load event still fires before the response, so 100% means
+  // "bytes sent, awaiting server confirmation", not prematurely "stored".
+  request.upload.onload = () => onProgress?.({ loaded: file.size, total: file.size });
+  request.onload = () => {
+    if (request.status < 200 || request.status >= 300) {
+      reject(new Error(attachmentUploadError(request)));
+      return;
+    }
+    try {
+      resolve(JSON.parse(request.responseText) as Attachment);
+    } catch {
+      reject(new Error('The upload completed, but the server returned an unreadable response. Retry the file.'));
+    }
+  };
+  request.onerror = () => reject(new Error(
+    typeof navigator !== 'undefined' && navigator.onLine === false
+      ? 'Upload stopped because this device is offline. Reconnect and retry.'
+      : 'Upload connection was interrupted before the server confirmed the file. Check the connection and retry.',
+  ));
+  request.onabort = () => reject(new Error('Upload was canceled before it completed. Retry the file.'));
+  request.ontimeout = () => reject(new Error('Upload timed out before it completed. Check the connection and retry.'));
+  onProgress?.({ loaded: 0, total: file.size });
+  request.send(file);
+});
 
 export const insertAttachments = (
   id: string,

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -208,6 +208,12 @@ export interface Attachment {
 }
 
 export interface AttachmentUploadProgress { loaded: number; total: number }
+export interface AttachmentUploadOptions {
+  onProgress?: (progress: AttachmentUploadProgress) => void;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+}
+export const ATTACHMENT_UPLOAD_TIMEOUT_MS = 20 * 60 * 1000;
 
 const attachmentUploadError = (request: XMLHttpRequest) => {
   let detail = '';
@@ -227,10 +233,23 @@ const attachmentUploadError = (request: XMLHttpRequest) => {
 export const uploadAttachment = (
   id: string,
   file: File,
-  onProgress?: (progress: AttachmentUploadProgress) => void,
+  { onProgress, signal, timeoutMs = ATTACHMENT_UPLOAD_TIMEOUT_MS }: AttachmentUploadOptions = {},
 ): Promise<Attachment> => new Promise((resolve, reject) => {
   const request = new XMLHttpRequest();
+  let settled = false;
+  const finish = (task: () => void) => {
+    if (settled) return;
+    settled = true;
+    signal?.removeEventListener('abort', abort);
+    task();
+  };
+  const abort = () => request.abort();
+  if (signal?.aborted) {
+    finish(() => reject(new Error('Upload was canceled before it completed.')));
+    return;
+  }
   request.open('POST', `/api/sessions/${encodeURIComponent(id)}/attachments`);
+  request.timeout = timeoutMs;
   request.setRequestHeader('x-am-origin', 'operator');
   request.setRequestHeader('x-file-name', encodeURIComponent(file.name || 'Attachment'));
   if (file.type) request.setRequestHeader('content-type', file.type);
@@ -244,25 +263,37 @@ export const uploadAttachment = (
   request.upload.onload = () => onProgress?.({ loaded: file.size, total: file.size });
   request.onload = () => {
     if (request.status < 200 || request.status >= 300) {
-      reject(new Error(attachmentUploadError(request)));
+      finish(() => reject(new Error(attachmentUploadError(request))));
       return;
     }
     try {
-      resolve(JSON.parse(request.responseText) as Attachment);
+      const attachment = JSON.parse(request.responseText) as Attachment;
+      finish(() => resolve(attachment));
     } catch {
-      reject(new Error('The upload completed, but the server returned an unreadable response. Retry the file.'));
+      finish(() => reject(new Error('The upload completed, but the server returned an unreadable response. Retry the file.')));
     }
   };
-  request.onerror = () => reject(new Error(
+  request.onerror = () => finish(() => reject(new Error(
     typeof navigator !== 'undefined' && navigator.onLine === false
       ? 'Upload stopped because this device is offline. Reconnect and retry.'
       : 'Upload connection was interrupted before the server confirmed the file. Check the connection and retry.',
-  ));
-  request.onabort = () => reject(new Error('Upload was canceled before it completed. Retry the file.'));
-  request.ontimeout = () => reject(new Error('Upload timed out before it completed. Check the connection and retry.'));
+  )));
+  request.onabort = () => finish(() => reject(new Error('Upload was canceled before it completed.')));
+  request.ontimeout = () => finish(() => reject(new Error(
+    `Upload timed out after ${Math.round(timeoutMs / 60_000)} minutes. Check the connection and retry.`,
+  )));
+  signal?.addEventListener('abort', abort, { once: true });
   onProgress?.({ loaded: 0, total: file.size });
   request.send(file);
 });
+
+export const deleteAttachment = (sessionId: string, attachmentId: string): Promise<{ ok: boolean }> =>
+  fetch(`/api/sessions/${encodeURIComponent(sessionId)}/attachments/${encodeURIComponent(attachmentId)}`, {
+    method: 'DELETE',
+  }).then(jsonOrError);
+
+export const discardUnstartedSession = (id: string): Promise<{ ok: boolean }> =>
+  fetch(`/api/sessions/${encodeURIComponent(id)}?ifNeverStarted=1`, { method: 'DELETE' }).then(jsonOrError);
 
 export const insertAttachments = (
   id: string,

--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,8 +1,9 @@
 import { useId, useRef } from 'react';
+import { attachmentFileError } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
 
 const fmtBytes = (bytes: number) => bytes < 1024 * 1024
-  ? `${Math.max(1, Math.round(bytes / 1024))} KB`
+  ? `${bytes ? Math.max(1, Math.round(bytes / 1024)) : 0} KB`
   : `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 
 const fileLabel = (name: string) => {
@@ -10,13 +11,14 @@ const fileLabel = (name: string) => {
   return extension && extension !== name ? extension.slice(0, 4).toUpperCase() : 'FILE';
 };
 
-export default function Attachments({ attachments, disabled, disabledReason, showPicker = true, onFiles, onRemove }: {
+export default function Attachments({ attachments, disabled, disabledReason, showPicker = true, onFiles, onRemove, onRetry }: {
   attachments: PendingAttachment[];
   disabled?: boolean;
   disabledReason?: string;
   showPicker?: boolean;
   onFiles: (files: File[]) => void;
   onRemove: (key: string) => void;
+  onRetry?: (key: string) => void;
 }) {
   const picker = useRef<HTMLInputElement>(null);
   const reasonId = useId();
@@ -53,25 +55,45 @@ export default function Attachments({ attachments, disabled, disabledReason, sho
         </>
       )}
       {showReason && <span id={reasonId} className="image-attachments-note">{disabledReason}</span>}
-      {attachments.map((attachment) => (
-        <div key={attachment.key} className={`image-chip ${attachment.status}`}>
-          {attachment.previewUrl ? (
-            <a className="image-chip-preview" href={attachment.previewUrl} target="_blank" rel="noreferrer" title={`Preview ${attachment.file.name || 'image'}`}>
-              <img src={attachment.previewUrl} alt="" />
-            </a>
-          ) : (
-            <span className="image-chip-placeholder mono" aria-hidden="true">{fileLabel(attachment.file.name || '')}</span>
-          )}
-          <span className="image-chip-copy">
-            <span className="image-chip-name">{attachment.file.name || 'Attachment'}</span>
-            <span className="image-chip-meta" aria-live="polite">
-              {attachment.status === 'uploading' ? 'uploading…'
-                : attachment.error || (attachment.status === 'uploaded' ? 'uploaded' : fmtBytes(attachment.file.size))}
+      {attachments.map((attachment) => {
+        const loaded = Math.min(attachment.file.size, attachment.uploadedBytes || 0);
+        const progress = attachment.file.size ? Math.round((loaded / attachment.file.size) * 100) : 0;
+        const retryable = attachment.status === 'error' && !attachmentFileError(attachment.file) && !!onRetry;
+        return (
+          <div key={attachment.key} className={`image-chip ${attachment.status}`}>
+            {attachment.previewUrl ? (
+              <a className="image-chip-preview" href={attachment.previewUrl} target="_blank" rel="noreferrer" title={`Preview ${attachment.file.name || 'image'}`}>
+                <img src={attachment.previewUrl} alt="" />
+              </a>
+            ) : (
+              <span className="image-chip-placeholder mono" aria-hidden="true">{fileLabel(attachment.file.name || '')}</span>
+            )}
+            <span className="image-chip-copy">
+              <span className="image-chip-name">{attachment.file.name || 'Attachment'}</span>
+              <span className="image-chip-meta" aria-live="polite" title={attachment.error}>
+                {attachment.status === 'uploading' ? `${progress}% · ${fmtBytes(loaded)} / ${fmtBytes(attachment.file.size)}`
+                  : attachment.error || (attachment.status === 'uploaded' ? 'uploaded' : fmtBytes(attachment.file.size))}
+              </span>
+              {attachment.status === 'uploading' && (
+                <span
+                  className="image-chip-progress"
+                  role="progressbar"
+                  aria-label={`Uploading ${attachment.file.name || 'file'}`}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-valuenow={progress}
+                >
+                  <span style={{ width: `${progress}%` }} />
+                </span>
+              )}
             </span>
-          </span>
-          <button type="button" onClick={() => onRemove(attachment.key)} disabled={disabled || attachment.status === 'uploading'} aria-label={`Remove ${attachment.file.name || 'file'}`}>×</button>
-        </div>
-      ))}
+            {retryable && (
+              <button type="button" className="image-chip-retry" onClick={() => onRetry(attachment.key)} disabled={disabled} aria-label={`Retry ${attachment.file.name || 'file'}`}>retry</button>
+            )}
+            <button type="button" onClick={() => onRemove(attachment.key)} disabled={disabled || attachment.status === 'uploading'} aria-label={`Remove ${attachment.file.name || 'file'}`}>×</button>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -90,7 +90,12 @@ export default function Attachments({ attachments, disabled, disabledReason, sho
             {retryable && (
               <button type="button" className="image-chip-retry" onClick={() => onRetry(attachment.key)} disabled={disabled} aria-label={`Retry ${attachment.file.name || 'file'}`}>retry</button>
             )}
-            <button type="button" onClick={() => onRemove(attachment.key)} disabled={disabled || attachment.status === 'uploading'} aria-label={`Remove ${attachment.file.name || 'file'}`}>×</button>
+            <button
+              type="button"
+              onClick={() => onRemove(attachment.key)}
+              disabled={disabled}
+              aria-label={`${attachment.status === 'uploading' ? 'Cancel upload' : 'Remove'} ${attachment.file.name || 'file'}`}
+            >×</button>
           </div>
         );
       })}

--- a/web/src/components/FolderPicker.tsx
+++ b/web/src/components/FolderPicker.tsx
@@ -83,20 +83,21 @@ function Level({ path, depth, value, onPick }: {
  * workspace root. Picking a not-yet-existing folder is fine: the server
  * creates it when the agent is created.
  */
-export default function FolderPicker({ value, onChange }: {
+export default function FolderPicker({ value, onChange, disabled = false }: {
   value: string;
   onChange: (p: string) => void;
+  disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const root = isRoot(value);
   return (
     <div className="fp">
-      <button className="fp-current" onClick={() => setOpen((o) => !o)} title="Choose where this agent runs">
+      <button className="fp-current" disabled={disabled} onClick={() => setOpen((o) => !o)} title="Choose where this agent runs">
         <FolderGlyph className="fp-ico" open={open || root} />
         <span className="fp-path">{root ? 'workspaces' : value}</span>
         <span className="fp-toggle">{open ? '▾' : '▸'}</span>
       </button>
-      {open && (
+      {open && !disabled && (
         <div className="fp-tree">
           <button className={`fp-row fp-root${root ? ' picked' : ''}`} onClick={() => onChange(ROOT)}>
             <FolderGlyph className="fp-ico" open />

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -171,6 +171,9 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
     imagesRef.current = merged;
     setImages(merged);
     setImageError(next.error);
+    void uploadPendingAttachments(s.id, next.attachments, updateImage).catch(() => {
+      // The affected chip owns the persistent, actionable error and retry.
+    });
   };
   const removeImage = (key: string) => {
     if (sending) return;
@@ -189,6 +192,11 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
       imagesRef.current = next;
       return next;
     });
+  };
+  const retryImage = (key: string) => {
+    const image = imagesRef.current.find((item) => item.key === key);
+    if (!image || sending) return;
+    void uploadPendingAttachments(s.id, [image], updateImage).catch(() => {});
   };
 
   // After you send (or when the transcript shows a prompt newer than the last
@@ -219,6 +227,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
     const text = draft.trim();
     const batch = imagesRef.current;
     if ((!text && !batch.length) || sending) return;
+    if (batch.some((image) => !image.attachment)) return;
     const optimisticText = text || defaultAttachmentPrompt(batch.length);
     setSending(true);
     setFailed(null);
@@ -227,8 +236,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
     setHistIdx(0);
     if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     try {
-      const attachments = await uploadPendingAttachments(s.id, batch, updateImage);
-      await api.sendInput(s.id, text, attachments.map((image) => image.id));
+      await api.sendInput(s.id, text, batch.map((image) => image.attachment!.id));
       revokePendingAttachments(batch);
       imagesRef.current = [];
       setImages([]);
@@ -371,13 +379,15 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
         sending={sending}
         isMobile={isMobile}
         inputRef={inputRef}
-        canSend={!!draft.trim() || images.length > 0}
+        canSend={(!!draft.trim() || images.length > 0)
+          && images.every((image) => !!image.attachment)}
         above={<Attachments
           attachments={images}
           disabled={sending || !allowAttachments}
           disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
           onFiles={addImages}
           onRemove={removeImage}
+          onRetry={retryImage}
         />}
         onChange={setDraft}
         onSend={send}

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -9,7 +9,8 @@ import { rankSessions, sortLabel } from '../lib/overviewSort';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
 import {
-  defaultAttachmentPrompt, pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
+  defaultAttachmentPrompt, discardPendingAttachment, discardPendingAttachments,
+  pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
 } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
 import Attachments from './Attachments';
@@ -162,7 +163,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   const allowAttachments = !isRemote(s.cli);
 
   useEffect(() => { imagesRef.current = images; }, [images]);
-  useEffect(() => () => revokePendingAttachments(imagesRef.current), []);
+  useEffect(() => () => discardPendingAttachments(s.id, imagesRef.current), [s.id]);
 
   const addImages = (files: File[]) => {
     if (!allowAttachments || sending || !files.length) return;
@@ -179,7 +180,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
     if (sending) return;
     setImages((current) => {
       const removed = current.find((image) => image.key === key);
-      if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl);
+      if (removed) discardPendingAttachment(s.id, removed);
       const next = current.filter((image) => image.key !== key);
       imagesRef.current = next;
       return next;

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,13 +1,13 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote, isShareable } from '../types';
-import { hiddenSessionIds } from '../lib/overviewHidden';
 import Logo from './Logo';
 import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
 import Attachments from './Attachments';
 import {
-  filesFromTransfer, pendingAttachmentsFromFiles, revokePendingAttachments, transferMayContainFile,
+  attachmentFileError, filesFromTransfer, pendingAttachmentsFromFiles, revokePendingAttachments,
+  transferMayContainFile, uploadPendingAttachments,
 } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
 import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
@@ -19,7 +19,6 @@ export interface QuickStartAttachmentOptions {
   sessionId: string | null;
   attachments: PendingAttachment[];
   onSessionCreated: (id: string) => void;
-  onAttachmentUpdate: (key: string, patch: Partial<PendingAttachment>) => void;
 }
 
 // Folded groups, remembered across reloads.
@@ -38,6 +37,7 @@ export default function Sidebar({
   clis, tree, activeRef, focusedId, defaultPath, ages,
   onActivate, onOpenSession, onNewSession, onNewGroup, onRenameGroup, onRenameSession, onDeleteGroup,
   onStopSession, onSetRemotePaused, onDeleteSession, onShareSession, onShareTrace, onTraceHandover, onOpenTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
+  onPrepareQuickStart,
   archived, showArchived, onToggleArchived,
   overviewHidden, onToggleOverviewHidden,
 }: {
@@ -67,6 +67,7 @@ export default function Sidebar({
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
   onQuickStart: (cli: string, prompt: string, name?: string, path?: string, attachmentOptions?: QuickStartAttachmentOptions) => Promise<void>;
+  onPrepareQuickStart: (cli: string, name?: string, path?: string) => Promise<Session>;
   archived: Set<string>;
   showArchived: boolean;
   onToggleArchived: () => void;
@@ -87,6 +88,9 @@ export default function Sidebar({
   const [quickImages, setQuickImages] = useState<PendingAttachment[]>([]);
   const quickImagesRef = useRef<PendingAttachment[]>([]);
   const [quickSessionId, setQuickSessionId] = useState<string | null>(null);
+  const quickSessionIdRef = useRef<string | null>(null);
+  const quickPrepareRef = useRef<Promise<Session> | null>(null);
+  const quickGenerationRef = useRef(0);
   const [quickSending, setQuickSending] = useState(false);
   const [quickDrop, setQuickDrop] = useState(false);
   // When creation was launched from a group's + the new agent lands there.
@@ -114,8 +118,15 @@ export default function Sidebar({
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
   const groupById = useMemo(() => Object.fromEntries(tree.groups.map((g) => [g.id, g])), [tree.groups]);
   const colorOf = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c.color])), [clis]);
+  const quickFilesBlocked = quickImages.some((image) => !image.attachment);
+
   useEffect(() => { quickImagesRef.current = quickImages; }, [quickImages]);
   useEffect(() => () => revokePendingAttachments(quickImagesRef.current), []);
+
+  const rememberQuickSession = (id: string | null) => {
+    quickSessionIdRef.current = id;
+    setQuickSessionId(id);
+  };
 
   const updateQuickImage = (key: string, patch: Partial<PendingAttachment>) => {
     setQuickImages((current) => {
@@ -124,6 +135,46 @@ export default function Sidebar({
       return next;
     });
   };
+  const prepareQuickTarget = async (generation: number) => {
+    if (quickSessionIdRef.current) return quickSessionIdRef.current;
+    if (!quickCli || isRemote(quickCli)) throw new Error('Choose a local agent before attaching files.');
+    if (!quickPrepareRef.current) {
+      quickPrepareRef.current = onPrepareQuickStart(
+        quickCli, quickMore ? quickName.trim() : '', quickMore ? quickLoc : '.',
+      );
+    }
+    const preparing = quickPrepareRef.current;
+    try {
+      const created = await preparing;
+      if (generation === quickGenerationRef.current) rememberQuickSession(created.id);
+      return created.id;
+    } catch (error) {
+      if (quickPrepareRef.current === preparing) quickPrepareRef.current = null;
+      throw error;
+    }
+  };
+  const startQuickUploads = (attachments: PendingAttachment[]) => {
+    const uploadable = attachments.filter((attachment) => !attachmentFileError(attachment.file));
+    if (!uploadable.length) return;
+    const generation = quickGenerationRef.current;
+    void (async () => {
+      let sessionId: string;
+      try {
+        sessionId = await prepareQuickTarget(generation);
+      } catch (error) {
+        if (generation !== quickGenerationRef.current) return;
+        const message = error instanceof Error ? error.message : 'Could not prepare an agent for this upload.';
+        for (const attachment of uploadable) updateQuickImage(attachment.key, { status: 'error', error: message });
+        setQuickError(message);
+        return;
+      }
+      if (generation !== quickGenerationRef.current) return;
+      setQuickError(null);
+      await uploadPendingAttachments(sessionId, uploadable, updateQuickImage).catch(() => {
+        // Each failed chip keeps the exact server or connection error and retry action.
+      });
+    })();
+  };
   const addQuickImages = (files: File[]) => {
     if (quickSending) return;
     const next = pendingAttachmentsFromFiles(files, quickImagesRef.current.length);
@@ -131,6 +182,7 @@ export default function Sidebar({
     quickImagesRef.current = merged;
     setQuickImages(merged);
     setQuickError(next.error);
+    startQuickUploads(next.attachments);
   };
   const removeQuickImage = (key: string) => {
     if (quickSending) return;
@@ -143,10 +195,17 @@ export default function Sidebar({
     });
     setQuickError(null);
   };
+  const retryQuickImage = (key: string) => {
+    const image = quickImagesRef.current.find((item) => item.key === key);
+    if (!image || quickSending) return;
+    startQuickUploads([image]);
+  };
   // A retry may reuse uploaded ids only while it still targets the same
   // server-created session. Changing its identity starts a fresh target.
   const resetQuickTarget = () => {
-    setQuickSessionId(null);
+    quickGenerationRef.current += 1;
+    quickPrepareRef.current = null;
+    rememberQuickSession(null);
     setQuickImages((current) => {
       const next = current.map((image) => image.attachment
         ? { ...image, attachment: undefined, status: 'pending' as const, error: undefined }
@@ -162,10 +221,12 @@ export default function Sidebar({
   const bump = (id: string, d: number) => setCart((c) => ({ ...c, [id]: Math.max(0, (c[id] || 0) + d) }));
   const closePanel = () => {
     if (panel === 'quick') {
+      quickGenerationRef.current += 1;
       revokePendingAttachments(quickImagesRef.current);
       quickImagesRef.current = [];
       setQuickImages([]);
-      setQuickSessionId(null);
+      quickPrepareRef.current = null;
+      rememberQuickSession(null);
       setQuickSending(false);
       setQuickDrop(false);
     }
@@ -181,9 +242,11 @@ export default function Sidebar({
   const quickable = clis.filter((c) => c.id !== 'shell' && !isPassive(c.id) && !isRemote(c.id));
   const remoteCli = clis.find((c) => isRemote(c.id)) || null;
   const openQuick = () => {
+    quickGenerationRef.current += 1;
     setQuickError(null);
     setQuickName('');
-    setQuickSessionId(null);
+    quickPrepareRef.current = null;
+    rememberQuickSession(null);
     setQuickCli((q) => q ?? (quickable.find((c) => c.available && c.ready)?.id || quickable.find((c) => c.available)?.id || null));
     setQuickMode('agent');
     setQuickLoc(defaultPath || '.');
@@ -212,6 +275,7 @@ export default function Sidebar({
   const submitQuick = async () => {
     const p = quickPrompt.trim();
     if (!quickCli || quickSending) return;
+    if (quickImagesRef.current.some((image) => !image.attachment)) return;
     // A remote agent names itself like any other agent when unnamed
     // (remote-agent-1, -2, …); its "location" is always its own message folder,
     // never the picker's.
@@ -231,11 +295,10 @@ export default function Sidebar({
     try {
       await onQuickStart(
         quickCli, p, quickMore ? quickName.trim() : '', quickMore ? quickLoc : '.',
-        quickImages.length ? {
+        quickSessionId || quickImages.length ? {
           sessionId: quickSessionId,
           attachments: quickImages,
-          onSessionCreated: setQuickSessionId,
-          onAttachmentUpdate: updateQuickImage,
+          onSessionCreated: rememberQuickSession,
         } : undefined,
       );
       setQuickPrompt('');
@@ -500,7 +563,7 @@ export default function Sidebar({
                   key={c.id}
                   className={`quick-cli${quickMode === 'agent' && quickCli === c.id ? ' on' : ''}${c.available ? '' : ' off'}`}
                   title={c.available ? c.label : `${c.label} (not installed)`}
-                  disabled={!c.available || quickSending}
+                  disabled={!c.available || quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === c.id ? { borderColor: c.color } : undefined}
                   onClick={() => { setQuickMode('agent'); if (quickCli !== c.id) resetQuickTarget(); setQuickCli(c.id); }}
                 ><Logo cli={c.id} size={14} /></button>
@@ -509,7 +572,7 @@ export default function Sidebar({
               <button
                 className={`quick-cli quick-grp${quickMode === 'group' ? ' on' : ''}`}
                 title="New group"
-                disabled={quickSending}
+                disabled={quickSending || quickImages.length > 0}
                 onClick={() => setQuickMode('group')}
               >
                 <span className="grp-mini">
@@ -523,10 +586,11 @@ export default function Sidebar({
                 <button
                   className={`quick-cli${quickMode === 'agent' && quickCli === 'remote' ? ' on' : ''}`}
                   title="Remote agent — an agent on another machine"
-                  disabled={quickSending}
+                  disabled={quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === 'remote' ? { borderColor: remoteCli.color } : undefined}
                   onClick={() => {
-                    setQuickMode('agent'); setQuickCli('remote'); setQuickSessionId(null);
+                    setQuickMode('agent'); setQuickCli('remote'); quickGenerationRef.current += 1;
+                    quickPrepareRef.current = null; rememberQuickSession(null);
                     revokePendingAttachments(quickImagesRef.current); quickImagesRef.current = []; setQuickImages([]); setQuickError(null);
                   }}
                 ><Logo cli="remote" size={14} /></button>
@@ -539,6 +603,15 @@ export default function Sidebar({
                 {quickError && quickSessionId && (
                   <div className="quick-recovery mono">
                     The agent was created. Retry will reuse it; delete it from the agent row if you want to start over.
+                  </div>
+                )}
+                {!quickError && quickSessionId && quickImages.length > 0 && (
+                  <div className="quick-recovery mono">
+                    {quickImages.every((image) => !!image.attachment)
+                      ? 'Files are uploaded to this stopped agent; launch will reuse them.'
+                      : quickImages.some((image) => image.status === 'error')
+                        ? 'A file needs attention before this stopped agent can launch.'
+                        : 'Files are uploading to this stopped agent now; launch waits until they are ready.'}
                   </div>
                 )}
                 <textarea
@@ -566,25 +639,26 @@ export default function Sidebar({
                   showPicker={false}
                   onFiles={addQuickImages}
                   onRemove={removeQuickImage}
+                  onRetry={retryQuickImage}
                 />
                 {quickMore && (
                   <>
                     <input
                       placeholder="Name (optional)"
                       value={quickName}
-                      disabled={quickSending}
+                      disabled={quickSending || quickImages.length > 0}
                       onChange={(e) => { resetQuickTarget(); setQuickName(e.target.value); }}
                       onKeyDown={(e) => { if (e.key === 'Enter') submitQuick(); if (e.key === 'Escape') closePanel(); }}
                     />
-                    <FolderPicker value={quickLoc} onChange={(value) => { resetQuickTarget(); setQuickLoc(value); }} />
+                    <FolderPicker disabled={quickSending || quickImages.length > 0} value={quickLoc} onChange={(value) => { resetQuickTarget(); setQuickLoc(value); }} />
                     <div className="widget-actions">
-                      <button className="btn-primary" onClick={submitQuick} disabled={quickSending}>{quickSending ? 'Uploading…' : `Create${quickPrompt.trim() || quickImages.length ? ' & send' : ''}`}</button>
+                      <button className="btn-primary" onClick={submitQuick} disabled={quickSending || quickFilesBlocked}>{quickSending ? 'Starting…' : `Create${quickPrompt.trim() || quickImages.length ? ' & send' : ''}`}</button>
                       <button className="btn-ghost" onClick={closePanel} disabled={quickSending}>Cancel</button>
                     </div>
                   </>
                 )}
                 <div className="quick-foot">
-                  <button className="quick-more" onClick={() => setQuickMore((v) => !v)} disabled={quickSending}>{quickMore ? '▴ less' : '▾ more options'}</button>
+                  <button className="quick-more" onClick={() => setQuickMore((v) => !v)} disabled={quickSending || quickImages.length > 0}>{quickMore ? '▴ less' : '▾ more options'}</button>
                   <span className="quick-hint mono">↵ launch · ⇧↵ newline</span>
                 </div>
               </>

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -6,8 +6,8 @@ import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
 import Attachments from './Attachments';
 import {
-  attachmentFileError, filesFromTransfer, pendingAttachmentsFromFiles, revokePendingAttachments,
-  transferMayContainFile, uploadPendingAttachments,
+  attachmentFileError, discardPendingAttachment, discardPendingAttachments, filesFromTransfer,
+  pendingAttachmentsFromFiles, revokePendingAttachments, transferMayContainFile, uploadPendingAttachments,
 } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
 import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
@@ -38,6 +38,7 @@ export default function Sidebar({
   onActivate, onOpenSession, onNewSession, onNewGroup, onRenameGroup, onRenameSession, onDeleteGroup,
   onStopSession, onSetRemotePaused, onDeleteSession, onShareSession, onShareTrace, onTraceHandover, onOpenTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
   onPrepareQuickStart,
+  onAbandonQuickStart,
   archived, showArchived, onToggleArchived,
   overviewHidden, onToggleOverviewHidden,
 }: {
@@ -68,6 +69,7 @@ export default function Sidebar({
   onToggleTheme: () => void;
   onQuickStart: (cli: string, prompt: string, name?: string, path?: string, attachmentOptions?: QuickStartAttachmentOptions) => Promise<void>;
   onPrepareQuickStart: (cli: string, name?: string, path?: string) => Promise<Session>;
+  onAbandonQuickStart: (id: string) => Promise<void>;
   archived: Set<string>;
   showArchived: boolean;
   onToggleArchived: () => void;
@@ -121,7 +123,6 @@ export default function Sidebar({
   const quickFilesBlocked = quickImages.some((image) => !image.attachment);
 
   useEffect(() => { quickImagesRef.current = quickImages; }, [quickImages]);
-  useEffect(() => () => revokePendingAttachments(quickImagesRef.current), []);
 
   const rememberQuickSession = (id: string | null) => {
     quickSessionIdRef.current = id;
@@ -135,6 +136,27 @@ export default function Sidebar({
       return next;
     });
   };
+  const abandonQuickTarget = (
+    sessionId: string | null,
+    preparing: Promise<Session> | null,
+    attachments: PendingAttachment[],
+  ) => {
+    discardPendingAttachments(sessionId || '', attachments);
+    const discard = sessionId
+      ? onAbandonQuickStart(sessionId)
+      : preparing?.then((created) => onAbandonQuickStart(created.id));
+    // App owns the visible cleanup error because this panel is intentionally
+    // already gone. The server-side condition makes this safe if the operator
+    // opened the target while its upload was still pending.
+    void discard?.catch(() => {});
+  };
+  useEffect(() => () => {
+    abandonQuickTarget(
+      quickSessionIdRef.current,
+      quickPrepareRef.current,
+      quickImagesRef.current,
+    );
+  }, []);
   const prepareQuickTarget = async (generation: number) => {
     if (quickSessionIdRef.current) return quickSessionIdRef.current;
     if (!quickCli || isRemote(quickCli)) throw new Error('Choose a local agent before attaching files.');
@@ -188,7 +210,7 @@ export default function Sidebar({
     if (quickSending) return;
     setQuickImages((current) => {
       const removed = current.find((image) => image.key === key);
-      if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl);
+      if (removed) discardPendingAttachment(quickSessionIdRef.current || '', removed);
       const next = current.filter((image) => image.key !== key);
       quickImagesRef.current = next;
       return next;
@@ -203,9 +225,13 @@ export default function Sidebar({
   // A retry may reuse uploaded ids only while it still targets the same
   // server-created session. Changing its identity starts a fresh target.
   const resetQuickTarget = () => {
+    const sessionId = quickSessionIdRef.current;
+    const preparing = quickPrepareRef.current;
+    const attachments = quickImagesRef.current;
     quickGenerationRef.current += 1;
     quickPrepareRef.current = null;
     rememberQuickSession(null);
+    abandonQuickTarget(sessionId, preparing, attachments);
     setQuickImages((current) => {
       const next = current.map((image) => image.attachment
         ? { ...image, attachment: undefined, status: 'pending' as const, error: undefined }
@@ -219,10 +245,14 @@ export default function Sidebar({
   // Archived sessions vanish from the tree unless the legend checkbox is on.
   const isHidden = (id: string) => !showArchived && archived.has(id);
   const bump = (id: string, d: number) => setCart((c) => ({ ...c, [id]: Math.max(0, (c[id] || 0) + d) }));
-  const closePanel = () => {
+  const finishPanel = (keepQuickTarget: boolean) => {
     if (panel === 'quick') {
+      const sessionId = quickSessionIdRef.current;
+      const preparing = quickPrepareRef.current;
+      const attachments = quickImagesRef.current;
       quickGenerationRef.current += 1;
-      revokePendingAttachments(quickImagesRef.current);
+      if (keepQuickTarget) revokePendingAttachments(attachments);
+      else abandonQuickTarget(sessionId, preparing, attachments);
       quickImagesRef.current = [];
       setQuickImages([]);
       quickPrepareRef.current = null;
@@ -232,6 +262,8 @@ export default function Sidebar({
     }
     setPanel('none'); setCreateTarget(null);
   };
+  const closePanel = () => finishPanel(false);
+  const completePanel = () => finishPanel(true);
   const openCreate = (target: string | null = null) => {
     setCreateTarget(target);
     setPanel('create');
@@ -283,7 +315,7 @@ export default function Sidebar({
       setQuickSending(true);
       try {
         await onQuickStart(quickCli, p, quickName.trim(), '.');
-        setQuickPrompt(''); setQuickName(''); closePanel();
+        setQuickPrompt(''); setQuickName(''); completePanel();
       } catch (error) {
         setQuickError(error instanceof Error ? error.message : 'could not create the remote agent');
       } finally { setQuickSending(false); }
@@ -303,7 +335,7 @@ export default function Sidebar({
       );
       setQuickPrompt('');
       setQuickName('');
-      closePanel();
+      completePanel();
     } catch (error) {
       setQuickError(error instanceof Error ? error.message : 'could not quickstart the agent');
     } finally { setQuickSending(false); }
@@ -573,7 +605,7 @@ export default function Sidebar({
                 className={`quick-cli quick-grp${quickMode === 'group' ? ' on' : ''}`}
                 title="New group"
                 disabled={quickSending || quickImages.length > 0}
-                onClick={() => setQuickMode('group')}
+                onClick={() => { resetQuickTarget(); setQuickMode('group'); }}
               >
                 <span className="grp-mini">
                   <Logo cli="claude" size={8} />
@@ -589,9 +621,7 @@ export default function Sidebar({
                   disabled={quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === 'remote' ? { borderColor: remoteCli.color } : undefined}
                   onClick={() => {
-                    setQuickMode('agent'); setQuickCli('remote'); quickGenerationRef.current += 1;
-                    quickPrepareRef.current = null; rememberQuickSession(null);
-                    revokePendingAttachments(quickImagesRef.current); quickImagesRef.current = []; setQuickImages([]); setQuickError(null);
+                    resetQuickTarget(); setQuickMode('agent'); setQuickCli('remote'); setQuickError(null);
                   }}
                 ><Logo cli="remote" size={14} /></button>
               )}

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -228,6 +228,7 @@ export default function TerminalPane({
   const uploadImagesRef = useRef<(files: File[]) => void>(() => {});
   const imagePickerRef = useRef<HTMLInputElement>(null);
   const imageUploadBusyRef = useRef(false);
+  const imageUploadAbortRef = useRef<AbortController | null>(null);
   const imageStatusTimerRef = useRef<number | null>(null);
   // Reachable from the mode switch: a flick can still be coasting through the
   // terminal's scrollback when the reader covers it.
@@ -261,6 +262,7 @@ export default function TerminalPane({
   const [imageDrop, setImageDrop] = useState(false);
   const [imageStatus, setImageStatus] = useState<{ kind: 'uploading' | 'success' | 'error'; text: string } | null>(null);
   const [imageUploadBusy, setImageUploadBusy] = useState(false);
+  const [imageUploadCancelable, setImageUploadCancelable] = useState(false);
   // The reader's search bar is hidden until asked for; the header owns the
   // switch because the icon that reveals it lives there.
   const [searchOpen, setSearchOpen] = useState(false);
@@ -355,6 +357,14 @@ export default function TerminalPane({
     }
   };
 
+  const discardTerminalInsert = () => {
+    const discarded = pendingInsert;
+    setPendingInsert([]);
+    void Promise.all(discarded.map((attachment) =>
+      api.deleteAttachment(session.id, attachment.id).catch(() => undefined)));
+    showImageStatus({ kind: 'success', text: `${discarded.length === 1 ? 'File' : 'Files'} removed` }, 2500);
+  };
+
   uploadImagesRef.current = (files: File[]) => {
     if (!supportsAttachments) return;
     if (conn !== 'connected') {
@@ -381,22 +391,39 @@ export default function TerminalPane({
     if (invalid) { showImageStatus({ kind: 'error', text: invalid }, 4000); return; }
     imageUploadBusyRef.current = true;
     setImageUploadBusy(true);
+    const uploadController = new AbortController();
+    imageUploadAbortRef.current = uploadController;
+    setImageUploadCancelable(true);
     void (async () => {
       const attachments: Attachment[] = [];
       try {
         for (let index = 0; index < images.length; index += 1) {
           const fileLabel = `file${images.length > 1 ? ` ${index + 1}/${images.length}` : ''}`;
           showImageStatus({ kind: 'uploading', text: `uploading ${fileLabel} · 0%` });
-          const attachment = await api.uploadAttachment(session.id, images[index], ({ loaded, total }) => {
-            const progress = total ? Math.min(100, Math.round((loaded / total) * 100)) : 0;
-            showImageStatus({ kind: 'uploading', text: `uploading ${fileLabel} · ${progress}%` });
+          const attachment = await api.uploadAttachment(session.id, images[index], {
+            signal: uploadController.signal,
+            onProgress: ({ loaded, total }) => {
+              const progress = total ? Math.min(100, Math.round((loaded / total) * 100)) : 0;
+              showImageStatus({ kind: 'uploading', text: `uploading ${fileLabel} · ${progress}%` });
+            },
           });
+          if (uploadController.signal.aborted) {
+            await api.deleteAttachment(session.id, attachment.id).catch(() => undefined);
+            throw new Error('Upload was canceled before it completed.');
+          }
           attachments.push(attachment);
         }
+        imageUploadAbortRef.current = null;
+        setImageUploadCancelable(false);
         showImageStatus({ kind: 'uploading', text: `inserting file${images.length === 1 ? '' : 's'}…` });
         await insertTerminalAttachments(attachments);
       } catch (error) {
-        if (attachments.length) {
+        if (uploadController.signal.aborted) {
+          await Promise.all(attachments.map((attachment) =>
+            api.deleteAttachment(session.id, attachment.id).catch(() => undefined)));
+          setPendingInsert([]);
+          showImageStatus({ kind: 'success', text: 'Upload canceled' }, 2500);
+        } else if (attachments.length) {
           const reason = error instanceof Error ? error.message : 'upload failed';
           setPendingInsert(attachments);
           showImageStatus({
@@ -407,11 +434,15 @@ export default function TerminalPane({
           showImageStatus({ kind: 'error', text: error instanceof Error ? error.message : 'file upload failed' }, 5000);
         }
       } finally {
+        if (imageUploadAbortRef.current === uploadController) imageUploadAbortRef.current = null;
         imageUploadBusyRef.current = false;
         setImageUploadBusy(false);
+        setImageUploadCancelable(false);
       }
     })();
   };
+
+  useEffect(() => () => imageUploadAbortRef.current?.abort(), []);
 
   // Phones have no Ctrl+V, so the key-bar needs an explicit paste. Two paths,
   // because the direct read is unavailable exactly where this app usually runs:
@@ -1030,7 +1061,11 @@ export default function TerminalPane({
     // The glide too: a flick left coasting under the reader keeps moving a
     // viewport nobody can see, and no touch can catch it — the handler that
     // would stop it now stands down in this mode.
-    if (reading) { termRef.current?.blur(); stopGlideRef.current(); }
+    if (reading) {
+      termRef.current?.blur();
+      stopGlideRef.current();
+      imageUploadAbortRef.current?.abort();
+    }
     else if (focused) termRef.current?.focus();
   }, [reading, focused]);
 
@@ -1199,13 +1234,19 @@ export default function TerminalPane({
       </div>
       {imageStatus && !reading && (
         <div
-          className={`term-image-status ${imageStatus.kind}${pendingInsert.length ? ' has-action' : ''} mono`}
+          className={`term-image-status ${imageStatus.kind}${pendingInsert.length || imageUploadCancelable ? ' has-action' : ''} mono`}
           role={imageStatus.kind === 'error' ? 'alert' : 'status'}
           aria-live={imageStatus.kind === 'error' ? 'assertive' : 'polite'}
         >
           <span>{imageStatus.text}</span>
+          {imageUploadCancelable && (
+            <button type="button" onClick={() => imageUploadAbortRef.current?.abort()}>cancel</button>
+          )}
           {pendingInsert.length > 0 && (
-            <button type="button" onClick={retryTerminalInsert} disabled={imageUploadBusy || conn !== 'connected' || !hasInputControl}>retry</button>
+            <>
+              <button type="button" onClick={retryTerminalInsert} disabled={imageUploadBusy || conn !== 'connected' || !hasInputControl}>retry</button>
+              <button type="button" onClick={discardTerminalInsert} disabled={imageUploadBusy}>remove</button>
+            </>
           )}
         </div>
       )}

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -385,18 +385,23 @@ export default function TerminalPane({
       const attachments: Attachment[] = [];
       try {
         for (let index = 0; index < images.length; index += 1) {
-          showImageStatus({ kind: 'uploading', text: `uploading file${images.length > 1 ? ` ${index + 1}/${images.length}` : ''}…` });
-          const attachment = await api.uploadAttachment(session.id, images[index]);
+          const fileLabel = `file${images.length > 1 ? ` ${index + 1}/${images.length}` : ''}`;
+          showImageStatus({ kind: 'uploading', text: `uploading ${fileLabel} · 0%` });
+          const attachment = await api.uploadAttachment(session.id, images[index], ({ loaded, total }) => {
+            const progress = total ? Math.min(100, Math.round((loaded / total) * 100)) : 0;
+            showImageStatus({ kind: 'uploading', text: `uploading ${fileLabel} · ${progress}%` });
+          });
           attachments.push(attachment);
         }
         showImageStatus({ kind: 'uploading', text: `inserting file${images.length === 1 ? '' : 's'}…` });
         await insertTerminalAttachments(attachments);
       } catch (error) {
         if (attachments.length) {
+          const reason = error instanceof Error ? error.message : 'upload failed';
           setPendingInsert(attachments);
           showImageStatus({
             kind: 'error',
-            text: `${attachments.length} file${attachments.length === 1 ? '' : 's'} saved; another failed to upload`,
+            text: `${attachments.length} file${attachments.length === 1 ? '' : 's'} saved; another failed: ${reason}`,
           });
         } else {
           showImageStatus({ kind: 'error', text: error instanceof Error ? error.message : 'file upload failed' }, 5000);

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -1232,6 +1232,9 @@ export default function TerminalPane({
           </div>
         )}
       </div>
+      {/* The header starts this flow, but xterm has no Agent Manager draft row
+          for operational chips. Keep progress and recovery over the terminal
+          itself, below the compact attach/search/info/close cluster. */}
       {imageStatus && !reading && (
         <div
           className={`term-image-status ${imageStatus.kind}${pendingInsert.length || imageUploadCancelable ? ' has-action' : ''} mono`}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -106,6 +106,9 @@ export default function ConversationView({
     attachmentsRef.current = merged;
     setAttachments(merged);
     setAttachmentError(next.error);
+    void uploadPendingAttachments(session.id, next.attachments, updateAttachment).catch(() => {
+      // The affected chip owns the persistent, actionable error and retry.
+    });
   };
   const removeAttachment = (key: string) => {
     if (sending) return;
@@ -124,6 +127,11 @@ export default function ConversationView({
       attachmentsRef.current = next;
       return next;
     });
+  };
+  const retryAttachment = (key: string) => {
+    const attachment = attachmentsRef.current.find((item) => item.key === key);
+    if (!attachment || sending) return;
+    void uploadPendingAttachments(session.id, [attachment], updateAttachment).catch(() => {});
   };
 
   // Closing the search CLEARS it. A query filters the reader to matching turns,
@@ -196,14 +204,14 @@ export default function ConversationView({
     const text = draft.trim();
     const batch = attachmentsRef.current;
     if ((!text && !batch.length) || sending) return;
+    if (batch.some((attachment) => !attachment.attachment)) return;
     const optimisticText = text || defaultAttachmentPrompt(batch.length);
     setSending(true); setFailed(null);
     setDraft(''); setSent({ text: optimisticText, at: Date.now() });
     if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     stick.current = true;
     try {
-      const uploaded = await uploadPendingAttachments(session.id, batch, updateAttachment);
-      await api.sendInput(session.id, text, uploaded.map((attachment) => attachment.id));
+      await api.sendInput(session.id, text, batch.map((attachment) => attachment.attachment!.id));
       revokePendingAttachments(batch);
       attachmentsRef.current = [];
       setAttachments([]);
@@ -562,7 +570,8 @@ export default function ConversationView({
           sending={sending}
           isMobile={isMobile}
           inputRef={inputRef}
-          canSend={!!draft.trim() || attachments.length > 0}
+          canSend={(!!draft.trim() || attachments.length > 0)
+            && attachments.every((attachment) => !!attachment.attachment)}
           above={<Attachments
             showPicker={false}
             attachments={attachments}
@@ -570,6 +579,7 @@ export default function ConversationView({
             disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
             onFiles={addAttachments}
             onRemove={removeAttachment}
+            onRetry={retryAttachment}
           />}
           onChange={setDraft}
           onSend={send}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -20,7 +20,8 @@ import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
 import {
-  defaultAttachmentPrompt, pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
+  defaultAttachmentPrompt, discardPendingAttachment, discardPendingAttachments,
+  pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
 } from '../../lib/attachments';
 import type { PendingAttachment } from '../../lib/attachments';
 import { recallReading, rememberReading } from './readingPosition';
@@ -97,7 +98,7 @@ export default function ConversationView({
   const allowAttachments = !isRemote(session.cli);
 
   useEffect(() => { attachmentsRef.current = attachments; }, [attachments]);
-  useEffect(() => () => revokePendingAttachments(attachmentsRef.current), []);
+  useEffect(() => () => discardPendingAttachments(session.id, attachmentsRef.current), [session.id]);
 
   const addAttachments = (files: File[]) => {
     if (!allowAttachments || sending || !files.length) return;
@@ -114,7 +115,7 @@ export default function ConversationView({
     if (sending) return;
     setAttachments((current) => {
       const removed = current.find((attachment) => attachment.key === key);
-      if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl);
+      if (removed) discardPendingAttachment(session.id, removed);
       const next = current.filter((attachment) => attachment.key !== key);
       attachmentsRef.current = next;
       return next;

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -564,6 +564,9 @@ export default function ConversationView({
       </div>
 
       {!readOnly && (
+        // Selection starts from the pane header, but transfer state belongs to
+        // this always-visible draft: progress, failure, Cancel, and Retry stay
+        // beside the message whose Send action they gate.
         <Composer
           className="cxv-live"
           containerClassName="cxv-composer"

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -12,6 +12,7 @@ export interface PendingAttachment {
   file: File;
   previewUrl?: string;
   status: PendingAttachmentStatus;
+  uploadedBytes?: number;
   error?: string;
   attachment?: Attachment;
 }
@@ -136,24 +137,33 @@ export async function uploadPendingAttachments(
   update: (key: string, patch: Partial<PendingAttachment>) => void,
 ) {
   const uploaded: Attachment[] = [];
+  let firstFailure: Error | null = null;
   for (const attachment of attachments) {
     if (attachment.attachment) {
       uploaded.push(attachment.attachment);
       continue;
     }
-    if (attachmentFileError(attachment.file)) {
-      throw new Error(attachment.error || 'invalid file');
+    const invalid = attachmentFileError(attachment.file);
+    if (invalid) {
+      update(attachment.key, { status: 'error', error: invalid });
+      firstFailure ??= new Error(invalid);
+      continue;
     }
-    update(attachment.key, { status: 'uploading', error: undefined });
+    update(attachment.key, { status: 'uploading', uploadedBytes: 0, error: undefined });
     try {
-      const stored = await api.uploadAttachment(sessionId, attachment.file);
-      update(attachment.key, { status: 'uploaded', attachment: stored });
+      const stored = await api.uploadAttachment(sessionId, attachment.file, ({ loaded }) => {
+        update(attachment.key, { uploadedBytes: loaded });
+      });
+      update(attachment.key, {
+        status: 'uploaded', uploadedBytes: attachment.file.size, attachment: stored,
+      });
       uploaded.push(stored);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'upload failed';
       update(attachment.key, { status: 'error', error: message });
-      throw error;
+      firstFailure ??= error instanceof Error ? error : new Error(message);
     }
   }
+  if (firstFailure) throw firstFailure;
   return uploaded;
 }

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -13,6 +13,7 @@ export interface PendingAttachment {
   previewUrl?: string;
   status: PendingAttachmentStatus;
   uploadedBytes?: number;
+  uploadController?: AbortController;
   error?: string;
   attachment?: Attachment;
 }
@@ -127,6 +128,19 @@ export function revokePendingAttachments(attachments: PendingAttachment[]) {
   }
 }
 
+/** Abandon an unsent chip: stop its transfer and remove any stored server file. */
+export function discardPendingAttachment(sessionId: string, attachment: PendingAttachment) {
+  attachment.uploadController?.abort();
+  if (attachment.attachment) {
+    void api.deleteAttachment(sessionId, attachment.attachment.id).catch(() => {});
+  }
+  if (attachment.previewUrl) URL.revokeObjectURL(attachment.previewUrl);
+}
+
+export function discardPendingAttachments(sessionId: string, attachments: PendingAttachment[]) {
+  for (const attachment of attachments) discardPendingAttachment(sessionId, attachment);
+}
+
 export const defaultAttachmentPrompt = (count: number) =>
   `Please inspect the attached file${count === 1 ? '' : 's'}.`;
 
@@ -138,6 +152,13 @@ export async function uploadPendingAttachments(
 ) {
   const uploaded: Attachment[] = [];
   let firstFailure: Error | null = null;
+  const controllers = new Map<string, AbortController>();
+  for (const attachment of attachments) {
+    if (attachment.attachment || attachmentFileError(attachment.file)) continue;
+    const controller = new AbortController();
+    controllers.set(attachment.key, controller);
+    update(attachment.key, { uploadController: controller });
+  }
   for (const attachment of attachments) {
     if (attachment.attachment) {
       uploaded.push(attachment.attachment);
@@ -149,18 +170,33 @@ export async function uploadPendingAttachments(
       firstFailure ??= new Error(invalid);
       continue;
     }
+    const controller = controllers.get(attachment.key)!;
+    if (controller.signal.aborted) continue;
     update(attachment.key, { status: 'uploading', uploadedBytes: 0, error: undefined });
     try {
-      const stored = await api.uploadAttachment(sessionId, attachment.file, ({ loaded }) => {
-        update(attachment.key, { uploadedBytes: loaded });
+      const stored = await api.uploadAttachment(sessionId, attachment.file, {
+        signal: controller.signal,
+        onProgress: ({ loaded }) => update(attachment.key, { uploadedBytes: loaded }),
       });
+      // An abort can race the final response: XHR may have settled while the
+      // click that removed the chip already marked the controller aborted.
+      // In that narrow window we learned the id, so remove the now-unsent file.
+      if (controller.signal.aborted) {
+        await api.deleteAttachment(sessionId, stored.id).catch(() => undefined);
+        continue;
+      }
       update(attachment.key, {
-        status: 'uploaded', uploadedBytes: attachment.file.size, attachment: stored,
+        status: 'uploaded', uploadedBytes: attachment.file.size,
+        uploadController: undefined, attachment: stored,
       });
       uploaded.push(stored);
     } catch (error) {
+      if (controller.signal.aborted) {
+        update(attachment.key, { uploadController: undefined });
+        continue;
+      }
       const message = error instanceof Error ? error.message : 'upload failed';
-      update(attachment.key, { status: 'error', error: message });
+      update(attachment.key, { status: 'error', uploadController: undefined, error: message });
       firstFailure ??= error instanceof Error ? error : new Error(message);
     }
   }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -195,19 +195,22 @@ body {
 .image-pick:disabled { opacity: 0.38; cursor: not-allowed; }
 .image-pick svg { width: 15px; height: 15px; }
 .image-attachments-note { min-width: 0; color: var(--muted); font-size: 10px; line-height: 1.3; }
-.image-chip { min-width: 0; max-width: 205px; height: 36px; display: flex; align-items: center; gap: 6px; padding: 3px 5px 3px 3px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
-.image-chip.error { border-color: color-mix(in srgb, var(--danger) 48%, var(--border)); }
+.image-chip { min-width: 0; max-width: 250px; height: 38px; display: flex; align-items: center; gap: 6px; padding: 3px 5px 3px 3px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
+.image-chip.error { max-width: min(100%, 360px); height: auto; min-height: 38px; border-color: color-mix(in srgb, var(--danger) 48%, var(--border)); }
 .image-chip.uploading { border-color: color-mix(in srgb, var(--accent) 42%, var(--border)); }
 .image-chip-preview { flex: none; width: 29px; height: 28px; border-radius: 3px; overflow: hidden; background: var(--panel-2); }
 .image-chip-preview:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
 .image-chip img { display: block; width: 29px; height: 28px; object-fit: cover; }
 .image-chip-placeholder { flex: none; width: 29px; height: 28px; display: inline-flex; align-items: center; justify-content: center; border-radius: 3px; background: var(--panel-2); color: var(--muted); font-size: 8px; }
-.image-chip-copy { min-width: 0; display: flex; flex-direction: column; line-height: 1.15; }
+.image-chip-copy { flex: 1; min-width: 0; display: flex; flex-direction: column; line-height: 1.15; }
 .image-chip-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; font-weight: 600; }
 .image-chip-meta { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; margin-top: 2px; color: var(--muted); font: 9.5px var(--font-mono); }
-.image-chip.error .image-chip-meta { color: var(--danger); }
-.image-chip.uploading .image-chip-meta { color: var(--accent); animation: breathe 1.2s ease-in-out infinite; }
+.image-chip.error .image-chip-meta { overflow: visible; text-overflow: clip; white-space: normal; color: var(--danger); line-height: 1.25; }
+.image-chip.uploading .image-chip-meta { color: var(--accent); }
+.image-chip-progress { display: block; width: 100%; height: 2px; margin-top: 3px; overflow: hidden; border-radius: 1px; background: color-mix(in srgb, var(--accent) 16%, var(--panel-2)); }
+.image-chip-progress > span { display: block; height: 100%; border-radius: inherit; background: var(--accent); transition: width 120ms linear; }
 .image-chip > button { flex: none; padding: 1px; border: none; background: transparent; color: var(--muted); font: 13px/1 var(--font-sans); cursor: pointer; }
+.image-chip > .image-chip-retry { color: var(--danger); font-size: 9px; font-weight: 650; }
 .image-chip > button:hover:not(:disabled) { color: var(--text); }
 .image-chip > button:disabled { opacity: 0.35; cursor: default; }
 .quick .image-attachments { align-items: flex-start; }
@@ -240,6 +243,7 @@ body {
 .fp { display: flex; flex-direction: column; gap: 4px; }
 .fp-current { display: flex; align-items: center; gap: 7px; width: 100%; padding: 7px 10px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md); color: var(--text); font: inherit; font-size: 12.5px; cursor: pointer; text-align: left; }
 .fp-current:hover { border-color: var(--border-strong); }
+.fp-current:disabled { opacity: 0.5; cursor: not-allowed; }
 .fp-ico { flex: none; width: 14px; height: 14px; color: var(--muted); }
 .fp-row .fp-ico { width: 13px; height: 13px; margin-right: 4px; }
 .fp-path { flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
@@ -892,7 +896,7 @@ body {
 .term-image-status { position: absolute; z-index: 8; left: 50%; bottom: 10px; transform: translateX(-50%); max-width: calc(100% - 24px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--r-sm); background: color-mix(in srgb, var(--term-bg) 92%, transparent); color: var(--muted); box-shadow: 0 4px 14px rgb(0 0 0 / 0.12); font-size: 10.5px; pointer-events: none; }
 .term-image-status.uploading { color: var(--accent); animation: breathe 1.2s ease-in-out infinite; }
 .term-image-status.success { color: var(--go); }
-.term-image-status.error { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 40%, var(--border)); }
+.term-image-status.error { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 40%, var(--border)); white-space: normal; text-overflow: clip; }
 .term-image-status.has-action { display: flex; align-items: center; gap: 8px; pointer-events: auto; }
 .term-image-status button { padding: 0; border: 0; background: none; color: inherit; font: inherit; font-weight: 700; cursor: pointer; text-decoration: underline; text-underline-offset: 2px; }
 .term-image-status button:disabled { opacity: 0.45; cursor: default; }


### PR DESCRIPTION
## Summary

- upload files as soon as they are chosen, pasted, or dropped in reader, Overview, quick creation, and terminal flows
- replace `fetch` for file bodies with an XHR transport that reports transferred bytes/percentage and distinguishes server, proxy, offline, and interrupted-connection failures
- keep Send/launch disabled until every attachment is server-confirmed; retry failed files in place and reuse successful attachment ids without reuploading
- preserve the specific failure reason when a later file in a terminal batch fails, instead of replacing it with “another failed to upload”
- document the attachment-time lifecycle and extend the browser suite for timing, progress, large files, interrupted requests, proxy errors, and quickstart id reuse

Quick creation needs a session id before it has an attachment scope, so its first file creates a stopped session immediately and uploads there. The CLI is not launched until the operator sends.

## Failure investigation

The server-side stream was not silently losing files in the cases I could reproduce:

- A 99 MiB file completed locally with HTTP 201.
- A 101 MiB request returned the explicit server error `413 file is larger than 100 MB`.
- Cutting a throttled upload after two seconds left no `.part` file; the server cleanup path worked.

The actionable error was being lost in the browser/UI:

1. Uploads in reader and Overview did not start until Send, so there was no opportunity to see or recover from a transfer failure beforehand.
2. Chromium reduces an interrupted `fetch` request to the statusless `TypeError: Failed to fetch`; that opaque string was the only reason the chip could show.
3. If a later terminal-batch file failed, the UI deliberately discarded even that error and displayed only “another failed to upload.”
4. A non-JSON ingress/proxy rejection was reduced to a bare HTTP number by the JSON-only response parser. The regression suite simulates an HTML `413` response and now reports what it means and what to do.

This PR changes the browser transport and error presentation while leaving the server's bounded streaming and partial-file cleanup intact.

## Verification

- `npm test` (`server`) — full suite passed
- `npm run typecheck && npm test` (`web`) — passed
- `SCREENSHOT_PORT=17899 PLAYWRIGHT_BROWSERS_PATH=$AM_LOCAL/pw-browsers/uploads npm run test:screenshots` (`server`) — all checks passed
- real Chromium upload throttled to 256 KiB/s: a 2 MiB body emitted 79 progress events (32 KiB through 2 MiB) and completed with HTTP 201
- interrupted browser request: immediate chip error named the interrupted connection and exposed Retry; retry succeeded
- client-side 101 MiB file: rejected on attachment with `too large (100 MB max)` before upload
- mobile-width visual inspection: long connection errors wrap without truncation; retry/remove remain reachable; the 20% / byte-count progress state remains compact
- `git diff --check` — clean

No production Space was changed or deployed.
