### PR TITLE
Make file editor wrap control an obvious toggle

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/FileWrapToggle.tsx
+++ b/web/src/components/FileWrapToggle.tsx
@@ -1,0 +1,18 @@
+export default function FileWrapToggle({ wrap, onChange }: {
+  wrap: boolean;
+  onChange: (next: boolean) => void;
+}) {
+  return (
+    <span className="seg file-wrap-toggle mono">
+      <button
+        type="button"
+        className={wrap ? 'on' : ''}
+        onClick={() => onChange(!wrap)}
+        title={wrap ? 'Long lines are wrapped — click to let them run' : 'Wrap long lines'}
+        aria-pressed={wrap}
+      >
+        wrap
+      </button>
+    </span>
+  );
+}

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1164,14 +1164,17 @@ export default function FilesPane({
               </button>
             )}
             {info.showWrap && edit && (
-              <button
-                className={`mini-btn${edit.wrap ? ' on' : ''}`}
-                onClick={() => edit.setWrap(!edit.wrap)}
-                title={edit.wrap ? 'Long lines are wrapped — click to let them run' : 'Wrap long lines'}
-                aria-pressed={edit.wrap}
-              >
-                Wrap
-              </button>
+              <span className="seg file-wrap-toggle mono">
+                <button
+                  type="button"
+                  className={edit.wrap ? 'on' : ''}
+                  onClick={() => edit.setWrap(!edit.wrap)}
+                  title={edit.wrap ? 'Long lines are wrapped — click to let them run' : 'Wrap long lines'}
+                  aria-pressed={edit.wrap}
+                >
+                  wrap
+                </button>
+              </span>
             )}
             {edit && !edit.can && edit.why && (
               <span className="fi-stat fi-extra" title={edit.why}>read-only</span>

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -6,6 +6,7 @@ import type { FileEntry, FileKind, FilePreview } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
 import CodeView from './CodeView';
+import FileWrapToggle from './FileWrapToggle';
 import PdfView from './PdfView';
 import { TraceView, type TraceHeadInfo, type TraceSource } from './TracePane';
 import {
@@ -1164,17 +1165,7 @@ export default function FilesPane({
               </button>
             )}
             {info.showWrap && edit && (
-              <span className="seg file-wrap-toggle mono">
-                <button
-                  type="button"
-                  className={edit.wrap ? 'on' : ''}
-                  onClick={() => edit.setWrap(!edit.wrap)}
-                  title={edit.wrap ? 'Long lines are wrapped — click to let them run' : 'Wrap long lines'}
-                  aria-pressed={edit.wrap}
-                >
-                  wrap
-                </button>
-              </span>
+              <FileWrapToggle wrap={edit.wrap} onChange={edit.setWrap} />
             )}
             {edit && !edit.can && edit.why && (
               <span className="fi-stat fi-extra" title={edit.why}>read-only</span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -800,6 +800,8 @@ body {
    the right — the corner that used to be blank. */
 .files-info { flex: none; container-type: inline-size; display: flex; align-items: center; gap: 10px; padding: 4px 11px; background: var(--panel-2); border-bottom: 1px solid var(--border); font-size: 11px; color: var(--muted); white-space: nowrap; overflow: hidden; }
 .files-info .spacer { flex: 1; }
+.file-wrap-toggle { flex: none; }
+.files-info .file-wrap-toggle button { height: 20px; padding: 0 8px; font-size: 10.5px; line-height: 1; }
 .fi-where { min-width: 0; overflow: hidden; text-overflow: ellipsis; font-family: var(--font-mono); font-size: 10.5px; color: var(--text); }
 .fi-stat { flex: none; font-variant-numeric: tabular-nums; }
 .fi-stat + .fi-stat::before { content: '·'; margin-right: 7px; color: var(--border-strong); }

--- a/web/test/fileWrapToggle.test.mjs
+++ b/web/test/fileWrapToggle.test.mjs
@@ -1,0 +1,43 @@
+// The wrap control is a toggle, not another fact in the file metadata strip.
+// Its visual selected state and its accessible pressed state must always tell
+// the same story. CodeMirror wrapping is covered elsewhere; this test pins the
+// small piece that is easy to regress while restyling the control.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(HERE, '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const out = path.join(outDir, 'file-wrap-toggle.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/components/FileWrapToggle.tsx')],
+  outfile: out, format: 'esm', bundle: true, jsx: 'automatic', logLevel: 'error',
+  external: ['react', 'react/jsx-runtime'],
+});
+const { default: FileWrapToggle } = await import(pathToFileURL(out).href);
+
+const render = (wrap) => renderToStaticMarkup(createElement(FileWrapToggle, {
+  wrap, onChange: () => {},
+}));
+const off = render(false);
+const on = render(true);
+
+assert.match(off, /^<span class="seg file-wrap-toggle mono">/);
+assert.match(off, /<button[^>]*class=""[^>]*aria-pressed="false"/);
+assert.doesNotMatch(off, /class="on"/);
+assert.match(on, /<button[^>]*class="on"[^>]*aria-pressed="true"/);
+
+let next = null;
+const offElement = FileWrapToggle({ wrap: false, onChange: (value) => { next = value; } });
+offElement.props.children.props.onClick();
+assert.equal(next, true);
+const onElement = FileWrapToggle({ wrap: true, onChange: (value) => { next = value; } });
+onElement.props.children.props.onClick();
+assert.equal(next, false);
+
+console.log('file-wrap-toggle: accessible, visual, and next states agree');


### PR DESCRIPTION
The file editor wrap control was already a semantic button, but it inherited the borderless `mini-btn` treatment used for incidental actions. In the metadata strip it therefore read as another fact, not something interactive.

This changes presentation only:

- wraps the existing button in the shared `.seg` control used by `terminal | reader` and the Overview filter selectors;
- uses the same hairline boundary, compact square-cornered geometry, muted off state, and teal selected state;
- uses the compact monospace `wrap` label already established by the surrounding file UI;
- retains `aria-pressed`, the explanatory tooltip, sticky preference, and existing wrapping behavior.

No new control pattern or state logic was added.

## Before / after

[Desktop and phone comparison](https://lvwerra-agent-artifacts.static.hf.space/wrap-toggle/index.html)

Captured from production builds at 1280×800 and 390×844. At both widths the toggle is 43×22 px, remains in the metadata strip without clipping, and reads clearly in both states.

## Verified

- `cd web && npm test`
- `cd web && npm run build`
- Chromium interaction at desktop and phone widths: `aria-pressed` flips false→true and `am.files.wrap` persists as `1`
- Actual editor layout changes from horizontal scrolling to wrapping: scroll width 2244→972 px on desktop and 2244→372 px on phone

No server behavior changed.