### PR TITLE
Settings: one rail and one type scale on a phone

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test": "node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/settingsMobile.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
     "test:render": "node test/statusMark.render.test.mjs",
     "preview": "vite preview"
   },

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -511,6 +511,25 @@ export default function SettingsView({
                   </div>
                 )}
 
+                {/* On demand regardless of the interval: taking one backup
+                    before a risky change should not mean switching on a
+                    schedule. It belongs directly under the intervals it stands
+                    beside — it used to sit past the skip-folders field, a screen
+                    away from the control it relates to. The cost note stays
+                    above it: that is what you want to have read before pressing
+                    a button that starts a billed Job. Disabled while a run is in
+                    flight — two Jobs uploading to one dataset would race. */}
+                {bk?.canRunNow && (
+                  <button
+                    className="btn-ghost bk-now"
+                    disabled={bkBusy || bk.running}
+                    onClick={doBackup}
+                  >
+                    {bkBusy ? 'Launching…' : bk.running ? 'Backing up…' : 'Back up now'}
+                  </button>
+                )}
+                {bkMsg && <div className="s-help" style={{ marginTop: 6 }}>{bkMsg}</div>}
+
                 {/* Folders to keep out of the history. An env directory is
                     thousands of files the backup has to hash and none of them
                     worth keeping — measured, that is 7s of work versus 1s.
@@ -573,22 +592,6 @@ export default function SettingsView({
                     </div>
                   </>
                 )}
-                {/* On demand regardless of the interval: taking one backup
-                    before a risky change should not mean switching on a
-                    schedule. Disabled while a run is in flight — two Jobs
-                    uploading to one dataset would race. */}
-                {bk?.canRunNow && (
-                  <button
-                    className="btn-ghost"
-                    style={{ marginTop: 8 }}
-                    disabled={bkBusy || bk.running}
-                    onClick={doBackup}
-                  >
-                    {bkBusy ? 'Launching…' : bk.running ? 'Backing up…' : 'Back up now'}
-                  </button>
-                )}
-                {bkMsg && <div className="s-help" style={{ marginTop: 6 }}>{bkMsg}</div>}
-
                 <div className="setting-row">
                   <div>
                     <div className="s-label">Restart sessions after a reboot</div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1444,7 +1444,13 @@ a.btn-ghost { text-decoration: none; }
   .app.settings .sidebar { width: 100%; border-right: none; border-bottom: 1px solid var(--border); }
   /* 14px, so the header (.brand), these tabs and the page below share one rail. */
   .app.settings .settings-nav { flex-direction: row; gap: 6px; padding: 8px 14px; }
-  .app.settings .settings-main { flex: 1; }
+  /* ONE owner for that gutter, and it is `.settings-page`. `.main` gives every
+     pane 12px (line 72) and the page then adds its own 14px on top, which put
+     the body on a 26px rail while the header and tabs sat at 14 — two
+     contributors, so tuning either drifts them apart again. The main gives up
+     its horizontal padding here; the vertical padding stays, since only the
+     side rail had a second claimant. Pinned by test/settingsMobile.test.mjs. */
+  .app.settings .settings-main { flex: 1; padding-left: 0; padding-right: 0; }
   /* wide pages (usage / skills) must never scroll the whole page sideways */
   .settings-page.wide { max-width: 100%; }
   .skills { flex-direction: column; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1074,8 +1074,20 @@ body {
 .settings-navitem { text-align: left; background: none; border: 1px solid transparent; border-radius: var(--r-md); padding: 9px 12px; font: inherit; font-size: 13px; color: var(--text); cursor: pointer; }
 .settings-navitem:hover { background: var(--panel-2); }
 .settings-navitem.active { background: color-mix(in srgb, var(--accent) 12%, transparent); border-color: color-mix(in srgb, var(--accent) 30%, transparent); color: var(--accent); font-weight: 600; }
-.settings-main { overflow-y: auto; }
-.settings-page { max-width: 640px; margin: 0 auto; padding: 6px 4px 30px; }
+/* The settings page reacts to the width of its own pane, not the window: with
+   the nav rail beside it a 768px tablet leaves the page 486px — as tight as a
+   phone — while a phone in the stacked layout gets the whole viewport. One
+   container query covers both, and the split-pane case nobody has asked for yet.
+   (Container queries are older than the color-mix() this sheet already relies
+   on, so this is not a new baseline.) */
+.settings-main { overflow-y: auto; container-type: inline-size; }
+/* width:100% is load-bearing. `.settings-main` is a column flex container, and
+   `margin: 0 auto` on a flex item switches off the cross-axis stretch: the page
+   box then sized itself from its widest content (524px) rather than from the
+   pane, so on anything narrower than that it hung over the right edge of the
+   scroller — controls off screen, descriptions cut mid-sentence — while the
+   centring still looked correct on a desktop wider than 524. */
+.settings-page { width: 100%; max-width: 640px; margin: 0 auto; padding: 6px 4px 30px; }
 .settings-page h2 { margin: 6px 0 18px; font-size: 22px; }
 .settings-page h3 { margin: 24px 0 8px; font-size: 14px; }
 /* plain rows, not cards: the bold label is the section header */
@@ -1085,9 +1097,14 @@ body {
 .setting-row.row-top { align-items: flex-start; }
 /* right-side controls share one width so the column reads as one rail */
 .setting-row > .btn-ghost, .setting-row .confirm-del { flex: none; }
+/* The text column may shrink. Without this a long mono value inside it (a
+   dataset id, a path) sets a min-content floor, the row cannot render under
+   ~524px, and anything narrower than that — a tablet, a phone, a split window —
+   pushes the control rail off the edge of the scroller instead of wrapping. */
+.setting-row > div { min-width: 0; }
 /* operator config (artifacts, jobs): every control sits in the same-width
    right-hand slot so the column lines up */
-.cfg-ctl { flex: none; width: 232px; display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
+.cfg-ctl { flex: 0 1 232px; width: 232px; display: flex; align-items: center; justify-content: flex-end; gap: 8px; }
 .cfg-seg { display: flex; width: 100%; }
 .cfg-seg button { flex: 1; padding: 6px 0; }
 .cfg-input { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); color: var(--text); font-size: 12.5px; }
@@ -1105,18 +1122,36 @@ body {
 .cfg-num { width: 90px; flex: none; text-align: right; }
 /* artifacts sub-settings stay visible when off, just clearly inert */
 .cfg-off { opacity: 0.45; pointer-events: none; }
+/* "Back up now" hangs off the interval control above it, so it sits on the page
+   rail rather than in the row's right-hand slot. */
+.bk-now { margin-top: 10px; }
 .setting-row > .btn-ghost, .setting-row > a.btn-ghost { min-width: 180px; white-space: nowrap; }
 a.btn-ghost { text-decoration: none; }
 .s-label { font-weight: 600; font-size: 14px; }
 .s-help { color: var(--muted); font-size: 12.5px; line-height: 1.5; margin: 2px 0 0; }
 .s-muted { color: var(--muted); }
+/* One voice for this page. Everywhere else in the app prose is sans and machine
+   values are mono at ~11.5px — the sidebar's session name and age (.row .name,
+   .row .age), the overview's state word (.ov-wait), the toolbar's segmented
+   options (.controls .seg button). Settings had drifted: option tokens and an
+   agent's state were sans while the version beside them was mono, and prose sat
+   at 12, 12.5 and 13 in adjacent blocks. Same split, one size for each role. */
+.settings-page .seg button { font-family: var(--font-mono); font-size: 11.5px; }
+.ar-state { font-family: var(--font-mono); }
+.kv b { font-family: var(--font-mono); }
+.kv > div { font-size: 12.5px; }
+.s-warn { font-size: 12.5px; }
+.tagf-chip { font-size: 11.5px; }
 /* agents: one hairline row per CLI — dot · logo · name · version · state */
 /* plain hairline rows — no box (sidebar voice: boundaries only where they mean something) */
 .agent-rows { display: flex; flex-direction: column; margin-top: 4px; }
 .agent-row { display: flex; align-items: center; gap: 10px; padding: 9px 2px; font-size: 13px; }
 .agent-row + .agent-row { border-top: 1px solid var(--border); }
 .agent-row .spacer { flex: 1; }
-.ar-name { white-space: nowrap; font-weight: 500; }
+/* The name is the only elastic thing in the row: it ellipsizes so the
+   version/state rail keeps its alignment in a narrow pane instead of pushing
+   the row past the edge. */
+.ar-name { white-space: nowrap; font-weight: 500; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .ar-ver { font-size: 11.5px; color: var(--muted); font-variant-numeric: tabular-nums; }
 .ar-state { flex: none; width: 88px; text-align: right; font-size: 11.5px; color: var(--muted); white-space: nowrap; }
 .ar-state.ok { color: var(--go); }
@@ -1182,6 +1217,44 @@ a.btn-ghost { text-decoration: none; }
 .zbtn:hover { color: var(--text); border-color: var(--border-strong); }
 .zlvl { min-width: 44px; background: none; border: none; color: var(--muted); font-size: 11px; cursor: pointer; font-variant-numeric: tabular-nums; }
 .zlvl:hover { color: var(--text); }
+
+/* ---- settings, narrow pane (phone, or a tablet beside the nav rail) ---- */
+@container (max-width: 560px) {
+  .settings-page { padding: 6px 14px 30px; }
+  /* A setting row is a text column plus a 232px control rail: it cannot render
+     much under ~450px, so in a 292px pane every control sat off the right edge
+     and the descriptions were cut mid-sentence. Stack instead — the control
+     lands under the text it belongs to, on the same rail as everything else. */
+  .settings-page .setting-row { flex-direction: column; align-items: stretch; gap: 9px; padding: 12px 0; }
+  /* flex:none, or the 232px basis inherited from the two-column layout becomes
+     a 232px-TALL control block once the row stacks and the main axis is vertical. */
+  .settings-page .cfg-ctl { flex: none; width: 100%; justify-content: flex-start; }
+  /* Options size to themselves. Stretching a two-word on/off across the pane
+     makes a toggle look like a banner; the intervals still line up because
+     every button in a group shares its width. */
+  .settings-page .cfg-seg { width: auto; }
+  .settings-page .cfg-seg button { white-space: nowrap; }
+  /* Buttons keep their own width and start at the rail rather than stretching:
+     a full-bleed "Show guide" reads as a banner, not as this row's control. */
+  .settings-page .setting-row > .btn-ghost,
+  .settings-page .setting-row > a.btn-ghost,
+  .settings-page .setting-row > .btn-primary { align-self: flex-start; }
+  .settings-page .setting-row .confirm-del { flex-wrap: wrap; }
+  /* Rows drop the 2px inset that put every label out of line with its heading. */
+  .settings-page .agent-row, .settings-page .kv > div { padding-left: 0; padding-right: 0; }
+  /* The 88px state rail plus a version string leaves ~45px for the name in a
+     320px pane, which ellipsises "Claude Code" to two letters. Drop the fixed
+     rail here: the states still end flush right, and the name is the part you
+     actually read. */
+  .settings-page .agent-row { gap: 8px; }
+  .settings-page .ar-state { width: auto; }
+  /* 22px against a 12.5px description is a magazine headline on a phone. */
+  .settings-page h2 { font-size: 18px; margin: 4px 0 14px; }
+  .settings-page h3 { margin: 22px 0 8px; }
+  /* Restore-defaults sits under its paragraph instead of squeezing it. */
+  .skiphead { flex-direction: column; gap: 8px; }
+  .skiprestore { align-self: flex-start; }
+}
 
 /* settings: skills editor */
 .settings-page.wide { max-width: 980px; }
@@ -1369,9 +1442,9 @@ a.btn-ghost { text-decoration: none; }
   /* settings stacks vertically */
   .app.settings { flex-direction: column; }
   .app.settings .sidebar { width: 100%; border-right: none; border-bottom: 1px solid var(--border); }
-  .app.settings .settings-nav { flex-direction: row; gap: 6px; padding: 8px 10px; }
+  /* 14px, so the header (.brand), these tabs and the page below share one rail. */
+  .app.settings .settings-nav { flex-direction: row; gap: 6px; padding: 8px 14px; }
   .app.settings .settings-main { flex: 1; }
-  .settings-page { padding: 6px 12px 30px; }
   /* wide pages (usage / skills) must never scroll the whole page sideways */
   .settings-page.wide { max-width: 100%; }
   .skills { flex-direction: column; }

--- a/web/test/settingsMobile.test.mjs
+++ b/web/test/settingsMobile.test.mjs
@@ -1,0 +1,189 @@
+// The settings page on a phone, in a real browser.
+//
+// Two things here are invariants rather than taste, and both were reported by
+// the operator ("all over the place on mobile", "the backup now button should
+// be below the time options"):
+//
+//   1. ONE horizontal gutter. The header, the section tabs and the page body
+//      start on the same rail. This is easy to break by accident because two
+//      elements can each contribute padding — `.main` gives every pane 12px and
+//      `.settings-page` adds its own — and the result is not a broken layout,
+//      just a body sitting 12px inside its own chrome, which is exactly the
+//      "not nicely aligned" that was reported.
+//   2. In a narrow pane a setting's control sits UNDER its label, and at desktop
+//      width it is back beside it. The stacking comes from a container query on
+//      the pane, so a change to the pane's width or padding can silently move
+//      the breakpoint.
+//
+// Plus the backup section's reading order: intervals → cost note → Back up now.
+//
+// The real SettingsView against a stubbed api module, so the fixture can hold
+// the states worth measuring (backup enabled with a token, a full skip list).
+// Run with:  node test/settingsMobile.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'settings-mobile-'));
+const bundle = path.join(tmp, 'app.js');
+
+// `export *` first, then the overrides: the named exports below win, and
+// everything else (whatever SkillsEditor/UsagePanel import) still resolves.
+const stub = path.join(tmp, 'api-stub.ts');
+fs.writeFileSync(stub, `
+export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
+const cfg = {
+  artifacts: { enabled: true, space: 'me/artifacts', visibility: 'public' },
+  jobs: { askAboveUsd: 5 },
+  archive: { after: 'month' },
+  revive: { enabled: true, days: 3 },
+  backup: { every: '1h', dataset: 'me/backup', exclude: ['node_modules', '.venv', '__pycache__', 'dist'] },
+};
+const bk = {
+  every: '1h', source: '/data', staging: '/tmp/s', dataset: 'me/backup',
+  defaults: { dataset: 'me/backup', staging: '/tmp/s' },
+  hasToken: true, canRunNow: true, running: false, unavailable: null,
+  last: { at: 1, jobId: 'j', stage: 'done' }, jobName: 'backup', jobsUrl: 'https://example.invalid',
+  exclude: cfg.backup.exclude, excludeDefaults: cfg.backup.exclude, excludeIsDefault: true,
+  health: null, failures: 0, lastFailure: null, lastSuccessAt: 1, nextDue: 2,
+  datasetPrivate: true, error: null,
+};
+export const getConfig = () => Promise.resolve(structuredClone(cfg));
+export const saveConfig = () => Promise.resolve({ ok: true });
+export const backupStatus = () => Promise.resolve(structuredClone(bk));
+export const runBackup = () => Promise.resolve({ job: 'j2' });
+export const getSecrets = () => Promise.resolve({ detected: ['HF_TOKEN'], notes: { HF_TOKEN: 'Hub access.' } });
+export const saveSecrets = () => Promise.resolve({ ok: true });
+export const checkUpdate = () => Promise.resolve({ ok: true, canUpdate: false, behind: false, current: 'abc1234' });
+export const runUpdate = () => Promise.resolve({ ok: true });
+export const relaunchSpace = () => Promise.resolve({ ok: true });
+export const getPushKey = () => Promise.resolve({ publicKey: '' });
+export const subscribePush = () => Promise.resolve({ ok: true });
+export const unsubscribePush = () => Promise.resolve({ ok: true });
+export const sendTestNotification = () => Promise.resolve({ sent: 0 });
+`);
+
+await build({
+  stdin: {
+    resolveDir: WEB,
+    loader: 'tsx',
+    contents: `
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import SettingsView from './src/components/SettingsView.tsx';
+
+      const clis = [
+        { id: 'claude', label: 'Claude Code', color: '#d97757', available: true, ready: true, version: '2.1.232' },
+        { id: 'gemini', label: 'Gemini CLI', color: '#4796e3', available: true, ready: false, version: '0.55.1', setup: 'Sign in once.' },
+      ];
+      const info = { dataDir: '/data', home: '/data/home', spaceId: 'me/space', ghostty: true, canRelaunch: true };
+      createRoot(document.getElementById('root')).render(
+        <SettingsView page="general" onPage={() => {}} onClose={() => {}}
+          theme="light" onToggleTheme={() => {}} clis={clis} info={info}
+          onShowWelcome={() => {}} demoMode={false} onToggleDemo={() => {}} />,
+      );
+    `,
+  },
+  outfile: bundle,
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  logLevel: 'error',
+  plugins: [{
+    name: 'stub-api',
+    setup(b) { b.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub })); },
+  }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const open = async (width) => {
+  const page = await browser.newPage({ viewport: { width, height: 900 } });
+  await page.setContent(`<style>${css}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  await page.waitForFunction(() => !!document.querySelector('.tagf'));   // backup section painted
+  return page;
+};
+
+try {
+  for (const width of [320, 390]) {
+    const page = await open(width);
+    const m = await page.evaluate(() => {
+      const left = (sel) => {
+        const el = document.querySelector(sel);
+        return el ? Math.round(el.getBoundingClientRect().left) : null;
+      };
+      const main = document.querySelector('.settings-main');
+      const row = [...document.querySelectorAll('.setting-row')].find((r) => r.querySelector('.cfg-ctl'));
+      const label = row.querySelector('.s-label').getBoundingClientRect();
+      const ctl = row.querySelector('.cfg-ctl').getBoundingClientRect();
+      const order = [...document.querySelectorAll('.settings-page *')];
+      const at = (el) => order.indexOf(el);
+      return {
+        back: left('.brand .icon-btn'),
+        tab: left('.settings-navitem'),
+        heading: left('.settings-page h2'),
+        label: Math.round(label.left),
+        control: Math.round(ctl.left),
+        scroll: main.scrollWidth,
+        client: main.clientWidth,
+        stacked: ctl.top >= label.bottom,
+        intervals: at([...document.querySelectorAll('.cfg-seg')].find((s) => s.textContent.includes('24h'))),
+        cost: at(document.querySelector('.s-warn')),
+        backup: at(document.querySelector('.bk-now')),
+        skips: at(document.querySelector('.tagf')),
+      };
+    });
+
+    console.log(`a phone at ${width}px`);
+    check(`one gutter: back arrow, tabs, heading, label and control all start at x=${m.back}`,
+      () => assert.deepEqual(
+        { tab: m.tab, heading: m.heading, label: m.label, control: m.control },
+        { tab: m.back, heading: m.back, label: m.back, control: m.back },
+      ));
+    check('nothing hangs past the scroller', () => assert.equal(m.scroll, m.client));
+    check('a control sits under its label, not beside it', () => assert.ok(m.stacked));
+    check('backup reads: intervals, then the cost note, then "Back up now", then the skip list',
+      () => assert.ok(m.intervals < m.cost && m.cost < m.backup && m.backup < m.skips,
+        `got ${JSON.stringify({ i: m.intervals, c: m.cost, b: m.backup, s: m.skips })}`));
+    await page.close();
+    console.log('');
+  }
+
+  // The stacking is a container query on the pane: at desktop width the two
+  // columns must come back, or every row would be twice as tall for nothing.
+  const page = await open(1200);
+  const d = await page.evaluate(() => {
+    const row = [...document.querySelectorAll('.setting-row')].find((r) => r.querySelector('.cfg-ctl'));
+    const label = row.querySelector('.s-label').getBoundingClientRect();
+    const ctl = row.querySelector('.cfg-ctl').getBoundingClientRect();
+    const main = document.querySelector('.settings-main');
+    return { beside: ctl.top < label.bottom, right: Math.round(ctl.right), rowRight: Math.round(row.getBoundingClientRect().right), scroll: main.scrollWidth, client: main.clientWidth };
+  });
+  console.log('a desktop at 1200px');
+  check('the control is beside its label again', () => assert.ok(d.beside));
+  check('and still ends on the row\'s right rail', () => assert.ok(Math.abs(d.right - d.rowRight) <= 3, `${d.right} vs ${d.rowRight}`));
+  check('nothing hangs past the scroller', () => assert.equal(d.scroll, d.client));
+  await page.close();
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(failed ? `\n${failed} failed` : '\nsettings-mobile: ok');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Two items from `improv.md` iteration two, both on the settings page.

**Screenshots and measurements at 320 / 390 / 768 / 1200, before and after: https://claude.ai/code/artifact/4eae5c54-4d2b-4ea3-8050-19a671fbcf29**

## 1. "all over the place on mobile"

It had a mechanical cause, not a styling one. `.settings-main` is a column flex container, and `margin: 0 auto` on a flex item switches off the cross-axis stretch — so `.settings-page` sized itself from its widest content (524px, the natural width of one setting row) instead of from the pane. Anything narrower than that and the whole page hung over the right edge of the scroller:

| viewport | pane | before (`scrollWidth`/`clientWidth`) | after |
| --- | --- | --- | --- |
| 320 | 320 | **572 / 320** | 320 / 320 |
| 390 | 390 | **572 / 390** | 390 / 390 |
| 768 | 486 | **556 / 486** | 486 / 486 |
| 1200 | 918 | 918 / 918 | 918 / 918 |

That is why it read as a phone-only mess: a desktop wider than 524px hid it completely. On a phone it meant the theme toggle, every segmented control and the whole right-hand rail were off screen, and each description was cut mid-sentence.

`width: 100%` fixes the box. The rest fixes what the box then contains:

- **Rows stack in a narrow pane.** A setting row is a text column plus a 232px control rail and cannot render much under ~450px, so below that the control moves under the text it belongs to, on the same 14px rail as the heading above it.
- **The rows can shrink at all** — `.setting-row > div { min-width: 0 }`. Without it a long mono value inside the text column (a dataset id, a path) sets a min-content floor and pushes the rail off the edge again.
- **The agent name ellipsizes** instead of forcing the row wide. At 320px the 88px state rail plus a version string left ~45px for the name, which truncated "Claude Code" to two letters; on a narrow pane the fixed rail is dropped, and the states still end flush right.

### Why a container query rather than a media query

The pane is what is narrow, not the window. At 768px the nav rail leaves the settings page 486px — as tight as a phone — while a phone in the stacked layout gets the whole viewport. A viewport media query at 720px would have left 768 broken, which the table above shows it was. One `@container (max-width: 560px)` on `.settings-main` covers both, and any split-pane width later. Container queries are an older baseline than the `color-mix()` this stylesheet already depends on, so this does not raise the browser requirement.

### Type

The app is consistent everywhere else: prose in sans, machine values in mono at ~11.5px — `.row .name` / `.row .age` in the sidebar, `.ov-wait` in the overview, `.controls .seg button` in the toolbar. Settings had drifted, with option tokens and an agent's state in sans beside a mono version, and prose at 12, 12.5 and 13px in adjacent blocks. Restored to that split: segmented options and agent state to mono 11.5, `.kv` values to mono, warnings and chips onto the same two sizes. No new sizes, no new colours.

The page's information architecture is untouched — same sections, same order, same copy.

## 2. "the backup now button should be below the time options"

It was past the skip-folders field, a screen away from the intervals it belongs to. It now sits directly under them, after the one-line cost note — that note is what you want read before pressing a button that starts a billed Job. On desktop it sits on the page's left rail rather than in the row's right-hand slot, like the other full-width pieces of that setting (the cost note, the skip-folders field); the 1200px pair in the artifact shows how that reads.

## Verification

- Real `SettingsView` rendered in Chromium at each width against a stubbed `api` module with the busy branches on screen (secrets present, backup enabled with a token and a full skip list, an update available). No horizontal overflow at any width; desktop layout unchanged; dark mode checked at 390.
- `web`: typecheck, `npm test`, `npm run build` — green. Server suite green (`migration.test.mjs` included, no port collision this run).
- One desktop difference worth naming: the page box now reaches its declared `max-width: 640px` instead of the ~624px it happened to settle on, so descriptions wrap a line later. Visible if you flip between the 1200px pair.

## Overlap with open PRs

Both open PRs that touch `web/src/styles.css` are in different parts of the file — #76 in `.image-chip*` (composer attachments), #78 one line at `.ovt-state.input` (overview tile). I trial-merged both against this branch: **clean, no conflicts.** Nothing here touches the composer or the overview.

## Reviewing this

The measurement numbers are the quickest check: `document.querySelector('.settings-main')` `scrollWidth` vs `clientWidth` at 320px, on `main` and on this branch. The screenshot harness was throwaway and is not in the diff — say the word if it is worth keeping as a script.
