### PR TITLE
Surface native TUI input requests in readers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,10 @@ RUN chmod 755 /etc/codex/hooks/am-codex-repin-hook.sh
 # Newer agents, best-effort so a publish hiccup can't break the image build;
 # the app marks any missing binary "unavailable" gracefully.
 RUN npm install -g @google/gemini-cli@latest || echo "gemini-cli install failed"
+# Gemini merges hook arrays across settings layers. The lowest-priority system
+# defaults layer adds an observation-only ToolPermission hook without replacing
+# any user or project hooks.
+COPY gemini-system-defaults.json /etc/gemini-cli/system-defaults.json
 RUN npm install -g opencode-ai@latest || echo "opencode install failed"
 RUN npm install -g openclaw@latest || echo "openclaw install failed"
 # ccusage powers the Usage page (token/cost aggregation across agents). Its

--- a/docs/tui-input-required.md
+++ b/docs/tui-input-required.md
@@ -9,12 +9,12 @@ such as `Allow` in terminal text. Those heuristics cannot distinguish a dialog
 from thinking, a completed turn, documentation, or agent-produced output; a
 false "blocked" badge would be worse than a missed prompt.
 
-The pane reader and Overview card replace their reply composer with a **Needs
-input** banner and an **open terminal** action. The session tile and sidebar
-also identify the condition. The normal composer is hidden because submitting
-text while a choice menu owns stdin can select the wrong option. The prompt and
-attachment APIs refuse the same operation with HTTP 409 while the signal is
-active; direct terminal input remains available.
+The pane reader and Overview card show a **Needs input** banner and an **open
+terminal** action above their normal reply composer. The session tile and
+sidebar also identify the condition. Detection is advisory: the composer,
+prompt API, and attachment delivery stay available while a signal is active.
+A false-positive warning is recoverable; turning it into a write denial would
+make detector error an availability bug.
 
 The reader does not answer the dialog in this version. The CLIs have different
 choice identifiers, validation, queueing, "allow once/always" semantics, and
@@ -80,13 +80,19 @@ removed at process exit.
 
 OpenCode's paired event remains authoritative through menu-navigation input and
 closes immediately when the final queued request closes. Every marker, including
-OpenCode's, also has a 30-minute ceiling so a lost close event cannot disable
-reader prompting indefinitely. For unpaired CLIs, an actual operator key or a
+OpenCode's, also has a 30-minute ceiling so a lost close event cannot leave a
+stale warning indefinitely. For unpaired CLIs, an actual operator key or a
 native completion event can clear the signal sooner; process exit clears every
 kind. Automatic terminal query replies do not count as operator input. The
 ceiling can create a false negative for a dialog left open longer than 30
 minutes; that is intentional because an indefinitely stale warning is the more
 damaging failure mode.
+
+Enforcement remains a possible later step per adapter, after every covered
+dialog and subtype has been observed end-to-end in the deployed environment.
+It should not be enabled globally: a notification such as Claude's
+`agent_needs_input` may describe a teammate that needs attention rather than a
+modal dialog owning the main pane's input.
 
 ## Verification
 

--- a/docs/tui-input-required.md
+++ b/docs/tui-input-required.md
@@ -19,7 +19,10 @@ active; direct terminal input remains available.
 The reader does not answer the dialog in this version. The CLIs have different
 choice identifiers, validation, queueing, "allow once/always" semantics, and
 secret-handling rules. Translating a reader form to raw keystrokes would be
-unsafe; doing this later requires a typed response API from each adapter.
+unsafe. OpenCode already exposes typed permission/question replies keyed by the
+request id tracked here, but Agent Manager has no authenticated client to that
+pane's OpenCode server. Other adapters would likewise need a typed, pane-scoped
+response path before reader-side answers are safe.
 
 ## Detection coverage
 
@@ -30,7 +33,7 @@ which native states emit each signal.
 
 | CLI | Signal used | Confidence | Deliberate misses |
 | --- | --- | --- | --- |
-| OpenCode | The plugin tracks `permission.asked`/`permission.replied` and `question.asked`/`question.replied`/`question.rejected`. It keeps the full pending queue and mirrors OpenCode's recovery when a Question tool completes without `question.replied`. | High, with paired open/close events. | Dialogs outside those two event families; a request already open before the plugin observes its event. |
+| OpenCode | The plugin tracks `permission.asked`/`permission.replied` and `question.asked`/`question.replied`/`question.rejected`. It keeps the full pending queue and mirrors OpenCode's recovery when a Question tool completes without `question.replied`. | High, with paired open/close events. | Dialogs outside those two event families; a request already open before the plugin observes its event. A missing close event expires after 30 minutes, which can hide a genuinely long-lived dialog. |
 | Claude Code | Observation-only `Notification` hooks for `permission_prompt`, MCP elicitation dialogs, and `agent_needs_input`. Unlike `PermissionRequest`, these fire after the actual UI has remained unanswered for about six seconds and cannot decide the permission. Native batch/stop/session/elicitation events and operator input clear the marker. | High once reported; intentionally delayed about six seconds. | The first six seconds; main-session choice UIs for which Claude exposes no matching notification (including versions where `AskUserQuestion` has no attention event); unlisted onboarding/configuration dialogs. |
 | Codex | Each managed invocation enables only the TUI's `approval-requested` and `plan-mode-prompt` OSC 9 notifications. Codex emits them from the TUI handlers that install exec/edit/MCP approval and request-user-input views. | High for the listed views. | `RequestPermissionsEvent` and generic queued approval paths that do not call Codex's notifier; onboarding/configuration dialogs. Codex exposes no paired close event, so input clears the signal and a 30-minute safety expiry prevents a stale badge. |
 | Gemini CLI | An observation-only `Notification` hook reports `ToolPermission`, including `ask_user`. Gemini's native attention notification additionally covers command, auth, filesystem, extension-update and loop-detection confirmations through OSC 9 when enabled. | High: both signals originate from Gemini's actual pending-confirmation state. | Non-tool attention notifications when a higher-precedence user/project setting disables notifications or Gemini suppresses them for terminal focus; other unlisted UI dialogs. Native completion/session events, input, and the safety expiry clear one-shot signals. |
@@ -75,13 +78,15 @@ Gemini hooks reject nested agent processes; OpenCode's plugin requires the pane
 root process. Marker files live on local `/tmp`, not the durable bucket, and are
 removed at process exit.
 
-OpenCode's paired event is authoritative until the final queued request closes.
-For CLIs without a paired close event, an actual operator key, a native
-completion event, process exit, or the 30-minute safety limit clears the signal.
-Automatic terminal query replies do not count as operator input. The safety
-limit can create a false negative for a dialog left open longer than 30 minutes;
-that is intentional because an indefinitely stale warning is the more damaging
-failure mode.
+OpenCode's paired event remains authoritative through menu-navigation input and
+closes immediately when the final queued request closes. Every marker, including
+OpenCode's, also has a 30-minute ceiling so a lost close event cannot disable
+reader prompting indefinitely. For unpaired CLIs, an actual operator key or a
+native completion event can clear the signal sooner; process exit clears every
+kind. Automatic terminal query replies do not count as operator input. The
+ceiling can create a false negative for a dialog left open longer than 30
+minutes; that is intentional because an indefinitely stale warning is the more
+damaging failure mode.
 
 ## Verification
 
@@ -92,9 +97,16 @@ nested-process rejection, preservation of existing Claude settings, reader/web
 typechecking, and the full terminal migration/resize suite. No assertion relies
 on screen text or process idleness.
 
-The installed Codex binary accepted the invocation-local notification settings,
-and the installed Gemini binary loaded the proposed system settings file. This
-branch was not deployed and did not drive authenticated live permission dialogs;
-the native event payloads and terminal sequences are exercised by automated
-fixtures. A deployment smoke test should deliberately trigger each covered
-dialog before release, especially after a CLI version update.
+The installed Codex 0.147.0 TUI was driven to a real command approval with only
+`approval-requested` enabled. Its raw PTY output contained
+`ESC ] 9 ; Approval requested: ... BEL` immediately before the menu. Repeating
+the approval with only `approval-request` reached the same menu without an OSC 9
+notification, confirming the configured spelling rather than merely confirming
+that Codex accepts arbitrary list values. The installed Gemini binary loaded the
+proposed system settings file.
+
+This branch was not deployed and did not drive authenticated live dialogs for
+the other adapters; their native event payloads and terminal sequences are
+exercised by automated fixtures. A deployment smoke test should deliberately
+trigger each covered dialog before release, especially after a CLI version
+update.

--- a/docs/tui-input-required.md
+++ b/docs/tui-input-required.md
@@ -1,0 +1,100 @@
+# Interactive TUI dialogs in the reader
+
+## Decision
+
+Agent Manager surfaces an interactive-dialog warning only when the CLI itself
+emits a lifecycle event for an open permission, question or confirmation UI.
+It does **not** infer this state from a quiet process, a static screen or words
+such as `Allow` in terminal text. Those heuristics cannot distinguish a dialog
+from thinking, a completed turn, documentation, or agent-produced output; a
+false "blocked" badge would be worse than a missed prompt.
+
+The pane reader and Overview card replace their reply composer with a **Needs
+input** banner and an **open terminal** action. The session tile and sidebar
+also identify the condition. The normal composer is hidden because submitting
+text while a choice menu owns stdin can select the wrong option. The prompt and
+attachment APIs refuse the same operation with HTTP 409 while the signal is
+active; direct terminal input remains available.
+
+The reader does not answer the dialog in this version. The CLIs have different
+choice identifiers, validation, queueing, "allow once/always" semantics, and
+secret-handling rules. Translating a reader form to raw keystrokes would be
+unsafe; doing this later requires a typed response API from each adapter.
+
+## Detection coverage
+
+Research covered the installed versions on 2026-08-15: Claude Code 2.1.232,
+Codex 0.147.0, Gemini CLI 0.55.1, OpenCode 1.18.18, Hermes 0.20.1, and
+OpenClaw 2026.7.1-2. The linked source revisions below are the evidence for
+which native states emit each signal.
+
+| CLI | Signal used | Confidence | Deliberate misses |
+| --- | --- | --- | --- |
+| OpenCode | The plugin tracks `permission.asked`/`permission.replied` and `question.asked`/`question.replied`/`question.rejected`. It keeps the full pending queue and mirrors OpenCode's recovery when a Question tool completes without `question.replied`. | High, with paired open/close events. | Dialogs outside those two event families; a request already open before the plugin observes its event. |
+| Claude Code | Observation-only `Notification` hooks for `permission_prompt`, MCP elicitation dialogs, and `agent_needs_input`. Unlike `PermissionRequest`, these fire after the actual UI has remained unanswered for about six seconds and cannot decide the permission. Native batch/stop/session/elicitation events and operator input clear the marker. | High once reported; intentionally delayed about six seconds. | The first six seconds; main-session choice UIs for which Claude exposes no matching notification (including versions where `AskUserQuestion` has no attention event); unlisted onboarding/configuration dialogs. |
+| Codex | Each managed invocation enables only the TUI's `approval-requested` and `plan-mode-prompt` OSC 9 notifications. Codex emits them from the TUI handlers that install exec/edit/MCP approval and request-user-input views. | High for the listed views. | `RequestPermissionsEvent` and generic queued approval paths that do not call Codex's notifier; onboarding/configuration dialogs. Codex exposes no paired close event, so input clears the signal and a 30-minute safety expiry prevents a stale badge. |
+| Gemini CLI | An observation-only `Notification` hook reports `ToolPermission`, including `ask_user`. Gemini's native attention notification additionally covers command, auth, filesystem, extension-update and loop-detection confirmations through OSC 9 when enabled. | High: both signals originate from Gemini's actual pending-confirmation state. | Non-tool attention notifications when a higher-precedence user/project setting disables notifications or Gemini suppresses them for terminal focus; other unlisted UI dialogs. Native completion/session events, input, and the safety expiry clear one-shot signals. |
+| Hermes | None shipped. Hermes has `_approval_state` and clarify/approval callbacks inside the Python TUI, but no supported external lifecycle hook for the `hermes` process Agent Manager launches. | No reliable external signal found. | All Hermes dialogs. Reading process memory, patching its installed Python package, or matching rendered text was rejected. |
+| OpenClaw | None shipped. OpenClaw's gateway has approval request/resolve events and can list open gateway approvals, but Agent Manager launches the local embedded TUI and has no stable, authenticated session-to-gateway approval stream to consume. | No reliable pane-scoped signal integrated. | All OpenClaw local-TUI dialogs. A future gateway adapter could support these without screen scraping. |
+
+Shell, Files, Trace, and Remote panes are not local agent TUIs and do not run
+these adapters.
+
+## Evidence
+
+- Claude documents that `permission_prompt` and elicitation notifications start
+  from an actual displayed dialog, fire after about six seconds without input,
+  and still run when desktop notifications are disabled. It also documents that
+  `PermissionRequest` runs in non-interactive sessions that cannot show a
+  prompt, which is why this implementation does not use it as proof of a visible
+  dialog: [Claude Code hooks reference](https://code.claude.com/docs/en/hooks#notification).
+- Codex calls its notifier in the handlers that push the approval and user-input
+  views: [tool request handlers](https://github.com/openai/codex/blob/c4941302c73c6322b153bba13ac0a9f4396301d6/codex-rs/tui/src/chatwidget/tool_requests.rs).
+  Its notification types distinguish `approval-requested` and
+  `plan-mode-prompt`: [notification model](https://github.com/openai/codex/blob/c4941302c73c6322b153bba13ac0a9f4396301d6/codex-rs/tui/src/chatwidget/notifications.rs).
+- Gemini fires `ToolPermission` immediately before it places the call in
+  `AwaitingApproval`: [confirmation scheduler](https://github.com/google-gemini/gemini-cli/blob/2a87e7be103308b8734246097ba723cc7deb4122/packages/core/src/scheduler/confirmation.ts).
+  Its own attention selector enumerates tool/ask-user, command, authentication,
+  filesystem, extension and loop confirmations:
+  [pending attention state](https://github.com/google-gemini/gemini-cli/blob/2a87e7be103308b8734246097ba723cc7deb4122/packages/cli/src/ui/utils/pendingAttentionNotification.ts).
+- OpenCode's own TUI notification plugin tracks the same paired permission and
+  question events used here: [OpenCode notifications](https://github.com/anomalyco/opencode/blob/4643e65ad6334de3e4e68dedc201d5fbb828c9fe/packages/tui/src/feature-plugins/system/notifications.ts).
+  Its session reducer documents and handles the missing-question-reply edge:
+  [session data recovery](https://github.com/anomalyco/opencode/blob/4643e65ad6334de3e4e68dedc201d5fbb828c9fe/packages/opencode/src/cli/cmd/run/session-data.ts).
+- Hermes's approval wait is an in-process queue behind `_approval_state`:
+  [Hermes callbacks](https://github.com/NousResearch/hermes-agent/blob/56a41715dc3b8bf6f50a740ff9416c4036ef4259/hermes_cli/callbacks.py).
+- OpenClaw's gateway-facing MCP adapter can list and resolve open approval
+  requests, but that stream is not the pane-scoped local TUI Agent Manager
+  launches: [OpenClaw MCP CLI](https://github.com/openclaw/openclaw/blob/0790d9f593ad30c940ed93b5872a8cf6d6f3cf8c/src/cli/mcp-cli.ts).
+
+## False-positive controls
+
+Every file signal carries the Agent Manager pane id, CLI id, and random launch
+id. The server accepts it only for the matching live PTY launch. Claude and
+Gemini hooks reject nested agent processes; OpenCode's plugin requires the pane
+root process. Marker files live on local `/tmp`, not the durable bucket, and are
+removed at process exit.
+
+OpenCode's paired event is authoritative until the final queued request closes.
+For CLIs without a paired close event, an actual operator key, a native
+completion event, process exit, or the 30-minute safety limit clears the signal.
+Automatic terminal query replies do not count as operator input. The safety
+limit can create a false negative for a dialog left open longer than 30 minutes;
+that is intentional because an indefinitely stale warning is the more damaging
+failure mode.
+
+## Verification
+
+Automated coverage includes stale/mismatched launch markers, unrelated terminal
+notifications, OSC sequences split across PTY chunks, one-shot expiry and clear
+events, OpenCode queues, reject/reply events, OpenCode's missing reply recovery,
+nested-process rejection, preservation of existing Claude settings, reader/web
+typechecking, and the full terminal migration/resize suite. No assertion relies
+on screen text or process idleness.
+
+The installed Codex binary accepted the invocation-local notification settings,
+and the installed Gemini binary loaded the proposed system settings file. This
+branch was not deployed and did not drive authenticated live permission dialogs;
+the native event payloads and terminal sequences are exercised by automated
+fixtures. A deployment smoke test should deliberately trigger each covered
+dialog before release, especially after a CLI version update.

--- a/gemini-system-defaults.json
+++ b/gemini-system-defaults.json
@@ -1,0 +1,47 @@
+{
+  "general": {
+    "enableNotifications": true,
+    "notificationMethod": "osc9"
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "ToolPermission",
+        "hooks": [
+          {
+            "name": "agent-manager-input-required",
+            "type": "command",
+            "command": "/app/scripts/am-input-required-hook.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "agent-manager-input-resolved",
+            "type": "command",
+            "command": "/app/scripts/am-input-required-hook.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "name": "agent-manager-input-session-end",
+            "type": "command",
+            "command": "/app/scripts/am-input-required-hook.sh",
+            "timeout": 5000
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/scripts/am-input-required-hook.sh
+++ b/scripts/am-input-required-hook.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# Observation-only hook for native CLI "this dialog is actually open" events.
+# It never approves, rejects or otherwise participates in the decision.
+
+[ -n "$AM_ID" ] || exit 0
+case "$AM_ID" in *[!a-zA-Z0-9_-]*) exit 0 ;; esac
+[ -n "$AM_RUN_ID" ] || exit 0
+case "$AM_RUN_ID" in *[!a-zA-Z0-9_-]*) exit 0 ;; esac
+case "$AM_PANE_PID" in '' | *[!0-9]*) exit 0 ;; esac
+command -v jq >/dev/null 2>&1 || exit 0
+
+payload=$(mktemp "${TMPDIR:-/tmp}/am-input-hook.XXXXXX") || exit 0
+trap 'rm -f "$payload"' EXIT HUP INT TERM
+cat > "$payload" || exit 0
+
+kind=
+source=
+clear=
+case "$AM_CLI" in
+  claude)
+    # A global Claude config is inherited by nested Claude processes. Its
+    # official entrypoint/pid fields let us keep only this pane's root CLI.
+    [ "$CLAUDE_CODE_ENTRYPOINT" = "cli" ] || exit 0
+    case "$CLAUDE_PID" in '' | *[!0-9]*) exit 0 ;; esac
+    if [ "$CLAUDE_PID" != "$AM_PANE_PID" ]; then
+      stat=$(cat "/proc/$CLAUDE_PID/stat" 2>/dev/null) || exit 0
+      rest=${stat##*) }
+      rest=${rest#* }
+      [ "${rest%% *}" = "$AM_PANE_PID" ] || exit 0
+    fi
+    case "$(jq -r '.hook_event_name // empty' "$payload")" in
+      Notification)
+        case "$(jq -r '.notification_type // empty' "$payload")" in
+          permission_prompt) kind=permission ;;
+          elicitation_dialog | elicitation_url_dialog | agent_needs_input) kind=question ;;
+          agent_completed) clear=1 ;;
+          *) exit 0 ;;
+        esac
+        ;;
+      PostToolBatch | Stop | SessionEnd | ElicitationResult | UserPromptSubmit) clear=1 ;;
+      *) exit 0 ;;
+    esac
+    source=claude-notification
+    ;;
+  gemini)
+    # Gemini spawns `bash -c` for command hooks. Bash normally execs this
+    # single-command script, but allowing that one runner process keeps the
+    # attribution correct if it forks instead. A Gemini started by an agent
+    # tool still has its own CLI and tool shell between here and the pane root.
+    stat=$(cat "/proc/$$/stat" 2>/dev/null) || exit 0
+    rest=${stat##*) }
+    rest=${rest#* }
+    parent=${rest%% *}
+    if [ "$parent" != "$AM_PANE_PID" ]; then
+      stat=$(cat "/proc/$parent/stat" 2>/dev/null) || exit 0
+      rest=${stat##*) }
+      rest=${rest#* }
+      [ "${rest%% *}" = "$AM_PANE_PID" ] || exit 0
+    fi
+    case "$(jq -r '.hook_event_name // empty' "$payload")" in
+      Notification)
+        [ "$(jq -r '.notification_type // empty' "$payload")" = "ToolPermission" ] || exit 0
+        if [ "$(jq -r '.details.type // empty' "$payload")" = "ask_user" ]; then kind=question; else kind=permission; fi
+        ;;
+      AfterAgent | SessionEnd) clear=1 ;;
+      *) exit 0 ;;
+    esac
+    source=gemini-notification
+    ;;
+  *) exit 0 ;;
+esac
+
+d=${AM_INPUT_REQUIRED_DIR:-/tmp/am-input-required}
+mkdir -p "$d" 2>/dev/null || exit 0
+if [ -n "$clear" ]; then
+  file="$d/$AM_ID.json"
+  [ "$(jq -r '.runId // empty' "$file" 2>/dev/null)" = "$AM_RUN_ID" ] || exit 0
+  [ "$(jq -r '.cli // empty' "$file" 2>/dev/null)" = "$AM_CLI" ] || exit 0
+  rm -f "$file"
+  exit 0
+fi
+at=$(( $(date +%s) * 1000 ))
+tmp="$d/$AM_ID.json.$$.tmp"
+jq -n --arg amId "$AM_ID" --arg runId "$AM_RUN_ID" --arg cli "$AM_CLI" \
+  --arg kind "$kind" --arg source "$source" --argjson at "$at" \
+  '{amId:$amId,runId:$runId,cli:$cli,kind:$kind,source:$source,at:$at}' > "$tmp" 2>/dev/null \
+  && mv -f "$tmp" "$d/$AM_ID.json"
+exit 0

--- a/scripts/am-opencode-repin.js
+++ b/scripts/am-opencode-repin.js
@@ -1,16 +1,21 @@
-import { mkdirSync, renameSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 
 const SAFE = /^[A-Za-z0-9_-]+$/;
 
-function report(sessionID, cwd, source) {
+function paneIdentity() {
   const amId = process.env.AM_ID;
   const runId = process.env.AM_RUN_ID;
-  if (process.env.AM_CLI !== 'opencode' || !SAFE.test(amId || '') || !SAFE.test(runId || '')) return;
-  // The global plugin is also loaded by nested OpenCode processes. Only the
-  // process that replaced the PTY's login shell owns this pane.
-  if (String(process.pid) !== process.env.AM_PANE_PID) return;
+  if (process.env.AM_CLI !== 'opencode' || !SAFE.test(amId || '') || !SAFE.test(runId || '')) return null;
+  if (String(process.pid) !== process.env.AM_PANE_PID) return null;
+  return { amId, runId };
+}
+
+function report(sessionID, cwd, source) {
+  const identity = paneIdentity();
+  if (!identity) return;
+  const { amId, runId } = identity;
   if (!/^ses_[A-Za-z0-9_-]+$/.test(sessionID || '') || typeof cwd !== 'string') return;
   const dir = process.env.AM_REPIN_DIR || path.join(os.tmpdir(), 'am-repin');
   const file = path.join(dir, `${amId}.opencode.json`);
@@ -31,26 +36,104 @@ function report(sessionID, cwd, source) {
   } catch { /* telemetry must never interfere with the user's prompt */ }
 }
 
+function syncInputRequired(pending) {
+  const identity = paneIdentity();
+  if (!identity) return;
+  const { amId, runId } = identity;
+  const dir = process.env.AM_INPUT_REQUIRED_DIR || path.join(os.tmpdir(), 'am-input-required');
+  const file = path.join(dir, `${amId}.json`);
+  const item = pending.values().next().value;
+  if (!item) {
+    try {
+      const existing = JSON.parse(readFileSync(file, 'utf8'));
+      if (existing?.runId === runId && existing?.source === 'opencode-event') unlinkSync(file);
+    } catch { /* already absent or no longer ours */ }
+    return;
+  }
+  const tmp = `${file}.${process.pid}.tmp`;
+  try {
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(tmp, JSON.stringify({
+      amId,
+      runId,
+      cli: 'opencode',
+      kind: item.kind,
+      source: 'opencode-event',
+      requestId: item.id,
+      at: item.at,
+    }));
+    renameSync(tmp, file);
+  } catch { /* an attention signal must never interfere with the TUI */ }
+}
+
 // OpenCode creates a new root session for /new (alias /clear). chat.message
 // additionally follows an explicit switch to an existing session; runner.js
 // verifies that id against the database and rejects child/subagent sessions.
-export const AgentManagerRepin = async ({ directory }) => ({
-  event: async ({ event }) => {
-    if (event?.type !== 'session.created') return;
-    const info = event.properties?.info;
-    if (!info?.id || info.parentID) return;
-    report(info.id, info.directory || directory, 'session.created');
-  },
-  'chat.message': async ({ sessionID }) => {
-    report(sessionID, directory, 'chat.message');
-  },
+export const AgentManagerRepin = async ({ directory }) => {
+  // OpenCode's own TUI uses the same asked/replied event pairs. Keep every
+  // queued request: resolving one must not hide another waiting behind it.
+  const pending = new Map();
+
+  const changed = () => syncInputRequired(pending);
+  const drop = (id) => {
+    if (!id || !pending.delete(id)) return;
+    changed();
+  };
+
+  return ({
+    event: async ({ event }) => {
+      const props = event?.properties || {};
+      if (event?.type === 'session.created') {
+        const info = props.info;
+        if (info?.id && !info.parentID) report(info.id, info.directory || directory, 'session.created');
+        return;
+      }
+      if (event?.type === 'permission.asked' || event?.type === 'question.asked') {
+        if (!props.id || pending.has(props.id)) return;
+        pending.set(props.id, {
+          id: props.id,
+          sessionID: props.sessionID,
+          kind: event.type === 'question.asked' ? 'question' : 'permission',
+          tool: props.tool || null,
+          at: Date.now(),
+        });
+        changed();
+        return;
+      }
+      if (event?.type === 'permission.replied'
+        || event?.type === 'question.replied'
+        || event?.type === 'question.rejected') {
+        drop(props.requestID);
+        return;
+      }
+      // A Question tool can complete without question.replied. OpenCode's TUI
+      // has this same recovery path; mirror it so the marker cannot stick.
+      if (event?.type === 'message.part.updated') {
+        const part = props.part;
+        if (part?.type !== 'tool' || part.tool !== 'question'
+          || (part.state?.status !== 'completed' && part.state?.status !== 'error')) return;
+        let dirty = false;
+        for (const [id, item] of pending) {
+          if (item.kind !== 'question' || !item.tool) continue;
+          if (item.tool.messageID === part.messageID && item.tool.callID === part.callID) {
+            pending.delete(id);
+            dirty = true;
+          }
+        }
+        if (dirty) changed();
+      }
+    },
+    'chat.message': async ({ sessionID }) => {
+      report(sessionID, directory, 'chat.message');
+    },
   // Tool shells must not pass the pane's private attribution markers to an
   // agent launched inside them. Empty values override OpenCode's process.env
   // merge and make the nested plugin a no-op.
-  'shell.env': async (_input, output) => {
-    output.env.AM_ID = '';
-    output.env.AM_RUN_ID = '';
-    output.env.AM_CLI = '';
-    output.env.AM_PANE_PID = '';
-  },
-});
+    'shell.env': async (_input, output) => {
+      output.env.AM_ID = '';
+      output.env.AM_RUN_ID = '';
+      output.env.AM_CLI = '';
+      output.env.AM_PANE_PID = '';
+    },
+  });
+};

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs",
     "test:screenshots": "node screenshot-input.test.mjs",
     "test:mobile": "node mobile.test.mjs",
-    "test": "node test/trace-download.test.mjs && node test/attachments.test.mjs && node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/trace-download.test.mjs && node test/attachments.test.mjs && node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/input-required.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -70,6 +70,15 @@ export const PASSIVE_CLIS = ['files', 'trace'];
 // it" path has to route around it — see isRemote() callers.
 export const isRemote = (cli) => cli === 'remote';
 
+// Codex's TUI emits OSC 9 only after it has installed one of these native
+// interactive views. Pin the notification backend per invocation so Agent
+// Manager can consume that control signal without changing the operator's
+// durable Codex preferences or enabling ordinary turn-complete notifications.
+const CODEX_INPUT_SIGNALS = '-c \'tui.notifications=["approval-requested","plan-mode-prompt"]\''
+  + ' -c \'tui.notification_method="osc9"\''
+  + ' -c \'tui.notification_condition="always"\'';
+const codexCommand = (tail = '') => `codex ${CODEX_INPUT_SIGNALS}${tail ? ` ${tail}` : ''}`;
+
 export const CLIS = [
   { id: 'shell',    label: 'Shell',       bin: 'bash',     color: '#8aa0ad', run: 'exec bash -il',  cont: null },
   { id: 'files',    label: 'Files',       bin: null,       color: '#d99a2b', run: null,             cont: null },
@@ -83,10 +92,11 @@ export const CLIS = [
   { id: 'claude',   label: 'Claude Code', bin: 'claude',   color: '#d97757', run: 'claude',         cont: 'claude --continue', resizeMode: 'repaint',
     withPrompt: (q) => `claude ${q}`,
     setup: setupHint('ANTHROPIC_API_KEY') },
-  { id: 'codex',    label: 'Codex',       bin: 'codex',    color: '#5eb6a6', run: 'codex',          cont: 'codex resume --last', resizeMode: 'repaint',
+  { id: 'codex',    label: 'Codex',       bin: 'codex',    color: '#5eb6a6', run: codexCommand(),   cont: codexCommand('resume --last'), resizeMode: 'repaint',
+    resume: (id) => codexCommand(`resume ${id}`),
     // `q` and image paths arrive shell-quoted from runner.commandFor(). Repeat
     // -i because Codex's variadic flag would otherwise consume the prompt.
-    withPrompt: (q, images = []) => `codex${images.length ? ` ${images.map((image) => `-i ${image}`).join(' ')}` : ''} ${q}`,
+    withPrompt: (q, images = []) => `${codexCommand()}${images.length ? ` ${images.map((image) => `-i ${image}`).join(' ')}` : ''} ${q}`,
     setup: setupHint('OPENAI_API_KEY') },
   { id: 'gemini',   label: 'Gemini CLI',  bin: 'gemini',   color: '#4796e3', run: 'gemini',         cont: null, resizeMode: 'repaint',
     withPrompt: (q) => `gemini -i ${q}`, // -i = interactive session seeded with the prompt

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -548,6 +548,7 @@ function agentRow(s, act, d, selfId, mates) {
     state: deriveState(s, act),
     // Seconds since its screen last changed. Small = actively working.
     idleFor: act ? act.age : null,
+    inputRequired: act?.inputRequired || null,
     workdir: workspacePath(folder),
     path: folder,
     // Who else writes to this same folder — the actual collision hazard.
@@ -2026,7 +2027,7 @@ function sessionsWithState() {
   const info = agentInfo();
   return store.list().map((s) => {
     const state = deriveState(s, info.get(s.id));
-    return { ...s, state, running: state !== 'stopped' };
+    return { ...s, state, running: state !== 'stopped', inputRequired: info.get(s.id)?.inputRequired || null };
   });
 }
 
@@ -2624,11 +2625,12 @@ wss.on('connection', (ws, req) => {
     let msg;
     try { msg = JSON.parse(raw.toString()); } catch { return; }
     if (msg.t === 'i') {
-      handle.write(msg.d);
+      const terminalReply = runstate.isTerminalReply(msg.d);
+      handle.write(msg.d, { terminalReply });
       // Not every frame on this channel is you: the emulator answers the TUI's
       // device-attribute and cursor queries down the same path, instantly on
       // attach. Opening a pane is not sending it something.
-      if (!runstate.isTerminalReply(msg.d)) touchInput(session.id);
+      if (!terminalReply) touchInput(session.id);
     }
     else if (msg.t === 'r') handle.resize(msg.cols, msg.rows);
     else if (msg.t === 'claim') handle.claim();

--- a/server/src/input-required.js
+++ b/server/src/input-required.js
@@ -1,0 +1,147 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const SAFE_ID = /^[A-Za-z0-9_-]+$/;
+const KINDS = new Set(['permission', 'question', 'confirmation']);
+const MARKER_SOURCES = new Map([
+  ['claude', new Set(['claude-notification'])],
+  ['gemini', new Set(['gemini-notification'])],
+  ['opencode', new Set(['opencode-event'])],
+]);
+const configuredMaxAge = Number(process.env.AM_INPUT_REQUIRED_MAX_AGE_MS);
+const ONE_SHOT_MAX_AGE_MS = Number.isFinite(configuredMaxAge) && configuredMaxAge > 0
+  ? configuredMaxAge : 30 * 60_000;
+
+function markerDirectory() {
+  return process.env.AM_INPUT_REQUIRED_DIR || path.join(os.tmpdir(), 'am-input-required');
+}
+
+function markerFile(id) {
+  return SAFE_ID.test(id || '') ? path.join(markerDirectory(), `${id}.json`) : null;
+}
+
+function readMarker(id, runId, cli, now) {
+  const file = markerFile(id);
+  if (!file) return null;
+  try {
+    const value = JSON.parse(fs.readFileSync(file, 'utf8'));
+    const at = Number(value?.at);
+    const source = typeof value?.source === 'string' ? value.source : '';
+    if (value?.amId !== id || value?.runId !== runId || value?.cli !== cli
+      || !KINDS.has(value?.kind) || !MARKER_SOURCES.get(cli)?.has(source)
+      || !Number.isFinite(at) || at <= 0 || at > now + 60_000) return null;
+    return {
+      file,
+      at,
+      kind: value.kind,
+      source,
+      requestId: typeof value.requestId === 'string' ? value.requestId : '',
+    };
+  } catch { return null; }
+}
+
+function removeMatchingMarker(id, runId, cli, { oneShotOnly = false } = {}) {
+  const marker = readMarker(id, runId, cli, Date.now());
+  if (!marker || (oneShotOnly && marker.source === 'opencode-event')) return;
+  try { fs.unlinkSync(marker.file); } catch {}
+}
+
+function publicState(current) {
+  if (!current) return null;
+  return {
+    kind: current.kind,
+    cli: current.cli,
+    confidence: 'high',
+    detectedAt: new Date(current.at).toISOString(),
+  };
+}
+
+/**
+ * Native interactive-dialog signals for one PTY launch.
+ *
+ * This intentionally has no screen-text or process-idle fallback. An agent can
+ * print any prompt-looking text, and an event-loop TUI polls stdin while both
+ * thinking and waiting. Only CLI lifecycle events enter this tracker.
+ */
+export function createInputRequiredTracker({ id, runId, cli, now = () => Date.now() }) {
+  let current = null;
+  let osc = '';
+
+  const set = (kind, source, at, transport, token = '') => {
+    current = { kind, source, at, transport, token, cli };
+  };
+
+  const get = () => {
+    const time = now();
+    const marker = readMarker(id, runId, cli, time);
+    if (marker) {
+      const paired = marker.source === 'opencode-event';
+      if (!paired && time - marker.at > ONE_SHOT_MAX_AGE_MS) {
+        removeMatchingMarker(id, runId, cli);
+        if (current?.transport === 'marker') current = null;
+      } else {
+        const token = `${marker.source}:${marker.at}:${marker.requestId}:${marker.kind}`;
+        if (current?.transport !== 'marker' || current.token !== token) {
+          set(marker.kind, marker.source, marker.at, 'marker', token);
+        }
+      }
+    } else if (current?.transport === 'marker') {
+      current = null;
+    }
+
+    if (current?.transport === 'terminal' && time - current.at > ONE_SHOT_MAX_AGE_MS) current = null;
+    return publicState(current);
+  };
+
+  const observeOutput = (chunk) => {
+    if ((cli !== 'codex' && cli !== 'gemini') || !chunk) return;
+    osc += String(chunk);
+    // Codex emits these OSC 9 messages only after its TUI has installed the
+    // corresponding approval/question view. Invocation-local config forces
+    // the exact backend and enables only these two notification classes.
+    const re = /\x1b\](9;|777;notify;)([^\x07\x1b]{1,2048})(?:\x07|\x1b\\)/g;
+    let match;
+    let consumed = 0;
+    while ((match = re.exec(osc))) {
+      consumed = re.lastIndex;
+      const message = match[2];
+      if (cli === 'codex') {
+        if (message.startsWith('Plan mode prompt:')) {
+          set('question', 'codex-notification', now(), 'terminal');
+        } else if (message.startsWith('Approval requested:')
+          || message.startsWith('Codex wants to edit ')
+          || message.startsWith('Approval requested by ')) {
+          set('permission', 'codex-notification', now(), 'terminal');
+        }
+      } else if (message.startsWith('Gemini CLI needs your attention')) {
+        set(message.includes('Answer requested by agent') ? 'question' : 'confirmation',
+          'gemini-notification', now(), 'terminal');
+      } else if (message.startsWith('Gemini CLI session complete')) {
+        removeMatchingMarker(id, runId, cli, { oneShotOnly: true });
+        current = null;
+      }
+    }
+    if (consumed) osc = osc.slice(consumed);
+    if (osc.length > 4096) osc = osc.slice(-4096);
+  };
+
+  const observeInput = () => {
+    // OpenCode has paired asked/replied events. Cursor movement in its menu is
+    // still input but does not resolve the request, so only the paired event may
+    // clear it. The other CLIs expose an exact open signal but no exact close;
+    // any operator key clears them conservatively (a false negative is safer).
+    const marker = readMarker(id, runId, cli, now());
+    if (current?.source === 'opencode-event' || marker?.source === 'opencode-event') return;
+    removeMatchingMarker(id, runId, cli, { oneShotOnly: true });
+    current = null;
+  };
+
+  const close = () => {
+    removeMatchingMarker(id, runId, cli);
+    current = null;
+    osc = '';
+  };
+
+  return { get, observeOutput, observeInput, close };
+}

--- a/server/src/input-required.js
+++ b/server/src/input-required.js
@@ -44,6 +44,10 @@ function readMarker(id, runId, cli, now) {
 function removeMatchingMarker(id, runId, cli, { oneShotOnly = false } = {}) {
   const marker = readMarker(id, runId, cli, Date.now());
   if (!marker || (oneShotOnly && marker.source === 'opencode-event')) return;
+  removeMarker(marker);
+}
+
+function removeMarker(marker) {
   try { fs.unlinkSync(marker.file); } catch {}
 }
 
@@ -76,9 +80,8 @@ export function createInputRequiredTracker({ id, runId, cli, now = () => Date.no
     const time = now();
     const marker = readMarker(id, runId, cli, time);
     if (marker) {
-      const paired = marker.source === 'opencode-event';
-      if (!paired && time - marker.at > ONE_SHOT_MAX_AGE_MS) {
-        removeMatchingMarker(id, runId, cli);
+      if (time - marker.at > ONE_SHOT_MAX_AGE_MS) {
+        removeMarker(marker);
         if (current?.transport === 'marker') current = null;
       } else {
         const token = `${marker.source}:${marker.at}:${marker.requestId}:${marker.kind}`;
@@ -128,12 +131,13 @@ export function createInputRequiredTracker({ id, runId, cli, now = () => Date.no
 
   const observeInput = () => {
     // OpenCode has paired asked/replied events. Cursor movement in its menu is
-    // still input but does not resolve the request, so only the paired event may
-    // clear it. The other CLIs expose an exact open signal but no exact close;
-    // any operator key clears them conservatively (a false negative is safer).
+    // still input but does not resolve the request, so only the paired event or
+    // the finite safety ceiling clears it. The other CLIs expose an exact open
+    // signal but no exact close; any operator key clears them conservatively (a
+    // false negative is safer).
     const marker = readMarker(id, runId, cli, now());
     if (current?.source === 'opencode-event' || marker?.source === 'opencode-event') return;
-    removeMatchingMarker(id, runId, cli, { oneShotOnly: true });
+    if (marker) removeMarker(marker);
     current = null;
   };
 

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -16,6 +16,7 @@ import {
   traceHistoryLines,
 } from './history-store.js';
 import { createTerminalModeTracker } from './terminal-modes.js';
+import { createInputRequiredTracker } from './input-required.js';
 
 // libghostty-vt ships prebuilts for linux x64/arm64 and macOS arm64. Loading it
 // is guarded so a platform without a prebuilt still boots and says so, rather
@@ -153,7 +154,11 @@ export function agentInfo() {
   const now = Date.now();
   for (const [id, host] of hosts) {
     const changedAt = host.screenChangedAt || host.startedAt;
-    map.set(id, { age: Math.round((now - changedAt) / 1000), bells: host.bells || 0 });
+    map.set(id, {
+      age: Math.round((now - changedAt) / 1000),
+      bells: host.bells || 0,
+      inputRequired: host.inputRequired.get(),
+    });
   }
   return map;
 }
@@ -1311,7 +1316,10 @@ export async function codexRolloutForId(id) {
 // not parse is left alone (clobbering the user's settings to install a hook
 // would be a terrible trade), and every failure is non-fatal: without the
 // hook the watcher simply keeps today's behaviour.
-export function installClaudeRepinHook(hookCmd = '/app/scripts/am-repin-hook.sh') {
+export function installClaudeRepinHook(
+  hookCmd = '/app/scripts/am-repin-hook.sh',
+  inputRequiredCmd = '/app/scripts/am-input-required-hook.sh',
+) {
   const dir = process.env.CLAUDE_CONFIG_DIR;
   if (!dir) return false;
   const file = path.join(dir, 'settings.json');
@@ -1322,19 +1330,49 @@ export function installClaudeRepinHook(hookCmd = '/app/scripts/am-repin-hook.sh'
     if (e.code !== 'ENOENT') { console.warn(`[claude] not installing repin hook: ${file} unreadable (${e.message})`); return false; }
   }
   if (typeof cfg !== 'object' || cfg === null || Array.isArray(cfg)) { console.warn(`[claude] not installing repin hook: ${file} is not an object`); return false; }
+  if (cfg.hooks !== undefined && (typeof cfg.hooks !== 'object' || cfg.hooks === null || Array.isArray(cfg.hooks))) {
+    console.warn(`[claude] not installing lifecycle hooks: ${file} hooks is not an object`);
+    return false;
+  }
   const entries = Array.isArray(cfg.hooks?.SessionStart) ? cfg.hooks.SessionStart : [];
   const present = entries.some((m) => (m?.hooks || []).some((h) => String(h?.command || '').includes('am-repin-hook.sh')));
-  if (present) return true;
+  const notifications = Array.isArray(cfg.hooks?.Notification) ? cfg.hooks.Notification : [];
+  const inputPresent = notifications.some((m) => (m?.hooks || [])
+    .some((h) => String(h?.command || '').includes('am-input-required-hook.sh')));
+  const clearEvents = ['PostToolBatch', 'Stop', 'SessionEnd', 'ElicitationResult', 'UserPromptSubmit'];
+  const missingClear = clearEvents.some((event) => {
+    const eventEntries = Array.isArray(cfg.hooks?.[event]) ? cfg.hooks[event] : [];
+    return !eventEntries.some((m) => (m?.hooks || [])
+      .some((h) => String(h?.command || '').includes('am-input-required-hook.sh')));
+  });
+  if (present && inputPresent && !missingClear) return true;
   // No matcher: fire for every source. `startup` replaces the "--session-id
   // not honoured" heuristic with a fact, `resume` is a proven no-op (same id),
   // and `clear` is the case this exists for. Filtering happens server-side.
   cfg.hooks = cfg.hooks || {};
-  cfg.hooks.SessionStart = [...entries, { hooks: [{ type: 'command', command: hookCmd, timeout: 5 }] }];
+  if (!present) cfg.hooks.SessionStart = [...entries, { hooks: [{ type: 'command', command: hookCmd, timeout: 5 }] }];
+  // Notification is deliberately later than PermissionRequest: it fires only
+  // after the actual permission/elicitation UI has remained unanswered for
+  // about six seconds, and cannot be intercepted by another decision hook.
+  if (!inputPresent) cfg.hooks.Notification = [...notifications, {
+    matcher: 'permission_prompt|elicitation_dialog|elicitation_url_dialog|agent_needs_input|agent_completed',
+    hooks: [{ type: 'command', command: inputRequiredCmd, timeout: 5 }],
+  }];
+  // These events prove the associated interaction has moved on. They only
+  // remove a marker carrying this pane launch's nonce; hook output stays empty.
+  for (const event of clearEvents) {
+    const eventEntries = Array.isArray(cfg.hooks[event]) ? cfg.hooks[event] : [];
+    const clearPresent = eventEntries.some((m) => (m?.hooks || [])
+      .some((h) => String(h?.command || '').includes('am-input-required-hook.sh')));
+    if (!clearPresent) cfg.hooks[event] = [...eventEntries, {
+      hooks: [{ type: 'command', command: inputRequiredCmd, timeout: 5 }],
+    }];
+  }
   try {
     const tmp = `${file}.am-tmp`;
     fs.writeFileSync(tmp, JSON.stringify(cfg, null, 2) + '\n');
     fs.renameSync(tmp, file);
-    console.warn(`[claude] repin hook installed in ${file}`);
+    console.warn(`[claude] lifecycle hooks installed in ${file}`);
     return true;
   } catch (e) { console.warn(`[claude] repin hook install failed: ${e.message}`); return false; }
 }
@@ -1726,7 +1764,7 @@ export function commandFor(session) {
   // pane instead of respawning. Unpinned sessions fall through to the generic
   // `resume --last` below (correct while the agent has its folder to itself).
   if (cli.id === 'codex' && session.codexSessionId && session.codexRollout) {
-    return `if [ -f '${session.codexRollout}' ]; then exec codex resume ${session.codexSessionId}; else exec codex; fi`;
+    return `if [ -f '${session.codexRollout}' ]; then exec ${cli.resume(session.codexSessionId)}; else exec ${cli.run}; fi`;
   }
 
   // opencode (seen on 1.17.13): at startup it creates a DIRECTORY named
@@ -1876,6 +1914,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
     screenChangedAt: Date.now(),
     bells: 0,
   };
+  host.inputRequired = createInputRequiredTracker({ id: session.id, runId, cli: session.cli });
   host.historyCheckpoint = createTerminalHistoryCheckpoint({
     directory: HISTORY_DIR,
     id: host.id,
@@ -1900,6 +1939,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
     host.lastOutputAt = Date.now();
     host.outputSeq++;
     host.terminalModes.feed(chunk);
+    host.inputRequired.observeOutput(chunk);
     if (host.traceHistoryTimer) {
       clearTimeout(host.traceHistoryTimer);
       host.traceHistoryTimer = null;
@@ -1947,6 +1987,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
     consumeBreadcrumb(session, host, workdir, true)
       .catch((e) => console.warn(`[${session.cli}] ${session.id}: final breadcrumb read failed (${e && e.message})`));
     hosts.delete(session.id);
+    host.inputRequired.close();
     stopping.delete(session.id);
     if (host.gridTimer) { clearTimeout(host.gridTimer); host.gridTimer = null; }
     if (host.traceHistoryTimer) { clearTimeout(host.traceHistoryTimer); host.traceHistoryTimer = null; }
@@ -2007,8 +2048,9 @@ export function attach(session, cols, rows) {
     onExit: (cb) => { sub.onExit = () => { try { cb(); } catch {} }; },
     onGrid: (cb) => { sub.onGrid = (c, r, controller, viewers, reset) => { try { cb(c, r, controller, viewers, reset); } catch {} }; },
     // Input and terminal-query responses are accepted from one emulator only.
-    write: (d) => {
+    write: (d, { terminalReply = false } = {}) => {
       if (host.controller !== sub) return;
+      if (!terminalReply) host.inputRequired.observeInput();
       try { host.pty.write(d); } catch {}
     },
     // Every viewer remembers what it can display, but only the current
@@ -2053,6 +2095,12 @@ export function attach(session, cols, rows) {
 export async function sendInput(id, text, { confirmEcho = false } = {}) {
   const host = hosts.get(id);
   if (!host || stopping.has(id)) throw new Error('session is not running');
+  if (host.inputRequired.get()) {
+    const error = new Error('session needs input in its terminal — a normal prompt was not sent into the open dialog');
+    error.statusCode = 409;
+    throw error;
+  }
+  host.inputRequired.observeInput();
   // Multi-line prompts go in as a bracketed paste so the CLI's composer treats
   // the inner newlines as soft line breaks instead of submitting early.
   const payload = text.includes('\n') ? `\x1b[200~${text}\x1b[201~` : text;
@@ -2102,8 +2150,14 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
 export function pasteInput(id, text) {
   const host = hosts.get(id);
   if (!host || stopping.has(id)) throw new Error('session is not running');
+  if (host.inputRequired.get()) {
+    const error = new Error('session needs input in its terminal — text was not pasted into the open dialog');
+    error.statusCode = 409;
+    throw error;
+  }
   const value = String(text || '');
   if (!value) return;
+  host.inputRequired.observeInput();
   const payload = value.includes('\n') ? `\x1b[200~${value}\x1b[201~` : value;
   host.pty.write(payload);
 }

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -2095,11 +2095,6 @@ export function attach(session, cols, rows) {
 export async function sendInput(id, text, { confirmEcho = false } = {}) {
   const host = hosts.get(id);
   if (!host || stopping.has(id)) throw new Error('session is not running');
-  if (host.inputRequired.get()) {
-    const error = new Error('session needs input in its terminal — a normal prompt was not sent into the open dialog');
-    error.statusCode = 409;
-    throw error;
-  }
   host.inputRequired.observeInput();
   // Multi-line prompts go in as a bracketed paste so the CLI's composer treats
   // the inner newlines as soft line breaks instead of submitting early.
@@ -2150,11 +2145,6 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
 export function pasteInput(id, text) {
   const host = hosts.get(id);
   if (!host || stopping.has(id)) throw new Error('session is not running');
-  if (host.inputRequired.get()) {
-    const error = new Error('session needs input in its terminal — text was not pasted into the open dialog');
-    error.statusCode = 409;
-    throw error;
-  }
   const value = String(text || '');
   if (!value) return;
   host.inputRequired.observeInput();

--- a/server/test/attachments.test.mjs
+++ b/server/test/attachments.test.mjs
@@ -156,17 +156,18 @@ try {
   assert.deepEqual(formatAttachmentPrelude('hermes', [stored]), [`/image ${JSON.stringify(stored.path)}`]);
   assert.deepEqual(formatAttachmentPrelude('hermes', [docx, stored]), [`/image ${JSON.stringify(stored.path)}`]);
   assert.deepEqual(formatAttachmentPrelude('codex', [stored]), []);
-  assert.equal(
-    cliById('codex').withPrompt("'compare  both'", ["'/tmp/first image.png'", "'/tmp/second.png'"]),
-    "codex -i '/tmp/first image.png' -i '/tmp/second.png' 'compare  both'",
+  const codexQuickstart = cliById('codex').withPrompt(
+    "'compare  both'", ["'/tmp/first image.png'", "'/tmp/second.png'"],
   );
-  assert.equal(
-    commandFor({
-      id: 'codex-first-image', cli: 'codex', everStarted: false,
-      pendingPrompt: 'compare  both', pendingImagePaths: ['/tmp/first image.png'],
-    }),
-    "exec codex -i '/tmp/first image.png' 'compare  both'",
-  );
+  assert.match(codexQuickstart, /tui\.notifications=/);
+  assert.match(codexQuickstart, /tui\.notification_method="osc9"/);
+  assert.ok(codexQuickstart.endsWith("-i '/tmp/first image.png' -i '/tmp/second.png' 'compare  both'"));
+  const codexFirst = commandFor({
+    id: 'codex-first-image', cli: 'codex', everStarted: false,
+    pendingPrompt: 'compare  both', pendingImagePaths: ['/tmp/first image.png'],
+  });
+  assert.ok(codexFirst.startsWith('exec codex '));
+  assert.ok(codexFirst.endsWith("-i '/tmp/first image.png' 'compare  both'"));
 
   const old = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000);
   const oldPart = path.join(path.dirname(stored.path), '.crashed.part');

--- a/server/test/attachments.test.mjs
+++ b/server/test/attachments.test.mjs
@@ -159,7 +159,7 @@ try {
   const codexQuickstart = cliById('codex').withPrompt(
     "'compare  both'", ["'/tmp/first image.png'", "'/tmp/second.png'"],
   );
-  assert.match(codexQuickstart, /tui\.notifications=/);
+  assert.match(codexQuickstart, /tui\.notifications=\["approval-requested","plan-mode-prompt"\]/);
   assert.match(codexQuickstart, /tui\.notification_method="osc9"/);
   assert.ok(codexQuickstart.endsWith("-i '/tmp/first image.png' -i '/tmp/second.png' 'compare  both'"));
   const codexFirst = commandFor({

--- a/server/test/input-required.test.mjs
+++ b/server/test/input-required.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-input-required-'));
+process.env.AM_INPUT_REQUIRED_DIR = root;
+const { createInputRequiredTracker } = await import('../src/input-required.js');
+
+const RUN = '11111111-2222-4333-8444-555555555555';
+const marker = (id, cli, value = {}) => fs.writeFileSync(path.join(root, `${id}.json`), JSON.stringify({
+  amId: id,
+  runId: RUN,
+  cli,
+  kind: 'permission',
+  source: `${cli}-notification`,
+  at: Date.now(),
+  ...value,
+}));
+
+try {
+  const quiet = createInputRequiredTracker({ id: 'quiet', runId: RUN, cli: 'claude' });
+  assert.equal(quiet.get(), null, 'a quiet/static terminal is not evidence');
+
+  marker('wrong-run', 'claude', { runId: 'old-launch' });
+  const wrong = createInputRequiredTracker({ id: 'wrong-run', runId: RUN, cli: 'claude' });
+  assert.equal(wrong.get(), null, 'a stale launch marker is ignored');
+
+  marker('wrong-source', 'claude', { source: 'opencode-event' });
+  const wrongSource = createInputRequiredTracker({ id: 'wrong-source', runId: RUN, cli: 'claude' });
+  assert.equal(wrongSource.get(), null, 'a marker source must belong to the matching CLI adapter');
+
+  marker('claude-pane', 'claude');
+  const claude = createInputRequiredTracker({ id: 'claude-pane', runId: RUN, cli: 'claude' });
+  assert.equal(claude.get()?.kind, 'permission');
+  claude.observeInput();
+  assert.equal(claude.get(), null, 'one-shot signals clear conservatively on operator input');
+  assert.equal(fs.existsSync(path.join(root, 'claude-pane.json')), false);
+
+  marker('oc-pane', 'opencode', {
+    kind: 'question', source: 'opencode-event', requestId: 'que_1',
+  });
+  const opencode = createInputRequiredTracker({ id: 'oc-pane', runId: RUN, cli: 'opencode' });
+  assert.equal(opencode.get()?.kind, 'question');
+  opencode.observeInput();
+  assert.equal(opencode.get()?.kind, 'question', 'menu navigation cannot clear a paired OpenCode request');
+  fs.unlinkSync(path.join(root, 'oc-pane.json'));
+  assert.equal(opencode.get(), null, 'the paired reply/removal clears OpenCode');
+
+  let now = 1_800_000_000_000;
+  const codex = createInputRequiredTracker({ id: 'codex-pane', runId: RUN, cli: 'codex', now: () => now });
+  codex.observeOutput('\x1b]9;ordinary turn complete\x07');
+  assert.equal(codex.get(), null, 'ordinary notifications are ignored');
+  codex.observeOutput('\x1b]9;Plan mode');
+  codex.observeOutput(' prompt: choose a path\x07');
+  assert.equal(codex.get()?.kind, 'question', 'a split native question signal is recognized');
+  codex.observeInput();
+  assert.equal(codex.get(), null);
+  codex.observeOutput('\x1b]9;Approval requested: run tests\x07');
+  assert.equal(codex.get()?.kind, 'permission');
+  now += 30 * 60_000 + 1;
+  assert.equal(codex.get(), null, 'an unpaired signal expires rather than sticking forever');
+
+  const geminiOsc = createInputRequiredTracker({ id: 'gemini-pane', runId: RUN, cli: 'gemini' });
+  geminiOsc.observeOutput('\x1b]9;Gemini CLI needs your attention | Answer requested by agent | choose one\x07');
+  assert.equal(geminiOsc.get()?.kind, 'question');
+  geminiOsc.observeInput();
+  geminiOsc.observeOutput('\x1b]777;notify;Gemini CLI needs your attention;Filesystem permission required\x07');
+  assert.equal(geminiOsc.get()?.kind, 'confirmation');
+  geminiOsc.observeOutput('\x1b]9;Gemini CLI session complete | Run finished\x07');
+  assert.equal(geminiOsc.get(), null);
+
+  const scripts = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', 'scripts');
+  const hook = path.join(scripts, 'am-input-required-hook.sh');
+  const baseEnv = {
+    ...process.env,
+    AM_ID: 'hook-pane',
+    AM_RUN_ID: RUN,
+    AM_INPUT_REQUIRED_DIR: root,
+    AM_PANE_PID: String(process.pid),
+  };
+  let child = spawnSync('sh', [hook], {
+    input: JSON.stringify({ hook_event_name: 'Notification', notification_type: 'permission_prompt' }),
+    env: {
+      ...baseEnv,
+      AM_CLI: 'claude',
+      CLAUDE_CODE_ENTRYPOINT: 'cli',
+      CLAUDE_PID: String(process.pid),
+    },
+  });
+  assert.equal(child.status, 0, child.stderr?.toString());
+  assert.equal(JSON.parse(fs.readFileSync(path.join(root, 'hook-pane.json'))).kind, 'permission');
+
+  fs.unlinkSync(path.join(root, 'hook-pane.json'));
+  child = spawnSync('bash', ['-c', 'sh "$1"; :', 'am-gemini-hook-test', hook], {
+    input: JSON.stringify({ hook_event_name: 'Notification', notification_type: 'ToolPermission', details: { type: 'ask_user' } }),
+    env: { ...baseEnv, AM_CLI: 'gemini' },
+  });
+  assert.equal(child.status, 0, child.stderr?.toString());
+  const gemini = JSON.parse(fs.readFileSync(path.join(root, 'hook-pane.json')));
+  assert.equal(gemini.kind, 'question');
+  assert.equal(gemini.source, 'gemini-notification');
+
+  child = spawnSync('sh', [hook], {
+    input: JSON.stringify({ hook_event_name: 'AfterAgent' }),
+    env: { ...baseEnv, AM_CLI: 'gemini' },
+  });
+  assert.equal(child.status, 0, child.stderr?.toString());
+  assert.equal(fs.existsSync(path.join(root, 'hook-pane.json')), false, 'native close event removes the marker');
+
+  child = spawnSync('bash', ['-c', 'sh "$1"; :', 'am-nested-gemini-hook-test', hook], {
+    input: JSON.stringify({ hook_event_name: 'Notification', notification_type: 'ToolPermission' }),
+    env: { ...baseEnv, AM_CLI: 'gemini', AM_PANE_PID: '1' },
+  });
+  assert.equal(child.status, 0, child.stderr?.toString());
+  assert.equal(fs.existsSync(path.join(root, 'hook-pane.json')), false, 'a Gemini hook outside the pane process tree is ignored');
+
+  const geminiDefaults = JSON.parse(fs.readFileSync(path.resolve(scripts, '..', 'gemini-system-defaults.json')));
+  assert.equal(geminiDefaults.hooks.Notification[0].matcher, 'ToolPermission');
+  assert.equal(geminiDefaults.general.notificationMethod, 'osc9');
+
+  console.log('input-required: all assertions passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/server/test/input-required.test.mjs
+++ b/server/test/input-required.test.mjs
@@ -39,15 +39,27 @@ try {
   assert.equal(claude.get(), null, 'one-shot signals clear conservatively on operator input');
   assert.equal(fs.existsSync(path.join(root, 'claude-pane.json')), false);
 
+  let opencodeNow = Date.now();
   marker('oc-pane', 'opencode', {
-    kind: 'question', source: 'opencode-event', requestId: 'que_1',
+    kind: 'question', source: 'opencode-event', requestId: 'que_1', at: opencodeNow,
   });
-  const opencode = createInputRequiredTracker({ id: 'oc-pane', runId: RUN, cli: 'opencode' });
+  const opencode = createInputRequiredTracker({
+    id: 'oc-pane', runId: RUN, cli: 'opencode', now: () => opencodeNow,
+  });
   assert.equal(opencode.get()?.kind, 'question');
   opencode.observeInput();
   assert.equal(opencode.get()?.kind, 'question', 'menu navigation cannot clear a paired OpenCode request');
-  fs.unlinkSync(path.join(root, 'oc-pane.json'));
-  assert.equal(opencode.get(), null, 'the paired reply/removal clears OpenCode');
+  opencodeNow += 30 * 60_000 + 1;
+  assert.equal(opencode.get(), null, 'a missing OpenCode close event cannot leave an unbounded marker');
+  assert.equal(fs.existsSync(path.join(root, 'oc-pane.json')), false, 'expiry removes the stale paired marker');
+
+  marker('oc-reply', 'opencode', {
+    kind: 'permission', source: 'opencode-event', requestId: 'per_1',
+  });
+  const opencodeReply = createInputRequiredTracker({ id: 'oc-reply', runId: RUN, cli: 'opencode' });
+  assert.equal(opencodeReply.get()?.kind, 'permission');
+  fs.unlinkSync(path.join(root, 'oc-reply.json'));
+  assert.equal(opencodeReply.get(), null, 'the paired reply/removal still clears OpenCode immediately');
 
   let now = 1_800_000_000_000;
   const codex = createInputRequiredTracker({ id: 'codex-pane', runId: RUN, cli: 'codex', now: () => now });

--- a/server/test/opencode-resume.test.mjs
+++ b/server/test/opencode-resume.test.mjs
@@ -14,6 +14,7 @@ const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'oc-resume-'));
 const XDG = path.join(TMP, 'xdg');
 const DATA = path.join(TMP, 'data');
 const REPIN = path.join(TMP, 'repin');
+const INPUT_REQUIRED = path.join(TMP, 'input-required');
 fs.mkdirSync(path.join(XDG, 'opencode'), { recursive: true });
 fs.mkdirSync(DATA, { recursive: true });
 
@@ -21,6 +22,7 @@ process.env.XDG_DATA_HOME = XDG;
 process.env.XDG_CONFIG_HOME = path.join(TMP, 'config');
 process.env.DATA_DIR = DATA;
 process.env.AM_REPIN_DIR = REPIN;
+process.env.AM_INPUT_REQUIRED_DIR = INPUT_REQUIRED;
 process.env.AM_ID = 'pane-1';
 process.env.AM_RUN_ID = '11111111-2222-4333-8444-555555555555';
 process.env.AM_CLI = 'opencode';
@@ -89,6 +91,37 @@ check('subagent create ignored', fs.existsSync(path.join(REPIN, 'pane-1.opencode
 await hooks['chat.message']({ sessionID: LIVE });
 crumb = JSON.parse(fs.readFileSync(path.join(REPIN, 'pane-1.opencode.json'), 'utf8'));
 check('message hook follows selected existing session', crumb.payload.session_id, LIVE);
+
+console.log('\nthe plugin tracks exact pending permissions and questions');
+const attentionFile = path.join(INPUT_REQUIRED, 'pane-1.json');
+await hooks.event({ event: { type: 'question.asked', properties: {
+  id: 'que_1', sessionID: LIVE, questions: [], tool: { messageID: 'msg_1', callID: 'call_1' },
+} } });
+let attention = JSON.parse(fs.readFileSync(attentionFile, 'utf8'));
+check('question asked writes a question marker', attention.kind, 'question');
+check('attention marker is tied to this launch', attention.runId, process.env.AM_RUN_ID);
+await hooks.event({ event: { type: 'permission.asked', properties: {
+  id: 'per_1', sessionID: LIVE, permission: 'bash', patterns: ['*'],
+} } });
+await hooks.event({ event: { type: 'question.replied', properties: {
+  sessionID: LIVE, requestID: 'que_1', answers: [],
+} } });
+attention = JSON.parse(fs.readFileSync(attentionFile, 'utf8'));
+check('resolving one queued item leaves the next one', attention.requestId, 'per_1');
+await hooks.event({ event: { type: 'permission.replied', properties: {
+  sessionID: LIVE, requestID: 'per_1', reply: 'once',
+} } });
+check('last paired reply removes the marker', fs.existsSync(attentionFile), false);
+
+await hooks.event({ event: { type: 'question.asked', properties: {
+  id: 'que_2', sessionID: LIVE, questions: [], tool: { messageID: 'msg_2', callID: 'call_2' },
+} } });
+await hooks.event({ event: { type: 'message.part.updated', properties: { part: {
+  id: 'part_2', type: 'tool', tool: 'question', messageID: 'msg_2', callID: 'call_2',
+  state: { status: 'completed' },
+} } } });
+check('completed Question tool clears a missing reply event', fs.existsSync(attentionFile), false);
+
 const shellOutput = { env: { KEEP: 'yes' } };
 await hooks['shell.env']({}, shellOutput);
 check('shell keeps unrelated environment', shellOutput.env.KEEP, 'yes');

--- a/server/test/repin.test.mjs
+++ b/server/test/repin.test.mjs
@@ -312,9 +312,14 @@ check('installs into existing file', runner.installClaudeRepinHook('/app/scripts
 let s = JSON.parse(fs.readFileSync(settings, 'utf8'));
 check('other keys kept', s.model, 'opus');
 check('hook entry present', s.hooks.SessionStart.length, 1);
+check('attention notification hook present', s.hooks.Notification.length, 1);
+check('attention hook uses post-dialog events', s.hooks.Notification[0].matcher,
+  'permission_prompt|elicitation_dialog|elicitation_url_dialog|agent_needs_input|agent_completed');
+check('attention marker gets a native clear path', s.hooks.PostToolBatch.length, 1);
 check('second run is a no-op', runner.installClaudeRepinHook('/app/scripts/am-repin-hook.sh'), true);
 s = JSON.parse(fs.readFileSync(settings, 'utf8'));
 check('no duplicate entry', s.hooks.SessionStart.length, 1);
+check('no duplicate attention entry', s.hooks.Notification.length, 1);
 
 console.log('\ninstaller refuses to clobber a corrupt settings file');
 fs.writeFileSync(settings, '{ not json');

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -15,6 +15,7 @@ import type { PendingAttachment } from '../lib/attachments';
 import Attachments from './Attachments';
 import Logo from './Logo';
 import Composer from './conversation/Composer';
+import InputRequiredNotice from './conversation/InputRequiredNotice';
 import ExchangeView, { PendingExchange } from './conversation/Exchange';
 import { useDraft } from './conversation/useDraft';
 import { writePaneMode } from '../lib/paneMode';
@@ -366,23 +367,30 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
         )}
       </div>
 
-      <Composer
-        draft={draft}
-        sending={sending}
-        isMobile={isMobile}
-        inputRef={inputRef}
-        canSend={!!draft.trim() || images.length > 0}
-        above={<Attachments
-          attachments={images}
-          disabled={sending || !allowAttachments}
-          disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
-          onFiles={addImages}
-          onRemove={removeImage}
-        />}
-        onChange={setDraft}
-        onSend={send}
-        onPasteFiles={allowAttachments ? addImages : undefined}
-      />
+      {s.inputRequired ? (
+        <InputRequiredNotice
+          input={s.inputRequired}
+          onOpenTerminal={() => { writePaneMode('terminal'); onOpen(s.id); }}
+        />
+      ) : (
+        <Composer
+          draft={draft}
+          sending={sending}
+          isMobile={isMobile}
+          inputRef={inputRef}
+          canSend={!!draft.trim() || images.length > 0}
+          above={<Attachments
+            attachments={images}
+            disabled={sending || !allowAttachments}
+            disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
+            onFiles={addImages}
+            onRemove={removeImage}
+          />}
+          onChange={setDraft}
+          onSend={send}
+          onPasteFiles={allowAttachments ? addImages : undefined}
+        />
+      )}
       {(imageError || failed) && <div className="ov-note" role="alert">{imageError || failed}</div>}
     </div>
   );
@@ -419,7 +427,9 @@ function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession; color
           {d?.lastPromptText
             ? <div className="ovt-prompt" title={d.lastPromptText}>{d.lastPromptText}</div>
             : <div className="ovt-prompt none">no prompt yet</div>}
-          {running
+          {s.inputRequired
+            ? <div className="ovt-state input mono">! needs input</div>
+            : running
             ? <div className="ovt-state running mono">running</div>
             : s.state === 'stopped'
               ? <div className="ovt-state stopped mono">stopped</div>

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -367,30 +367,29 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
         )}
       </div>
 
-      {s.inputRequired ? (
+      {s.inputRequired && (
         <InputRequiredNotice
           input={s.inputRequired}
           onOpenTerminal={() => { writePaneMode('terminal'); onOpen(s.id); }}
         />
-      ) : (
-        <Composer
-          draft={draft}
-          sending={sending}
-          isMobile={isMobile}
-          inputRef={inputRef}
-          canSend={!!draft.trim() || images.length > 0}
-          above={<Attachments
-            attachments={images}
-            disabled={sending || !allowAttachments}
-            disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
-            onFiles={addImages}
-            onRemove={removeImage}
-          />}
-          onChange={setDraft}
-          onSend={send}
-          onPasteFiles={allowAttachments ? addImages : undefined}
-        />
       )}
+      <Composer
+        draft={draft}
+        sending={sending}
+        isMobile={isMobile}
+        inputRef={inputRef}
+        canSend={!!draft.trim() || images.length > 0}
+        above={<Attachments
+          attachments={images}
+          disabled={sending || !allowAttachments}
+          disabledReason={!allowAttachments ? 'Files are not available for remote agents yet — that agent cannot read files stored on this Space.' : undefined}
+          onFiles={addImages}
+          onRemove={removeImage}
+        />}
+        onChange={setDraft}
+        onSend={send}
+        onPasteFiles={allowAttachments ? addImages : undefined}
+      />
       {(imageError || failed) && <div className="ov-note" role="alert">{imageError || failed}</div>}
     </div>
   );

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -346,7 +346,10 @@ export default function Sidebar({
       >
         {/* The same three lights, but for a remote agent they mean connection,
             not process: working / listening / not connected. */}
-        <span className={`status ${s.state}`} title={s.inputRequired ? 'needs input in terminal' : (isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
+        <span
+          className={`status ${s.inputRequired ? 'needs-input' : s.state}`}
+          title={s.inputRequired ? 'needs input in terminal' : (isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]}
+        />
         <Logo cli={s.cli} size={12} tint={colorOf[s.cli]} />
         {editing ? (
           <input

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -346,10 +346,10 @@ export default function Sidebar({
       >
         {/* The same three lights, but for a remote agent they mean connection,
             not process: working / listening / not connected. */}
-        <span
-          className={`status ${s.inputRequired ? 'needs-input' : s.state}`}
-          title={s.inputRequired ? 'needs input in terminal' : (isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]}
-        />
+        <span className="row-status">
+          <span className={`status ${s.state}`} title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
+          {s.inputRequired && <span className="row-input-required" aria-hidden="true">!</span>}
+        </span>
         <Logo cli={s.cli} size={12} tint={colorOf[s.cli]} />
         {editing ? (
           <input

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -342,11 +342,11 @@ export default function Sidebar({
         onDragStart={dnd.onDragStart} onDragEnd={dnd.onDragEnd} onDragOver={dnd.onDragOver} onDrop={dnd.onDrop}
         onClick={() => onOpenSession(s.id, groupId)}
         onDoubleClick={(e) => { e.stopPropagation(); startEdit(ref, s.name); }}
-        title={s.path ? `${s.name} · ${s.path}` : s.name}
+        title={s.inputRequired ? `${s.name} · needs input in terminal` : (s.path ? `${s.name} · ${s.path}` : s.name)}
       >
         {/* The same three lights, but for a remote agent they mean connection,
             not process: working / listening / not connected. */}
-        <span className={`status ${s.state}`} title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
+        <span className={`status ${s.state}`} title={s.inputRequired ? 'needs input in terminal' : (isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
         <Logo cli={s.cli} size={12} tint={colorOf[s.cli]} />
         {editing ? (
           <input

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -342,14 +342,11 @@ export default function Sidebar({
         onDragStart={dnd.onDragStart} onDragEnd={dnd.onDragEnd} onDragOver={dnd.onDragOver} onDrop={dnd.onDrop}
         onClick={() => onOpenSession(s.id, groupId)}
         onDoubleClick={(e) => { e.stopPropagation(); startEdit(ref, s.name); }}
-        title={s.inputRequired ? `${s.name} · needs input in terminal` : (s.path ? `${s.name} · ${s.path}` : s.name)}
+        title={s.path ? `${s.name} · ${s.path}` : s.name}
       >
         {/* The same three lights, but for a remote agent they mean connection,
             not process: working / listening / not connected. */}
-        <span className="row-status">
-          <span className={`status ${s.state}`} title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
-          {s.inputRequired && <span className="row-input-required" aria-hidden="true">!</span>}
-        </span>
+        <span className={`status ${s.state}`} title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
         <Logo cli={s.cli} size={12} tint={colorOf[s.cli]} />
         {editing ? (
           <input

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -559,7 +559,7 @@ export default function ConversationView({
       {!readOnly && session.inputRequired && (
         <InputRequiredNotice input={session.inputRequired} onOpenTerminal={() => writePaneMode('terminal')} />
       )}
-      {!readOnly && !session.inputRequired && (
+      {!readOnly && (
         <Composer
           className="cxv-live"
           containerClassName="cxv-composer"

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -29,6 +29,8 @@ import { fmtTok, splitExchanges } from './exchanges';
 import ExchangeView, { PendingExchange } from './Exchange';
 import Attachments from '../Attachments';
 import Composer from './Composer';
+import InputRequiredNotice from './InputRequiredNotice';
+import { writePaneMode } from '../../lib/paneMode';
 
 const NEAR_TOP_PX = 300;   // start fetching older turns before the reader arrives
 
@@ -554,7 +556,10 @@ export default function ConversationView({
         </div>
       </div>
 
-      {!readOnly && (
+      {!readOnly && session.inputRequired && (
+        <InputRequiredNotice input={session.inputRequired} onOpenTerminal={() => writePaneMode('terminal')} />
+      )}
+      {!readOnly && !session.inputRequired && (
         <Composer
           className="cxv-live"
           containerClassName="cxv-composer"

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -172,6 +172,8 @@ export default function ConversationView({
   const turns: TraceTurn[] = turnsRef.current;
   const exchanges = useMemo(() => splitExchanges(turns), [version, turns]); // eslint-disable-line react-hooks/exhaustive-deps
   const last = exchanges[exchanges.length - 1];
+  const inputRequiredKey = session.inputRequired
+    ? `${session.inputRequired.detectedAt}:${session.inputRequired.kind}` : '';
 
   // Group reader mode gives the focused pane the critical path. Its siblings
   // wait for this signal before mounting their own readers, so one click cannot
@@ -319,7 +321,7 @@ export default function ConversationView({
     if (a == null) return;
     el.scrollTop = el.scrollHeight - a;
     anchor.current = null;
-  }, [version, live, sent]);
+  }, [version, live, sent, inputRequiredKey]);
 
   // ---- where you had got to -----------------------------------------------
   // Opening on the end is right for a conversation you have not read; it is not
@@ -553,12 +555,12 @@ export default function ConversationView({
           ))}
           {sent && <PendingExchange text={sent.text} />}
           {!exchanges.length && !sent && <div className="cxv-msg mono">nothing in this trace yet</div>}
+          {!readOnly && session.inputRequired && (
+            <InputRequiredNotice input={session.inputRequired} onOpenTerminal={() => writePaneMode('terminal')} />
+          )}
         </div>
       </div>
 
-      {!readOnly && session.inputRequired && (
-        <InputRequiredNotice input={session.inputRequired} onOpenTerminal={() => writePaneMode('terminal')} />
-      )}
       {!readOnly && (
         <Composer
           className="cxv-live"

--- a/web/src/components/conversation/InputRequiredNotice.tsx
+++ b/web/src/components/conversation/InputRequiredNotice.tsx
@@ -1,9 +1,9 @@
 import type { InputRequired } from '../../types';
 
 const detail = (kind: InputRequired['kind']) => {
-  if (kind === 'permission') return 'A permission prompt is waiting in the terminal.';
-  if (kind === 'question') return 'A question or choice menu is waiting in the terminal.';
-  return 'A confirmation dialog is waiting in the terminal.';
+  if (kind === 'permission') return 'permission prompt waiting in the terminal';
+  if (kind === 'question') return 'question or choice menu waiting in the terminal';
+  return 'confirmation dialog waiting in the terminal';
 };
 
 export default function InputRequiredNotice({ input, onOpenTerminal }: {
@@ -14,8 +14,7 @@ export default function InputRequiredNotice({ input, onOpenTerminal }: {
     <div className="input-required" role="status">
       <span className="input-required-mark" aria-hidden="true">!</span>
       <span className="input-required-copy">
-        <strong>Needs input</strong>
-        <span>{detail(input.kind)}</span>
+        <span className="input-required-label">needs input</span> · {detail(input.kind)}
       </span>
       <button type="button" onClick={onOpenTerminal}>open terminal</button>
     </div>

--- a/web/src/components/conversation/InputRequiredNotice.tsx
+++ b/web/src/components/conversation/InputRequiredNotice.tsx
@@ -1,0 +1,23 @@
+import type { InputRequired } from '../../types';
+
+const detail = (kind: InputRequired['kind']) => {
+  if (kind === 'permission') return 'A permission prompt is waiting in the terminal.';
+  if (kind === 'question') return 'A question or choice menu is waiting in the terminal.';
+  return 'A confirmation dialog is waiting in the terminal.';
+};
+
+export default function InputRequiredNotice({ input, onOpenTerminal }: {
+  input: InputRequired;
+  onOpenTerminal: () => void;
+}) {
+  return (
+    <div className="input-required" role="status">
+      <span className="input-required-mark" aria-hidden="true">!</span>
+      <span className="input-required-copy">
+        <strong>Needs input</strong>
+        <span>{detail(input.kind)}</span>
+      </span>
+      <button type="button" onClick={onOpenTerminal}>open terminal</button>
+    </div>
+  );
+}

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -399,6 +399,14 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 }
 .input-required button:hover { color: var(--text); border-color: var(--border-strong); }
 .input-required + .ov-composer { border-top: 0; }
+.cxv-col > .input-required {
+  align-self: flex-start; max-width: calc(100% - 1.23em); min-height: 0;
+  margin: 8px 0 2px 1.23em; padding: 5px 6px 5px 8px; border: 0; border-radius: var(--r-md);
+  background: var(--accent); color: var(--accent-fg);
+}
+.cxv-col > .input-required :is(.input-required-mark, .input-required-label, button) { color: inherit; }
+.cxv-col > .input-required button { height: 18px; border-color: color-mix(in srgb, var(--accent-fg) 40%, transparent); background: transparent; }
+.cxv-col > .input-required button:hover { color: inherit; border-color: var(--accent-fg); background: color-mix(in srgb, var(--accent-fg) 12%, transparent); }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the
      rule above is later in the cascade, so it would otherwise win. A phone

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -400,8 +400,9 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 .input-required button:hover { color: var(--text); border-color: var(--border-strong); }
 .input-required + .ov-composer { border-top: 0; }
 .cxv-col > .input-required {
-  align-self: flex-start; max-width: calc(100% - 1.23em); min-height: 0;
-  margin: 8px 0 2px 1.23em; padding: 5px 6px 5px 8px; border: 0; border-radius: var(--r-md);
+  align-self: stretch; max-width: none; min-height: 0;
+  margin: 8px calc(-1 * var(--cx-gutter)) 2px 0;
+  padding: 5px var(--cx-gutter) 5px 8px; border: 0; border-radius: 0;
   background: var(--accent); color: var(--accent-fg);
 }
 .cxv-col > .input-required :is(.input-required-mark, .input-required-label, button) { color: inherit; }

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -385,6 +385,22 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    hardcoded 13px line and mis-centre the controls at every zoom but 100%. */
 .ov-composer.cxv-composer { --ov-first-line: calc(1.45em + 4px); }
 .cxv-note { flex: none; padding: 0 12px 6px; }
+.input-required {
+  flex: none; display: flex; align-items: center; gap: 9px; min-width: 0;
+  padding: 8px 12px; border-top: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, var(--panel)); font-size: 0.88em;
+}
+.input-required-mark {
+  display: grid; place-items: center; flex: none; width: 18px; height: 18px;
+  border-radius: 50%; background: var(--accent); color: var(--panel); font-weight: 800;
+}
+.input-required-copy { display: flex; flex-direction: column; min-width: 0; line-height: 1.25; }
+.input-required-copy span { color: var(--muted); }
+.input-required button {
+  flex: none; margin-left: auto; border: 1px solid var(--border); border-radius: 5px;
+  padding: 4px 8px; background: var(--panel-2); color: var(--text); font: inherit; cursor: pointer;
+}
+.input-required button:hover { border-color: var(--accent); }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the
      rule above is later in the cascade, so it would otherwise win. A phone

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -401,6 +401,7 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
   padding: 4px 8px; background: var(--panel-2); color: var(--text); font: inherit; cursor: pointer;
 }
 .input-required button:hover { border-color: var(--accent); }
+.input-required + .ov-composer { border-top: 0; }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the
      rule above is later in the cascade, so it would otherwise win. A phone

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -386,21 +386,18 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 .ov-composer.cxv-composer { --ov-first-line: calc(1.45em + 4px); }
 .cxv-note { flex: none; padding: 0 12px 6px; }
 .input-required {
-  flex: none; display: flex; align-items: center; gap: 9px; min-width: 0;
-  padding: 8px 12px; border-top: 1px solid color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: color-mix(in srgb, var(--accent) 8%, var(--panel)); font-size: 0.88em;
+  flex: none; display: flex; align-items: center; gap: 5px; min-width: 0; min-height: 24px;
+  padding: 2px 9px; border-top: 1px solid var(--border); background: var(--panel-2);
+  color: var(--muted); font: 0.81em/1.2 var(--font-mono);
 }
-.input-required-mark {
-  display: grid; place-items: center; flex: none; width: 18px; height: 18px;
-  border-radius: 50%; background: var(--accent); color: var(--panel); font-weight: 800;
-}
-.input-required-copy { display: flex; flex-direction: column; min-width: 0; line-height: 1.25; }
-.input-required-copy span { color: var(--muted); }
+.input-required-mark, .input-required-label { color: var(--accent); font-weight: 700; }
+.input-required-copy { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .input-required button {
-  flex: none; margin-left: auto; border: 1px solid var(--border); border-radius: 5px;
-  padding: 4px 8px; background: var(--panel-2); color: var(--text); font: inherit; cursor: pointer;
+  flex: none; margin-left: auto; height: 20px; padding: 0 7px;
+  border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel);
+  color: var(--muted); font: inherit; line-height: 1; cursor: pointer;
 }
-.input-required button:hover { border-color: var(--accent); }
+.input-required button:hover { color: var(--text); border-color: var(--border-strong); }
 .input-required + .ov-composer { border-top: 0; }
 @media (max-width: 720px) and (pointer: coarse) {
   /* Restating styles.css's iOS guard: 16px is what stops zoom-on-focus, and the

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -422,6 +422,7 @@ body {
 .ovt-prompt.none::before { color: var(--border-strong); }
 .ovt-state { font-size: 10.5px; color: var(--muted); }
 .ovt-state.running { color: var(--accent); }
+.ovt-state.input { color: var(--accent); font-weight: 650; }
 .ovt-state.running::before {
   content: '⠋'; display: inline-flex; align-items: center;
   width: var(--mark-w); height: var(--mark-h);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,5 +1,12 @@
 export type SessionState = 'working' | 'waiting' | 'idle' | 'stopped';
 
+export interface InputRequired {
+  kind: 'permission' | 'question' | 'confirmation';
+  cli: string;
+  confidence: 'high';
+  detectedAt: string;
+}
+
 export interface Session {
   id: string;
   name: string;
@@ -11,6 +18,8 @@ export interface Session {
   everStarted: boolean;
   running: boolean;
   state: SessionState;
+  /** Native CLI event says an interactive TUI dialog is currently pending. */
+  inputRequired?: InputRequired | null;
   // Only on `cli: 'trace'` panes: what the read-only trace view is pointed at.
   // A regular agent session needs no such record — it reads its own transcript.
   traceSource?: { kind: 'session' | 'bundle'; ref: string } | null;


### PR DESCRIPTION
## Summary

- Surface a **Needs input** state in the reader's conversation flow and in Overview cards/tiles when a supported CLI natively reports an open permission, question, or confirmation dialog. The sidebar deliberately remains a status-dot-only inventory.
- Detect high-confidence subsets for Claude Code, Codex, Gemini CLI, and OpenCode without using screen text, process idleness, or generic stdin polling.
- Keep the signal advisory: the normal reader/Overview composer stays visible and enabled, and prompt plus attachment delivery remain available. The flow element offers **open terminal** for the CLI's native choice UI.
- Bound every marker to 30 minutes and remove expired marker files, including paired OpenCode events, so a missed close event cannot leave a permanent warning.
- Document the evidence, confidence, deliberate misses, and why Hermes/OpenClaw remain on the current no-indicator fallback.

## Detection and confidence

| CLI | Native signal | Confidence / important misses |
| --- | --- | --- |
| OpenCode | Paired `permission.asked`/replied and `question.asked`/replied/rejected plugin events, including queues and the missing-question-reply recovery path. | High with authoritative open/close pairs. Misses dialogs outside those event families. |
| Claude Code | Post-display `Notification` hooks for permission, elicitation, and agent-input attention events. | High once emitted, intentionally about six seconds late. Misses prompt types for which Claude exposes no notification, including some `AskUserQuestion` paths; teammate attention may not mean the main pane owns stdin. |
| Codex | Invocation-local OSC 9 notifications emitted by the TUI handlers that install approval and request-user-input views. | High for those handlers. A live Codex 0.147.0 approval confirmed that `approval-requested` is the emitted notification name. Misses permission/generic queue paths that do not notify. |
| Gemini CLI | `ToolPermission` hook plus Gemini's native pending-attention OSC notification. | High for reported states. Higher-precedence user/project settings can suppress the non-tool OSC subset. |
| Hermes / OpenClaw | No integration shipped. | No reliable pane-scoped external signal was found for the local TUIs Agent Manager launches. |

Every file marker is local-only and bound to the exact pane id, CLI adapter, random launch id, and top-level process tree. Automatic terminal-query replies do not clear it. Unpaired signals can clear on operator input or a native completion event; every signal has the same 30-minute ceiling. See [`docs/tui-input-required.md`](docs/tui-input-required.md) for the source evidence and complete miss list.

## Advisory behavior

A false-positive warning is recoverable; a false-positive write denial is an availability bug. This first version therefore never hides the composer or rejects prompt/attachment delivery merely because the marker is active.

The reader does not answer the native dialog itself. The CLIs do not expose one common typed response API: identifiers, validation, queued requests, allow-once/always semantics, and secret handling differ. Translating a reader form into raw keystrokes could select the wrong menu item, so the action opens the native TUI.

Enforcement can be reconsidered later **per adapter**, not globally, after a deployed live matrix has exercised every covered dialog and subtype. Claude's teammate-attention event is one reason that distinction matters.

## Reader placement and scrolling

The reader renders one compact primary-colour box after the newest exchange, inside `.cxv-body` / `.cxv-col`. It has the answer/tool column's left edge, scrolls with the transcript, and has no pinned duplicate. The Overview tile remains unchanged; the sidebar has no needs-input treatment at all.

- **Fresh arrival:** the reader's existing open-on-end layout path includes the box in `scrollHeight`, so a session that already needs input opens with it visible without another scroll.
- **Signal while following the end:** the marker's stable `detectedAt:kind` key re-runs that same layout path. If the reader was already at the end, it follows the newly appended box and stays at the end.
- **Signal while reading older content:** the existing `stick.current === false` path performs no scroll. Browser verification appended the box while `scrollTop` remained exactly unchanged.
- **Scrolled-up tradeoff:** the box is intentionally below the viewport with the newest exchange. There is no sidebar or pinned fallback to compensate; this is the operator-selected behavior.

## Rendered states

[View the reader and Overview in needs-input, scrolled-up, and normal states](https://lvwerra-agent-artifacts.static.hf.space/pr78-advisory-input.html). These are captures of the rebased branch running the real backend and production React components; the fixture varies only the session state returned through the normal API contracts.

## Verification

- `cd web && npm test && npm run build` — green on `260f532`; the build includes TypeScript checking and reports only the existing Vite chunk-size warning.
- `cd server && npm test` — full server suite green on the immediate parent; `260f532` changes web presentation only. Focused `server/test/input-required.test.mjs` is green on the current tree.
- Browser integration checks: fresh marker visible at end; late marker while at end preserves `endGap: 0`; late marker after scrolling up preserves `scrollTop` exactly and remains below the viewport; sidebar contains the ordinary idle dot and no needs-input marker.
- `sh -n scripts/am-input-required-hook.sh` and `git diff --check` — green.
- A live Codex 0.147.0 A/B approval run emitted OSC 9 for `approval-requested`; the near-spelling `approval-request` reached the same approval menu but emitted no notification.
- Focused detector tests cover stale/wrong launch and adapter markers, nested-process rejection, split and unrelated OSC sequences, the universal 30-minute expiry/removal behavior, OpenCode queues and missing reply recovery, and Claude settings merge/idempotency.

This branch was not deployed. Claude, Gemini, and OpenCode detection is supported by the pinned native code paths and fixture tests documented in the design note, but those adapters still need the deliberate deployed smoke matrix described there before any enforcement should be considered.
