### PR TITLE
Sidebar: a group's whole frame takes the drop, not just its name

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs",
+    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -12,7 +12,7 @@ import {
 import type { PendingAttachment } from '../lib/attachments';
 import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
 
-import { dropZone, backgroundAnchor } from './sidebar-dnd';
+import { dropZone, backgroundAnchor, isBackgroundTarget } from './sidebar-dnd';
 import type { Zone, Kind } from './sidebar-dnd';
 
 // Harnesses whose traces the Hub renders natively, so a share ships the file
@@ -325,14 +325,14 @@ export default function Sidebar({
     onDragLeave: (e: React.DragEvent) => { if (e.currentTarget === e.target) setDrop(null); },
     onDragOver: (e: React.DragEvent) => {
       // Only the background: anything over a row or a frame is theirs to answer.
-      if (!dragRef || e.target !== e.currentTarget) return;
+      if (!dragRef || !isBackgroundTarget(e.target as HTMLElement, e.currentTarget)) return;
       const a = treeAnchor(e.currentTarget as HTMLElement, e.clientY);
       if (!a) return;
       e.preventDefault();
       setDrop(a);
     },
     onDrop: (e: React.DragEvent) => {
-      if (!dragRef || e.target !== e.currentTarget) return;
+      if (!dragRef || !isBackgroundTarget(e.target as HTMLElement, e.currentTarget)) return;
       const a = treeAnchor(e.currentTarget as HTMLElement, e.clientY);
       if (!a) { clearDrag(); return; }
       e.preventDefault();

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -12,7 +12,8 @@ import {
 import type { PendingAttachment } from '../lib/attachments';
 import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
 
-type Zone = 'before' | 'after' | 'on';
+import { dropZone, backgroundAnchor } from './sidebar-dnd';
+import type { Zone, Kind } from './sidebar-dnd';
 
 // Harnesses whose traces the Hub renders natively, so a share ships the file
 // verbatim (mirrors SHAREABLE_CLIS in server/src/share.js). The others need
@@ -294,35 +295,68 @@ export default function Sidebar({
     setEditRef(null);
   };
 
-  // shared drag-and-drop wiring for any row
-  const dndProps = (ref: string, kind: 'group' | 'session', nested: boolean) => ({
+  const zoneFor = (ref: string, kind: Kind, nested: boolean, rect: DOMRect, clientY: number): Zone | null =>
+    dropZone({
+      dragRef, ref, kind, nested, box: rect, clientY,
+      isMember: kind === 'group' && !!dragRef && groupById[ref.slice(2)]?.sessionIds.includes(dragRef.slice(2)),
+    });
+
+  const applyDrop = (ref: string, kind: Kind, zone: Zone) => {
+    const id = ref.slice(2);
+    if (zone === 'on') {
+      if (kind === 'group') onMove(dragRef!, { kind: 'into', groupId: id });
+      else onMove(dragRef!, { kind: 'pair', sessionId: id });
+    } else {
+      onMove(dragRef!, { kind: zone, ref });
+    }
+    clearDrag();
+  };
+
+  // The tree's own background — the margins between frames, and the empty space
+  // below the list. Without this there is no way to pull an agent out of a group
+  // once every agent is in one: the top level would have no row left to aim at.
+  const treeAnchor = (el: HTMLElement, clientY: number) => backgroundAnchor(
+    Array.from(el.querySelectorAll<HTMLElement>(':scope > [data-ref]')).map((k) => ({ ref: k.dataset.ref!, box: k.getBoundingClientRect() })),
+    dragRef,
+    clientY,
+  );
+  const treeDnd = {
+    onDragEnd: clearDrag,
+    onDragLeave: (e: React.DragEvent) => { if (e.currentTarget === e.target) setDrop(null); },
+    onDragOver: (e: React.DragEvent) => {
+      // Only the background: anything over a row or a frame is theirs to answer.
+      if (!dragRef || e.target !== e.currentTarget) return;
+      const a = treeAnchor(e.currentTarget as HTMLElement, e.clientY);
+      if (!a) return;
+      e.preventDefault();
+      setDrop(a);
+    },
+    onDrop: (e: React.DragEvent) => {
+      if (!dragRef || e.target !== e.currentTarget) return;
+      const a = treeAnchor(e.currentTarget as HTMLElement, e.clientY);
+      if (!a) { clearDrag(); return; }
+      e.preventDefault();
+      onMove(dragRef, { kind: a.zone, ref: a.ref });
+      clearDrag();
+    },
+  };
+
+  // shared drag-and-drop wiring for any row or group frame
+  const dndProps = (ref: string, kind: Kind, nested: boolean) => ({
     draggable: editRef !== ref,
     onDragStart: (e: React.DragEvent) => { e.dataTransfer.setData('text/plain', ref); e.dataTransfer.effectAllowed = 'move'; setDragRef(ref); onDragState?.(ref); },
     onDragEnd: clearDrag,
     onDragOver: (e: React.DragEvent) => {
-      if (!dragRef || dragRef === ref) return;
-      const draggingGroup = dragRef.startsWith('g:');
-      if (nested && draggingGroup) return; // can't nest a group
+      const zone = zoneFor(ref, kind, nested, e.currentTarget.getBoundingClientRect(), e.clientY);
+      if (!zone) return; // let it bubble — an enclosing frame may still take it
       e.preventDefault(); e.stopPropagation();
-      const rect = e.currentTarget.getBoundingClientRect();
-      const y = e.clientY - rect.top;
-      let zone: Zone;
-      if (draggingGroup) zone = y < rect.height / 2 ? 'before' : 'after';
-      else { const th = rect.height / 3; zone = y < th ? 'before' : y > 2 * th ? 'after' : 'on'; }
       setDrop({ ref, zone });
     },
     onDrop: (e: React.DragEvent) => {
-      if (!dragRef || dragRef === ref) { clearDrag(); return; }
+      const zone = zoneFor(ref, kind, nested, e.currentTarget.getBoundingClientRect(), e.clientY);
+      if (!zone) return;
       e.preventDefault(); e.stopPropagation();
-      const zone = drop && drop.ref === ref ? drop.zone : 'after';
-      const id = ref.slice(2);
-      if (zone === 'on') {
-        if (kind === 'group') onMove(dragRef, { kind: 'into', groupId: id });
-        else onMove(dragRef, { kind: 'pair', sessionId: id });
-      } else {
-        onMove(dragRef, { kind: zone, ref });
-      }
-      clearDrag();
+      applyDrop(ref, kind, zone);
     },
     className: drop && drop.ref === ref ? ` drop-${drop.zone}` : '',
   });
@@ -337,6 +371,7 @@ export default function Sidebar({
     return (
       <div
         key={s.id}
+        data-ref={ref}
         className={`row session${active ? ' active' : ''}${nested ? ' nested' : ''}${archived.has(s.id) ? ' archived' : ''}${dragRef === ref ? ' dragging' : ''}${dnd.className}`}
         draggable={dnd.draggable}
         onDragStart={dnd.onDragStart} onDragEnd={dnd.onDragEnd} onDragOver={dnd.onDragOver} onDrop={dnd.onDrop}
@@ -389,16 +424,35 @@ export default function Sidebar({
 
   const GroupBlock = (g: Group) => {
     const ref = `g:${g.id}`;
+    // The whole frame takes drops — its edges place a neighbour, its middle
+    // takes an agent in. The name chip is only ~17px tall and no wider than the
+    // name, far too small to be the group's only target.
     const dnd = dndProps(ref, 'group', false);
     const open = !collapsed.has(g.id);
     const editing = editRef === ref;
+    const at = drop && drop.ref === ref ? drop.zone : null;
+    // The chip rides *above* the frame, so it can't share the frame's geometry:
+    // it simply reads as the group itself. An agent dropped on the name goes in;
+    // a group dropped on it lands above.
+    const headZone = (): Zone | null => {
+      if (!dragRef || dragRef === ref) return null;
+      if (dragRef.startsWith('g:')) return 'before';
+      return g.sessionIds.includes(dragRef.slice(2)) ? null : 'on';
+    };
     return (
-      <div key={g.id} className={`group${activeRef === ref ? ' active' : ''}${!open ? ' closed' : ''}${drop && drop.ref === ref && drop.zone === 'on' ? ' drop-into' : ''}`}>
+      <div
+        key={g.id}
+        data-ref={ref}
+        className={`group${activeRef === ref ? ' active' : ''}${!open ? ' closed' : ''}${at ? ` drop-${at === 'on' ? 'into' : at}` : ''}`}
+        onDragOver={dnd.onDragOver} onDrop={dnd.onDrop} onDragEnd={dnd.onDragEnd}
+      >
         {/* the group's name rides its frame — still the drag handle / click target */}
         <div
-          className={`row group-head${dragRef === ref ? ' dragging' : ''}${dnd.className}`}
+          className={`row group-head${dragRef === ref ? ' dragging' : ''}`}
           draggable={dnd.draggable}
-          onDragStart={dnd.onDragStart} onDragEnd={dnd.onDragEnd} onDragOver={dnd.onDragOver} onDrop={dnd.onDrop}
+          onDragStart={dnd.onDragStart} onDragEnd={dnd.onDragEnd}
+          onDragOver={(e) => { const z = headZone(); if (!z) return; e.preventDefault(); e.stopPropagation(); setDrop({ ref, zone: z }); }}
+          onDrop={(e) => { const z = headZone(); if (!z) return; e.preventDefault(); e.stopPropagation(); applyDrop(ref, 'group', z); }}
           onClick={() => onActivate(ref)}
           onDoubleClick={(e) => { e.stopPropagation(); startEdit(ref, g.name); }}
         >
@@ -637,7 +691,7 @@ export default function Sidebar({
         </div>
       </div>
 
-      <div className="tree" onDragEnd={clearDrag}>
+      <div className={`tree${dragRef ? ' dragging' : ''}`} {...treeDnd}>
         {tree.order.length === 0 && (
           <div className="empty-hint">Nothing yet. Add an agent with the + above.<br />Drag an agent onto another to group them.</div>
         )}

--- a/web/src/components/sidebar-dnd.ts
+++ b/web/src/components/sidebar-dnd.ts
@@ -79,3 +79,25 @@ export function backgroundAnchor(
   }
   return { ref: rest[rest.length - 1].ref, zone: 'after' };
 }
+
+/** The bit of `closest` we need, so this stays testable without a DOM. */
+type Closest = { closest(selector: string): unknown };
+
+/**
+ * Is this event the tree's to answer, rather than a row's or a frame's?
+ *
+ * "The target is the tree itself" is the obvious test and it is wrong: the tree
+ * has children that are not items — the archived-sessions note, which
+ * `margin-top: auto` parks at the bottom directly over the landing strip, and
+ * the empty-list hint. Those are background as far as a drag is concerned, and
+ * treating them as someone else's turf puts a dead patch exactly where a drop
+ * meaning "take this out of its group" would land.
+ *
+ * So: the tree answers unless a row or frame encloses the target, since those
+ * carry `data-ref` and stop the event themselves when they want it.
+ */
+export function isBackgroundTarget(target: Closest | null, tree: unknown): boolean {
+  if (!target) return false;
+  if (target === tree) return true;
+  return !target.closest('[data-ref]');
+}

--- a/web/src/components/sidebar-dnd.ts
+++ b/web/src/components/sidebar-dnd.ts
@@ -1,0 +1,81 @@
+// Where a drag would land in the sidebar tree.
+//
+// Pure geometry, kept out of the component because it is the whole of the
+// behaviour and it was quietly wrong: the only target a group offered was the
+// name chip riding its top border — roughly 17px tall and no wider than the
+// name — while the frame below it, often a hundred pixels of it, refused every
+// drop. Reordering two groups meant threading a moving cursor through that chip,
+// and once every agent lived in a group there was no top-level row left to aim
+// at, so an agent could go into a group and never come back out.
+//
+// Three rules come out of that:
+//   * a target is as big as the thing it represents (the frame, not the label),
+//   * a target that cannot take this particular drag answers null, so the event
+//     keeps bubbling to something that can, and
+//   * the background between and below the frames is itself a target — that is
+//     what "put this back at the top level" means.
+
+export type Zone = 'before' | 'after' | 'on';
+export type Kind = 'group' | 'session';
+
+/** Just the geometry we need from a DOMRect, so tests can hand-build one. */
+export type Box = { top: number; height: number };
+
+export type DropQuery = {
+  dragRef: string | null;   // what's in flight ('s:…' / 'g:…'), null when nothing is
+  ref: string;              // the row or frame being hovered
+  kind: Kind;
+  nested: boolean;          // a session row inside a group
+  isMember?: boolean;       // hovering a group that already holds the dragged session
+  box: Box;
+  clientY: number;
+};
+
+// A frame is tall, so its before/after strips are a fixed band at the edges
+// rather than half the box: everything between them means "into this group".
+const EDGE = 14;
+
+/**
+ * The zone a drop on `ref` would use, or null when this target can't take the
+ * drag — the caller must then leave the event alone (no preventDefault, no
+ * stopPropagation) so an enclosing frame, or the tree itself, still gets a say.
+ */
+export function dropZone(q: DropQuery): Zone | null {
+  const { dragRef, ref, kind, nested, box, clientY } = q;
+  if (!dragRef || dragRef === ref) return null;
+  const draggingGroup = dragRef.startsWith('g:');
+  // A group can't nest. Rather than swallow the event, hand it to the frame
+  // around this row — that's what makes a group's interior a live target for
+  // another group instead of a dead zone the size of the group.
+  if (nested && draggingGroup) return null;
+
+  const y = clientY - box.top;
+  const band = kind === 'group' && !nested ? Math.min(EDGE, box.height / 3) : box.height / 3;
+
+  // Reordering groups: every point on the frame has to mean something, so split
+  // it down the middle.
+  if (draggingGroup) return y < box.height / 2 ? 'before' : 'after';
+  // The agent already lives in this group, so 'into' is a no-op — only the edges
+  // (pull it out, above or below) still say anything.
+  if (kind === 'group' && q.isMember) return y < band ? 'before' : y > box.height - band ? 'after' : null;
+  return y < band ? 'before' : y > box.height - band ? 'after' : 'on';
+}
+
+/**
+ * A drop on the tree's own background — the margins between frames, and the
+ * empty space under the list. Answers with the top-level item it lands next to,
+ * so an agent dragged out of a group becomes loose in the right place.
+ */
+export function backgroundAnchor(
+  items: Array<{ ref: string; box: Box }>,
+  dragRef: string | null,
+  clientY: number,
+): { ref: string; zone: 'before' | 'after' } | null {
+  if (!dragRef) return null;
+  const rest = items.filter((i) => i.ref !== dragRef);
+  if (!rest.length) return null;
+  for (const i of rest) {
+    if (clientY < i.box.top + i.box.height / 2) return { ref: i.ref, zone: 'before' };
+  }
+  return { ref: rest[rest.length - 1].ref, zone: 'after' };
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -452,9 +452,9 @@ body {
 .empty-hint { color: var(--muted); font-size: 12px; padding: 12px 10px; line-height: 1.5; }
 .empty-hint.nested { padding: 6px 10px 8px 38px; font-size: 11.5px; }
 
-.gap { height: 8px; }
-.gap.over { position: relative; }
-.gap.over::after { content: ''; position: absolute; left: 8px; right: 8px; top: 3px; height: 2px; border-radius: 2px; background: var(--accent); }
+/* While something is in flight the tree keeps a landing strip below the last
+   item, so "put this back at the top level" is always reachable. */
+.tree.dragging { padding-bottom: 40px; }
 
 .row { position: relative; display: flex; align-items: center; gap: 7px; padding: 3.5px 8px; border-radius: var(--r-sm); cursor: pointer; border: 1px solid transparent; }
 .row.session { cursor: grab; }
@@ -488,7 +488,14 @@ body {
 .group.closed { padding: 6px 3px; }
 .group.active { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 .group.drop-into { background: var(--drop); outline: 1px dashed var(--accent); }
-.row.group-head { position: absolute; top: -10px; left: 8px; max-width: calc(100% - 52px); padding: 0 6px 0 3px; gap: 4px; background: var(--panel); border: none; border-radius: 0; cursor: pointer; z-index: 1; }
+/* a whole frame's worth of target: its edges place a neighbour, its middle takes
+   an agent in — drawn in the margin so the frame's own border stays readable */
+.group.drop-before::before, .group.drop-after::before { content: ''; position: absolute; left: 0; right: 0; height: 2px; background: var(--accent); border-radius: 2px; }
+/* clear of the name chip, which rides 10px above the frame's own top border —
+   a line drawn any lower reads as underlining the label instead of preceding it */
+.group.drop-before::before { top: -13px; }
+.group.drop-after::before { bottom: -5px; }
+.row.group-head { position: absolute; top: -10px; left: 8px; max-width: calc(100% - 52px); padding: 0 6px 0 3px; gap: 4px; background: var(--panel); border: none; border-radius: 0; cursor: grab; z-index: 1; }
 .row.group-head:hover, .group.active .row.group-head { background: var(--panel); }
 .row.group-head .name { flex: initial; font-size: 11.5px; font-weight: 400; color: var(--text); }
 .row.group-head:hover .name { color: var(--accent); }

--- a/web/test/sidebar-dnd.test.mjs
+++ b/web/test/sidebar-dnd.test.mjs
@@ -1,0 +1,147 @@
+// Where a sidebar drag lands.
+//
+// Every case here is one that used to fail. A group's only drop target was the
+// name chip on its top border, so dragging a group past another group crossed a
+// frame that answered nothing; and with every agent inside a group there was no
+// top-level row left to aim at, so nothing could be dragged back out.
+//
+// No test runner: esbuild is already here for vite, so the module is transpiled
+// and imported directly. Run with:  node test/sidebar-dnd.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'dnd-')), 'sidebar-dnd.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/components/sidebar-dnd.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { dropZone, backgroundAnchor } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); } catch (e) { failed++; console.error(`✗ ${what}\n  ${e.message}`); return; }
+  console.log(`✓ ${what}`);
+};
+
+// A group frame with two members: tall, unlike the 17px name chip it used to be.
+const FRAME = { top: 100, height: 120 };
+const ROW = { top: 100, height: 24 };
+const frame = (extra) => ({ ref: 'g:1', kind: 'group', nested: false, box: FRAME, ...extra });
+const row = (extra) => ({ ref: 's:2', kind: 'session', nested: false, box: ROW, ...extra });
+
+check('an agent dropped on the body of a group goes into it', () => {
+  assert.equal(dropZone(frame({ dragRef: 's:9', clientY: 160 })), 'on');
+  // ...anywhere in the body, not just on the label
+  assert.equal(dropZone(frame({ dragRef: 's:9', clientY: 120 })), 'on');
+  assert.equal(dropZone(frame({ dragRef: 's:9', clientY: 200 })), 'on');
+});
+
+check('the frame keeps thin edge bands for placing a neighbour', () => {
+  assert.equal(dropZone(frame({ dragRef: 's:9', clientY: 105 })), 'before');
+  assert.equal(dropZone(frame({ dragRef: 's:9', clientY: 215 })), 'after');
+});
+
+check('a group dragged over another group takes the whole frame, split in half', () => {
+  // This is the regression: the frame used to answer null everywhere, leaving
+  // only a name chip to aim at.
+  assert.equal(dropZone(frame({ dragRef: 'g:2', clientY: 105 })), 'before');
+  assert.equal(dropZone(frame({ dragRef: 'g:2', clientY: 155 })), 'before');
+  assert.equal(dropZone(frame({ dragRef: 'g:2', clientY: 165 })), 'after');
+  assert.equal(dropZone(frame({ dragRef: 'g:2', clientY: 215 })), 'after');
+});
+
+check('a nested row declines a dragged group so the frame around it answers', () => {
+  assert.equal(dropZone(row({ dragRef: 'g:2', nested: true, clientY: 110 })), null);
+});
+
+check('a nested row still takes an agent, by thirds', () => {
+  assert.equal(dropZone(row({ dragRef: 's:9', nested: true, clientY: 103 })), 'before');
+  assert.equal(dropZone(row({ dragRef: 's:9', nested: true, clientY: 112 })), 'on');
+  assert.equal(dropZone(row({ dragRef: 's:9', nested: true, clientY: 121 })), 'after');
+});
+
+check('a group offers only its edges to an agent it already holds', () => {
+  const held = { dragRef: 's:9', isMember: true };
+  assert.equal(dropZone(frame({ ...held, clientY: 160 })), null); // 'into' would be a no-op
+  assert.equal(dropZone(frame({ ...held, clientY: 105 })), 'before'); // pull it out, above
+  assert.equal(dropZone(frame({ ...held, clientY: 215 })), 'after');
+});
+
+check('nothing is a target for itself, or when nothing is in flight', () => {
+  assert.equal(dropZone(frame({ dragRef: 'g:1', clientY: 160 })), null);
+  assert.equal(dropZone(frame({ dragRef: null, clientY: 160 })), null);
+});
+
+check('an empty group still has an "into" middle for its "Drag agents here"', () => {
+  // The hint that literally says "drag here" carries no handlers of its own —
+  // it works because the frame under it answers. A frame that short must not be
+  // all edge band, or the one place the UI advertises would take nothing.
+  const empty = { ref: 'g:3', kind: 'group', nested: false, box: { top: 0, height: 44 } };
+  assert.equal(dropZone({ ...empty, dragRef: 's:9', clientY: 22 }), 'on');
+});
+
+check('the edge bands never eat a whole frame, however short', () => {
+  // min(EDGE, height/3) is what guarantees it: at any height the middle third
+  // survives, so "into" is always reachable.
+  for (const height of [12, 20, 30, 44, 120, 400]) {
+    const short = { ref: 'g:3', kind: 'group', nested: false, box: { top: 0, height } };
+    assert.equal(dropZone({ ...short, dragRef: 's:9', clientY: height / 2 }), 'on', `height ${height}`);
+  }
+});
+
+check('a row and a frame answer every point between them, so nothing is dead', () => {
+  // The bug was a gap in coverage, not a wrong answer: a dragged group crossing
+  // an expanded group met rows that declined (null) inside a frame that also
+  // declined, and fell through to a tree that had no handler at all. Whatever
+  // declines here must have something behind it that does not.
+  for (let y = 100; y <= 220; y += 5) {
+    const onRow = dropZone(row({ dragRef: 'g:2', nested: true, clientY: y, box: { top: y, height: 24 } }));
+    const onFrame = dropZone(frame({ dragRef: 'g:2', clientY: y }));
+    assert.ok(onRow || onFrame, `nothing answers at y=${y}`);
+  }
+});
+
+// The tree background: top-level items at 0-100, 120-220, 240-280.
+const ITEMS = [
+  { ref: 'g:1', box: { top: 0, height: 100 } },
+  { ref: 'g:2', box: { top: 120, height: 100 } },
+  { ref: 's:3', box: { top: 240, height: 40 } },
+];
+
+check('the margin between two frames places the drop between them', () => {
+  assert.deepEqual(backgroundAnchor(ITEMS, 's:9', 110), { ref: 'g:2', zone: 'before' });
+});
+
+check('the empty space below the list means "last, at the top level"', () => {
+  // Without this an agent could go into a group and never come back out.
+  assert.deepEqual(backgroundAnchor(ITEMS, 's:9', 600), { ref: 's:3', zone: 'after' });
+});
+
+check('above everything means first', () => {
+  assert.deepEqual(backgroundAnchor(ITEMS, 's:9', 2), { ref: 'g:1', zone: 'before' });
+});
+
+check('a dragged top-level item is never its own anchor', () => {
+  // The server rejects an anchor that is the moving ref itself ('bad anchor'),
+  // so it has to be filtered out before the nearest-neighbour walk — including
+  // when hovering the space it currently occupies.
+  for (const y of [0, 110, 150, 230, 600]) {
+    assert.notEqual(backgroundAnchor(ITEMS, 'g:2', y)?.ref, 'g:2', `at y=${y}`);
+  }
+  // Hovering its own slot resolves to the position it already has: g:1, g:2, s:3.
+  assert.deepEqual(backgroundAnchor(ITEMS, 'g:2', 110), { ref: 's:3', zone: 'before' });
+  // The only item there is, is the one in flight → no anchor at all.
+  assert.deepEqual(backgroundAnchor([ITEMS[0]], 'g:1', 50), null);
+});
+
+check('nothing in flight, nothing to anchor', () => {
+  assert.equal(backgroundAnchor(ITEMS, null, 110), null);
+});
+
+if (failed) { console.error(`\n${failed} failing`); process.exit(1); }
+console.log('\nall good');

--- a/web/test/sidebar-dnd.test.mjs
+++ b/web/test/sidebar-dnd.test.mjs
@@ -20,7 +20,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/components/sidebar-dnd.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { dropZone, backgroundAnchor } = await import(pathToFileURL(out).href);
+const { dropZone, backgroundAnchor, isBackgroundTarget } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -141,6 +141,35 @@ check('a dragged top-level item is never its own anchor', () => {
 
 check('nothing in flight, nothing to anchor', () => {
   assert.equal(backgroundAnchor(ITEMS, null, 110), null);
+});
+
+// Which events the tree answers. A tiny stand-in for the DOM: `owner` is the
+// nearest ancestor carrying data-ref, which is what .closest('[data-ref]') finds.
+const TREE = { closest: () => null };
+const node = (owner) => ({ closest: (sel) => (sel === '[data-ref]' ? owner : null) });
+
+check('the tree answers for its own background', () => {
+  assert.equal(isBackgroundTarget(TREE, TREE), true);
+});
+
+check('a row or frame keeps its own events', () => {
+  // Both the item itself and anything inside it (a name, a mini-button).
+  assert.equal(isBackgroundTarget(node({}), TREE), false);
+});
+
+check('the archived note is background, not someone else\'s turf', () => {
+  // Regression: this note carries no data-ref, and `margin-top: auto` parks it
+  // at the BOTTOM of the tree — directly over the landing strip. Testing for
+  // "the target is the tree itself" made the one place a user aims for when
+  // pulling an agent out of a group silently ignore the drop.
+  const archNote = node(null); // a direct child of .tree with no data-ref above it
+  assert.equal(isBackgroundTarget(archNote, TREE), true);
+  const emptyHint = node(null);
+  assert.equal(isBackgroundTarget(emptyHint, TREE), true);
+});
+
+check('no target, no answer', () => {
+  assert.equal(isBackgroundTarget(null, TREE), false);
 });
 
 if (failed) { console.error(`\n${failed} failing`); process.exit(1); }


### PR DESCRIPTION
Dragging groups around, and dragging an agent back out of one, had quietly stopped working. Reported from use: *"the dragging behavior in the side bar is not working as well as before, in particular in the case of having groups, dragging groups around or dragging sessions outside of groups."*

## Cause

The group became a labeled frame, with its name riding the top border as an absolutely-positioned chip (`.row.group-head`, ~17px tall and no wider than the name). The drag-and-drop wiring stayed on that chip. The frame under it — often 100+px — was inert.

- **Dragging groups.** The only place to grab *or* drop a group was that chip. And `dndProps` bailed out of `onDragOver` before `preventDefault` for nested rows while nothing enclosing them listened, so the interior of every expanded group was a dead zone. Moving group B past group A meant threading a moving cursor through A's name chip.
- **Dragging agents out of groups.** Rows were the only drop targets. Once every agent lived in a group, the top level had no row left to aim at, so there was no reachable "make this loose" target. `.tree` had `onDragEnd` but no `onDragOver`/`onDrop`, so the empty space did nothing either.

A fossil confirms the older design: `styles.css` still carried `.gap` / `.gap.over::after` rules for insertion strips between items, with no `.gap` element left in the JSX. This PR drops them — the background anchor now does that job.

## Fix

Three rules, with the geometry lifted into `web/src/components/sidebar-dnd.ts` so it can be tested:

- **A target is as big as the thing it represents.** The whole frame takes drops: thin bands at its edges place a neighbour, everything between them means "into this group". The chip stays a handle and still reads as "into".
- **A target that cannot take this drag returns `null` and does not swallow the event**, so it bubbles to something that can. That is what turns a group's interior from a dead zone into a live target for another group.
- **The tree's own background is a target** — the margins between frames and the space below the list resolve to the nearest top-level item. That is the way back out of a group, and why `.tree` keeps a landing strip while a drag is in flight.

Plus: a group already holding the dragged agent offers only its edges (`into` would be a no-op), and `cursor: grab` on the group head so it reads as draggable.

## Verification

Driven in Chromium with real HTML5 drag events, with unmodified `main` as a control:

| drag | before | after |
|---|---|---|
| group beta above group alpha, released mid-frame | no-op | `beta[3,4] alpha[1,2]` |
| group beta over alpha's member row (the dead zone) | no-op | `beta[3,4] alpha[1,2]` |
| agent 1 out of alpha → empty space below list | no-op | `alpha[2] … 1` |
| agent 3 out of beta → margin between frames | no-op | `alpha[1,2] 3 beta[4]` |
| agent 1 → top edge of its own group | no-op | `1 alpha[2]` |

The three that already worked — drop on the name chip, pairing two loose agents, dropping into a group's body — are unchanged.

## Regression tests

`web/test/sidebar-dnd.test.mjs` (15 cases, wired into `npm test`, no new dependency — esbuild transpiles the module the way `exchanges.test.mjs` already does). Each case is one that failed. **11 of the 15 go red** against a model of the pre-fix behaviour; the 4 that stay green are invariants that were never broken (self-drop, nothing-in-flight, a nested row declining a group, a nested row's thirds).

Two guard the shape of the fix rather than a specific drag:

- *"the edge bands never eat a whole frame, however short"* — `min(EDGE, height/3)` is what keeps an `into` middle at every frame height, including the short empty-group frame whose "Drag agents here" hint carries no handlers of its own and works only because the frame under it answers.
- *"a row and a frame answer every point between them, so nothing is dead"* — sweeps the frame and asserts something always responds. The original bug was a gap in coverage, not a wrong answer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)