### PR TITLE
Reader: align the newest prompt, trim under the composer, controls on the first line

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -297,10 +297,17 @@ pane with nothing to render (a shell) simply stays a terminal.
 
 - **Below the composer, only an action earns the space.** The reader used to end in a strip of
   grey: the workspace's absolute path and the date the conversation started, printed under a reply
-  box. The path is in the pane header a few centimetres above and in the Files pane; the date —
-  the one fact nothing else showed, since turn times are clock-only — now rides on the turn
-  count's tooltip. What is left is `continue in a new agent`, and when there is no handover to
-  offer the footer does not render at all rather than leaving an empty bordered strip.
+  box. The path goes for good — on a desktop it is in the pane header and the Files pane, and on a
+  phone `.ph-path` is hidden by `@container (max-width: 520px)`, so there it is simply nowhere in
+  the reader, which is the right amount of nowhere for a path under a reply box. The date stays,
+  because turn times are clock-only and nothing else says which *day*; it is text in `.cxv-bar`
+  beside the other conversation-level facts. **Not a `title`** — a tooltip cannot be opened by
+  touch at all (iOS long-press opens the callout menu instead), so parking it there amounts to
+  deleting the fact on the device these items were filed from while claiming to keep it. The bar
+  wraps at any width, so the date costs no height: the reader body measures the same at 320 and
+  390 with it as without. What is left below the composer is `continue in a new agent`, and with
+  no handover to offer the footer does not render at all rather than leaving an empty bordered
+  strip.
 
   Both surfaces use one `Composer` component. A composer accretes features — paste-to-attach,
   history recall, a slash-command menu — and duplicated markup is how one surface quietly gets

--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -278,8 +278,29 @@ pane with nothing to render (a shell) simply stays a terminal.
   round trip, which left a beat where the box was still full and nothing had happened. A failed
   send withdraws the echo and puts the text back in the box.
 
+  The echo is a `PendingExchange` — a `.cx` section, the same shape as the turn it becomes a
+  second later — and not a loose `.cx-prompt`. Written out by hand it was neither: the band's
+  `margin-left` exists to cancel `.cx`'s matching padding, so with no `.cx` around it the newest
+  prompt in a conversation hung a gutter's width left of every prompt above it, its `❯` half off
+  the pane on a phone. One component, both surfaces, so it cannot drift apart again.
+
   Only a trace with **no agent behind it** — a shared file, an import — is read-only, which is
   what `readOnly` is for.
+
+- **The composer's controls sit on the draft's first line.** A composer grows downward as you
+  type; controls centred in it drift down with the text, so at six lines on a phone the `❯` and
+  the paperclip ended up 56px below the line they belong to, level with the middle of a sentence.
+  Alignment is `start`, and each control is then offset by half the difference between its own
+  height and the first line's — `--ov-first-line`, restated wherever the textarea's size is
+  decided (13px in the card, `--cx-base` in the reader, 16px on a touch phone, where iOS demands
+  it). A one-line composer looks exactly as it did.
+
+- **Below the composer, only an action earns the space.** The reader used to end in a strip of
+  grey: the workspace's absolute path and the date the conversation started, printed under a reply
+  box. The path is in the pane header a few centimetres above and in the Files pane; the date —
+  the one fact nothing else showed, since turn times are clock-only — now rides on the turn
+  count's tooltip. What is left is `continue in a new agent`, and when there is no handover to
+  offer the footer does not render at all rather than leaving an empty bordered strip.
 
   Both surfaces use one `Composer` component. A composer accretes features — paste-to-attach,
   history recall, a slash-command menu — and duplicated markup is how one surface quietly gets

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/mobileBack.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs",
+    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -15,7 +15,7 @@ import type { PendingAttachment } from '../lib/attachments';
 import Attachments from './Attachments';
 import Logo from './Logo';
 import Composer from './conversation/Composer';
-import ExchangeView from './conversation/Exchange';
+import ExchangeView, { PendingExchange } from './conversation/Exchange';
 import { useDraft } from './conversation/useDraft';
 import { writePaneMode } from '../lib/paneMode';
 import { splitExchanges } from './conversation/exchanges';
@@ -324,12 +324,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
             </div>
             {/* Optimistic echo: the digest round-trip can take seconds, and a
                 frozen card reads as "did that get lost?". */}
-            {justSent && sent && (
-              <>
-                <div className="cx-prompt">{sent.text}</div>
-                <div className="cx-running mono">working</div>
-              </>
-            )}
+            {justSent && sent && <PendingExchange text={sent.text} />}
           </>
         ) : (
           /* No transcript to read yet (never started, or a harness with no

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -35,6 +35,15 @@ const NEAR_TOP_PX = 300;   // start fetching older turns before the reader arriv
 const fmtNum = (n: number) => n.toLocaleString();
 const fmtUsage = (u?: { in: number; out: number } | null) =>
   (u ? `${fmtTok(u.in)}↓ ${fmtTok(u.out)}↑` : '');
+/** The day a conversation started: "14 Aug", and the year too when it is not
+ *  this one. Turn times are clock-only, so this is the only place a reader can
+ *  learn which day — it has to be readable, not hidden behind a hover. */
+const fmtStarted = (ms: number) => {
+  const d = new Date(ms);
+  return d.toLocaleDateString(undefined, d.getFullYear() === new Date().getFullYear()
+    ? { month: 'short', day: 'numeric' }
+    : { year: 'numeric', month: 'short', day: 'numeric' });
+};
 
 export default function ConversationView({ session, paused, isMobile, readOnly, onHandover, onReady, readyKey }: {
   session: Session;
@@ -410,19 +419,24 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
           header above has no spare width. */}
       <div className="cxv-bar mono">
         {head.model && <span className="cxv-chip">{head.model}</span>}
-        <span className="cxv-count" title={[
-          head.total != null ? `${fmtNum(head.total)} messages in this conversation` : `${fmtNum(head.loaded)} messages loaded`,
-          // The one fact the footer line below the composer carried that
-          // nothing else shows: turn times are clock-only, so a conversation
-          // read on Friday never says which day it started.
-          head.firstTs ? `started ${new Date(head.firstTs).toLocaleDateString()}` : '',
-        ].filter(Boolean).join(' · ')}>
+        <span className="cxv-count" title={head.total != null ? `${fmtNum(head.total)} messages in this conversation` : `${fmtNum(head.loaded)} messages loaded`}>
           {fmtNum(exchanges.length)} turn{exchanges.length === 1 ? '' : 's'}
           {head.total != null && head.loaded < head.total ? ` of ${fmtNum(head.total)} messages` : ''}
         </span>
         {head.usage && (
           <span className="cxv-tok" title={head.usage.cacheRead ? `${fmtNum(head.usage.cacheRead)} cached` : undefined}>
             {fmtUsage(head.usage)}
+          </span>
+        )}
+        {/* When the conversation started. It used to be printed under the
+            composer, and briefly lived on the tooltip above — which a phone
+            cannot open at all, so on the device these items were filed from the
+            fact was nowhere. Here it is text among the other conversation-level
+            facts, and the bar wraps at any width, so it costs no height: the
+            reader body measures the same at 320 and 390 with it as without. */}
+        {head.firstTs != null && (
+          <span className="cxv-when" title={new Date(head.firstTs).toLocaleString()}>
+            {fmtStarted(head.firstTs)}
           </span>
         )}
         <span className="spacer" />

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -26,7 +26,7 @@ import type { PendingAttachment } from '../../lib/attachments';
 import { recallReading, rememberReading } from './readingPosition';
 import { useDraft } from './useDraft';
 import { fmtTok, splitExchanges } from './exchanges';
-import ExchangeView from './Exchange';
+import ExchangeView, { PendingExchange } from './Exchange';
 import Attachments from '../Attachments';
 import Composer from './Composer';
 
@@ -410,7 +410,13 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
           header above has no spare width. */}
       <div className="cxv-bar mono">
         {head.model && <span className="cxv-chip">{head.model}</span>}
-        <span className="cxv-count" title={head.total != null ? `${fmtNum(head.total)} messages in this conversation` : `${fmtNum(head.loaded)} messages loaded`}>
+        <span className="cxv-count" title={[
+          head.total != null ? `${fmtNum(head.total)} messages in this conversation` : `${fmtNum(head.loaded)} messages loaded`,
+          // The one fact the footer line below the composer carried that
+          // nothing else shows: turn times are clock-only, so a conversation
+          // read on Friday never says which day it started.
+          head.firstTs ? `started ${new Date(head.firstTs).toLocaleDateString()}` : '',
+        ].filter(Boolean).join(' · ')}>
           {fmtNum(exchanges.length)} turn{exchanges.length === 1 ? '' : 's'}
           {head.total != null && head.loaded < head.total ? ` of ${fmtNum(head.total)} messages` : ''}
         </span>
@@ -481,12 +487,7 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
               />
             </div>
           ))}
-          {sent && (
-            <>
-              <div className="cx-prompt">{sent.text}</div>
-              <div className="cx-running mono">working</div>
-            </>
-          )}
+          {sent && <PendingExchange text={sent.text} />}
           {!exchanges.length && !sent && <div className="cxv-msg mono">nothing in this trace yet</div>}
         </div>
       </div>
@@ -514,18 +515,20 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
       )}
       {(attachmentError || failed) && <div className="ov-note cxv-note" role="alert">{attachmentError || failed}</div>}
 
-      <div className="cxv-foot mono">
-        <span className="cxv-path" title={head.cwd || undefined}>
-          {head.cwd}
-          {head.firstTs ? ` · ${new Date(head.firstTs).toLocaleDateString()}` : ''}
-        </span>
-        <span className="spacer" />
-        {onHandover && (
+      {/* Below the composer, only an action earns the space. What used to live
+          here — the workspace's absolute path and the date the conversation
+          started — was reference material printed under a reply box: the path
+          is in the pane header a few centimetres above (and in the Files pane),
+          and the date now rides on the turn-count's tooltip. A reader that ends
+          in a strip of grey path is a reader that ends in nothing to do. */}
+      {onHandover && (
+        <div className="cxv-foot mono">
+          <span className="spacer" />
           <button className="cxv-mini" onClick={onHandover} title="Start a new agent from this conversation">
             continue in a new agent ↗
           </button>
-        )}
-      </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -233,4 +233,23 @@ export function ExchangeView({
   );
 }
 
+/**
+ * The prompt you just sent, before the transcript has caught up.
+ *
+ * It is laid out as an exchange — a `.cx` section, exactly like the turn it
+ * becomes a second later — and not as a loose band. Written out by hand at both
+ * call sites it was neither: `.cx-prompt`'s `margin-left: -1.23em` exists to
+ * cancel `.cx`'s matching padding, and with no `.cx` around it there was
+ * nothing to cancel, so the newest prompt in a conversation hung 16px left of
+ * every prompt above it — in the reader and in the card alike.
+ */
+export function PendingExchange({ text }: { text: string }) {
+  return (
+    <section className="cx">
+      <div className="cx-prompt">{text}</div>
+      <div className="cx-running mono">working</div>
+    </section>
+  );
+}
+
 export default ExchangeView;

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -219,7 +219,6 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
   padding: 5px 10px; border-top: 1px solid var(--border); background: var(--panel);
   color: var(--muted); font-size: 0.81em; overflow: hidden;
 }
-.cxv-foot .cxv-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .cxv-foot .spacer { flex: 1; min-width: 4px; }
 
 /* The prompt band used to stick to the top of this scroller, on the theory that
@@ -236,7 +235,11 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    rather than as the head of it. Full bleed both sides, with the text inside
    still on the column. */
 .cxv-col .cx-prompt { margin-right: calc(-1 * var(--cx-gutter)); padding-right: var(--cx-gutter); }
-.cxv-body > .cxv-col > .cx { padding-left: 16px; }
+/* No px restatement of .cx's own 1.23em gutter here. The rule that used to sit
+   on this line never matched anything (every exchange is wrapped in a row div,
+   so no .cx is a direct child of .cxv-col) — and the moment one was, it would
+   have pinned the newest turn to 16px while every turn above it kept the em and
+   moved under zoom. */
 
 /* Grouping: the meta row is the prompt's, not the answer's, so it sits tight
    under the band — and one exchange ends well before the next begins. */
@@ -299,10 +302,14 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 /* The card's reply line is a fixed 13px; here it follows the conversation above
    it, the way the remote pane's composer follows its log. */
 .cxv-live .ov-p, .cxv-live textarea { font-size: 1em; }
+.cxv-composer { --ov-first-line: calc(1.45em + 4px); }
 .cxv-note { flex: none; padding: 0 12px 6px; }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the
      rule above is later in the cascade, so it would otherwise win. A phone
      keyboard field is the one place the zoom does not reach. */
   .cxv-live textarea { font-size: 16px; }
+  /* …and the first line the controls align to is that pinned 16px one, not the
+     conversation's own type size, or they sit a couple of pixels high of it. */
+  .cxv-composer { --ov-first-line: calc(1.45 * 16px + 4px); }
 }

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -171,7 +171,9 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 }
 .cxv-bar .spacer { flex: 1; }
 .cxv-chip { padding: 0 5px; border: 1px solid var(--border); border-radius: var(--r-sm); white-space: nowrap; }
-.cxv-count, .cxv-tok { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-variant-numeric: tabular-nums; }
+.cxv-count, .cxv-tok, .cxv-when { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-variant-numeric: tabular-nums; }
+/* the day it started — the last of the bar's facts to give up room */
+.cxv-when { flex: 0 1 auto; }
 .cxv-tok { flex: 0 1 auto; }
 .cxv-mini {
   flex: none; white-space: nowrap; background: none; border: 1px solid transparent; border-radius: var(--r-sm);
@@ -242,9 +244,12 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    moved under zoom. */
 
 /* Grouping: the meta row is the prompt's, not the answer's, so it sits tight
-   under the band — and one exchange ends well before the next begins. */
+   under the band. What separates one exchange from the next is the band itself
+   — its top hairline and tint — not a margin: the rule that used to add 15px
+   here needed two .cx siblings directly under .cxv-col, and there has never
+   been one pair (every exchange sits in its own row div). Removed with the
+   other dead gutter rule above rather than left to be read as live. */
 .cxv-col .cx-prompt + .cx-meta { margin-top: -3px; }
-.cxv-col > .cx + .cx { margin-top: 15px; }
 
 /* ---------- phone ---------- */
 @media (max-width: 720px) {
@@ -302,7 +307,12 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 /* The card's reply line is a fixed 13px; here it follows the conversation above
    it, the way the remote pane's composer follows its log. */
 .cxv-live .ov-p, .cxv-live textarea { font-size: 1em; }
-.cxv-composer { --ov-first-line: calc(1.45em + 4px); }
+/* Two selectors set this on the SAME element — the reader's composer carries
+   both classes — so this one is written to win on specificity (0,2,0 against
+   styles.css's 0,1,0) rather than on which stylesheet main.tsx imports second.
+   Swapping those two imports would otherwise drop the reader back to a
+   hardcoded 13px line and mis-centre the controls at every zoom but 100%. */
+.ov-composer.cxv-composer { --ov-first-line: calc(1.45em + 4px); }
 .cxv-note { flex: none; padding: 0 12px 6px; }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the
@@ -311,5 +321,5 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
   .cxv-live textarea { font-size: 16px; }
   /* …and the first line the controls align to is that pinned 16px one, not the
      conversation's own type size, or they sit a couple of pixels high of it. */
-  .cxv-composer { --ov-first-line: calc(1.45 * 16px + 4px); }
+  .ov-composer.cxv-composer { --ov-first-line: calc(1.45 * 16px + 4px); }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -408,15 +408,30 @@ body {
 .ov-x:hover { color: var(--text); }
 
 /* reply: a quiet, always-there input line — its ❯ mirrors the prompt's */
-.ov-composer { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: center; gap: 7px 8px; border-top: 1px solid var(--border); padding-top: 7px; }
+/* Controls sit on the FIRST line of the draft, not in the middle of it. A
+   composer grows downward as you type, and centred controls drift down with it
+   — at six lines on a phone the ❯ and the paperclip ended up 56px below the
+   line they belong to, next to the middle of a sentence. Alignment is start,
+   and each control is then nudged to the centre of that first line box (its
+   height is the textarea's line-height plus the textarea's 2px padding), so a
+   one-line composer looks exactly as it always has. */
+.ov-composer { --ov-first-line: calc(1.45 * 13px + 4px); display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: start; gap: 7px 8px; border-top: 1px solid var(--border); padding-top: 7px; }
 .ov-composer.image-drop { outline: 1px dashed var(--accent); outline-offset: 5px; background: var(--drop); }
 .ov-composer .image-attachments.has-images { grid-column: 1 / -1; }
 .ov-composer .image-attachments.has-note { grid-column: 1 / -1; }
 .ov-composer .image-attachments.has-images + .ov-live,
 .ov-composer .image-attachments.has-note + .ov-live { grid-column: 1 / -1; }
 .ov-composer .ov-live { border-top: none; padding-top: 0; }
-.ov-live { display: flex; gap: 8px; align-items: center; border-top: 1px solid var(--border); padding-top: 7px; font-size: 13px; }
-.ov-live .ov-p { color: var(--accent); font-weight: 700; font-size: 13px; }
+.ov-live { display: flex; gap: 8px; align-items: flex-start; border-top: 1px solid var(--border); padding-top: 7px; font-size: 13px; }
+/* Each control is centred on the first line rather than on the whole box. The
+   offset is the same expression every time — half the difference between the
+   line and the control — so a control keeps its own size and still lands on the
+   line. --ov-first-line is restated wherever the textarea's size is (below, and
+   in conversation.css for the reader), because that is what it measures. */
+.ov-live .ov-p {
+  color: var(--accent); font-weight: 700; font-size: 13px; line-height: 1.45; padding: 2px 0;
+  margin-top: calc((var(--ov-first-line) - (1.45em + 4px)) / 2);
+}
 .ov-live textarea { flex: 1; min-width: 0; border: none; background: none; font: inherit; font-size: 13px; line-height: 1.45; color: var(--text); outline: none; padding: 2px 0; resize: none; overflow: hidden; max-height: 140px; }
 .ov-live textarea::placeholder { color: var(--muted); opacity: 0.7; }
 .ov-hint { font-size: 10.5px; color: var(--muted); flex: none; }
@@ -424,6 +439,9 @@ body {
 /* A square key, not a bubble: it sits at the end of a line of type, and the
    rounded pill read as a chat app rather than as a prompt. */
 .ov-send { flex: none; width: 26px; height: 26px; padding: 0; border: none; border-radius: 7px; background: var(--accent); color: var(--accent-fg); cursor: pointer; display: inline-flex; align-items: center; justify-content: center; }
+/* the two square controls, centred on the first line by the same expression */
+.ov-live .ov-send { margin-top: calc((var(--ov-first-line, calc(1.45 * 13px + 4px)) - 26px) / 2); }
+.ov-composer .image-pick { margin-top: calc((var(--ov-first-line, calc(1.45 * 13px + 4px)) - 28px) / 2); }
 .ov-send svg { width: 15px; height: 15px; }
 .ov-send:disabled { opacity: 0.5; cursor: default; }
 .ov-note { font-size: 11px; color: var(--danger); }
@@ -1283,6 +1301,7 @@ a.btn-ghost { text-decoration: none; }
      DESKTOP window keeps the reply line at card size */
   @media (pointer: coarse) {
     .widget input, .widget select, .row .rename, .secret-desc, .fp-input, .pane-head .ph-title-input, .ov-live textarea { font-size: 16px; }
+    .ov-composer { --ov-first-line: calc(1.45 * 16px + 4px); }
   }
   .ov-headrow { flex-wrap: wrap; }
   /* install page: the decorative sidebar makes no sense on a phone */

--- a/web/test/composerAlign.test.mjs
+++ b/web/test/composerAlign.test.mjs
@@ -1,0 +1,81 @@
+// The composer's controls sit on the FIRST line of the draft, and the offset
+// that puts them there is measured from that line's height: `--ov-first-line`.
+//
+// The bug this pins is not the alignment, it is the *drift*. The line's height
+// is the textarea's line-height times the textarea's font size — and that font
+// size is pinned in three different places (the card's 13px, the reader's `1em`
+// so it follows zoom, and 16px on a touch phone because iOS zooms the page on
+// any smaller field). Add a fourth pin without a matching `--ov-first-line` and
+// nothing breaks loudly: the controls simply sit a couple of pixels off the
+// line, at one breakpoint, which is exactly what happened on the phone while
+// this was being written.
+//
+// So: every size the input is pinned to must have a first-line height declared
+// for it. No runner, no DOM — this reads the two stylesheets. Run with:
+//   node test/composerAlign.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8');
+const css = `${read('styles.css')}\n${read('conversation.css')}`;
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+// Every rule that pins the composer textarea's size, and what it pins it to.
+const pinned = new Set();
+for (const [, selector, body] of css.matchAll(/([^{}]*textarea[^{}]*)\{([^}]*)\}/g)) {
+  if (!/ov-live|cxv-live/.test(selector)) continue;
+  const size = body.match(/font-size:\s*([^;]+);/);
+  if (size) pinned.add(size[1].trim());
+}
+// …and every first-line height declared, reduced to the size it is built from.
+const declared = new Set();
+for (const [, value] of css.matchAll(/--ov-first-line:\s*calc\(([^;]+)\);/g)) {
+  const px = value.match(/1\.45\s*\*\s*([\d.]+px)/);
+  declared.add(px ? px[1] : (/1\.45em/.test(value) ? '1em' : value.trim()));
+}
+
+console.log('the first line is measured wherever the input is sized');
+check(`something pins the input's size (found: ${[...pinned].join(', ') || 'nothing'})`,
+  () => assert.ok(pinned.size >= 2));
+check(`and each of those sizes has a first-line height (found: ${[...declared].join(', ') || 'nothing'})`,
+  () => assert.deepEqual([...pinned].sort(), [...declared].sort()));
+
+console.log('\nand every control is offset from that one number');
+for (const [what, selector] of [
+  ['the ❯', /\.ov-live \.ov-p \{[^}]*\}/],
+  ['the send key', /\.ov-live \.ov-send \{[^}]*\}/],
+  ['the paperclip', /\.ov-composer \.image-pick \{[^}]*\}/],
+]) {
+  check(`${what} centres on the first line`, () => {
+    const rule = css.match(selector);
+    assert.ok(rule, `no rule matched ${selector}`);
+    assert.match(rule[0], /margin-top:\s*calc\(\(var\(--ov-first-line/);
+  });
+}
+check('and the row is top-aligned, or there is no first line to sit on',
+  () => assert.match(css, /\.ov-live \{[^}]*align-items:\s*flex-start/));
+check('…including the strip the paperclip lives in',
+  () => assert.match(css, /\.ov-composer \{[^}]*align-items:\s*start/));
+
+console.log('\nand the reader wins on specificity, not on import order');
+check('the reader restates it as .ov-composer.cxv-composer (0,2,0)', () => {
+  assert.match(css, /\.ov-composer\.cxv-composer \{[^}]*--ov-first-line/);
+  // Both classes are on the same element, so a bare .cxv-composer here would
+  // tie with styles.css's .ov-composer and be decided by main.tsx's import
+  // order — swap those two lines and the reader silently takes the card's
+  // hardcoded 13px line and mis-centres at every zoom but 100%.
+  assert.doesNotMatch(css, /(^|[\s,>])\.cxv-composer \{[^}]*--ov-first-line/m);
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -1,0 +1,86 @@
+// The prompt you just sent, before the transcript catches up — and the one
+// thing about it that can silently break.
+//
+// `.cx-prompt` carries `margin-left: -1.23em`, which exists ONLY to cancel the
+// matching `padding-left` on the `.cx` section around it. Written as a loose
+// band with no section, that negative margin has nothing to cancel and the
+// newest prompt in a conversation hangs a gutter's width left of every prompt
+// above it — 16px at the base size, its ❯ half off the pane on a phone. That
+// was live in both the reader and the Overview card, and nothing failed.
+//
+// So this pins the nesting, not the pixels: the echo is a `.cx` section with the
+// band inside it, the same shape ExchangeView gives a real turn. Same style as
+// exchanges.test.mjs — esbuild is already here for vite, so the component is
+// transpiled and rendered with react-dom/server. Run with:
+//   node test/pendingExchange.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+// Inside node_modules, not os.tmpdir(): react stays external to the bundle, so
+// the output has to sit somewhere that can resolve it.
+const outDir = path.join(HERE, '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const out = path.join(outDir, 'exchange.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/components/conversation/Exchange.tsx')],
+  outfile: out, format: 'esm', bundle: true, jsx: 'automatic', logLevel: 'error',
+  external: ['react', 'react-dom', 'react/jsx-runtime'],
+});
+const { PendingExchange, ExchangeView } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const render = (Component, props) => renderToStaticMarkup(createElement(Component, props));
+const html = render(PendingExchange, { text: 'what changed in the deploy config?' });
+
+console.log('the echo is an exchange, not a loose band');
+check('it is wrapped in a .cx section — the padding that cancels the band’s margin',
+  () => assert.match(html, /^<section class="cx">/));
+check('the prompt band is INSIDE that section, never a sibling of it',
+  () => assert.match(html, /^<section class="cx">\s*<div class="cx-prompt">/));
+check('…and the section closes after it, so nothing escapes the wrapper',
+  () => assert.match(html, /<\/section>$/));
+check('the prompt text is the prompt you sent',
+  () => assert.match(html, />what changed in the deploy config\?</));
+check('a working line rides inside the same section',
+  () => assert.match(html, /<div class="cx-running mono">working<\/div>\s*<\/section>/));
+
+console.log('\nand it has the shape of the turn it becomes a second later');
+// A real turn at the same moment the echo represents: asked, not yet answered.
+// (No answer also keeps renderMarkdown out of it — DOMPurify needs a DOM, and
+// this test is about the wrapper, not about markdown.)
+const turn = {
+  key: 'x1', at: 1, startTs: 1_700_000_000_000, endTs: 1_700_000_030_000, tokens: 0, toolCalls: 0,
+  prompt: { role: 'user', ts: 1_700_000_000_000, blocks: [{ type: 'text', text: 'what changed in the deploy config?' }] },
+  steps: [], answer: [],
+};
+const real = render(ExchangeView, { x: turn, n: 1, total: 1 });
+check('a real turn opens with the same wrapper',
+  () => assert.match(real, /^<section class="cx">/));
+check('with its prompt band in the same place',
+  () => assert.match(real, /^<section class="cx">\s*<div class="cx-prompt">/));
+check('so the echo and the turn share one left edge',
+  () => assert.equal(html.slice(0, html.indexOf('cx-prompt')), real.slice(0, real.indexOf('cx-prompt'))));
+
+console.log('\nand the CSS pair the nesting exists for is still a pair');
+const css = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');
+check('.cx pays out the gutter in em', () => assert.match(css, /\.cx\s*\{[^}]*padding:[^;]*1\.23em/));
+check('.cx-prompt takes it back, by the same amount',
+  () => assert.match(css, /\.cx-prompt\s*\{[^}]*margin-left:\s*-1\.23em/));
+check('and no px restatement of that gutter has crept back in',
+  () => assert.doesNotMatch(css, /\.cxv-body\s*>\s*\.cxv-col\s*>\s*\.cx\s*\{[^}]*padding-left/));
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Three items from the operator's design list (`improv.md`), all in the rendered conversation's prompt/composer area. Each was reproduced and measured at a real viewport first — desktop 1280×900 and iPhone 13 — not read off the stylesheet.

## 1. The newest prompt sat 16px left of every prompt above it

The optimistic echo — the prompt you just sent, before the transcript catches up — was written out by hand at **both** call sites as a loose `.cx-prompt`:

```jsx
{sent && (<><div className="cx-prompt">{sent.text}</div><div className="cx-running mono">working</div></>)}
```

`.cx-prompt`'s `margin-left: -1.23em` exists to cancel `.cx`'s matching `padding-left`. With no `.cx` around it there was nothing to cancel, so the band hung a full gutter to the left — and on a phone its `❯` was half off the pane edge.

It is a `PendingExchange` now: a `.cx` section, the same shape as the turn it becomes a second later, exported from `Exchange.tsx` and used by the reader **and** the card, so they cannot drift again.

Measured, left edge relative to the reading column:

| | older prompts | newest prompt |
| --- | --- | --- |
| before | `0` | **`-16px`** (parent `.cxv-col`) |
| after | `0` | `0` (parent `.cx`) |

The dead `.cxv-body > .cxv-col > .cx { padding-left: 16px }` rule from #49 goes with it. It matched nothing — every exchange is wrapped in a row div — and the moment something *did* match, it would have pinned that turn to a 16px gutter while every turn above it kept the em and moved under zoom.

## 2. Under the composer was reference material, not an action

The reader ended in a 25px strip of grey: the workspace's **absolute path** and the **date** the conversation started.

- **Removed the path.** Printed under a reply box it is something you read once and then scroll past forever. (An earlier version of this description said "it is in the pane header a few centimetres above" — that holds on a desktop and **not** on a phone, where `styles.css:692` hides `.ph-path` under `@container (max-width: 520px)` and a 390px viewport leaves the pane ~374px. Corrected after review: on a phone the path is now nowhere in the reader, and that is the right amount of nowhere for a path under a reply box.)
- **Kept the date, moved it — twice.** This was the one fact nothing else showed: turn times are clock-only (`fmtClock` → `07:00 PM`), so a conversation read on Friday never said which day it started. It first went onto the turn-count's `title`, which was wrong — touch has no hover, and iOS Safari long-presses into the callout menu, so on the device these items were filed from the fact was shown nowhere at all. It is now **visible text** in `.cxv-bar` (`.cxv-when`, "Aug 14", with the year when it is not this one), beside the model, turns and tokens. Measured before choosing it: the bar `flex-wrap`s at any width, so it costs no height — bar 56px and reader body 548px at 390px, identical with the date and without, and the same at 320px. The full timestamp stays on its own `title` as a bonus for a mouse, never as the only channel.
- **Kept `continue in a new agent ↗`.** It is an action, and it has no other home.
- With no handover to offer, `.cxv-foot` no longer renders at all, instead of leaving an empty bordered strip.

## 3. The arrow and the paperclip drifted down as the draft grew

A composer grows downward as you type, and centred controls follow it. At six lines on a phone the `❯` and the paperclip sat **56px** below the line they belong to, level with the middle of a sentence.

Alignment is `start` now, and each control is offset by half the difference between its own height and the first line's — one expression, three controls. `--ov-first-line` is restated wherever the textarea's size is actually decided (13px in the card, `--cx-base` in the reader, 16px on a touch phone where iOS demands it to prevent zoom-on-focus), because that is the thing it measures.

Controls vs the first line's middle:

| | desktop (2 lines) | phone (6 lines) |
| --- | --- | --- |
| before | arrow/clip/send **+10px** | arrow/clip/send **+56px** |
| after | `0` / `+1px` / `+1px` | `0` / `0` / `0` |

The send key follows the same rule. Leaving it centred while the other two moved would have read as an accident rather than a decision.

## The Overview card

#37 made this renderer shared, so the card was **checked, not assumed** — and it does change, in one intended way:

- its composer's controls land on the first line too: `0.0px` off, empty and one-line drafts, both viewports (before: also ~0, since with one line centring and top-alignment coincide — the visible difference is only in a wrapping draft, screenshot below)
- the reply row is **2.6px shorter on desktop / 0.4px on a phone**, because the negative offsets no longer let the 26px send key set the row's height. If a reviewer wants byte-identical card metrics, a `min-height` on `.ov-live` restores it — I left it out rather than pin a number to an old accident.
- nothing else in the card moves; the compact tile view has no composer and is untouched
- the card's own pending echo goes through the digest's `.ov-prompt` when it has no transcript loaded — that path is unchanged

## Verification

**[Before/after captures, all three items →](https://claude.ai/code/artifact/ca6ab387-8fde-4034-96e0-8f6e5799674b)** — the screenshots below were `/tmp` paths on a dev box whose local disk does not survive a Space restart, so nobody but me could see them. They are now a page anyone can open.

**Two tests pin this in the repo** (added after review; `web/package.json`'s script runs them):

| test | what it pins | fails when |
|---|---|---|
| `web/test/pendingExchange.test.mjs` | the echo renders as a `.cx` section with the band *inside* it, and a real `ExchangeView` turn opens with the same wrapper — so the two share one left edge | the loose-band markup returns: 4 checks fail |
| `web/test/composerAlign.test.mjs` | the set of sizes the composer's textarea is pinned to equals the set of `--ov-first-line` heights declared for them, every control offsets from that variable, and the reader's declaration wins on specificity rather than import order | a fourth size pin is added without a matching line, or the reader's rule loses its specificity: 1 check each |

Both were mutation-tested — I reintroduced each bug and watched the test fail — because a test that cannot fail is decoration.

Local screenshots, before → after, same viewport (superseded by the page above):

- reader, phone: `improv-before-phone-align.png` → `improv-after-phone-align.png` — shows all three at once: the newest prompt's `❯` clipped at the pane edge → aligned; the path strip → gone
- composer, phone: `improv-before-phone-composer.png` → `improv-after-phone-composer.png`
- reader, desktop: `improv-before-desktop-*.png` → `improv-after-desktop-*.png`
- card: `card-before-{desktop,phone}-draft.png` → `card-after-…`, and the stacked crop `cmp2-phone-draft.png`

Typecheck, web suite (11/11) and server suite (all green) pass. `migration.test.mjs` collided with another agent's run once and passed on retry, as expected this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

