### PR TITLE
Sidebar: one mark for agent state, and drop the waiting count

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test": "node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
-import { hiddenSessionIds } from '../lib/overviewHidden';
 import Logo from './Logo';
 import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
@@ -78,7 +77,7 @@ export default function Sidebar({
   onToggleArchived: () => void;
   // Refs hidden from the OVERVIEW. The sidebar keeps showing them — it is where
   // you hide a group and the only way back to one — so this only drives the
-  // per-group button and the overview row's count.
+  // per-group button.
   overviewHidden: Set<string>;
   onToggleOverviewHidden: (ref: string, hidden: boolean) => void;
 }) {
@@ -124,14 +123,6 @@ export default function Sidebar({
   const sessById = useMemo(() => Object.fromEntries(tree.sessions.map((s) => [s.id, s])), [tree.sessions]);
   const groupById = useMemo(() => Object.fromEntries(tree.groups.map((g) => [g.id, g])), [tree.groups]);
   const colorOf = useMemo(() => Object.fromEntries(clis.map((c) => [c.id, c.color])), [clis]);
-  // This badge sits ON the overview row, so it has to count what the overview
-  // would actually show: not a hidden group's agents (being told about the group
-  // you hid is exactly what you hid it to stop), and not archived ones either,
-  // which the feed has always dropped while this number quietly included them.
-  const hiddenIds = useMemo(() => hiddenSessionIds(tree), [tree]);
-  const waiting = tree.sessions.filter((s) =>
-    s.state === 'waiting' && !hiddenIds.has(s.id) && !archived.has(s.id)).length;
-
   useEffect(() => { quickImagesRef.current = quickImages; }, [quickImages]);
   useEffect(() => () => revokePendingAttachments(quickImagesRef.current), []);
 
@@ -675,9 +666,11 @@ export default function Sidebar({
         </div>
       )}
 
-      {/* Overview: pinned above the tree with the row anatomy (tile · name ·
-          right slot) so it reads as clickable; the right slot counts agents
-          waiting on you. */}
+      {/* Overview: pinned above the tree with the row anatomy (tile · name) so
+          it reads as clickable. It used to carry an "N waiting" count in a
+          right slot; the rows directly below already show each of those agents
+          with its own state mark, so the number was a second, vaguer telling of
+          what the list says exactly. */}
       <div className="ov-fixed">
         <div
           className={`row session ov-row${activeRef === 'overview' ? ' active' : ''}`}
@@ -687,7 +680,6 @@ export default function Sidebar({
           <span className="status ov-spacer" />
           <span className="ov-tile"><GridGlyph /></span>
           <span className="name">overview</span>
-          {waiting > 0 && <span className="ov-wait">{waiting} waiting</span>}
         </div>
       </div>
 

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -134,7 +134,11 @@
 }
 .cx-running-at { margin-left: 7px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: 0.85; }
 .cx-running::before {
-  content: '⠋'; display: inline-block; width: 1.2em; color: var(--accent);
+  /* --mark-w rather than a second 1.2em: the spinner's cell is declared with
+     the animation in styles.css and read by everything that draws it — this,
+     .ov-busy, and the static state marks that stand in for it while an agent
+     is not working. */
+  content: '⠋'; display: inline-block; width: var(--mark-w); color: var(--accent);
   animation: ov-spin 0.9s steps(1) infinite;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -357,9 +357,17 @@ body {
 .markdown.ov-md { border: none; background: none; padding: 0; font-size: 12.5px; }
 .ov-md pre { font-size: 11px; }
 
-/* braille spinner: unmistakably a process, never an input line */
+/* braille spinner: unmistakably a process, never an input line.
+
+   Its cell is declared here, with the animation, because everything that draws
+   this spinner — and everything that stands in for it while an agent is NOT
+   working (see `.status.waiting` and friends) — sizes itself from these two
+   numbers. Change the glyph, the font or the spinner's box and the static
+   marks follow, instead of being left behind at a size that used to match.
+   em, so each surface gets the cell at its own type size. */
+:root { --mark-w: 1.2em; --mark-h: 1.05em; }
 .ov-busy { font-size: 12.5px; color: var(--muted); }
-.ov-busy::before { content: '⠋'; display: inline-block; width: 1.2em; color: var(--accent); animation: ov-spin 0.9s steps(1) infinite; }
+.ov-busy::before { content: '⠋'; display: inline-block; width: var(--mark-w); color: var(--accent); animation: ov-spin 0.9s steps(1) infinite; }
 @keyframes ov-spin {
   0% { content: '⠋'; } 12.5% { content: '⠙'; } 25% { content: '⠹'; } 37.5% { content: '⠸'; }
   50% { content: '⠼'; } 62.5% { content: '⠴'; } 75% { content: '⠦'; } 87.5% { content: '⠧'; }
@@ -511,41 +519,57 @@ body {
 .g-add svg { width: 11px; height: 11px; display: block; }
 .row.nested { margin-left: 0; padding-left: 8px; }
 
+/* A bare `.status` is a plain colour dot and has to stay one: UsagePanel and
+   SettingsView use it with an inline `background` to carry a provider's or a
+   CLI's own colour, and no state class at all. The state vocabulary below is a
+   specialisation of this, never a replacement — anything drawn on bare
+   `.status` paints over those colours and they lose their identity. */
+.status { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s; }
+
 /* ---- agent state: one mark, one footprint ----
    A working agent shows the braille spinner the reader and the cards already
    run (`ov-spin`) — the same animation, not a second thing that also means
    "busy". Every other state is that same cell standing still: a rectangle,
-   filled or outlined.
+   filled, or outlined for stopped.
 
-   The cell is declared once, here, and the spinner is centred in it, so the
-   animated mark and the static ones cannot drift apart — the lesson of
-   --cx-gutter (#71) and --ph-pad-y (#75). 0.5em x 1.05em is the braille cell's
-   own ink, measured in Geist Mono (8 x 16.8px at 16px) rather than guessed, so
-   the rectangle and the spinner cover the same pixels. Sizing is em, so a mark
-   follows the type size of whatever row, header or card it sits in — the
-   sidebar no longer needs a px override to be smaller than the others. */
-.status {
-  --st-w: 0.5em;
-  --st-h: 1.05em;
-  width: var(--st-w); height: var(--st-h); flex: none; border-radius: 1px;
+   The cell is `--mark-w` by `--mark-h`, declared once beside `ov-spin` itself
+   and consumed by every renderer of that animation as well as by these four
+   states. That is the whole point: the static mark cannot drift away from the
+   animation it stands in for, because there is one box and everyone reads it.
+   Same shape as --cx-gutter (#71) and --ph-pad-y (#75).
+
+   `font-size` is the only thing these states set for themselves — a size down
+   from the surrounding type — which is what lets one cell work in a sidebar
+   row and in a card header alike without either restating a geometry. */
+.status.working, .status.waiting, .status.idle, .status.stopped {
+  width: var(--mark-w); height: var(--mark-h);
+  font-size: 0.62em; font-family: var(--font-mono); line-height: 1;
+  border-radius: 0; background: none;
   display: inline-flex; align-items: center; justify-content: center;
-  font-family: var(--font-mono); line-height: 1;
   transition: color 0.2s, opacity 0.2s;
 }
-.status::before { content: ''; display: block; width: 100%; height: 100%; border-radius: inherit; background: currentColor; }
-/* The spinner's ink is exactly --st-w wide, so it needs no box of its own; it
-   sits on the same footprint the rectangle fills. Under prefers-reduced-motion
-   the global animation kill freezes it at ⠋ — a part-filled cell, which still
-   reads as different from the full rectangle a ready agent shows. */
+.status.working::before, .status.waiting::before,
+.status.idle::before, .status.stopped::before {
+  content: ''; display: block; box-sizing: border-box;
+  width: 100%; height: 100%; background: currentColor;
+}
+/* The same spinner, in the same cell. `overflow: hidden` keeps the glyph from
+   painting outside the footprint the other three fill, whatever a font does
+   with it. Under prefers-reduced-motion the global animation kill freezes it
+   at ⠋ — a part-filled cell, still not the full rectangle a ready agent
+   shows. */
+.status.working { overflow: hidden; }
 .status.working::before {
-  content: '⠋'; width: auto; height: auto; background: none;
+  content: '⠋'; background: none;
   animation: ov-spin 0.9s steps(1) infinite;
 }
 /* working and your-turn are both the accent: one is moving, one is not. */
 .status.working, .status.waiting { color: var(--accent); }
 .status.idle, .status.stopped { color: var(--muted); opacity: 0.5; }
-/* stopped is the cell's outline — nothing is running to fill it */
-.status.stopped::before { background: none; border: 1.5px solid currentColor; }
+/* stopped is the cell's outline. An inset shadow, not a border: a border is
+   laid OUTSIDE a percentage height, so the stopped mark painted 2px taller
+   than the three it claims to match (and flex-shrank narrower to compensate). */
+.status.stopped::before { background: none; box-shadow: inset 0 0 0 1.5px currentColor; }
 
 /* quick-add utilities (shell / files) pinned above the legend */
 .quick-add { display: flex; gap: 6px; padding: 10px 10px; border-top: 1px solid var(--border); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -274,7 +274,6 @@ body {
 .ov-tile { flex: none; box-sizing: content-box; width: 12px; height: 12px; padding: 3px; border-radius: 4px; background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); display: inline-flex; align-items: center; justify-content: center; }
 .ov-tile svg { width: 100%; height: 100%; display: block; }
 .ov-row .name { color: var(--text); }
-.ov-wait { flex: none; font-family: var(--font-mono); font-size: 10px; color: var(--accent); }
 /* ---- Overview: one reading column of capsules (design mock v4.12) ---- */
 .ov-wrap { height: 100%; overflow-y: auto; }
 .ov-feed { max-width: 680px; margin: 0 auto; display: flex; flex-direction: column; gap: 18px; padding: 2px 2px 40px; }
@@ -465,8 +464,8 @@ body {
 .row.drop-before::after { top: -1px; }
 .row.drop-after::after { bottom: -1px; }
 .row.drop-on { background: var(--drop); outline: 1px solid var(--accent); outline-offset: -1px; }
-/* the dot column is a size down from the app-wide 8px dots */
-.row .status { width: 6px; height: 6px; }
+/* No size override here any more: the mark is em-based, so a sidebar row's own
+   type size already makes it a size down from a card's. See .status. */
 /* mono for THINGS (session names, counts), sans for commentary. Member names
    speak in the muted voice — state (dot) and place (frame) carry the color. */
 .row .name { flex: 1; font-family: var(--font-mono); font-size: 11.5px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -512,13 +511,41 @@ body {
 .g-add svg { width: 11px; height: 11px; display: block; }
 .row.nested { margin-left: 0; padding-left: 8px; }
 
-/* status dots */
-.status { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s; }
-.status.working { background: var(--accent); animation: breathe 2.2s ease-in-out infinite; }
-/* your turn: hollow ring in the primary color — "paused, waiting on you" */
-.status.waiting { background: transparent; border: 1.5px solid var(--accent); }
-.status.idle { background: var(--muted); opacity: 0.5; }
-.status.stopped { background: transparent; border: 1.5px solid var(--muted); opacity: 0.5; }
+/* ---- agent state: one mark, one footprint ----
+   A working agent shows the braille spinner the reader and the cards already
+   run (`ov-spin`) — the same animation, not a second thing that also means
+   "busy". Every other state is that same cell standing still: a rectangle,
+   filled or outlined.
+
+   The cell is declared once, here, and the spinner is centred in it, so the
+   animated mark and the static ones cannot drift apart — the lesson of
+   --cx-gutter (#71) and --ph-pad-y (#75). 0.5em x 1.05em is the braille cell's
+   own ink, measured in Geist Mono (8 x 16.8px at 16px) rather than guessed, so
+   the rectangle and the spinner cover the same pixels. Sizing is em, so a mark
+   follows the type size of whatever row, header or card it sits in — the
+   sidebar no longer needs a px override to be smaller than the others. */
+.status {
+  --st-w: 0.5em;
+  --st-h: 1.05em;
+  width: var(--st-w); height: var(--st-h); flex: none; border-radius: 1px;
+  display: inline-flex; align-items: center; justify-content: center;
+  font-family: var(--font-mono); line-height: 1;
+  transition: color 0.2s, opacity 0.2s;
+}
+.status::before { content: ''; display: block; width: 100%; height: 100%; border-radius: inherit; background: currentColor; }
+/* The spinner's ink is exactly --st-w wide, so it needs no box of its own; it
+   sits on the same footprint the rectangle fills. Under prefers-reduced-motion
+   the global animation kill freezes it at ⠋ — a part-filled cell, which still
+   reads as different from the full rectangle a ready agent shows. */
+.status.working::before {
+  content: '⠋'; width: auto; height: auto; background: none;
+  animation: ov-spin 0.9s steps(1) infinite;
+}
+/* working and your-turn are both the accent: one is moving, one is not. */
+.status.working, .status.waiting { color: var(--accent); }
+.status.idle, .status.stopped { color: var(--muted); opacity: 0.5; }
+/* stopped is the cell's outline — nothing is running to fill it */
+.status.stopped::before { background: none; border: 1.5px solid currentColor; }
 
 /* quick-add utilities (shell / files) pinned above the legend */
 .quick-add { display: flex; gap: 6px; padding: 10px 10px; border-top: 1px solid var(--border); }

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -1,0 +1,102 @@
+// What the state marks actually PAINT, in a browser.
+//
+// The source lint next door cannot answer this. Both of the bugs this test
+// exists for were invisible to it and to reading the CSS:
+//
+//   · `.status.stopped::before` drew its outline with a border on a
+//     `content-box` pseudo-element, so the border was laid OUTSIDE `height:
+//     100%`. The source said 100% like the other three; Chromium painted
+//     8 x 18.8px against their 8 x 16.8, and flex-shrank the width to boot.
+//   · an unconditional `.status::before` painted `currentColor` over the
+//     inline provider and CLI colours that UsagePanel and SettingsView put on
+//     a bare `.status`, which have no state class at all.
+//
+// Needs Chromium; run with:  node test/statusMark.render.test.mjs
+// (not in `npm test`, which stays browser-free — see package.json's test:render)
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const css = ['styles.css', 'conversation.css']
+  .map((f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8')).join('\n');
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await (await browser.newContext({ viewport: { width: 900, height: 600 } })).newPage();
+// The markup the app renders: four state marks, and the two bare dots that
+// carry a colour of their own (UsagePanel.tsx, SettingsView.tsx).
+await page.setContent(`<style>${css}</style>
+  <div class="row" style="font-size:16px">
+    <span class="status working" id="working"></span>
+    <span class="status waiting" id="waiting"></span>
+    <span class="status idle" id="idle"></span>
+    <span class="status stopped" id="stopped"></span>
+    <span class="status" id="provider" style="background: rgb(214, 69, 69)"></span>
+    <span class="status" id="ready" style="background: rgb(46, 158, 91)"></span>
+  </div>`);
+await page.waitForTimeout(150);
+
+const marks = await page.evaluate((ids) => {
+  const out = {};
+  for (const id of ids) {
+    const el = document.getElementById(id);
+    const b = getComputedStyle(el, '::before');
+    const border = parseFloat(b.borderTopWidth) || 0;
+    const w = parseFloat(b.width) || 0;
+    const h = parseFloat(b.height) || 0;
+    out[id] = {
+      // what lands on screen, border included whichever box model is in play
+      painted: b.content === 'none' ? null
+        : (b.boxSizing === 'border-box' ? [w, h] : [w + 2 * border, h + 2 * border]),
+      content: b.content,
+      elementBackground: getComputedStyle(el).backgroundColor,
+      cell: (() => { const r = el.getBoundingClientRect(); return [r.width, r.height]; })(),
+    };
+  }
+  return out;
+}, ['working', 'waiting', 'idle', 'stopped', 'provider', 'ready']);
+await browser.close();
+
+const round = (xs) => xs.map((n) => Math.round(n * 100) / 100);
+const STATES = ['working', 'waiting', 'idle', 'stopped'];
+
+console.log('every state paints the same cell');
+const ref = round(marks.waiting.painted);
+for (const s of STATES) {
+  check(`${s} paints ${ref.join(' x ')}`, () => {
+    assert.deepEqual(round(marks[s].painted), ref);
+  });
+}
+check('and the cells themselves agree', () => {
+  for (const s of STATES) assert.deepEqual(round(marks[s].cell), round(marks.waiting.cell));
+});
+
+console.log('\nworking is the only one drawing a glyph');
+check('working renders a braille frame', () => {
+  assert.match(marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+});
+check('the other three render an empty box', () => {
+  for (const s of ['waiting', 'idle', 'stopped']) assert.equal(marks[s].content, '""');
+});
+
+console.log('\nand a bare .status keeps the colour its caller gave it');
+for (const [id, colour] of [['provider', 'rgb(214, 69, 69)'], ['ready', 'rgb(46, 158, 91)']]) {
+  check(`${id} still shows ${colour}`, () => {
+    assert.equal(marks[id].elementBackground, colour);
+    assert.equal(marks[id].content, 'none', 'something is painted over it');
+  });
+}
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -1,14 +1,18 @@
-// The state mark has ONE footprint, declared once.
+// One geometry contract for the working animation and everything that stands
+// in for it.
 //
 // A working agent shows the braille spinner; every other state is that same
-// cell as a rectangle. The two only read as the same mark while they are the
-// same size, and the way that quietly breaks is a second rule elsewhere giving
-// `.status` its own width/height for one surface — which is exactly what
-// `.row .status { width: 6px; height: 6px }` used to do for the sidebar.
+// cell standing still. They only read as the same mark while they are the same
+// box, and the way that quietly breaks is someone giving one of them its own
+// number — which is what the first cut of this change did: the static states
+// measured a copy of the glyph instead of reading the spinner's own cell, so a
+// font or spinner change would have left the rectangles behind.
 //
-// So this is a lint on the stylesheet, not a rendering test: it pins that the
-// box is declared in one place. What it LOOKS like was checked with playwright
-// against a live app (see the PR), which this cannot do.
+// So this lints the contract, not the numbers: --mark-w/--mark-h are declared
+// once, and every renderer of the spinner AND every static state reads them
+// rather than restating a length. What the marks actually PAINT is a separate
+// question this cannot answer — a border sits outside a percentage height and
+// the source still says `100%`. That is statusMark.render.test.mjs.
 //
 // Run with:  node test/statusMark.test.mjs
 import assert from 'node:assert/strict';
@@ -17,7 +21,10 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const css = fs.readFileSync(path.join(HERE, '../src/styles.css'), 'utf8');
+const read = (f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8');
+const styles = read('styles.css');
+const conversation = read('conversation.css');
+const css = `${styles}\n${conversation}`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -27,53 +34,101 @@ const check = (what, fn) => {
   }
 };
 
-// Every rule whose selector targets .status, with its body.
-const rules = [...css.matchAll(/([^{}]*\.status[^{}]*)\{([^}]*)\}/g)]
-  .map(([, selector, body]) => ({ selector: selector.trim().split('\n').pop().trim(), body }));
+const rulesOf = (text) => [...text.matchAll(/([^{}]*)\{([^}]*)\}/g)]
+  .map(([, selector, body]) => ({ selector: selector.trim().split('\n').pop().trim(), body }))
+  .filter((r) => r.selector && !r.selector.startsWith('@'));
+const rules = rulesOf(css);
+const LENGTH = /(?:^|[\s:])-?\d*\.?\d+(?:px|em|rem|%)/;
 
-console.log('the state mark is declared once');
+console.log('the cell is declared once');
 
-check('the .status rule declares the box', () => {
-  const base = rules.find((r) => r.selector === '.status');
-  assert.ok(base, 'no bare `.status` rule found');
-  assert.match(base.body, /--st-w:/, 'the width variable is not declared there');
-  assert.match(base.body, /--st-h:/, 'the height variable is not declared there');
-  assert.match(base.body, /width:\s*var\(--st-w\)/, 'width does not come from the variable');
-  assert.match(base.body, /height:\s*var\(--st-h\)/, 'height does not come from the variable');
+check('--mark-w and --mark-h are declared exactly once each', () => {
+  for (const name of ['--mark-w', '--mark-h']) {
+    const declarations = [...css.matchAll(new RegExp(`${name}\\s*:`, 'g'))].length;
+    assert.equal(declarations, 1, `${name} is declared ${declarations} times`);
+  }
 });
 
-check('no other rule gives .status its own width or height', () => {
-  const offenders = rules
-    .filter((r) => r.selector !== '.status')
-    .filter((r) => /(^|;|\s)(width|height)\s*:/.test(r.body))
-    // ::before is the mark inside the box: it fills it (100%) or is the glyph
-    // (auto). Neither is a second opinion about how big the box is.
+check('they are declared with the animation, not with one of its consumers', () => {
+  const decl = rules.find((r) => /--mark-w\s*:/.test(r.body));
+  assert.equal(decl.selector, ':root', `declared on \`${decl.selector}\``);
+  // ov-spin's keyframes and the :root declaration should be neighbours, so the
+  // next person to touch the animation sees the box it promises.
+  const gap = Math.abs(styles.indexOf('--mark-w') - styles.indexOf('@keyframes ov-spin'));
+  assert.ok(gap < 800, `the declaration is ${gap} chars from @keyframes ov-spin`);
+});
+
+console.log('\nevery renderer of the spinner reads it');
+
+const spinners = rules.filter((r) => /animation:\s*ov-spin/.test(r.body));
+check('there is more than one spinner renderer to keep in step', () => {
+  assert.ok(spinners.length >= 3, `found ${spinners.length}`);
+});
+check('none of them restates a width', () => {
+  const offenders = spinners
+    .filter((r) => /(?:^|;|\s)width\s*:/.test(r.body))
+    .filter((r) => !/width\s*:\s*var\(--mark-w\)/.test(r.body))
+    .map((r) => r.selector);
+  assert.deepEqual(offenders, [], `these size the spinner themselves: ${offenders.join(', ')}`);
+});
+
+console.log('\nand so does every state that stands in for it');
+
+const STATES = ['working', 'waiting', 'idle', 'stopped'];
+const stateRules = rules.filter((r) => STATES.some((s) => r.selector.includes(`.status.${s}`)));
+check('the four states are sized from the cell', () => {
+  const sized = stateRules.filter((r) => /width\s*:\s*var\(--mark-w\)/.test(r.body)
+    && /height\s*:\s*var\(--mark-h\)/.test(r.body));
+  assert.ok(sized.length >= 1, 'no state rule takes its box from --mark-w/--mark-h');
+  for (const s of STATES) {
+    assert.ok(sized.some((r) => r.selector.includes(`.${s}`)), `${s} is not covered by that rule`);
+  }
+});
+check('no state rule restates a length for its box', () => {
+  const offenders = stateRules
+    // ::before is the mark INSIDE the cell; that it fills it (100%) is the next
+    // check's business, not a second opinion about how big the cell is.
     .filter((r) => !/::before/.test(r.selector))
+    .filter((r) => [...r.body.matchAll(/(?:^|;|\s)(width|height)\s*:\s*([^;]+)/g)]
+      .some(([, , value]) => LENGTH.test(value) && !/var\(--mark-[wh]\)/.test(value)))
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these restate the box: ${offenders.join(', ')}`);
 });
-
-check('the mark inside the box only ever fills it or is the glyph', () => {
-  for (const r of rules.filter((x) => /::before/.test(x.selector))) {
-    const sizes = [...r.body.matchAll(/(?:^|;|\s)(?:width|height)\s*:\s*([^;]+)/g)].map((m) => m[1].trim());
-    for (const v of sizes) {
-      assert.ok(['100%', 'auto'].includes(v), `${r.selector} sizes the mark to ${v}`);
+check('the mark inside the cell only fills it', () => {
+  for (const r of stateRules.filter((x) => /::before/.test(x.selector))) {
+    for (const [, , value] of r.body.matchAll(/(?:^|;|\s)(width|height)\s*:\s*([^;]+)/g)) {
+      assert.equal(value.trim(), '100%', `${r.selector} sizes the mark to ${value.trim()}`);
     }
   }
 });
 
-check('working is the spinner the rest of the app already runs', () => {
-  const w = rules.find((r) => r.selector === '.status.working::before');
-  assert.ok(w, 'no `.status.working::before` rule');
-  assert.match(w.body, /animation:\s*ov-spin/, 'working does not use the ov-spin animation');
-  assert.ok(/content:\s*'⠋'/.test(w.body), 'working does not render the braille frame');
+console.log('\nand the plain colour dot is left alone');
+
+check('bare .status draws nothing of its own', () => {
+  const bare = rules.filter((r) => /(^|,\s*)\.status::before\s*$/.test(r.selector));
+  assert.deepEqual(bare.map((r) => r.selector), [],
+    'a pseudo-element on bare `.status` paints over the inline provider/CLI colours '
+    + 'in UsagePanel.tsx and SettingsView.tsx');
 });
+check('bare .status keeps a box of its own for those callers', () => {
+  const base = rules.find((r) => r.selector === '.status');
+  assert.ok(base, 'no bare `.status` rule');
+  assert.match(base.body, /width:\s*8px/, 'the plain dot lost its size');
+});
+
+console.log('\nand only working animates');
 
 check('the states that are not working carry no animation', () => {
   for (const state of ['waiting', 'idle', 'stopped']) {
-    const own = rules.filter((r) => r.selector.includes(`.status.${state}`));
-    for (const r of own) assert.doesNotMatch(r.body, /animation:/, `.status.${state} animates`);
+    for (const r of rules.filter((x) => x.selector.includes(`.status.${state}`))) {
+      assert.doesNotMatch(r.body, /animation:/, `.status.${state} animates`);
+    }
   }
+});
+check('working runs the same animation the rest of the app runs', () => {
+  const w = rules.find((r) => r.selector === '.status.working::before');
+  assert.ok(w, 'no `.status.working::before` rule');
+  assert.match(w.body, /animation:\s*ov-spin/, 'working does not use ov-spin');
 });
 
 console.log(failed ? `\n${failed} failed` : '\nall checks passed');

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -1,0 +1,80 @@
+// The state mark has ONE footprint, declared once.
+//
+// A working agent shows the braille spinner; every other state is that same
+// cell as a rectangle. The two only read as the same mark while they are the
+// same size, and the way that quietly breaks is a second rule elsewhere giving
+// `.status` its own width/height for one surface — which is exactly what
+// `.row .status { width: 6px; height: 6px }` used to do for the sidebar.
+//
+// So this is a lint on the stylesheet, not a rendering test: it pins that the
+// box is declared in one place. What it LOOKS like was checked with playwright
+// against a live app (see the PR), which this cannot do.
+//
+// Run with:  node test/statusMark.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const css = fs.readFileSync(path.join(HERE, '../src/styles.css'), 'utf8');
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+// Every rule whose selector targets .status, with its body.
+const rules = [...css.matchAll(/([^{}]*\.status[^{}]*)\{([^}]*)\}/g)]
+  .map(([, selector, body]) => ({ selector: selector.trim().split('\n').pop().trim(), body }));
+
+console.log('the state mark is declared once');
+
+check('the .status rule declares the box', () => {
+  const base = rules.find((r) => r.selector === '.status');
+  assert.ok(base, 'no bare `.status` rule found');
+  assert.match(base.body, /--st-w:/, 'the width variable is not declared there');
+  assert.match(base.body, /--st-h:/, 'the height variable is not declared there');
+  assert.match(base.body, /width:\s*var\(--st-w\)/, 'width does not come from the variable');
+  assert.match(base.body, /height:\s*var\(--st-h\)/, 'height does not come from the variable');
+});
+
+check('no other rule gives .status its own width or height', () => {
+  const offenders = rules
+    .filter((r) => r.selector !== '.status')
+    .filter((r) => /(^|;|\s)(width|height)\s*:/.test(r.body))
+    // ::before is the mark inside the box: it fills it (100%) or is the glyph
+    // (auto). Neither is a second opinion about how big the box is.
+    .filter((r) => !/::before/.test(r.selector))
+    .map((r) => r.selector);
+  assert.deepEqual(offenders, [], `these restate the box: ${offenders.join(', ')}`);
+});
+
+check('the mark inside the box only ever fills it or is the glyph', () => {
+  for (const r of rules.filter((x) => /::before/.test(x.selector))) {
+    const sizes = [...r.body.matchAll(/(?:^|;|\s)(?:width|height)\s*:\s*([^;]+)/g)].map((m) => m[1].trim());
+    for (const v of sizes) {
+      assert.ok(['100%', 'auto'].includes(v), `${r.selector} sizes the mark to ${v}`);
+    }
+  }
+});
+
+check('working is the spinner the rest of the app already runs', () => {
+  const w = rules.find((r) => r.selector === '.status.working::before');
+  assert.ok(w, 'no `.status.working::before` rule');
+  assert.match(w.body, /animation:\s*ov-spin/, 'working does not use the ov-spin animation');
+  assert.ok(/content:\s*'⠋'/.test(w.body), 'working does not render the braille frame');
+});
+
+check('the states that are not working carry no animation', () => {
+  for (const state of ['waiting', 'idle', 'stopped']) {
+    const own = rules.filter((r) => r.selector.includes(`.status.${state}`));
+    for (const r of own) assert.doesNotMatch(r.body, /animation:/, `.status.${state} animates`);
+  }
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Two items from iteration two of `improv.md`:

> on the sidebar: let's harmonize this with the working animation. if working, make it the same and if it's ready or inactive make it a recangle with the same shape as the working animation

> lets remove the "waiting" from the overview, i dont think it adds anything

## 1. The app had two ways of saying "busy"

A round dot that breathes (`.status.working`) in the sidebar, pane headers and cards — and the braille spinner (`ov-spin`) that the reader, the Overview cards and the tiles run. Two marks, two shapes, one meaning.

A working agent now shows **the spinner itself**, and every other state is **that same cell standing still**: a rectangle, filled for your-turn (accent) and idle (muted), outlined for stopped.

| | before | after |
| --- | --- | --- |
| working | breathing circle | the `ov-spin` braille cell |
| your turn | hollow accent ring | filled accent rectangle |
| idle | filled muted circle | filled muted rectangle |
| stopped | hollow muted ring | outlined muted rectangle |

### Where the geometry comes from

The cell is declared once, on `.status`:

```css
--st-w: 0.5em;
--st-h: 1.05em;
```

`0.5em × 1.05em` is **the braille cell's own ink**, measured in Geist Mono with `measureText` (8 × 16.8px at 16px) rather than guessed, so the rectangle and the spinner cover the same pixels. The spinner is centred in that box and needs no box of its own — its ink is exactly `--st-w` wide. Change the box and the animated mark and the four static ones move together, instead of two numbers being kept in sync by hand. Same lesson as `--cx-gutter` in #71 and `--ph-pad-y` in #75.

`.row .status { width: 6px; height: 6px }` goes with it. The mark is em-based now, so a sidebar row's smaller type already makes its mark smaller than a card's — the sidebar no longer restates a size the mark already knows.

`web/test/statusMark.test.mjs` (5 checks) pins that invariant as a stylesheet lint: the box is declared in exactly one rule, nothing else gives `.status` a width or height, the mark inside only ever fills the box or is the glyph, `working` uses `ov-spin`, and no other state animates. Verified it has teeth — putting the old `.row .status` px rule back fails it.

### Scope: this is more than the sidebar, on purpose

`.status` is one shared class used by pane headers, Overview cards and tiles, the group strip and the mobile chips. Harmonising the sidebar alone would have replaced one inconsistency with two, so the change is to `.status` itself. **It is CSS only** — no component that renders a state was touched, and Overview.tsx is not in this diff at all. If a reviewer wants it scoped back to the sidebar, that is a selector change in one rule.

### Reduced motion

`prefers-reduced-motion` kills all animation app-wide (styles.css:59), which freezes the spinner at `⠋` — a part-filled cell. Still visibly not the full rectangle a ready agent shows, so the vocabulary degrades rather than collapsing.

## 2. The waiting count

The Overview row's `N waiting` badge is gone, with the count and the `hiddenSessionIds` import that fed it, and `.ov-wait`.

I checked what it meant before cutting, as asked. It counted sessions in state `waiting`, excluding hidden groups and archived — genuinely the only place that number appeared. But the thing it summarises is directly underneath it: **every one of those agents is a row in the same list**, each with its own mark, and the Overview's `done` chip filters for exactly that state. It was a vaguer second telling of a list you are already looking at. Nothing becomes unreadable — which is the one thing that would have made me push back instead.

I read #60 first (`started`, deliberately "without a second name for `working`"). Nothing there depends on this badge: #60 works on `OverviewChip`/`chipBuckets` in the Overview's own bar, and `waiting` remains a bucket, a chip (`done`), and a per-row state. This removes a display of the count, not the state.

The two items reinforce each other: item 1 is what makes each waiting agent legible at a glance in the list, which is what item 2 leans on.

## Verification

**[Before/after screenshots &rarr;](https://claude.ai/code/artifact/772eb598-fed0-426f-b138-a24b77d0e12e)**

Playwright against a live app, all four states forced onto real rows:

- one footprint: `working` / `waiting` / `idle` / `stopped` all measure **8.0 × 16.8px**, `border-radius: 1px`
- `working` renders a live braille frame (`⠼` at capture) with `animation-name: ov-spin`; the other three render `content: ''` and `animation-name: none`
- the badge: with two sessions forced to `waiting` via an intercepted `/api/tree`, **the old build renders "2 waiting" and this one renders nothing**, while both still show those two agents as rows. (Worth saying: the seeded sessions never reach `waiting` on their own, so an unforced before/after would have shown "no badge" on both and proved nothing.)
- before/after screenshots of the sidebar at 1280 and 390

Web suite green (new lint + 9 existing), server suite green — all 13 files, no retry needed this time.

Not verified: how the mark looks on a real phone (checked at phone viewport in Chromium only), and the animated states are stills in the screenshots.

## Conflicts

Trial-merged both open PRs the manager flagged:

- **#78** — clean.
- **#76** (`fix/immediate-upload-progress`) — **one conflict hunk**, `web/src/components/Sidebar.tsx` around line 133. #76 adds `const quickFilesBlocked = …` immediately after the `waiting`/`hiddenIds` block this PR deletes, so git cannot tell whether the new line survives the deletion. Resolution is mechanical: **keep `quickFilesBlocked`, drop the `hiddenIds` and `waiting` lines.** #76 touches neither the badge JSX nor `.ov-wait`, so there is no second hunk and nothing semantic to reconcile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
