### PR TITLE
Reader: the answer where it was said, one working line, a still turn column

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -268,7 +268,9 @@ pane with nothing to render (a shell) simply stays a terminal.
   above. Only the last exchange shows it, and while an optimistic echo is pending the echo owns
   the spot: the agent is one process working on one thing, and two `working` lines stacked (the
   live turn's and the echo's) is what read as the indicator being "sometimes below and above".
-  The card has had this guard since it grew an echo; the reader had not.
+  The card has had this guard since it grew an echo; the reader had not. The cost of choosing the
+  echo's line is that it is the bare one — the live turn's carries `· what it is doing now`, and
+  that detail is gone for the second or two until the transcript catches up and the echo clears.
 - **The turn column holds still.** `turn 9/10` and `turn 10/10` are different widths, so the whole
   right-hand cluster stepped sideways the moment a session passed nine turns. The number is padded
   to the width of the total with figure spaces (U+2007) — the row is mono and tabular, so a figure

--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -253,6 +253,26 @@ pane with nothing to render (a shell) simply stays a terminal.
   tool call is unusable while a task runs; one that never moves makes you chase it.
 - **The prompt band sticks to the top** while you read a long turn. What you want overhead deep
   in someone's 67-step answer is the question it is answering — not a row of numbers.
+- **An exchange reads in the order it happened.** Usually the answer is the last thing the agent
+  said, so it goes under the work. But an agent that answers and then keeps going — a resumed
+  task, a reply followed by more tool calls — leaves its answer in the *middle* of the turn, and
+  the reader used to lift it out and print it under work it predates. With the steps expanded that
+  reads as nonsense: "I will add the index and re-run" sitting below the edit and the re-run.
+  `answerAt` (exchanges.ts) remembers the index the answer was lifted from, and the work renders as
+  two runs of steps with the answer between them. Grouping runs over each side separately, so two
+  `Read`s either side of the reply stay two rows rather than collapsing into `Read ×2` and erasing
+  the sequence.
+- **One working line, and it is the last thing in the reader.** It carries what the agent is doing
+  *now* (`working · Bash …`), so it belongs at the end of the rail it continues — putting it above
+  the steps would report the present before the past, which is the same disorder as the bullet
+  above. Only the last exchange shows it, and while an optimistic echo is pending the echo owns
+  the spot: the agent is one process working on one thing, and two `working` lines stacked (the
+  live turn's and the echo's) is what read as the indicator being "sometimes below and above".
+  The card has had this guard since it grew an echo; the reader had not.
+- **The turn column holds still.** `turn 9/10` and `turn 10/10` are different widths, so the whole
+  right-hand cluster stepped sideways the moment a session passed nine turns. The number is padded
+  to the width of the total with figure spaces (U+2007) — the row is mono and tabular, so a figure
+  space is exactly a digit — and the clock beside it was already stable.
 - **The prompt band spans the pane.** Reaching into the left gutter but stopping at the text
   column on the right made it read as a card floating over the answer rather than as the head of
   it. Full bleed both sides; the meta row sits tight under the band it belongs to, and one

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -497,7 +497,13 @@ export default function ConversationView({ session, paused, isMobile, readOnly, 
                 total={exchanges.length}
                 q={q || undefined}
                 baseModel={head.model || undefined}
-                running={live && x === exchanges[exchanges.length - 1]}
+                // One working line in the reader, and it is the last thing on
+                // the page. While an echo is pending it owns that spot — the
+                // agent is one process working on one thing, and two `working`
+                // lines stacked (the live turn's and the echo's) is what read
+                // as the widget being "sometimes below and above". The card has
+                // had this guard since it grew an echo; the reader had not.
+                running={live && x === exchanges[exchanges.length - 1] && !sent}
               />
             </div>
           ))}

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -22,6 +22,10 @@ const textOf = (t: TraceTurn | TraceTurn[] | null) =>
 const moreOf = (t: TraceTurn | TraceTurn[] | null) =>
   blocksOf(t).reduce((n, b) => n + (('more' in b && b.more) || 0), 0);
 
+/** `9` under `10` — a figure space (U+2007) is a digit wide in tabular figures. */
+const padTurn = (n: number, total?: number) =>
+  String(n).padStart(String(total ?? n).length, '\u2007');
+
 const moreLabel = (more?: number) =>
   (more ? `+${more > 1024 ? `${Math.round(more / 1024)} KB` : `${more} chars`} not retained` : '');
 
@@ -169,7 +173,14 @@ export function ExchangeView({
   const [selfOpen, setSelfOpen] = useState(false);
   const toggle = onToggle ?? (() => setSelfOpen((o) => !o));
 
-  const steps = useMemo(() => stepsOf(x.steps), [x.steps]);
+  // The work, split where the answer belongs. Grouping runs over each side
+  // separately on purpose: two Reads either side of the agent's reply are two
+  // things it did, before and after saying it, and collapsing them into one
+  // `Read ×2` row would erase exactly the sequence this is here to keep.
+  const at = x.answerAt;
+  const stepsBefore = useMemo(() => stepsOf(at == null ? x.steps : x.steps.slice(0, at)), [x.steps, at]);
+  const stepsAfter = useMemo(() => (at == null ? [] : stepsOf(x.steps.slice(at))), [x.steps, at]);
+  const steps = useMemo(() => [...stepsBefore, ...stepsAfter], [stepsBefore, stepsAfter]);
   // A turn whose match is buried in the work unfolds it, or the search would
   // report a hit with nothing on screen to look at.
   const hitInWork = useMemo(
@@ -206,22 +217,33 @@ export function ExchangeView({
           <>
             <span className="spacer" />
             {model && <span className="cx-model">{model}</span>}
-            <span className="cx-n">turn {n}{total ? `/${total}` : ''}</span>
+            {/* Padded to the width of the total, in FIGURE spaces: the row is
+                mono and tabular, so one figure space is exactly one digit, and
+                "turn  9/10" lines up under "turn 10/10" instead of the whole
+                right cluster stepping left the moment a session passes nine
+                turns. A plain space would collapse in HTML. */}
+            <span className="cx-n">turn {padTurn(n, total)}{total ? `/${total}` : ''}</span>
             {x.startTs ? <span className="cx-time">{fmtClock(x.startTs)}</span> : null}
           </>
         )}
       </div>
       )}
-      {isOpen && steps.length > 0 && (
-        <div className="cx-steps">{steps.map((s, i) => <StepRow key={i} s={s} q={q} />)}</div>
+      {isOpen && stepsBefore.length > 0 && (
+        <div className="cx-steps">{stepsBefore.map((s, i) => <StepRow key={i} s={s} q={q} />)}</div>
       )}
 
+      {/* The answer sits where it was said. Usually that is after all the work;
+          when the agent answered and then kept going, `answerAt` puts it back
+          between the two runs of steps instead of under work it predates. */}
       {answerHtml ? (
         <div className="cx-answer">
           <div className="markdown cx-md" dangerouslySetInnerHTML={{ __html: answerHtml }} />
           {!!answerMore && <div className="cx-note mono">…{moreLabel(answerMore)}</div>}
         </div>
       ) : null}
+      {isOpen && stepsAfter.length > 0 && (
+        <div className="cx-steps">{stepsAfter.map((s, i) => <StepRow key={`a${i}`} s={s} q={q} />)}</div>
+      )}
       {/* Mid-task there is no answer — an agent's aside is not a reply — so the
           running line carries the latest thing that happened instead. */}
       {running && (

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -191,6 +191,13 @@ export function ExchangeView({
   const answerHtml = useMemo(
     () => (answer ? highlightHtml(renderMarkdown(answer), q) : ''), [answer, q]);
   const answerMore = moreOf(x.answer);
+  // Counted over the split, deliberately: the fold control says how many rows
+  // are behind it, so "2 steps" has to mean two rows when you open it. The cost
+  // is that a turn whose answer landed mid-work can report one row more than an
+  // identical turn whose answer came last — same tools, same time, different
+  // grouping. `stepSummary(x, stepsOf(x.steps))` would count the whole turn
+  // instead and disagree with what unfolds; between the two, the number that
+  // matches what you are about to see wins.
   const summary = stepSummary(x, steps);
   const latest = running ? nowDoing(steps[steps.length - 1]) : '';
   // Naming the model on every turn is noise when it never changes; when it DOES

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -12,6 +12,14 @@ export interface Exchange {
   steps: TraceTurn[];
   /** Everything the agent said after its last action — usually one turn. */
   answer: TraceTurn[];
+  /**
+   * Where the answer sits among the steps, when it is NOT last: the index in
+   * `steps` the answer was lifted from. An agent that answered and then went
+   * back to work leaves its reply in the middle of the turn, and a reader that
+   * prints it under the tools that ran after it is telling the story in the
+   * wrong order. Undefined — the usual case — means the answer is simply last.
+   */
+  answerAt?: number;
   startTs: number;
   endTs: number;
   tokens: number;
@@ -80,11 +88,15 @@ export function splitExchanges(turns: TraceTurn[]): Exchange[] {
       continue;
     }
     // Nothing at the end: an agent that answered and then went back to work
-    // (a resumed task) still answered. Its last `final` stands, where it is.
+    // (a resumed task) still answered. Its last `final` stands — and `answerAt`
+    // remembers WHERE, because it is not the last thing that happened. The
+    // steps that follow it are the work it did afterwards, and they belong
+    // below it, not above.
     for (let i = x.steps.length - 1; i >= 0; i--) {
       if (x.steps[i].kind === 'final' && saidSomething(x.steps[i])) {
         x.answer = [x.steps[i]];
         x.steps.splice(i, 1);
+        x.answerAt = i;
         break;
       }
     }

--- a/web/test/exchanges.test.mjs
+++ b/web/test/exchanges.test.mjs
@@ -161,6 +161,39 @@ const kinds = (steps) => steps.map((s) => (s.kind === 'tools' ? `${s.name}×${s.
   assert.equal(stepsOf(x.steps)[0].details[0], 'server/src/runner.js');
 }
 
+// ------------------------------------------------- answered, then kept going
+// The agent replies and goes back to work. The reply is still the answer — but
+// it is NOT the last thing that happened, and printing it under the tools that
+// ran afterwards tells the story in the wrong order. `answerAt` is where it
+// belongs; the steps either side of it are the work before and after.
+{
+  const [x] = splitExchanges([
+    user('why is the nightly job slow, and can you fix it?'),
+    agent([call('Bash', { command: 'explain analyze …' }), result('Seq Scan on usage')]),
+    agent([text('Found it — no index behind the group-by. I will add one and re-run.')], 'final'),
+    agent([call('Edit', { file_path: 'migrations/014_usage_index.sql' }), result('created')]),
+    agent([call('Bash', { command: 'node scripts/nightly.mjs' }), result('ok · 12.4s')]),
+  ]);
+  assert.match(said(x.answer), /^Found it/, 'the reply is still the answer');
+  assert.equal(x.answerAt, 1, 'and it is remembered where it was said');
+  assert.deepEqual(kinds(stepsOf(x.steps.slice(0, x.answerAt))), ['Bash×1'],
+    'the work it followed stays above it');
+  assert.deepEqual(kinds(stepsOf(x.steps.slice(x.answerAt))), ['Edit×1', 'Bash×1'],
+    'and the work it promised stays below it');
+}
+
+// An answer that really is last says so by leaving answerAt unset, which is
+// what keeps the ordinary turn one plain block of steps.
+{
+  const [x] = splitExchanges([
+    user('what changed in the deploy config?'),
+    agent([call('Read', { file_path: 'deploy.yaml' }), result('healthz: /api/health')]),
+    agent([text('Only the health-check path.')], 'final'),
+  ]);
+  assert.match(said(x.answer), /^Only the health-check/);
+  assert.equal(x.answerAt, undefined, 'nothing to remember: it is simply last');
+}
+
 // ------------------------------------------------------------- formatting
 assert.equal(fmtTok(954), '954');
 assert.equal(fmtTok(21_000), '21.0k');

--- a/web/test/exchanges.test.mjs
+++ b/web/test/exchanges.test.mjs
@@ -182,6 +182,26 @@ const kinds = (steps) => steps.map((s) => (s.kind === 'tools' ? `${s.name}×${s.
     'and the work it promised stays below it');
 }
 
+// The other end of the same rule: an agent that answers FIRST and then does the
+// work — "I will add one now", then the edit and the run, and it never speaks
+// again. markFinalTurns marks that text at index 0, so answerAt is 0 and every
+// step belongs below it. Zero is the value a falsy check silently loses: swap
+// `at == null` for `!at` in Exchange.tsx and this turn renders its answer under
+// both tool rows again, which is the bug this whole change exists to remove.
+{
+  const [x] = splitExchanges([
+    user('add an index for the nightly job'),
+    agent([text('I will add one now.')], 'final'),
+    agent([call('Edit', { file_path: 'migrations/014_usage_index.sql' }), result('created')]),
+    agent([call('Bash', { command: 'node scripts/nightly.mjs' }), result('ok · 12.4s')]),
+  ]);
+  assert.match(said(x.answer), /^I will add one now/);
+  assert.equal(x.answerAt, 0, 'answered before doing anything: index zero, not undefined');
+  assert.deepEqual(kinds(stepsOf(x.steps.slice(0, x.answerAt))), [], 'nothing above it');
+  assert.deepEqual(kinds(stepsOf(x.steps.slice(x.answerAt))), ['Edit×1', 'Bash×1'],
+    'and all of the work below it');
+}
+
 // An answer that really is last says so by leaving answerAt unset, which is
 // what keeps the ordinary turn one plain block of steps.
 {

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -109,6 +109,22 @@ check('the work it promised is below the answer',
   () => assert.ok(mid.indexOf('Found it') < mid.indexOf('014.sql'), 'the Edit should follow the answer'));
 check('so the steps render as two runs, not one',
   () => assert.equal((mid.match(/class="cx-steps"/g) || []).length, 2));
+// answerAt can be 0 — the agent answered before it did anything — and 0 is the
+// value a falsy guard drops. With `!at` in place of `at == null` every other
+// check here still passes and this one does not, which is the point of it.
+check('an answer given BEFORE the work renders above all of it', () => {
+  const first = render(ExchangeView, {
+    x: { ...midTurn, answerAt: 0, answer: [{ role: 'assistant', ts: 1_700_000_005_000, kind: 'final', blocks: [{ type: 'text', text: 'I will add one now.' }] }] },
+    n: 2, total: 2, open: true,
+  });
+  assert.ok(first.indexOf('I will add one now') < first.indexOf('explain analyze'),
+    'the answer should precede the first tool row');
+  assert.ok(first.indexOf('explain analyze') < first.indexOf('014.sql'),
+    'and the work should stay in its own order below it');
+  assert.equal((first.match(/class="cx-steps"/g) || []).length, 1,
+    'nothing above the answer, so one run of steps below it');
+});
+
 check('an answer that IS last still renders one run of steps', () => {
   const plain = render(ExchangeView, { x: { ...midTurn, answerAt: undefined, answer: midTurn.answer }, n: 2, total: 2, open: true });
   assert.equal((plain.match(/class="cx-steps"/g) || []).length, 1);

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -9,7 +9,10 @@
 // was live in both the reader and the Overview card, and nothing failed.
 //
 // So this pins the nesting, not the pixels: the echo is a `.cx` section with the
-// band inside it, the same shape ExchangeView gives a real turn. Same style as
+// band inside it, the same shape ExchangeView gives a real turn. The rest of the
+// file pins the other two things about an exchange that are order, not style:
+// where the answer sits among the steps, and that the turn column does not step
+// sideways when the count gains a digit. Same style as
 // exchanges.test.mjs — esbuild is already here for vite, so the component is
 // transpiled and rendered with react-dom/server. Run with:
 //   node test/pendingExchange.test.mjs
@@ -27,10 +30,22 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const outDir = path.join(HERE, '../node_modules/.test-build');
 fs.mkdirSync(outDir, { recursive: true });
 const out = path.join(outDir, 'exchange.mjs');
+// Markdown is stubbed, not rendered: sanitising wants a DOM, and what these
+// checks are about is which order the blocks come out in, not what marked does
+// with a paragraph. Everything else is the real component.
+const stubMarkdown = {
+  name: 'stub-markdown',
+  setup(b) {
+    b.onResolve({ filter: /lib\/markdown$/ }, () => ({ path: 'markdown-stub', namespace: 'stub' }));
+    b.onLoad({ filter: /.*/, namespace: 'stub' }, () => ({
+      contents: 'export const renderMarkdown = (md) => `<p>${md}</p>`;', loader: 'js',
+    }));
+  },
+};
 await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/Exchange.tsx')],
   outfile: out, format: 'esm', bundle: true, jsx: 'automatic', logLevel: 'error',
-  external: ['react', 'react-dom', 'react/jsx-runtime'],
+  external: ['react', 'react-dom', 'react/jsx-runtime'], plugins: [stubMarkdown],
 });
 const { PendingExchange, ExchangeView } = await import(pathToFileURL(out).href);
 
@@ -73,6 +88,47 @@ check('with its prompt band in the same place',
   () => assert.match(real, /^<section class="cx">\s*<div class="cx-prompt">/));
 check('so the echo and the turn share one left edge',
   () => assert.equal(html.slice(0, html.indexOf('cx-prompt')), real.slice(0, real.indexOf('cx-prompt'))));
+
+console.log('\nand an answer that was not last renders where it was said');
+// The agent answered and then kept working: `answerAt` puts the reply between
+// the work it followed and the work it promised, instead of under both.
+const midTurn = {
+  key: 'x2', at: 2, startTs: 1_700_000_000_000, endTs: 1_700_000_090_000, tokens: 0, toolCalls: 2,
+  prompt: { role: 'user', ts: 1_700_000_000_000, blocks: [{ type: 'text', text: 'fix the nightly job' }] },
+  steps: [
+    { role: 'assistant', ts: 1_700_000_010_000, blocks: [{ type: 'tool_use', name: 'Bash', text: '{"command":"explain analyze"}' }] },
+    { role: 'assistant', ts: 1_700_000_050_000, blocks: [{ type: 'tool_use', name: 'Edit', text: '{"file_path":"014.sql"}' }] },
+  ],
+  answer: [{ role: 'assistant', ts: 1_700_000_030_000, kind: 'final', blocks: [{ type: 'text', text: 'Found it — adding the index now.' }] }],
+  answerAt: 1,
+};
+const mid = render(ExchangeView, { x: midTurn, n: 2, total: 2, open: true });
+check('the work it followed is above the answer',
+  () => assert.ok(mid.indexOf('explain analyze') < mid.indexOf('Found it'), 'Bash should precede the answer'));
+check('the work it promised is below the answer',
+  () => assert.ok(mid.indexOf('Found it') < mid.indexOf('014.sql'), 'the Edit should follow the answer'));
+check('so the steps render as two runs, not one',
+  () => assert.equal((mid.match(/class="cx-steps"/g) || []).length, 2));
+check('an answer that IS last still renders one run of steps', () => {
+  const plain = render(ExchangeView, { x: { ...midTurn, answerAt: undefined, answer: midTurn.answer }, n: 2, total: 2, open: true });
+  assert.equal((plain.match(/class="cx-steps"/g) || []).length, 1);
+});
+
+console.log('\nand the turn column holds still as the count gains a digit');
+const turnCell = (n, total) => {
+  const html = render(ExchangeView, { x: { ...midTurn, answerAt: undefined }, n, total });
+  return (html.match(/class="cx-n">([^<]*)</) || [])[1];
+};
+check('a single digit is padded to the width of the total', () => {
+  const nine = turnCell(9, 10);
+  assert.ok(nine.includes('\u2007'), `expected a figure space in ${JSON.stringify(nine)}`);
+  assert.equal(nine.replace(/\u2007/g, '').trim(), 'turn 9/10');
+});
+check('and the padded cell is exactly as wide as the widest one', () => {
+  assert.equal(turnCell(9, 10).length, turnCell(10, 10).length);
+});
+check('a session that never reaches ten pads nothing',
+  () => assert.equal(turnCell(3, 9), 'turn 3/9'));
 
 console.log('\nand the CSS pair the nesting exists for is still a pair');
 const css = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');


### PR DESCRIPTION
Three items from **iteration two** of `improv.md`, all in the reader's layout. Each was reproduced on a running instance and measured on both builds before anything was edited.

**[Before/after captures →](https://claude.ai/code/artifact/b0ff0c11-3b20-4433-857c-7fe14a2a216d)**

## 1. The last assistant message was printed after work it predates

> the last assisstant message is sometimes rendered at the very end even when the tools are expanded which looks odd as it's not in order with the tools

The substantive one, and it is an ordering bug in `splitExchanges`, not spacing. **Source order first:** `markFinalTurns` (server/src/traces.js:1496) marks the last assistant *text* turn before the next user turn as `final` — that text can be followed by more tool calls. When an exchange doesn't END on the agent's words, `splitExchanges` searched backwards for that `final`, **spliced it out of the middle of the steps** and rendered it below all of them. ~~`unmarkTrailingFinal` means this only bites *completed* exchanges, which is why it shows up when scrolling back rather than while watching.~~ **Corrected after review:** `unmarkTrailingFinal` only runs when the window does *not* reach the end (`traces.js:1720`, `if (!atEnd && openEdge)`), so on a live tail the trailing `final` *is* marked and a turn that answers and then starts another tool gets `answerAt` while you are watching it. The behaviour is the same either way; the blast radius is larger than that sentence claimed.

The fixture makes it self-evident — the reply promises the two things printed above it:

```
✓ Bash  psql -c "explain analyze select …"
✓ Edit  …/migrations/014_usage_index.sql
✓ Bash  node scripts/nightly.mjs --dry-run
Found it — no index behind the group-by. I will add one and re-run.
```

`Exchange.answerAt` now records the index the answer was lifted from, and `ExchangeView` renders the work as two runs with the answer between them: **Bash → answer → Edit → Bash**. Step grouping runs over each side separately on purpose — two `Read`s either side of the reply are two things the agent did, and collapsing them into `Read ×2` would erase the sequence this exists to keep.

The card shares the renderer, so it gets the same treatment when one of its exchanges has an `answerAt`.

## 2. Two working lines could be on screen at once

> the working widget in the reader is sometimes below and above.

Send a prompt while the agent is still working and you get both: the live exchange's `working` at its bottom, and the optimistic echo's `working` below that. Measured 2 → 1 at both 1280 and 390.

The Overview card has guarded exactly this since it grew an echo (`running={running && !justSent}`); the reader had not. One line changes.

**Which position, and why** — either is defensible, so: **the last thing in the reader, once.** The line carries what the agent is doing *now* (`working · Bash …`), so it continues the step rail rather than preceding it. Putting it above the steps would report the present before the past — the same disorder as item 1. It also sits where new content lands, which is where the reader is already looking while it follows the tail. Consequence worth knowing: with the work collapsed there is nothing between the meta row and the line, so it sits right under the prompt; expanded, it is below the steps. That is the same rule ("last"), not a second position.

## 3. The turn column stepped sideways at ten

> the time also doesnt seem to be super aligned in the reader

Ambiguous, so I measured all the candidates before picking one:

| candidate | measured |
|---|---|
| clock right edges, 10 turns | `1253` on every row, both builds — already aligned |
| baselines within the meta row (summary / turn / clock) | 0.0px apart |
| clock vs the prompt band's right edge | 14px (desktop) / 8px (phone) — the band's deliberate full bleed from #49 |
| **`turn N/M` left edge** | **1126 for single digits, 1119 at `turn 10/10` — the cluster shifts 7px** |

So the clock is stable and its *neighbour* is not: the whole right-hand cluster steps left the moment a session passes nine turns. That is the one thing visibly off, and it is what I fixed — the number is padded to the width of the total with figure spaces (U+2007), which is exactly a digit wide in this mono, tabular row. Distinct left edges: 2 → 1.

I left the band-edge difference alone: that is #49's full bleed, the band is a tint rather than text, and pulling it in would reopen "the band reads as a card floating over the answer".

## Tests

All mutation-checked — I reintroduced each bug and watched the check fail:

| test | pins | fails when |
|---|---|---|
| `exchanges.test.mjs` | `answerAt` is 1 for an answer followed by two tool calls; the steps split correctly either side; `undefined` when the answer really is last | `x.answerAt = i` is removed |
| `pendingExchange.test.mjs` | the component renders two `.cx-steps` runs around the answer, one when it is last, and the padded turn cell (`turn␇9/10` as wide as `turn 10/10`) | the render ignores `answerAt`, or the padding is dropped |

The render test bundles the component with markdown stubbed — sanitising wants a DOM, and what these check is which order the blocks come out in.

## Collisions

Trial-merged both open PRs against this branch: **#76 clean, #78 clean.**

One semantic note for whoever lands second: **#78 renders `InputRequiredNotice` at the very bottom of the reading column** (after the pending echo) — the same "last thing in the reader" slot this PR assigns to the working line. No textual conflict, and the ordering is probably right as-is (a blocked prompt outranks "working"), but the two are adjacent and it is worth deciding whether `working` should be suppressed while an input-required notice is showing, since the agent is waiting rather than working.

I did not touch `.cxv-bar` — agent-manager-1 owns it this round.

## Suites

Web green (including the two new files). Server: `resize.test.mjs` and `migration.test.mjs` each failed once during another agent's concurrent run and pass in isolation — the known fixed-port contention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

