### PR TITLE
One button on a session row, and archive as the way out

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -474,14 +474,17 @@ pane with nothing to render (a shell) simply stays a terminal.
 
 ### 3.4 What leaves the sidebar
 
-| Today | Tomorrow |
+| Was on the row | Where it is now |
 |---|---|
-| `Read this session's trace` on every agent row (`Sidebar.tsx:245`) | bottom bar → **reader** |
-| `Share this session` on every agent row (`Sidebar.tsx:246`) | pane header → **share** |
-| A `trace` **session row per read** (`App.tsx:openTrace`) | **gone** — no duplicate rows |
-| Trace row's `Share` (`Sidebar.tsx:237`) | trace pane header (imported traces keep a pane) |
-| Trace row's `Handover` (`Sidebar.tsx:238`) | reader / trace-pane footer |
-| Quick-add **Trace** = open a shared dataset (`Sidebar.tsx:482`) | **Settings → Open a shared trace** (2026-08-16) |
+| `Read this session's trace` on every agent row | **reader mode** — a session's own history is a mode of its pane (done, #86) |
+| `Share this session` on every agent row | **pane header → `i` → Share** (done, #86) |
+| A `trace` **session row per read** (`App.tsx:openTrace`) | **gone**, with `openTrace` itself — no duplicate rows (done, #86) |
+| Trace row's `Share` | **trace pane header** — imported traces keep a pane (done, #86) |
+| Trace row's `Handover` | **trace pane header**, beside Share. Not the reader's `i`: that panel is `TraceInfo`, which a trace pane does not use (done, #86) |
+| Quick-add **Trace** = open a shared dataset | **Settings → Open a shared trace** (2026-08-16) |
+| `Start` | the row's own click already opened the pane (done, #86) |
+| `Stop` | **nowhere, deliberately.** An idle CLI costs nothing; a runaway one is interrupted in its pane, where Ctrl-C carries the CLI's own semantics (done, #86) |
+| `Delete` | **the archived view only** — archive a session, then remove it; the server enforces it (done, #86) |
 
 The last row was `stays` until the operator asked for the sidebar's trace widget to go
 (improv.md, iteration two). It moved rather than went away, because it is the one trace
@@ -493,8 +496,10 @@ dataset id, which is furniture for something you do when a link arrives.
 What disappears is the *local* trace pane — a session's own history is now a mode of its own
 pane, not a second entity.
 
-Agent rows keep stop/play and delete. Three glyphs less per row, which is most visible exactly
-where the sidebar is worst: on a phone.
+An agent row is now **one** control: `×`, which archives — it stops the agent and files it
+away, and it is the only route to deleting one. A remote agent keeps its reconnect/disconnect
+pair beside it, because that is a line to another machine rather than a local process. Up to
+four glyphs less per row, which is most visible exactly where the sidebar is worst: on a phone.
 
 ---
 
@@ -585,7 +590,7 @@ the block model already supports.
 - One component to style, so "the overview is more pleasant" becomes true everywhere at once.
 - The card answers "what did it actually do?" without leaving the Overview.
 - A session's history is reachable from the session, not from a second sidebar row.
-- Three glyphs less per sidebar row, and a full-screen card on a phone.
+- A sidebar row down to one control, and a full-screen card on a phone.
 - Removed code: the `turnsLog` stepper in the card, `openTrace`'s pane-creation path, two
   sidebar buttons, `.tv-badge` and the terminal-styled viewer chrome.
 
@@ -668,11 +673,13 @@ Built (this branch):
 5. Tests for the one piece of judgement in the renderer — what counts as the answer, and what
    stays in the work (`web/test/exchanges.test.mjs`, `npm test` in `web/`).
 
+7. The sidebar lost its trace buttons and `openTrace`, and the row came down to one control
+   (#86, §3.4). Share moved into the pane header's `i` with #84.
+
 Not yet, in the order I would do it:
 
 6. `head.prompts[]` (§5) — index, first line and timestamp per prompt, so a surface can draw the
    skeleton and label "show previous turn" before fetching the page that holds it.
-7. The sidebar loses its trace buttons and `openTrace`; share moves into the pane header (§3.4).
 8. Windowing by exchange in reader mode: a collapsed turn is 2–3 rows, so the DOM stays small,
    `head.prompts[]` gives the skeleton up front, and only an opened turn needs its page. The
    measured-height machinery in `TraceView` is reused as-is — what changes is what a "row" means.

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs",
     "test:screenshots": "node screenshot-input.test.mjs",
     "test:mobile": "node mobile.test.mjs",
-    "test": "node test/trace-download.test.mjs && node test/attachments.test.mjs && node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node test/archive.test.mjs && node test/trace-download.test.mjs && node test/attachments.test.mjs && node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/reader-info.test.mjs
+++ b/server/reader-info.test.mjs
@@ -6,7 +6,7 @@
  *     including the two that were title attributes a phone cannot open;
  *   - it closes on Escape and on a press outside it;
  *   - it offers the transcript as a file, and that URL really answers;
- *   - it offers Share, which is the same dialog the sidebar opens;
+ *   - it offers Share, which is the only place that dialog opens from now;
  *   - the sidebar no longer carries a trace widget, and Settings does.
  *
  * Set READER_INFO_PUBLIC_DIR to a prebuilt web/dist to skip the build, and
@@ -310,7 +310,8 @@ try {
   check('a press outside closes the panel',
     await waitFor(async () => await page.locator('.tinfo').count() === 0, 2_000));
 
-  // 6. Share, from the reader — the same dialog the sidebar row opens.
+  // 6. Share, from the reader. The sidebar row used to open this dialog too;
+  //    since #86 the panel is the one place it comes from.
   await page.locator('.tinfo-btn').tap();
   await page.locator('.tinfo-actions button', { hasText: 'Share' }).tap();
   const shareOpen = await waitFor(async () => await page.locator('.share-card').isVisible(), 5_000);
@@ -375,6 +376,17 @@ try {
   check('the sidebar has no trace widget left',
     await page.locator('.quick-add button', { hasText: 'Trace' }).count() === 0
       && await page.locator('.open-trace').count() === 0);
+  // …and the row is down to one control. Read-trace and Share left it because
+  // the panel above now holds both; start and stop left it because the row
+  // itself opens the pane and Ctrl-C interrupts a runaway better than a button.
+  // What remains is archive, which is also the only route to deleting a
+  // session. (docs/conversation-view.md §3.4)
+  const rowActions = page.locator('.sidebar .row[title^="reader-info-e2e"]')
+    .first().locator('.row-actions button');
+  check('the session row carries exactly one control', await rowActions.count() === 1,
+    `titles: ${JSON.stringify(await rowActions.evaluateAll((bs) => bs.map((b) => b.title)))}`);
+  check('and that control archives',
+    /archive/i.test(await rowActions.first().getAttribute('title') || ''));
   await page.locator('.sidebar .set-btn, .sidebar button[title="Settings"]').first().click();
   const traceRow = page.locator('.setting-row', { hasText: 'Open a shared trace' });
   await traceRow.waitFor({ state: 'visible', timeout: 10_000 });

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -522,6 +522,11 @@ try {
   await page.close();
   const existing = await (await fetch(`${API}/api/sessions`)).json();
   for (const session of existing) {
+    // Archive first: since #86 the server refuses to delete a session that has
+    // not been retired, so a bulk teardown has to go through the same door the
+    // sidebar does. These fixtures have started, so `?ifNeverStarted=1` is not
+    // the route for them — that one is for a session that never ran.
+    await fetch(`${API}/api/sessions/${session.id}/archive`, { method: 'POST' });
     await fetch(`${API}/api/sessions/${session.id}`, { method: 'DELETE' });
   }
   const freshContext = await browser.newContext({ viewport: { width: 390, height: 844 } });
@@ -568,6 +573,9 @@ try {
   check('conditional cleanup cannot delete a target that has started',
     conditionalDelete.response.status === 409
       && afterConditionalDelete.some((session) => session.id === retained.body.id));
+  // Same reason as the teardown above: this one has started, so it is archived
+  // before it can be removed.
+  await fetch(`${API}/api/sessions/${retained.body.id}/archive`, { method: 'POST' });
   await fetch(`${API}/api/sessions/${retained.body.id}`, { method: 'DELETE' });
   await freshContext.close();
 } finally {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2173,6 +2173,35 @@ app.put('/api/sessions/:id', (req, res) => {
   res.json(store.update(existing.id, { name: name.trim() }));
 });
 
+// ---------- archiving ----------
+//
+// Archiving is how a session leaves the working list, and it is STORED rather
+// than derived. The idle window (`archive.after`) measures an absence of
+// activity; "I am finished with this one" cannot be expressed that way — an
+// agent you retire the moment it answers is as active as it will ever be.
+//
+// The two roads meet in the sidebar's archived view, but they are not the same
+// road: the window's verdict changes when the setting changes, and this one
+// does not. Only this one unlocks delete — see the DELETE route below.
+app.post('/api/sessions/:id/archive', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  // Archiving stops the agent. Putting a session away while its CLI keeps
+  // running is how you end up paying for work behind a row you can no longer
+  // see. A remote agent has no process here — its connection is a separate
+  // control that stays where it is, so archiving one only files it away.
+  if (!isRemote(s.cli) && !PASSIVE_CLIS.includes(s.cli)) stop(s.id);
+  res.json(store.update(s.id, { archivedAt: new Date().toISOString() }));
+});
+
+// Restore. Deliberately does NOT start the agent again: unarchiving says "I
+// want to see this again", and starting is what opening the pane does.
+app.post('/api/sessions/:id/unarchive', (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  return res.json(store.update(s.id, { archivedAt: undefined }));
+});
+
 app.post('/api/sessions/:id/stop', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
@@ -2415,6 +2444,22 @@ app.put('/api/trace/:id/source', (req, res) => {
 app.delete('/api/sessions/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
+  // Delete is an archived-only action: retire a session, then remove it. That
+  // is what keeps the one destructive control out of the working list, and it
+  // is enforced here rather than only in the sidebar so the rule holds for any
+  // caller. Being quiet for a month is NOT this flag — see the archive route.
+  //
+  // #76 adds `?ifNeverStarted=1` for the wrong-CLI mistake: a session that has
+  // never run has nothing worth archiving and should go in one step. When that
+  // lands, the exemption belongs on this guard and `everStarted` already
+  // carries the answer:
+  //     if (!s.archivedAt && !(req.query.ifNeverStarted === '1' && !s.everStarted)) …
+  if (!s.archivedAt) {
+    return res.status(409).json({
+      error: 'archive this session before deleting it',
+      code: 'not-archived',
+    });
+  }
   stop(s.id);
   // Close the agent's poll and drop the in-memory log, so a pane later created
   // with the same name reads the folder fresh instead of inheriting a ghost.

--- a/server/test/archive.test.mjs
+++ b/server/test/archive.test.mjs
@@ -1,0 +1,114 @@
+// Archiving, and the rule that delete hangs off it.
+//
+// The point of the feature is that one destructive action is reachable from
+// exactly one place: you retire a session, and only then can you remove it.
+// That rule is enforced here rather than only in the sidebar, so this drives
+// the API directly — a caller that is not the UI has to meet it too.
+//
+// Run with:  node test/archive.test.mjs
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const PORT = 7894;
+const API = `http://localhost:${PORT}`;
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'archive-'));
+
+let pass = 0; let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+
+// Test servers must not publish skills over a live Space (same strip the other
+// boot suites use).
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+const srv = spawn('node', ['src/index.js'], {
+  env: { ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent', AM_ALLOW_MISSING_ORIGIN: '1' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let log = '';
+srv.stdout.on('data', (d) => { log += d; });
+srv.stderr.on('data', (d) => { log += d; });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const api = async (route, init = {}) => {
+  const sep = route.includes('?') ? '&' : '?';
+  const r = await fetch(`${API}${route}${sep}from=operator`, {
+    headers: { 'content-type': 'application/json' }, ...init,
+  });
+  let body = null;
+  try { body = await r.json(); } catch { /* empty */ }
+  return { status: r.status, body };
+};
+const mkSession = async (name, cli = 'shell') =>
+  (await api('/api/sessions', { method: 'POST', body: JSON.stringify({ name, cli, path: name }) })).body;
+const sessionOf = async (id) =>
+  (await api('/api/tree')).body.sessions.find((s) => s.id === id);
+
+try {
+  for (let i = 0; i < 120; i++) {
+    if (await fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false)) break;
+    await sleep(250);
+  }
+
+  // ---- delete is gated on archiving ----
+  const a = await mkSession('to-delete');
+  const refused = await api(`/api/sessions/${a.id}`, { method: 'DELETE' });
+  check('a live session cannot be deleted', refused.status === 409, `status ${refused.status}`);
+  check('and the refusal says why, in words the UI can show',
+    /archive/i.test(refused.body?.error || ''), JSON.stringify(refused.body));
+  check('the refusal carries a code', refused.body?.code === 'not-archived');
+  check('and the session is still there', !!(await sessionOf(a.id)));
+
+  const archived = await api(`/api/sessions/${a.id}/archive`, { method: 'POST' });
+  check('archiving succeeds', archived.status === 200, `status ${archived.status}`);
+  check('and stamps when it happened', !!archived.body?.archivedAt);
+
+  const deleted = await api(`/api/sessions/${a.id}`, { method: 'DELETE' });
+  check('an archived session deletes', deleted.status === 200, `status ${deleted.status}`);
+  check('and is gone from the tree', !(await sessionOf(a.id)));
+
+  // ---- the flag survives a restart, which is the whole reason it is stored ----
+  const b = await mkSession('survivor');
+  await api(`/api/sessions/${b.id}/archive`, { method: 'POST' });
+  const persisted = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'sessions.json'), 'utf8'));
+  const onDisk = (Array.isArray(persisted) ? persisted : persisted.sessions || []).find((s) => s.id === b.id);
+  check('the archive is written to disk, not held in a browser', !!onDisk?.archivedAt);
+
+  // ---- restore ----
+  const restored = await api(`/api/sessions/${b.id}/unarchive`, { method: 'POST' });
+  check('unarchiving succeeds', restored.status === 200, `status ${restored.status}`);
+  check('and clears the stamp', !(await sessionOf(b.id))?.archivedAt);
+  const refusedAgain = await api(`/api/sessions/${b.id}`, { method: 'DELETE' });
+  check('so it is undeletable again', refusedAgain.status === 409, `status ${refusedAgain.status}`);
+
+  // ---- archiving stops the agent ----
+  const c = await mkSession('running-one');
+  // Opening a terminal socket is what starts the process; the resize suite does
+  // the same. A shell is enough — the point is that something is running.
+  const ws = new WebSocket(`ws://localhost:${PORT}/ws?session=${c.id}&cols=80&rows=24`);
+  await new Promise((r) => { ws.onopen = r; ws.onerror = r; });
+  await sleep(1200);
+  const before = await sessionOf(c.id);
+  check('the agent is running before archiving', before?.running === true, `state ${before?.state}`);
+  await api(`/api/sessions/${c.id}/archive`, { method: 'POST' });
+  await sleep(600);
+  const after = await sessionOf(c.id);
+  check('archiving stopped it', after?.running === false, `state ${after?.state}`);
+  check('and `stopped` is still the state it lands in', after?.state === 'stopped', `state ${after?.state}`);
+  try { ws.close(); } catch { /* already gone */ }
+
+  // ---- unknown ids ----
+  const missing = await api('/api/sessions/nope-nope/archive', { method: 'POST' });
+  check('archiving something that does not exist is a 404', missing.status === 404, `status ${missing.status}`);
+} catch (e) {
+  check(`suite threw: ${e && e.message}`, false, log.slice(-600));
+} finally {
+  srv.kill();
+  try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* tmp */ }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -132,10 +132,18 @@ export default function App() {
     return s === 'prompt' || s === 'answer' ? s : 'manual';
   });
   const setOvSort = (v: OverviewSort) => { setOvSortRaw(v); writeStored('am-ov-sort', v); };
-  // Archiving: sessions quiet for longer than the configured window are hidden
-  // from the sidebar and overview unless "archived" is checked. Derived, never
-  // stored — flipping the setting instantly (un)archives.
+  // Archiving takes two roads into the same view, and they are not the same
+  // thing. The operator archives a session deliberately (`archivedAt` on the
+  // record, server-side, and the agent is stopped); separately, a session quiet
+  // for longer than the configured window is hidden the way it always was —
+  // derived, so flipping the setting instantly (un)archives it again.
+  // Both are hidden unless "archived" is checked. Only the stored one can be
+  // deleted, which is why the two sets stay distinguishable below.
   const [showArchived, setShowArchived] = useState(false);
+  // A trace pane asking to be continued in a new agent. The prefilled create
+  // panel belongs to the sidebar, so the request is passed there and cleared
+  // once it has been picked up.
+  const [handoverFor, setHandoverFor] = useState<string | null>(null);
   const [archiveAfter, setArchiveAfter] = useState<'week' | 'month' | 'never'>('month');
   // Hiding a group from the Overview is a standing choice and lives on the server
   // (tree.hidden). REVEALING it is a glance, so that half stays here and resets on
@@ -462,18 +470,33 @@ export default function App() {
     if (settingsOpen) return;
     api.getConfig().then((c) => setArchiveAfter(c.archive?.after ?? 'month')).catch(() => {});
   }, [settingsOpen]);
-  const archivedIds = useMemo(() => {
+  // Road one: the operator said so. The server holds it, so it survives a
+  // reload and means the same thing on every device.
+  const retiredIds = useMemo(
+    () => new Set(tree.sessions.filter((s) => s.archivedAt).map((s) => s.id)),
+    [tree.sessions],
+  );
+  // Road two: quiet for longer than the window. Unchanged, and still derived —
+  // it is a statement about the clock, so it has to be recomputed against the
+  // clock rather than written down once.
+  const quietIds = useMemo(() => {
     const out = new Set<string>();
     if (archiveAfter === 'never') return out;
     const cut = Date.now() - (archiveAfter === 'week' ? 7 : 30) * 864e5;
     for (const s of tree.sessions) {
       // Shells and passive panels have no trace clock — never archive them.
       if (s.cli === 'shell' || isPassive(s.cli) || s.state === 'working') continue;
+      if (s.archivedAt) continue;                       // already on road one
       const last = ages[s.id] || Date.parse(s.createdAt) || 0;
       if (last && last < cut) out.add(s.id);
     }
     return out;
   }, [tree.sessions, ages, archiveAfter]);
+  // What the sidebar and overview leave out of the working list.
+  const archivedIds = useMemo(
+    () => new Set([...retiredIds, ...quietIds]),
+    [retiredIds, quietIds],
+  );
 
   // What the operator hid from the Overview, as refs (`g:<id>` / `s:<id>`). The
   // server owns the list; this is just the shape the sidebar wants for a lookup.
@@ -702,12 +725,24 @@ export default function App() {
   const renameGroup = (id: string, name: string) => api.renameGroup(id, name).then(refresh).catch(showErr('Couldn’t rename'));
   const renameSession = (id: string, name: string) => { if (name.trim()) api.renameSession(id, name.trim()).then(refresh).catch(showErr('Couldn’t rename')); };
   const deleteGroup = (id: string) => api.deleteGroup(id).then(() => { if (activeRef === `g:${id}`) setActiveRef(null); refresh(); }).catch(showErr('Couldn’t delete the group'));
-  const stopSession = (id: string) => api.stopSession(id).then(refresh).catch(showErr('Couldn’t stop the agent'));
+  // Archiving stops the agent server-side, so there is no separate stop call
+  // left in the UI — `api.stopSession` stays for the archive route's own use
+  // and for anything that needs to end a process without filing it away.
+  const archiveSession = (id: string) => api.archiveSession(id)
+    .then(() => { if (activeRef === `s:${id}`) setActiveRef(null); closePane(id); refresh(); })
+    .catch(showErr('Couldn’t archive that agent'));
+  const unarchiveSession = (id: string) => api.unarchiveSession(id).then(refresh)
+    .catch(showErr('Couldn’t restore that agent'));
   // A remote agent has no process: "stopped" is a closed connection, so the
   // sidebar's stop/play pair disconnects and reconnects instead.
   const setRemotePaused = (id: string, paused: boolean) =>
     api.setRemotePaused(id, paused).then(refresh).catch(showErr(paused ? 'Couldn’t disconnect' : 'Couldn’t reconnect'));
-  const deleteSession = (id: string) => api.deleteSession(id).then(() => { if (activeRef === `s:${id}`) setActiveRef(null); refresh(); }).catch(showErr('Couldn’t delete the agent'));
+  // The server refuses to delete anything that has not been archived, and says
+  // so in words worth passing on — a generic toast here would leave the reader
+  // guessing at a rule the UI is meant to be teaching.
+  const deleteSession = (id: string) => api.deleteSession(id)
+    .then(() => { if (activeRef === `s:${id}`) setActiveRef(null); refresh(); })
+    .catch((e: unknown) => showErr(e instanceof Error && e.message ? e.message : 'Couldn’t delete the agent')(e));
   const shareTrace = async (id: string) => {
     const pane = sessById[id];
     if (!pane || pane.cli !== 'trace') return;
@@ -749,26 +784,6 @@ export default function App() {
     setActiveRef(ref);
     setPage(0);
     if (isMobile) setMobileStage(true);
-  };
-  // Read an agent's own transcript in a read-only trace pane. The pane is a
-  // session record like any other (so it survives reload, tiles, and drag), and
-  // it's REUSED per source — clicking Trace twice reopens the same pane instead
-  // of littering the sidebar with duplicates.
-  const openTrace = async (sid: string) => {
-    const src = sessById[sid];
-    if (!src) return;
-    const existing = tree.sessions.find((p) => p.cli === 'trace' && p.traceSource?.kind === 'session' && p.traceSource.ref === sid);
-    if (existing) { openSession(existing.id, tree.groups.find((g) => g.sessionIds.includes(existing.id))?.id); return; }
-    try {
-      // '.' = the workspaces root: a trace pane reads a transcript, so it owns no
-      // folder and must not create one.
-      const pane = await api.createSession(`Trace: ${src.name}`, 'trace', undefined, '.');
-      await api.setTraceSource(pane.id, 'session', sid);
-      await refresh();
-      setActiveRef(`s:${pane.id}`);
-      setPage(0);
-      if (isMobile) setMobileStage(true);
-    } catch (e) { showErr('Couldn’t open the trace')(e); }
   };
   // Someone shared a session as a Hub dataset: pull it down, then open a pane on
   // it. Errors propagate so the sidebar can show the server's own reason inline
@@ -965,6 +980,10 @@ export default function App() {
                 dragId={canDrag ? `p:${s.id}` : undefined}
                 onDragActive={setPaneDrag}
                 onFocus={() => setFocusedId(s.id)}
+                onShare={() => shareTrace(s.id)}
+                // The prefilled create panel lives in the sidebar, so the
+                // request travels there rather than the panel moving here.
+                onHandover={() => setHandoverFor(s.id)}
                 onClose={() => closePane(s.id)}
               />
             ))}
@@ -1049,16 +1068,16 @@ export default function App() {
         onActivate={activate}
         onOpenSession={openSession}
         onNewSession={newSession}
-        onShareSession={setShareId}
-        onShareTrace={shareTrace}
         onTraceHandover={api.getTraceLocation}
-        onOpenTrace={openTrace}
+        handoverFor={handoverFor}
+        onHandoverHandled={() => setHandoverFor(null)}
         onNewGroup={newGroup}
         onRenameGroup={renameGroup}
         onRenameSession={renameSession}
         onDeleteGroup={deleteGroup}
         onSetRemotePaused={setRemotePaused}
-        onStopSession={stopSession}
+        onArchiveSession={archiveSession}
+        onUnarchiveSession={unarchiveSession}
         onDeleteSession={deleteSession}
         onMove={doMove}
         onDragState={setSessionDrag}
@@ -1067,6 +1086,7 @@ export default function App() {
         onToggleTheme={toggleTheme}
         onQuickStart={quickStart}
         archived={archivedIds}
+        retired={retiredIds}
         showArchived={showArchived}
         onToggleArchived={() => setShowArchived((v) => !v)}
         overviewHidden={hiddenRefs}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -47,8 +47,18 @@ export const listFolders = (p = ''): Promise<{ path: string; folders: string[] }
 export const stopSession = (id: string) =>
   fetch(`/api/sessions/${id}/stop`, { method: 'POST' }).then(json);
 
+// Put a session away: it stops, and it leaves the working list. The server
+// refuses to delete anything that has not been through here first.
+export const archiveSession = (id: string) =>
+  fetch(`/api/sessions/${id}/archive`, { method: 'POST' }).then(json);
+
+export const unarchiveSession = (id: string) =>
+  fetch(`/api/sessions/${id}/unarchive`, { method: 'POST' }).then(json);
+
+// Keeps the server's own words: refusing to delete a session that is not
+// archived is an ordinary, explainable answer, not a failure.
 export const deleteSession = (id: string) =>
-  fetch(`/api/sessions/${id}`, { method: 'DELETE' }).then(json);
+  fetch(`/api/sessions/${id}`, { method: 'DELETE' }).then(jsonOrError);
 
 export const renameSession = (id: string, name: string) =>
   fetch(`/api/sessions/${id}`, { method: 'PUT', headers: HEADERS, body: JSON.stringify({ name }) }).then(json);

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
-import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote, isShareable } from '../types';
+import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import Logo from './Logo';
 import NewSession from './NewSession';
@@ -10,7 +10,7 @@ import {
   filesFromTransfer, pendingAttachmentsFromFiles, revokePendingAttachments, transferMayContainFile,
 } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
-import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, ShareGlyph, HandoverGlyph, ListGlyph, EyeGlyph, EyeOffGlyph } from './icons';
+import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, EyeGlyph, EyeOffGlyph } from './icons';
 
 import { dropZone, backgroundAnchor, isBackgroundTarget } from './sidebar-dnd';
 import type { Zone, Kind } from './sidebar-dnd';
@@ -37,8 +37,8 @@ const fmtAgo = (ts?: number) => {
 export default function Sidebar({
   clis, tree, activeRef, focusedId, defaultPath, ages,
   onActivate, onOpenSession, onNewSession, onNewGroup, onRenameGroup, onRenameSession, onDeleteGroup,
-  onStopSession, onSetRemotePaused, onDeleteSession, onShareSession, onShareTrace, onTraceHandover, onOpenTrace, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
-  archived, showArchived, onToggleArchived,
+  onArchiveSession, onUnarchiveSession, onSetRemotePaused, onDeleteSession, onTraceHandover, handoverFor, onHandoverHandled, onMove, onDragState, onOpenSettings, theme, onToggleTheme, onQuickStart,
+  archived, retired, showArchived, onToggleArchived,
   overviewHidden, onToggleOverviewHidden,
 }: {
   clis: Cli[];
@@ -55,19 +55,28 @@ export default function Sidebar({
   onRenameGroup: (id: string, name: string) => void;
   onRenameSession: (id: string, name: string) => void;
   onDeleteGroup: (id: string) => void;
-  onStopSession: (id: string) => void;
+  // Archiving stops the agent and takes it out of the working list; it is
+  // also the only route to deleting one (the server enforces that).
+  onArchiveSession: (id: string) => void;
+  onUnarchiveSession: (id: string) => void;
   onSetRemotePaused: (id: string, paused: boolean) => void;
   onDeleteSession: (id: string) => void;
-  onShareSession: (id: string) => void;
-  onShareTrace: (id: string) => void;
+  // Continuing from a trace is triggered on the trace's own pane now, but the
+  // prefilled create panel it opens lives here — so the request arrives as an
+  // id, and is handed back once this has acted on it.
   onTraceHandover: (id: string) => Promise<{ path: string; sessionId?: string | null }>;
-  onOpenTrace: (id: string) => void;
+  handoverFor: string | null;
+  onHandoverHandled: () => void;
   onMove: (ref: string, to: MoveTarget) => void;
   onDragState?: (ref: string | null) => void; // lets the stage offer per-tile drop targets
   theme: 'light' | 'dark';
   onToggleTheme: () => void;
   onQuickStart: (cli: string, prompt: string, name?: string, path?: string, attachmentOptions?: QuickStartAttachmentOptions) => Promise<void>;
+  // Everything kept out of the working list, by either road…
   archived: Set<string>;
+  // …and the subset the operator archived on purpose. Only these can be
+  // deleted; the rest are merely quiet and are offered the archive instead.
+  retired: Set<string>;
   showArchived: boolean;
   onToggleArchived: () => void;
   // Refs hidden from the OVERVIEW. The sidebar keeps showing them — it is where
@@ -155,6 +164,16 @@ export default function Sidebar({
       return next;
     });
   };
+
+  // A trace pane asked to be continued in a new agent: open the create panel
+  // prefilled, exactly as the old per-row button did, then release the request
+  // so re-opening it later fires again.
+  useEffect(() => {
+    if (!handoverFor) return;
+    const s = sessById[handoverFor];
+    onHandoverHandled();
+    if (s) openHandover(s);
+  }, [handoverFor]);
 
   const clearDrag = () => { setDragRef(null); setDrop(null); onDragState?.(null); };
   // Archived sessions vanish from the tree unless the legend checkbox is on.
@@ -360,28 +379,37 @@ export default function Sidebar({
           <span className="name">{s.name}</span>
         )}
         <span className="age">{fmtAgo(ages?.[s.id])}</span>
+        {/* One button on a live row, and it files the agent away. Start was the
+            row's own onClick spelled twice; stop went because an idle CLI costs
+            nothing and a runaway one is interrupted in its pane, where Ctrl-C
+            has the CLI's own semantics. A remote agent keeps its connection
+            pair: that is a line to another machine, not a local process. */}
         <span className="row-actions">
-          {s.cli === 'trace' ? (
-            <>
-              <button className="mini-btn" title="Share this trace" onClick={(e) => { e.stopPropagation(); onShareTrace(s.id); }}><ShareGlyph /></button>
-              <button className="mini-btn" title="Continue from this trace in a new agent" onClick={(e) => { e.stopPropagation(); openHandover(s); }}><HandoverGlyph /></button>
-            </>
-          ) : isRemote(s.cli) ? (
-            // No process to kill: stop/play are disconnect/reconnect, and
-            // "reconnect" must not try to open a terminal for this pane.
+          {isRemote(s.cli) && (
             s.remote?.paused
               ? <button className="mini-btn" title="Reconnect" onClick={(e) => { e.stopPropagation(); onSetRemotePaused(s.id, false); }}><PlayGlyph /></button>
               : <button className="mini-btn" title="Disconnect" onClick={(e) => { e.stopPropagation(); onSetRemotePaused(s.id, true); }}><StopGlyph /></button>
-          ) : s.running
-            ? <button className="mini-btn" title="Stop" onClick={(e) => { e.stopPropagation(); onStopSession(s.id); }}><StopGlyph /></button>
-            : <button className="mini-btn" title="Start" onClick={(e) => { e.stopPropagation(); onOpenSession(s.id, groupId); }}><PlayGlyph /></button>}
-          {isShareable(s.cli) && (
-            <>
-              <button className="mini-btn" title="Read this session's trace" onClick={(e) => { e.stopPropagation(); onOpenTrace(s.id); }}><ListGlyph /></button>
-              <button className="mini-btn" title="Share this session" onClick={(e) => { e.stopPropagation(); onShareSession(s.id); }}><ShareGlyph /></button>
-            </>
           )}
-          <button className="mini-btn" title="Delete" onClick={(e) => { e.stopPropagation(); onDeleteSession(s.id); }}><CloseGlyph /></button>
+          {showArchived && archived.has(s.id) ? (
+            // The archived view, where the two roads show themselves. A session
+            // the operator retired can come back or be removed; one that is
+            // merely quiet has not been decided about, so it is offered the
+            // decision rather than the delete.
+            retired.has(s.id) ? (
+              <>
+                <button className="mini-btn" title="Restore to the working list"
+                  onClick={(e) => { e.stopPropagation(); onUnarchiveSession(s.id); }}><PlayGlyph /></button>
+                <button className="mini-btn danger-hover" title="Delete — the folder on disk is kept"
+                  onClick={(e) => { e.stopPropagation(); onDeleteSession(s.id); }}><CloseGlyph /></button>
+              </>
+            ) : (
+              <button className="mini-btn" title="Quiet for a while. Archive it to stop it and be able to delete it."
+                onClick={(e) => { e.stopPropagation(); onArchiveSession(s.id); }}><CloseGlyph /></button>
+            )
+          ) : (
+            <button className="mini-btn" title="Archive — stops the agent and files it away"
+              onClick={(e) => { e.stopPropagation(); onArchiveSession(s.id); }}><CloseGlyph /></button>
+          )}
         </span>
       </div>
     );

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   pendingAttachmentsFromFiles, revokePendingAttachments, transferMayContainFile, uploadPendingAttachments,
 } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
-import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, GridGlyph, PlusGlyph, AmMark, EyeGlyph, EyeOffGlyph } from './icons';
+import { SlidersGlyph, SunGlyph, MoonGlyph, CloseGlyph, PencilGlyph, StopGlyph, PlayGlyph, UpGlyph, TrashGlyph, GridGlyph, PlusGlyph, AmMark, EyeGlyph, EyeOffGlyph } from './icons';
 
 import { dropZone, backgroundAnchor, isBackgroundTarget } from './sidebar-dnd';
 import type { Zone, Kind } from './sidebar-dnd';
@@ -493,19 +493,28 @@ export default function Sidebar({
             // the operator retired can come back or be removed; one that is
             // merely quiet has not been decided about, so it is offered the
             // decision rather than the delete.
+            //
+            // Deleting is the one irreversible thing here, so it does NOT reuse
+            // the `×` that means archive on the row above — a reversible action
+            // and a permanent one must not share a mark. It is the same trash
+            // the Files pane and the skills editor use, so destructive looks the
+            // same wherever it appears. Restore is an arrow back up into the
+            // list rather than a ▷, which on this very row already means
+            // "reconnect" for a remote agent — and which would in any case
+            // promise a start that unarchiving deliberately does not do.
             retired.has(s.id) ? (
               <>
-                <button className="mini-btn" title="Restore to the working list"
-                  onClick={(e) => { e.stopPropagation(); onUnarchiveSession(s.id); }}><PlayGlyph /></button>
-                <button className="mini-btn danger-hover" title="Delete — the folder on disk is kept"
-                  onClick={(e) => { e.stopPropagation(); onDeleteSession(s.id); }}><CloseGlyph /></button>
+                <button className="mini-btn" title="Restore to the working list" aria-label="Restore"
+                  onClick={(e) => { e.stopPropagation(); onUnarchiveSession(s.id); }}><UpGlyph /></button>
+                <button className="mini-btn danger-hover" title="Delete — the folder on disk is kept" aria-label="Delete"
+                  onClick={(e) => { e.stopPropagation(); onDeleteSession(s.id); }}><TrashGlyph /></button>
               </>
             ) : (
-              <button className="mini-btn" title="Quiet for a while. Archive it to stop it and be able to delete it."
+              <button className="mini-btn" title="Quiet for a while. Archive it to stop it and be able to delete it." aria-label="Archive"
                 onClick={(e) => { e.stopPropagation(); onArchiveSession(s.id); }}><CloseGlyph /></button>
             )
           ) : (
-            <button className="mini-btn" title="Archive — stops the agent and files it away"
+            <button className="mini-btn" title="Archive — stops the agent and files it away" aria-label="Archive"
               onClick={(e) => { e.stopPropagation(); onArchiveSession(s.id); }}><CloseGlyph /></button>
           )}
         </span>

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -21,7 +21,7 @@ import type { TraceBlock, TraceTurn } from '../api';
 import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../lib/traceWindows';
 import { renderMarkdown } from '../lib/markdown';
 import Logo from './Logo';
-import { CloseGlyph } from './icons';
+import { CloseGlyph, ShareGlyph, HandoverGlyph } from './icons';
 
 const ROW_EST = 44;        // unmeasured row height, collapsed
 const OVERSCAN_PX = 600;
@@ -569,7 +569,7 @@ export function TraceView({ src, srcKey, zoom = 100, query = '', live, onHead, o
 }
 
 export default function TracePane({
-  session, focused, zoom = 100, dragId, sourceLive, onDragActive, onFocus, onClose,
+  session, focused, zoom = 100, dragId, sourceLive, onDragActive, onFocus, onShare, onHandover, onClose,
 }: {
   session: Session;
   focused?: boolean;
@@ -579,6 +579,12 @@ export default function TracePane({
   dragId?: string;
   onDragActive?: (dragging: boolean) => void;
   onFocus?: () => void;
+  /** Publish this trace, and continue from it in a new agent. Both used to be
+   *  buttons on the sidebar row; they belong to the trace, so they live on the
+   *  pane that shows it. (The reader's `i` panel is ConversationView's, and a
+   *  trace pane does not use ConversationView.) */
+  onShare?: () => void;
+  onHandover?: () => void;
   onClose: () => void;
 }) {
   const [head, setHead] = useState<TraceHeadInfo | null>(null);
@@ -629,6 +635,14 @@ export default function TracePane({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
+        {onShare && (
+          <button className="mini-btn" title="Share this trace"
+            onClick={(e) => { e.stopPropagation(); onShare(); }}><ShareGlyph /></button>
+        )}
+        {onHandover && (
+          <button className="mini-btn" title="Continue from this trace in a new agent"
+            onClick={(e) => { e.stopPropagation(); onHandover(); }}><HandoverGlyph /></button>
+        )}
         <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
       </div>
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1056,6 +1056,11 @@ body {
 .files-new.err { color: var(--danger); }
 .tw-confirm { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; }
 .tw-warn { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* A destructive ICON in a row turns red under the pointer, the way the Files
+   pane's trash does (.tw-act.danger). Distinct from .mini-btn.danger below,
+   which is the filled red button for a surface whose whole point is the
+   action — too loud for one glyph among others in a list row. */
+.mini-btn.danger-hover:hover { color: var(--danger); }
 .mini-btn.danger { background: var(--danger); color: #fff; border-color: transparent; }
 .mini-btn.danger:disabled { opacity: .5; }
 /* the one obvious action in a group — Create, Save and close */

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -11,6 +11,10 @@ export interface Session {
   everStarted: boolean;
   running: boolean;
   state: SessionState;
+  // Set when the operator archived this session — a stored decision, not the
+  // idle window's verdict, which is computed in App.tsx and expires when the
+  // setting changes. Only a session with this can be deleted (server-enforced).
+  archivedAt?: string;
   // Only on `cli: 'trace'` panes: what the read-only trace view is pointed at.
   // A regular agent session needs no such record — it reads its own transcript.
   traceSource?: { kind: 'session' | 'bundle'; ref: string } | null;


### PR DESCRIPTION
> **Depends on #84 and must merge after it.** The base of this PR is `feat/trace-share-and-reader-info`, not main — #84 works in the same row.

The sidebar row carried up to four controls. It keeps one: `×`, which archives.

| row | before | after |
| --- | --- | --- |
| a claude session | Start · Read trace · Share · Delete | **Archive** |
| a shell | Start/Stop · Delete | **Archive** |
| archived, retired on purpose | — | **Restore · Delete** |
| archived, merely quiet | — | **Archive** |
| a remote agent | Reconnect/Disconnect · … | **Reconnect/Disconnect · Archive** |

## What went, and why it did not need a new home

**Start** was the row's own `onClick` spelled a second time — both call `onOpenSession(...)`. **Stop** went on the operator's reasoning, which I agree with: an idle CLI costs nothing, so "pause this" is not a real case; the real one is a runaway agent, and in that moment you open the pane, where Ctrl-C interrupts with the CLI's own semantics rather than a button's. `onStopSession` loses its last UI consumer, but `stop()` stays — archiving calls it.

**The remote reconnect/disconnect pair is untouched**, as asked, and I agree it should be: it is a line to another machine, not a local process. Group rows are untouched.

## A correction to the brief: #84 did not remove the trace buttons

The brief said read-trace, share-trace and share-session would already be gone on this base. They are not — #84's own body says *"Per-row trace actions are untouched: read-trace, share, handover, and the trace-pane rows all still work."* What #84 removed was the sidebar's trace *widget*, not the row's buttons. So this PR removes them, and had to find homes:

- **Share a session** — already has one: #84 put Share in the reader's `i` panel. Nothing to do.
- **Read a session's own trace** — that is what reader mode is, and #84's panel now hands over the file too. Its only trigger was this button, so `openTrace` and the pane-spawning path it owned are dead code and go with it.
- **Share a trace / continue from a trace** — these had **no** other home. The brief says to put handover in the `i` panel, but that panel is `ConversationView`'s and a **trace pane does not use ConversationView** — it renders its own view. So both now sit on the trace pane's header, which is the thing they act on. The prefilled create panel still belongs to the sidebar, so the request travels there as an id rather than the panel moving.

## Archiving is stored now, and it stops the agent

It had to become stored: *"I am finished with this one"* cannot be expressed as an absence of activity, which is all the idle window measures — an agent you retire the moment it answers is as active as it will ever be. `archivedAt` lives on the session record, so it survives a reload and reads the same on every device.

`POST /api/sessions/:id/archive` stops the agent and stamps it. `POST …/unarchive` clears the stamp and deliberately does **not** restart: unarchiving says "let me see this again", and starting is what opening the pane does.

**Delete is gated server-side** (409, `code: not-archived`), not just hidden in the UI, so the rule holds for any caller. The refusal is a sentence worth showing, and the toast shows it.

## Two judgement calls

### What archiving a running agent does

It kills the PTY mid-turn (`host.pty.kill()`), and the honest account of what that costs is:

- **Completed turns survive.** The harness writes its own transcript as it goes, so everything already said is on disk and is what the reader shows afterwards.
- **The in-flight answer is lost.** A reply being generated when you archive is gone; nothing replays it.
- **Files it already wrote stay written.** An agent edits the workspace directly, so a half-finished refactor is half-finished on disk, not rolled back.
- **Reopening resumes.** Restore, open the pane, and the harness `--resume`s its pinned conversation — the session picks up its thread rather than starting blank.

So the cost is bounded and recoverable except for one in-flight answer. That is why I did **not** put a confirmation in front of archive. But it is the one place in this design where a single unconfirmed click can lose work someone is waiting on, so if you want a guard, the right one is narrow: confirm only when `state === 'working'`, not on every archive. Say the word and I will add it.

### Auto-archived sessions becoming deletable — I did not do this, and here is why

This is the part you said you were least sure of, and I think the worry is right, so the two roads lead to the same *view* but not the same *powers*:

- a session **you archived** — restore, or delete
- a session **merely quiet** for longer than the window — offered the archive, and nothing else

Three reasons. First, the window's verdict is not a decision: it is a statement about the clock that flips back the moment the setting changes, and letting a config change hand out delete rights to sessions nobody considered is a strange amount of power for a dropdown. Second, it keeps one sentence true — *only a thing you retired can be removed* — where the union version needs a footnote about a month. Third, it costs one click in the rare case and removes a whole class of accident in the common one.

The cost of being wrong here is smaller than it looks in one respect worth stating: `store.remove()` deliberately leaves the workspace folder on disk, so deleting removes the session record and its place in the list, never the work. The button says so.

If you would rather have the simpler rule — everything in the archived view is deletable — it is a one-line change (drop the `retired` split) and I will make it.

### And the no-dialog question

Agreed, no confirmation for delete. The archived view is somewhere you went on purpose, the row is already out of your way, and the files survive. A dialog there would be the third time the system asked you whether you meant it.

## `stopped` stays a state

Untouched, and it must be: it is what every session lands in after a Space restart, and the archive route asserts it explicitly.

## Verified

`server/test/archive.test.mjs`, **16 checks** against a real server rather than mocks:

- a live session refuses to delete — 409, `code: not-archived`, and a sentence with the word *archive* in it; the session is still there afterwards
- an archived one deletes and leaves the tree
- the flag is **on disk** in `sessions.json`, which is the entire reason it is stored
- restore clears it and makes the session undeletable again
- **archiving a running agent stops it** — driven through a real terminal socket, `running: true` → `running: false`
- `stopped` is still the state it lands in
- archiving an unknown id is a 404

Also: web typecheck, web suite, the full server suite (12 files, no retries), and before/after screenshots of the row and the archived view against a live instance, with the button inventory read out of the DOM rather than eyeballed.

**[Screenshots and the button inventory →](https://claude.ai/code/artifact/0172c34d-cd7f-4b87-99e3-aaebd866a755)**

Not verified: how this reads on a phone (checked at desktop width only), and I have not exercised archive against a *remote* agent with a live peer attached — it takes the no-process branch, so it files the session away and leaves the connection alone, which is what the brief asked for.

## Conflicts

- **#85** — clean.
- **#76** — two files, both mechanical, and one of them is the tie-in you flagged:
  - **`server/src/index.js`, 1 hunk.** #76 adds its `?ifNeverStarted=1` guard in exactly the spot this PR puts the archive guard — my comment there predicts it by name. They compose rather than compete:
    ```js
    if (req.query.ifNeverStarted === '1') {
      if (s.everStarted) return res.status(409).json({ error: 'session has already started' });
    } else if (!s.archivedAt) {
      return res.status(409).json({ error: 'archive this session before deleting it', code: 'not-archived' });
    }
    ```
    That gives the wrong-CLI mistake its one-step delete without opening a hole in the rule for anything that has ever run.
  - **`web/src/components/Sidebar.tsx`, 3 hunks**, all in the props destructure and its type. #76 adds `onPrepareQuickStart`/`onAbandonQuickStart`; this removes `onStopSession`, `onShareSession`, `onShareTrace`, `onOpenTrace` and adds `onArchiveSession`, `onUnarchiveSession`, `retired`, `handoverFor`, `onHandoverHandled`. Take both sides. (#76 still carries `onOpenSharedTrace`, which #84 removed — that resolves when #76 rebases onto #84.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
