### PR TITLE
Draw static states as the completed braille path

### DIFF
--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -134,11 +134,13 @@
 }
 .cx-running-at { margin-left: 7px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: 0.85; }
 .cx-running::before {
-  /* --mark-w rather than a second 1.2em: the spinner's cell is declared with
-     the animation in styles.css and read by everything that draws it — this,
-     .ov-busy, and the static state marks that stand in for it while an agent
-     is not working. */
-  content: '⠋'; display: inline-block; width: var(--mark-w); color: var(--accent);
+  /* The spinner's type and cell are declared with the animation in styles.css
+     and read by everything that draws it — this, .ov-busy, and the static
+     state glyphs that stand in for it while an agent is not working. */
+  content: '⠋'; display: inline-flex; align-items: center;
+  width: var(--mark-w); height: var(--mark-h);
+  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
+  color: var(--accent);
   animation: ov-spin 0.9s steps(1) infinite;
 }
 

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -136,11 +136,12 @@
 .cx-running::before {
   /* The spinner's type and cell are declared with the animation in styles.css
      and read by everything that draws it — this, .ov-busy, and the static
-     state glyphs that stand in for it while an agent is not working. */
+     path that stands in for it while an agent is not working. */
   content: '⠋'; display: inline-flex; align-items: center;
   width: var(--mark-w); height: var(--mark-h);
-  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
-  color: var(--accent);
+  font-family: var(--font-mono); font-size: var(--mark-size);
+  font-weight: var(--mark-weight); line-height: 1;
+  color: var(--accent); transform: translateY(var(--mark-optical-y));
   animation: ov-spin 0.9s steps(1) infinite;
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -369,23 +369,31 @@ body {
    The path values are measured from the bundled Geist Mono at --mark-size in
    Chromium, rasterised 16x (alpha >= 16): ⠿ ink is 5.5 x 8.8125px, one dot is
    1.875px, and the ink begins 1.8125px from the cell's left edge. A DOM raster
-   puts its top at 1.25px. Chromium quantises CSS border widths to whole CSS
+   puts its natural top at 1.25px. That natural ink sits 0.90625px high inside
+   the cell; the adjacent 600-weight 12px title's x-height centre sits another
+   0.5px below the cell centre. --mark-optical-y applies the full 1.40625px
+   correction, and the static path starts at the same corrected 2.65625px.
+
+   Chromium quantises CSS border widths to whole CSS
    pixels (1.875px paints as 1px), so --mark-stroke uses the nearest paintable
    diameter, 2px. Ratios keep those measurements tied to --mark-size.
    If the font fails and the mono fallback has different braille metrics, the
    spinner may briefly drift; the rectangle deliberately stays on the bundled
    font's measured path rather than guessing from an unknown fallback. */
 :root {
-  --mark-size: 12.5px; --mark-w: 1.2em; --mark-h: 1.05em;
-  --mark-ink-x: 0.145em; --mark-ink-y: 0.1em;
+  --mark-size: 12.5px; --mark-weight: 400;
+  --mark-w: 1.2em; --mark-h: 1.05em; --mark-optical-y: 0.1125em;
+  --mark-ink-x: 0.145em; --mark-ink-y: 0.2125em;
   --mark-ink-w: 0.44em; --mark-ink-h: 0.705em; --mark-stroke: 0.16em;
 }
 .ov-busy { font-size: 12.5px; color: var(--muted); }
 .ov-busy::before {
   content: '⠋'; display: inline-flex; align-items: center;
   width: var(--mark-w); height: var(--mark-h);
-  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
-  color: var(--accent); animation: ov-spin 0.9s steps(1) infinite;
+  font-family: var(--font-mono); font-size: var(--mark-size);
+  font-weight: var(--mark-weight); line-height: 1;
+  color: var(--accent); transform: translateY(var(--mark-optical-y));
+  animation: ov-spin 0.9s steps(1) infinite;
 }
 @keyframes ov-spin {
   0% { content: '⠋'; } 12.5% { content: '⠙'; } 25% { content: '⠹'; } 37.5% { content: '⠸'; }
@@ -417,7 +425,9 @@ body {
 .ovt-state.running::before {
   content: '⠋'; display: inline-flex; align-items: center;
   width: var(--mark-w); height: var(--mark-h);
-  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
+  font-family: var(--font-mono); font-size: var(--mark-size);
+  font-weight: var(--mark-weight); line-height: 1;
+  transform: translateY(var(--mark-optical-y));
   animation: ov-spin 0.9s steps(1) infinite;
 }
 .ovt-state.stopped { opacity: 0.7; }
@@ -563,7 +573,8 @@ body {
    Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
 .status.working, .status.waiting, .status.idle, .status.stopped {
   width: var(--mark-w); height: var(--mark-h);
-  font-size: var(--mark-size); font-family: var(--font-mono); line-height: 1;
+  font-family: var(--font-mono); font-size: var(--mark-size);
+  font-weight: var(--mark-weight); line-height: 1;
   border-radius: 0; background: none;
   display: inline-flex; align-items: center; position: relative;
   transition: color 0.2s, opacity 0.2s;
@@ -575,7 +586,8 @@ body {
 /* The same spinner, in the same cell. */
 .status.working { overflow: hidden; }
 .status.working::before {
-  content: '⠋'; animation: ov-spin 0.9s steps(1) infinite;
+  content: '⠋'; transform: translateY(var(--mark-optical-y));
+  animation: ov-spin 0.9s steps(1) infinite;
 }
 .status.waiting::before, .status.idle::before, .status.stopped::before {
   content: ''; position: absolute;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -362,10 +362,24 @@ body {
    Its type and cell are declared here, with the animation, because everything
    that draws this spinner — and everything that stands in for it while an
    agent is NOT working (see `.status.waiting` and friends) — reads the same
-   three values. Change the glyph, font size or cell and every renderer follows,
+   values. Change the glyph, font size or cell and every renderer follows,
    instead of leaving a static approximation behind. The cell remains em-based
-   on the shared mark size. */
-:root { --mark-size: 12.5px; --mark-w: 1.2em; --mark-h: 1.05em; }
+   on the shared mark size.
+
+   The path values are measured from the bundled Geist Mono at --mark-size in
+   Chromium, rasterised 16x (alpha >= 16): ⠿ ink is 5.5 x 8.8125px, one dot is
+   1.875px, and the ink begins 1.8125px from the cell's left edge. A DOM raster
+   puts its top at 1.25px. Chromium quantises CSS border widths to whole CSS
+   pixels (1.875px paints as 1px), so --mark-stroke uses the nearest paintable
+   diameter, 2px. Ratios keep those measurements tied to --mark-size.
+   If the font fails and the mono fallback has different braille metrics, the
+   spinner may briefly drift; the rectangle deliberately stays on the bundled
+   font's measured path rather than guessing from an unknown fallback. */
+:root {
+  --mark-size: 12.5px; --mark-w: 1.2em; --mark-h: 1.05em;
+  --mark-ink-x: 0.145em; --mark-ink-y: 0.1em;
+  --mark-ink-w: 0.44em; --mark-ink-h: 0.705em; --mark-stroke: 0.16em;
+}
 .ov-busy { font-size: 12.5px; color: var(--muted); }
 .ov-busy::before {
   content: '⠋'; display: inline-flex; align-items: center;
@@ -536,44 +550,44 @@ body {
    `.status` paints over those colours and they lose their identity. */
 .status { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s; }
 
-/* ---- agent state: one braille mark, one footprint ----
+/* ---- agent state: one path, moving or still ----
    A working agent shows the braille spinner the reader and the cards already
    run (`ov-spin`) — the same animation, not a second thing that also means
-   "busy". Every other state is a distinct, stationary arrangement of those
-   same braille dots: your-turn ⠿ (full attention), idle ⠶ (a settled pair of
-   rows), and stopped ⠤ (the final bottom row). Their density and silhouettes
-   stay legible when colour is not, none occurs in the animation, and
-   reduced-motion working freezes on ⠋, so no two states collapse.
+   "busy". Every other state shows that motion's completed path: the same
+   square-cornered hollow rectangle, measured from the six-dot ink rather than
+   from the much larger layout cell. State comes only from colour/intensity.
 
-   `--mark-size`, `--mark-w` and `--mark-h` are declared once beside `ov-spin`
-   and consumed by every renderer of that animation as well as by these four
-   states. That is the whole point: the static glyph cannot drift away from the
-   animation it stands in for, because there is one type-and-cell contract and
-   everyone reads it. Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
+   The type/cell/path values are declared once beside `ov-spin` and consumed by
+   every renderer. The static path cannot drift away from the animation it
+   stands in for because there is one measured contract and everyone reads it.
+   Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
 .status.working, .status.waiting, .status.idle, .status.stopped {
   width: var(--mark-w); height: var(--mark-h);
   font-size: var(--mark-size); font-family: var(--font-mono); line-height: 1;
   border-radius: 0; background: none;
-  display: inline-flex; align-items: center;
+  display: inline-flex; align-items: center; position: relative;
   transition: color 0.2s, opacity 0.2s;
 }
-.status.working::before, .status.waiting::before,
-.status.idle::before, .status.stopped::before {
+.status.working::before {
   display: inline-flex; align-items: center; box-sizing: border-box;
   width: 100%; height: 100%; background: none; border: none; box-shadow: none;
 }
-/* The same spinner, in the same cell. Under prefers-reduced-motion the global
-   animation kill freezes it at ⠋, which is deliberately not used below. */
+/* The same spinner, in the same cell. */
 .status.working { overflow: hidden; }
 .status.working::before {
   content: '⠋'; animation: ov-spin 0.9s steps(1) infinite;
 }
-.status.waiting::before { content: '⠿'; }
-.status.idle::before { content: '⠶'; }
-.status.stopped::before { content: '⠤'; }
-/* working and your-turn are both the accent: one is moving, one is not. */
+.status.waiting::before, .status.idle::before, .status.stopped::before {
+  content: ''; position: absolute;
+  left: var(--mark-ink-x); top: var(--mark-ink-y);
+  width: var(--mark-ink-w); height: var(--mark-ink-h);
+  box-sizing: border-box; background: none;
+  border: var(--mark-stroke) solid currentColor; border-radius: 0; box-shadow: none;
+}
+/* working and your-turn are both the accent: one moves, one is asking. */
 .status.working, .status.waiting { color: var(--accent); }
-.status.idle, .status.stopped { color: var(--muted); opacity: 0.5; }
+.status.idle, .status.stopped { color: var(--muted); }
+.status.stopped { opacity: 0.5; }
 
 /* quick-add utilities (shell / files) pinned above the legend */
 .quick-add { display: flex; gap: 6px; padding: 10px 10px; border-top: 1px solid var(--border); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -359,15 +359,20 @@ body {
 
 /* braille spinner: unmistakably a process, never an input line.
 
-   Its cell is declared here, with the animation, because everything that draws
-   this spinner — and everything that stands in for it while an agent is NOT
-   working (see `.status.waiting` and friends) — sizes itself from these two
-   numbers. Change the glyph, the font or the spinner's box and the static
-   marks follow, instead of being left behind at a size that used to match.
-   em, so each surface gets the cell at its own type size. */
-:root { --mark-w: 1.2em; --mark-h: 1.05em; }
+   Its type and cell are declared here, with the animation, because everything
+   that draws this spinner — and everything that stands in for it while an
+   agent is NOT working (see `.status.waiting` and friends) — reads the same
+   three values. Change the glyph, font size or cell and every renderer follows,
+   instead of leaving a static approximation behind. The cell remains em-based
+   on the shared mark size. */
+:root { --mark-size: 12.5px; --mark-w: 1.2em; --mark-h: 1.05em; }
 .ov-busy { font-size: 12.5px; color: var(--muted); }
-.ov-busy::before { content: '⠋'; display: inline-block; width: var(--mark-w); color: var(--accent); animation: ov-spin 0.9s steps(1) infinite; }
+.ov-busy::before {
+  content: '⠋'; display: inline-flex; align-items: center;
+  width: var(--mark-w); height: var(--mark-h);
+  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
+  color: var(--accent); animation: ov-spin 0.9s steps(1) infinite;
+}
 @keyframes ov-spin {
   0% { content: '⠋'; } 12.5% { content: '⠙'; } 25% { content: '⠹'; } 37.5% { content: '⠸'; }
   50% { content: '⠼'; } 62.5% { content: '⠴'; } 75% { content: '⠦'; } 87.5% { content: '⠧'; }
@@ -395,7 +400,12 @@ body {
 .ovt-prompt.none::before { color: var(--border-strong); }
 .ovt-state { font-size: 10.5px; color: var(--muted); }
 .ovt-state.running { color: var(--accent); }
-.ovt-state.running::before { content: '⠋ '; display: inline-block; animation: ov-spin 0.9s steps(1) infinite; }
+.ovt-state.running::before {
+  content: '⠋'; display: inline-flex; align-items: center;
+  width: var(--mark-w); height: var(--mark-h);
+  font-family: var(--font-mono); font-size: var(--mark-size); line-height: 1;
+  animation: ov-spin 0.9s steps(1) infinite;
+}
 .ovt-state.stopped { opacity: 0.7; }
 .ovt-group { position: relative; border: 1px solid var(--border); border-radius: 13px; padding: 12px 10px 10px; margin-top: 6px; }
 /* loose tiles align with tiles INSIDE group boxes (1px border + 10px padding),
@@ -526,50 +536,44 @@ body {
    `.status` paints over those colours and they lose their identity. */
 .status { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s; }
 
-/* ---- agent state: one mark, one footprint ----
+/* ---- agent state: one braille mark, one footprint ----
    A working agent shows the braille spinner the reader and the cards already
    run (`ov-spin`) — the same animation, not a second thing that also means
-   "busy". Every other state is that same cell standing still: a rectangle,
-   filled, or outlined for stopped.
+   "busy". Every other state is a distinct, stationary arrangement of those
+   same braille dots: your-turn ⠿ (full attention), idle ⠶ (a settled pair of
+   rows), and stopped ⠤ (the final bottom row). Their density and silhouettes
+   stay legible when colour is not, none occurs in the animation, and
+   reduced-motion working freezes on ⠋, so no two states collapse.
 
-   The cell is `--mark-w` by `--mark-h`, declared once beside `ov-spin` itself
+   `--mark-size`, `--mark-w` and `--mark-h` are declared once beside `ov-spin`
    and consumed by every renderer of that animation as well as by these four
-   states. That is the whole point: the static mark cannot drift away from the
-   animation it stands in for, because there is one box and everyone reads it.
-   Same shape as --cx-gutter (#71) and --ph-pad-y (#75).
-
-   `font-size` is the only thing these states set for themselves — a size down
-   from the surrounding type — which is what lets one cell work in a sidebar
-   row and in a card header alike without either restating a geometry. */
+   states. That is the whole point: the static glyph cannot drift away from the
+   animation it stands in for, because there is one type-and-cell contract and
+   everyone reads it. Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
 .status.working, .status.waiting, .status.idle, .status.stopped {
   width: var(--mark-w); height: var(--mark-h);
-  font-size: 0.62em; font-family: var(--font-mono); line-height: 1;
+  font-size: var(--mark-size); font-family: var(--font-mono); line-height: 1;
   border-radius: 0; background: none;
-  display: inline-flex; align-items: center; justify-content: center;
+  display: inline-flex; align-items: center;
   transition: color 0.2s, opacity 0.2s;
 }
 .status.working::before, .status.waiting::before,
 .status.idle::before, .status.stopped::before {
-  content: ''; display: block; box-sizing: border-box;
-  width: 100%; height: 100%; background: currentColor;
+  display: inline-flex; align-items: center; box-sizing: border-box;
+  width: 100%; height: 100%; background: none; border: none; box-shadow: none;
 }
-/* The same spinner, in the same cell. `overflow: hidden` keeps the glyph from
-   painting outside the footprint the other three fill, whatever a font does
-   with it. Under prefers-reduced-motion the global animation kill freezes it
-   at ⠋ — a part-filled cell, still not the full rectangle a ready agent
-   shows. */
+/* The same spinner, in the same cell. Under prefers-reduced-motion the global
+   animation kill freezes it at ⠋, which is deliberately not used below. */
 .status.working { overflow: hidden; }
 .status.working::before {
-  content: '⠋'; background: none;
-  animation: ov-spin 0.9s steps(1) infinite;
+  content: '⠋'; animation: ov-spin 0.9s steps(1) infinite;
 }
+.status.waiting::before { content: '⠿'; }
+.status.idle::before { content: '⠶'; }
+.status.stopped::before { content: '⠤'; }
 /* working and your-turn are both the accent: one is moving, one is not. */
 .status.working, .status.waiting { color: var(--accent); }
 .status.idle, .status.stopped { color: var(--muted); opacity: 0.5; }
-/* stopped is the cell's outline. An inset shadow, not a border: a border is
-   laid OUTSIDE a percentage height, so the stopped mark painted 2px taller
-   than the three it claims to match (and flex-shrank narrower to compensate). */
-.status.stopped::before { background: none; box-shadow: inset 0 0 0 1.5px currentColor; }
 
 /* quick-add utilities (shell / files) pinned above the legend */
 .quick-add { display: flex; gap: 6px; padding: 10px 10px; border-top: 1px solid var(--border); }

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -1,12 +1,10 @@
-// What the state marks actually PAINT, in a browser.
+// What the state marks actually render, in a browser.
 //
 // The source lint next door cannot answer this. Both of the bugs this test
 // exists for were invisible to it and to reading the CSS:
 //
-//   · `.status.stopped::before` drew its outline with a border on a
-//     `content-box` pseudo-element, so the border was laid OUTSIDE `height:
-//     100%`. The source said 100% like the other three; Chromium painted
-//     8 x 18.8px against their 8 x 16.8, and flex-shrank the width to boot.
+//   · static states used to draw filled/outlined CSS boxes beside a light
+//     braille working glyph, despite occupying the same outer cell.
 //   · an unconditional `.status::before` painted `currentColor` over the
 //     inline provider and CLI colours that UsagePanel and SettingsView put on
 //     a bare `.status`, which have no state class at all.
@@ -60,6 +58,12 @@ const marks = await page.evaluate((ids) => {
       painted: b.content === 'none' ? null
         : (b.boxSizing === 'border-box' ? [w, h] : [w + 2 * border, h + 2 * border]),
       content: b.content,
+      fontFamily: b.fontFamily,
+      fontSize: b.fontSize,
+      color: b.color,
+      background: b.backgroundColor,
+      borderStyle: b.borderTopStyle,
+      boxShadow: b.boxShadow,
       elementBackground: getComputedStyle(el).backgroundColor,
       cell: (() => { const r = el.getBoundingClientRect(); return [r.width, r.height]; })(),
     };
@@ -71,7 +75,7 @@ await browser.close();
 const round = (xs) => xs.map((n) => Math.round(n * 100) / 100);
 const STATES = ['working', 'waiting', 'idle', 'stopped'];
 
-console.log('every state paints the same cell');
+console.log('every state occupies the same cell');
 const ref = round(marks.waiting.painted);
 for (const s of STATES) {
   check(`${s} paints ${ref.join(' x ')}`, () => {
@@ -82,12 +86,36 @@ check('and the cells themselves agree', () => {
   for (const s of STATES) assert.deepEqual(round(marks[s].cell), round(marks.waiting.cell));
 });
 
-console.log('\nworking is the only one drawing a glyph');
-check('working renders a braille frame', () => {
-  assert.match(marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+console.log('\nevery state is a distinct glyph in the spinner\'s braille cell');
+const GLYPHS = { waiting: '⠿', idle: '⠶', stopped: '⠤' };
+check('the four glyphs are distinct', () => {
+  const animated = new Set(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']);
+  assert.equal(new Set(['animated', ...Object.values(GLYPHS)]).size, STATES.length);
+  for (const glyph of Object.values(GLYPHS)) assert.ok(!animated.has(glyph));
 });
-check('the other three render an empty box', () => {
-  for (const s of ['waiting', 'idle', 'stopped']) assert.equal(marks[s].content, '""');
+check('working renders one of the animation frames with the shared font and no box', () => {
+  assert.match(marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+  assert.equal(marks.working.fontSize, '12.5px');
+  assert.match(marks.working.fontFamily, /Geist Mono/);
+  assert.equal(marks.working.background, 'rgba(0, 0, 0, 0)');
+  assert.equal(marks.working.borderStyle, 'none');
+  assert.equal(marks.working.boxShadow, 'none');
+});
+for (const [state, glyph] of Object.entries(GLYPHS)) {
+  check(`${state} renders ${glyph} with the shared font and no box`, () => {
+    assert.equal(marks[state].content, `"${glyph}"`);
+    assert.equal(marks[state].fontSize, '12.5px');
+    assert.match(marks[state].fontFamily, /Geist Mono/);
+    assert.equal(marks[state].background, 'rgba(0, 0, 0, 0)');
+    assert.equal(marks[state].borderStyle, 'none');
+    assert.equal(marks[state].boxShadow, 'none');
+  });
+}
+check('working and your-turn share the accent treatment', () => {
+  assert.equal(marks.working.color, marks.waiting.color);
+});
+check('idle and stopped share the muted treatment', () => {
+  assert.equal(marks.idle.color, marks.stopped.color);
 });
 
 console.log('\nand a bare .status keeps the colour its caller gave it');

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -2,8 +2,9 @@
 //
 // This complements statusMark.test.mjs by proving three things source lint
 // cannot: the static rectangle follows Geist Mono's real braille ink, its
-// stroke is one braille dot thick, and a state pseudo-element never paints
-// over the inline provider/CLI colours carried by bare `.status` dots.
+// stroke is one braille dot thick, surrounding title weight cannot change a
+// mark, and a state pseudo-element never paints over the inline provider/CLI
+// colours carried by bare `.status` dots.
 //
 // Needs Chromium; run with:  node test/statusMark.render.test.mjs
 // (not in `npm test`, which stays browser-free — see package.json's test:render)
@@ -25,7 +26,12 @@ const embeddedFont = `@font-face {
   font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
   src: url(data:font/woff2;base64,${geistMono}) format('woff2');
 }
-:root { --font-mono: 'Geist Mono Test'; }`;
+:root { --font-mono: 'Geist Mono Test'; }
+.parity-sidebar { display:flex; align-items:center; font-weight:400; }
+.parity-overview { display:flex; align-items:center; font-weight:700; }
+.mark-baseline { display:inline-block; width:0; height:0; padding:0; margin:0; }
+.status.working::before, .ov-busy::before, .cx-running::before,
+.ovt-state.running::before { animation:none !important; }`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -47,14 +53,38 @@ await page.setContent(`<style>${css}\n${embeddedFont}</style>
     <span class="status stopped" id="stopped"></span>
     <span class="status" id="provider" style="background: rgb(214, 69, 69)"></span>
     <span class="status" id="ready" style="background: rgb(46, 158, 91)"></span>
-  </div>`);
+  </div>
+  <div class="parity-sidebar"><span class="status working" id="sidebar-working"></span></div>
+  <div class="parity-overview">
+    <span class="status working" id="overview-working"></span>
+    <span class="status waiting" id="overview-waiting"></span>
+  </div>
+  <div class="pane-head" style="width:600px">
+    <span class="ph-left"></span>
+    <span class="ph-title">
+      <span class="status working" id="header-working"></span>
+      <span class="ph-name">claude-code-4</span>
+    </span>
+    <span class="ph-right"></span>
+  </div>
+  <div class="pane-head" style="width:600px">
+    <span class="ph-left"></span>
+    <span class="ph-title" id="header-static-wrap">
+      <span class="status waiting" id="header-waiting"></span>
+      <span class="ph-name">claude-code-4<span class="mark-baseline" id="header-baseline"></span></span>
+    </span>
+    <span class="ph-right"></span>
+  </div>
+  <div class="ov-busy" id="overview-busy">running</div>
+  <div class="ovt-state running" id="overview-group-working"></div>
+  <div class="cx-running" id="reader-working">working</div>`);
 await page.evaluate(async () => {
   await document.fonts.load('12.5px "Geist Mono Test"', '⠿⠁');
   await document.fonts.ready;
 });
 await page.waitForTimeout(150);
 
-const { marks, ink } = await page.evaluate((ids) => {
+const { marks, ink, optics } = await page.evaluate((ids) => {
   const out = {};
   for (const id of ids) {
     const el = document.getElementById(id);
@@ -70,6 +100,8 @@ const { marks, ink } = await page.evaluate((ids) => {
       content: b.content,
       fontFamily: b.fontFamily,
       fontSize: b.fontSize,
+      fontWeight: b.fontWeight,
+      lineHeight: b.lineHeight,
       color: b.color,
       background: b.backgroundColor,
       borderStyle: b.borderTopStyle,
@@ -79,6 +111,8 @@ const { marks, ink } = await page.evaluate((ids) => {
       left: parseFloat(b.left),
       top: parseFloat(b.top),
       position: b.position,
+      transform: b.transform,
+      parentWeight: getComputedStyle(el.parentElement).fontWeight,
       elementBackground: style.backgroundColor,
       elementOpacity: parseFloat(style.opacity),
       cell: (() => { const r = el.getBoundingClientRect(); return [r.width, r.height]; })(),
@@ -112,8 +146,33 @@ const { marks, ink } = await page.evaluate((ids) => {
       height: (maxY - minY + 1) / scale,
     };
   };
-  return { marks: out, ink: { full: measure('⠿'), dot: measure('⠁') } };
-}, ['working', 'waiting', 'idle', 'stopped', 'provider', 'ready']);
+  const headerMark = document.getElementById('header-waiting');
+  const headerBefore = getComputedStyle(headerMark, '::before');
+  const headerRect = headerMark.getBoundingClientRect();
+  const baseline = document.getElementById('header-baseline').getBoundingClientRect().top;
+  const nameStyle = getComputedStyle(document.querySelector('#header-static-wrap .ph-name'));
+  const ctx = document.createElement('canvas').getContext('2d');
+  ctx.font = `${nameStyle.fontWeight} ${nameStyle.fontSize} "Geist Mono Test"`;
+  const x = ctx.measureText('x');
+  const xTop = baseline - x.actualBoundingBoxAscent;
+  const xBottom = baseline + x.actualBoundingBoxDescent;
+  const markTop = headerRect.top + parseFloat(headerBefore.top);
+  const markBottom = markTop + parseFloat(headerBefore.height);
+  return {
+    marks: out,
+    ink: { full: measure('⠿'), dot: measure('⠁') },
+    optics: {
+      markCenter: (markTop + markBottom) / 2,
+      xHeightCenter: (xTop + xBottom) / 2,
+      delta: (markTop + markBottom - xTop - xBottom) / 2,
+    },
+  };
+}, [
+  'working', 'waiting', 'idle', 'stopped', 'provider', 'ready',
+  'sidebar-working', 'overview-working', 'overview-waiting',
+  'header-working', 'header-waiting', 'overview-busy',
+  'overview-group-working', 'reader-working',
+]);
 await browser.close();
 
 const round = (xs) => xs.map((n) => Math.round(n * 100) / 100);
@@ -135,6 +194,8 @@ check('it renders one frame with the shared font and no box', () => {
   assert.match(marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
   assert.equal(marks.working.fontSize, '12.5px');
   assert.match(marks.working.fontFamily, /Geist Mono Test/);
+  assert.equal(marks.working.fontWeight, '400');
+  assert.equal(marks.working.lineHeight, '12.5px');
   assert.equal(marks.working.background, 'rgba(0, 0, 0, 0)');
   assert.equal(marks.working.borderStyle, 'none');
   assert.equal(marks.working.boxShadow, 'none');
@@ -166,9 +227,9 @@ for (const state of STATIC) {
     // than letting Chromium floor a fractional declaration to 1px.
     assert.equal(marks[state].borderWidth, Math.round(ink.dot.width));
   });
-  check(`${state} starts at the measured ink offset`, () => {
+  check(`${state} starts at the optically corrected ink offset`, () => {
     close(marks[state].left, 1.8125);
-    close(marks[state].top, 1.25);
+    close(marks[state].top, 2.65625);
   });
 }
 check('all three static rectangles have identical geometry', () => {
@@ -188,6 +249,47 @@ check('idle and stopped share the muted colour', () => {
 check('stopped is dimmer than idle', () => {
   assert.equal(marks.idle.elementOpacity, 1);
   assert.equal(marks.stopped.elementOpacity, 0.5);
+});
+
+console.log('\ntypography and optical alignment survive every real context');
+const STATUS_WORKING = ['sidebar-working', 'overview-working', 'header-working'];
+check('the fixture actually stresses normal, heavy and header typography', () => {
+  assert.equal(marks['sidebar-working'].parentWeight, '400');
+  assert.equal(marks['overview-working'].parentWeight, '700');
+  assert.equal(marks['header-working'].parentWeight, '600');
+});
+for (const id of [...STATUS_WORKING, 'overview-waiting', 'header-waiting']) {
+  check(`${id} owns the same type regardless of its parent`, () => {
+    assert.match(marks[id].fontFamily, /Geist Mono Test/);
+    assert.equal(marks[id].fontSize, '12.5px');
+    assert.equal(marks[id].fontWeight, '400');
+    assert.equal(marks[id].lineHeight, '12.5px');
+  });
+}
+check('sidebar, Overview and header working marks paint the same cell', () => {
+  for (const id of STATUS_WORKING) {
+    assert.deepEqual(round(marks[id].painted), round(marks['sidebar-working'].painted));
+  }
+});
+check('Overview and header static paths have identical geometry', () => {
+  assert.deepEqual(round(marks['overview-waiting'].painted), round(marks['header-waiting'].painted));
+  close(marks['overview-waiting'].top, marks['header-waiting'].top, 0.001);
+  close(marks['overview-waiting'].left, marks['header-waiting'].left, 0.001);
+});
+for (const id of [
+  ...STATUS_WORKING, 'overview-busy', 'overview-group-working', 'reader-working',
+]) {
+  check(`${id} uses the same normal-weight, optically corrected spinner`, () => {
+    assert.match(marks[id].content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+    assert.match(marks[id].fontFamily, /Geist Mono Test/);
+    assert.equal(marks[id].fontSize, '12.5px');
+    assert.equal(marks[id].fontWeight, '400');
+    assert.equal(marks[id].lineHeight, '12.5px');
+    assert.match(marks[id].transform, /^matrix\(1, 0, 0, 1, 0, 1\.40625\)$/);
+  });
+}
+check('the static path centre meets the 600-weight title x-height centre', () => {
+  close(optics.markCenter, optics.xHeightCenter, 0.2);
 });
 
 console.log('\na bare .status keeps the colour its caller gave it');

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -1,13 +1,9 @@
 // What the state marks actually render, in a browser.
 //
-// The source lint next door cannot answer this. Both of the bugs this test
-// exists for were invisible to it and to reading the CSS:
-//
-//   · static states used to draw filled/outlined CSS boxes beside a light
-//     braille working glyph, despite occupying the same outer cell.
-//   · an unconditional `.status::before` painted `currentColor` over the
-//     inline provider and CLI colours that UsagePanel and SettingsView put on
-//     a bare `.status`, which have no state class at all.
+// This complements statusMark.test.mjs by proving three things source lint
+// cannot: the static rectangle follows Geist Mono's real braille ink, its
+// stroke is one braille dot thick, and a state pseudo-element never paints
+// over the inline provider/CLI colours carried by bare `.status` dots.
 //
 // Needs Chromium; run with:  node test/statusMark.render.test.mjs
 // (not in `npm test`, which stays browser-free — see package.json's test:render)
@@ -21,6 +17,15 @@ import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const css = ['styles.css', 'conversation.css']
   .map((f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8')).join('\n');
+const geistMono = fs.readFileSync(path.join(HERE, '../public/fonts/GeistMono.woff2')).toString('base64');
+// The source stylesheet points at /fonts, which setContent cannot serve. Put an
+// otherwise identical face after it so this test measures the bundled font,
+// independent of whichever mono font happens to be installed on the runner.
+const embeddedFont = `@font-face {
+  font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
+  src: url(data:font/woff2;base64,${geistMono}) format('woff2');
+}
+:root { --font-mono: 'Geist Mono Test'; }`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -34,7 +39,7 @@ const browser = await chromium.launch(chromiumLaunchOptions());
 const page = await (await browser.newContext({ viewport: { width: 900, height: 600 } })).newPage();
 // The markup the app renders: four state marks, and the two bare dots that
 // carry a colour of their own (UsagePanel.tsx, SettingsView.tsx).
-await page.setContent(`<style>${css}</style>
+await page.setContent(`<style>${css}\n${embeddedFont}</style>
   <div class="row" style="font-size:16px">
     <span class="status working" id="working"></span>
     <span class="status waiting" id="waiting"></span>
@@ -43,12 +48,17 @@ await page.setContent(`<style>${css}</style>
     <span class="status" id="provider" style="background: rgb(214, 69, 69)"></span>
     <span class="status" id="ready" style="background: rgb(46, 158, 91)"></span>
   </div>`);
+await page.evaluate(async () => {
+  await document.fonts.load('12.5px "Geist Mono Test"', '⠿⠁');
+  await document.fonts.ready;
+});
 await page.waitForTimeout(150);
 
-const marks = await page.evaluate((ids) => {
+const { marks, ink } = await page.evaluate((ids) => {
   const out = {};
   for (const id of ids) {
     const el = document.getElementById(id);
+    const style = getComputedStyle(el);
     const b = getComputedStyle(el, '::before');
     const border = parseFloat(b.borderTopWidth) || 0;
     const w = parseFloat(b.width) || 0;
@@ -63,66 +73,129 @@ const marks = await page.evaluate((ids) => {
       color: b.color,
       background: b.backgroundColor,
       borderStyle: b.borderTopStyle,
+      borderWidth: border,
+      borderRadius: b.borderRadius,
       boxShadow: b.boxShadow,
-      elementBackground: getComputedStyle(el).backgroundColor,
+      left: parseFloat(b.left),
+      top: parseFloat(b.top),
+      position: b.position,
+      elementBackground: style.backgroundColor,
+      elementOpacity: parseFloat(style.opacity),
       cell: (() => { const r = el.getBoundingClientRect(); return [r.width, r.height]; })(),
     };
   }
-  return out;
+
+  // Raster at 16x and count pixels at alpha >= 16. This is the measurement
+  // documented beside the CSS contract, reproduced here by the browser that
+  // will render the result. ⠁ isolates one dot; ⠿ gives the six-dot extent.
+  const measure = (glyph) => {
+    const scale = 16;
+    const canvas = document.createElement('canvas');
+    canvas.width = 32 * scale; canvas.height = 32 * scale;
+    const ctx = canvas.getContext('2d');
+    ctx.scale(scale, scale);
+    ctx.font = '12.5px "Geist Mono Test"';
+    ctx.textBaseline = 'alphabetic';
+    ctx.fillStyle = '#000';
+    ctx.fillText(glyph, 8, 20);
+    const data = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+    let minX = canvas.width; let minY = canvas.height; let maxX = -1; let maxY = -1;
+    for (let y = 0; y < canvas.height; y++) {
+      for (let x = 0; x < canvas.width; x++) {
+        if (data[(y * canvas.width + x) * 4 + 3] < 16) continue;
+        minX = Math.min(minX, x); minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x); maxY = Math.max(maxY, y);
+      }
+    }
+    return {
+      width: (maxX - minX + 1) / scale,
+      height: (maxY - minY + 1) / scale,
+    };
+  };
+  return { marks: out, ink: { full: measure('⠿'), dot: measure('⠁') } };
 }, ['working', 'waiting', 'idle', 'stopped', 'provider', 'ready']);
 await browser.close();
 
 const round = (xs) => xs.map((n) => Math.round(n * 100) / 100);
+const close = (actual, expected, tolerance = 0.07) => {
+  assert.ok(Math.abs(actual - expected) <= tolerance, `${actual} is not within ${tolerance} of ${expected}`);
+};
 const STATES = ['working', 'waiting', 'idle', 'stopped'];
+const STATIC = ['waiting', 'idle', 'stopped'];
 
-console.log('every state occupies the same cell');
-const ref = round(marks.waiting.painted);
+console.log('every state occupies the same outer cell');
 for (const s of STATES) {
-  check(`${s} paints ${ref.join(' x ')}`, () => {
-    assert.deepEqual(round(marks[s].painted), ref);
+  check(`${s} uses the shared ${round(marks.working.cell).join(' x ')} cell`, () => {
+    assert.deepEqual(round(marks[s].cell), round(marks.working.cell));
   });
 }
-check('and the cells themselves agree', () => {
-  for (const s of STATES) assert.deepEqual(round(marks[s].cell), round(marks.waiting.cell));
-});
 
-console.log('\nevery state is a distinct glyph in the spinner\'s braille cell');
-const GLYPHS = { waiting: '⠿', idle: '⠶', stopped: '⠤' };
-check('the four glyphs are distinct', () => {
-  const animated = new Set(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']);
-  assert.equal(new Set(['animated', ...Object.values(GLYPHS)]).size, STATES.length);
-  for (const glyph of Object.values(GLYPHS)) assert.ok(!animated.has(glyph));
-});
-check('working renders one of the animation frames with the shared font and no box', () => {
+console.log('\nworking is the animated braille mark');
+check('it renders one frame with the shared font and no box', () => {
   assert.match(marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
   assert.equal(marks.working.fontSize, '12.5px');
-  assert.match(marks.working.fontFamily, /Geist Mono/);
+  assert.match(marks.working.fontFamily, /Geist Mono Test/);
   assert.equal(marks.working.background, 'rgba(0, 0, 0, 0)');
   assert.equal(marks.working.borderStyle, 'none');
   assert.equal(marks.working.boxShadow, 'none');
 });
-for (const [state, glyph] of Object.entries(GLYPHS)) {
-  check(`${state} renders ${glyph} with the shared font and no box`, () => {
-    assert.equal(marks[state].content, `"${glyph}"`);
-    assert.equal(marks[state].fontSize, '12.5px');
-    assert.match(marks[state].fontFamily, /Geist Mono/);
+
+console.log('\nthe static path is measured from Geist Mono, not guessed from the cell');
+check('the full six-dot ink is 5.5 x 8.8125px at 12.5px', () => {
+  close(ink.full.width, 5.5);
+  close(ink.full.height, 8.8125);
+});
+check('one braille dot is 1.875px in both axes', () => {
+  close(ink.dot.width, 1.875);
+  close(ink.dot.height, 1.875);
+});
+for (const state of STATIC) {
+  check(`${state} draws the same square, hollow rectangle`, () => {
+    assert.equal(marks[state].content, '""');
+    assert.equal(marks[state].position, 'absolute');
     assert.equal(marks[state].background, 'rgba(0, 0, 0, 0)');
-    assert.equal(marks[state].borderStyle, 'none');
+    assert.equal(marks[state].borderStyle, 'solid');
+    assert.equal(marks[state].borderRadius, '0px');
     assert.equal(marks[state].boxShadow, 'none');
   });
+  check(`${state} spans the six-dot ink and uses one-dot stroke`, () => {
+    close(marks[state].painted[0], ink.full.width);
+    close(marks[state].painted[1], ink.full.height);
+    // CSS border widths are integer CSS pixels in Chromium. The implementation
+    // deliberately rounds the measured 1.875px dot to the nearest value rather
+    // than letting Chromium floor a fractional declaration to 1px.
+    assert.equal(marks[state].borderWidth, Math.round(ink.dot.width));
+  });
+  check(`${state} starts at the measured ink offset`, () => {
+    close(marks[state].left, 1.8125);
+    close(marks[state].top, 1.25);
+  });
 }
-check('working and your-turn share the accent treatment', () => {
-  assert.equal(marks.working.color, marks.waiting.color);
-});
-check('idle and stopped share the muted treatment', () => {
-  assert.equal(marks.idle.color, marks.stopped.color);
+check('all three static rectangles have identical geometry', () => {
+  for (const state of STATIC.slice(1)) {
+    assert.deepEqual(round(marks[state].painted), round(marks.waiting.painted));
+    close(marks[state].borderWidth, marks.waiting.borderWidth, 0.001);
+  }
 });
 
-console.log('\nand a bare .status keeps the colour its caller gave it');
+console.log('\nstate treatment changes only colour/intensity');
+check('working and waiting share the accent', () => {
+  assert.equal(marks.working.color, marks.waiting.color);
+});
+check('idle and stopped share the muted colour', () => {
+  assert.equal(marks.idle.color, marks.stopped.color);
+});
+check('stopped is dimmer than idle', () => {
+  assert.equal(marks.idle.elementOpacity, 1);
+  assert.equal(marks.stopped.elementOpacity, 0.5);
+});
+
+console.log('\na bare .status keeps the colour its caller gave it');
 for (const [id, colour] of [['provider', 'rgb(214, 69, 69)'], ['ready', 'rgb(46, 158, 91)']]) {
   check(`${id} still shows ${colour}`, () => {
     assert.equal(marks[id].elementBackground, colour);
     assert.equal(marks[id].content, 'none', 'something is painted over it');
+    assert.deepEqual(round(marks[id].cell), [8, 8]);
   });
 }
 

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -8,11 +8,10 @@
 // measured a copy of the glyph instead of reading the spinner's own cell, so a
 // font or spinner change would have left the rectangles behind.
 //
-// So this lints the contract, not the numbers: --mark-w/--mark-h are declared
-// once, and every renderer of the spinner AND every static state reads them
-// rather than restating a length. What the marks actually PAINT is a separate
-// question this cannot answer — a border sits outside a percentage height and
-// the source still says `100%`. That is statusMark.render.test.mjs.
+// So this lints the contract, not the numbers: --mark-size/--mark-w/--mark-h
+// are declared once, and every renderer of the spinner AND every static state
+// reads them rather than restating a length. What the marks actually PAINT is a
+// separate question this cannot answer. That is statusMark.render.test.mjs.
 //
 // Run with:  node test/statusMark.test.mjs
 import assert from 'node:assert/strict';
@@ -42,8 +41,8 @@ const LENGTH = /(?:^|[\s:])-?\d*\.?\d+(?:px|em|rem|%)/;
 
 console.log('the cell is declared once');
 
-check('--mark-w and --mark-h are declared exactly once each', () => {
-  for (const name of ['--mark-w', '--mark-h']) {
+check('--mark-size, --mark-w and --mark-h are declared exactly once each', () => {
+  for (const name of ['--mark-size', '--mark-w', '--mark-h']) {
     const declarations = [...css.matchAll(new RegExp(`${name}\\s*:`, 'g'))].length;
     assert.equal(declarations, 1, `${name} is declared ${declarations} times`);
   }
@@ -71,6 +70,17 @@ check('none of them restates a width', () => {
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these size the spinner themselves: ${offenders.join(', ')}`);
 });
+check('every spinner consumes the shared type-and-cell contract', () => {
+  for (const spinner of spinners) {
+    if (spinner.selector === '.status.working::before') {
+      assert.match(spinner.body, /content:\s*'⠋'/, 'working lost the shared braille family');
+      continue; // its parent owns the contract; the mark fills it below
+    }
+    assert.match(spinner.body, /font-size\s*:\s*var\(--mark-size\)/, `${spinner.selector} has its own type size`);
+    assert.match(spinner.body, /width\s*:\s*var\(--mark-w\)/, `${spinner.selector} has its own width`);
+    assert.match(spinner.body, /height\s*:\s*var\(--mark-h\)/, `${spinner.selector} has its own height`);
+  }
+});
 
 console.log('\nand so does every state that stands in for it');
 
@@ -78,7 +88,8 @@ const STATES = ['working', 'waiting', 'idle', 'stopped'];
 const stateRules = rules.filter((r) => STATES.some((s) => r.selector.includes(`.status.${s}`)));
 check('the four states are sized from the cell', () => {
   const sized = stateRules.filter((r) => /width\s*:\s*var\(--mark-w\)/.test(r.body)
-    && /height\s*:\s*var\(--mark-h\)/.test(r.body));
+    && /height\s*:\s*var\(--mark-h\)/.test(r.body)
+    && /font-size\s*:\s*var\(--mark-size\)/.test(r.body));
   assert.ok(sized.length >= 1, 'no state rule takes its box from --mark-w/--mark-h');
   for (const s of STATES) {
     assert.ok(sized.some((r) => r.selector.includes(`.${s}`)), `${s} is not covered by that rule`);
@@ -100,6 +111,26 @@ check('the mark inside the cell only fills it', () => {
       assert.equal(value.trim(), '100%', `${r.selector} sizes the mark to ${value.trim()}`);
     }
   }
+});
+check('the four states are unique braille glyphs, never boxes', () => {
+  const expected = { working: '⠋', waiting: '⠿', idle: '⠶', stopped: '⠤' };
+  const animated = new Set(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']);
+  const seen = new Set();
+  for (const [state, glyph] of Object.entries(expected)) {
+    const own = rules.find((r) => r.selector === `.status.${state}::before`);
+    assert.ok(own, `no pseudo-element for ${state}`);
+    assert.match(own.body, new RegExp(`content:\\s*['"]${glyph}['"]`), `${state} does not use ${glyph}`);
+    seen.add(glyph);
+
+    if (state !== 'working') assert.ok(!animated.has(glyph), `${state} can look identical to a working frame`);
+
+    const bodies = stateRules.filter((r) => r.selector.includes(`.status.${state}`) && /::before/.test(r.selector))
+      .map((r) => r.body).join('\n');
+    for (const [, prop, value] of bodies.matchAll(/(?:^|;)\s*(background|border(?:-[\w-]+)?|box-shadow)\s*:\s*([^;]+)/g)) {
+      assert.equal(value.trim(), 'none', `${state} paints ${prop}: ${value.trim()}`);
+    }
+  }
+  assert.equal(seen.size, 4, 'two states share a glyph');
 });
 
 console.log('\nand the plain colour dot is left alone');

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -42,6 +42,7 @@ console.log('the cell is declared once');
 check('the type, cell and measured path values are declared exactly once each', () => {
   for (const name of [
     '--mark-size', '--mark-w', '--mark-h',
+    '--mark-weight', '--mark-optical-y',
     '--mark-ink-x', '--mark-ink-y', '--mark-ink-w', '--mark-ink-h', '--mark-stroke',
   ]) {
     const declarations = [...css.matchAll(new RegExp(`${name}\\s*:`, 'g'))].length;
@@ -71,15 +72,20 @@ check('none of them restates a width', () => {
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these size the spinner themselves: ${offenders.join(', ')}`);
 });
-check('every spinner consumes the shared type-and-cell contract', () => {
+check('every spinner consumes the shared type, weight and cell contract', () => {
   for (const spinner of spinners) {
     if (spinner.selector === '.status.working::before') {
       assert.match(spinner.body, /content:\s*'⠋'/, 'working lost the shared braille family');
+      assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, 'working lost the optical correction');
       continue; // its parent owns the contract; the mark fills it below
     }
+    assert.match(spinner.body, /font-family\s*:\s*var\(--font-mono\)/, `${spinner.selector} inherits its font family`);
     assert.match(spinner.body, /font-size\s*:\s*var\(--mark-size\)/, `${spinner.selector} has its own type size`);
+    assert.match(spinner.body, /font-weight\s*:\s*var\(--mark-weight\)/, `${spinner.selector} inherits its weight`);
+    assert.match(spinner.body, /line-height\s*:\s*1/, `${spinner.selector} inherits its line height`);
     assert.match(spinner.body, /width\s*:\s*var\(--mark-w\)/, `${spinner.selector} has its own width`);
     assert.match(spinner.body, /height\s*:\s*var\(--mark-h\)/, `${spinner.selector} has its own height`);
+    assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, `${spinner.selector} lost the optical correction`);
   }
 });
 
@@ -94,6 +100,16 @@ check('the four states are sized from the cell', () => {
   assert.ok(sized.length >= 1, 'no state rule takes its box from --mark-w/--mark-h');
   for (const s of STATES) {
     assert.ok(sized.some((r) => r.selector.includes(`.${s}`)), `${s} is not covered by that rule`);
+  }
+});
+check('the four states own their typography instead of inheriting it', () => {
+  const typed = stateRules.filter((r) => !/::before/.test(r.selector)
+    && /font-family\s*:\s*var\(--font-mono\)/.test(r.body)
+    && /font-size\s*:\s*var\(--mark-size\)/.test(r.body)
+    && /font-weight\s*:\s*var\(--mark-weight\)/.test(r.body)
+    && /line-height\s*:\s*1/.test(r.body));
+  for (const s of STATES) {
+    assert.ok(typed.some((r) => r.selector.includes(`.${s}`)), `${s} inherits surrounding typography`);
   }
 });
 check('no state rule restates a length for its box', () => {

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -1,17 +1,15 @@
 // One geometry contract for the working animation and everything that stands
 // in for it.
 //
-// A working agent shows the braille spinner; every other state is that same
-// cell standing still. They only read as the same mark while they are the same
-// box, and the way that quietly breaks is someone giving one of them its own
-// number — which is what the first cut of this change did: the static states
-// measured a copy of the glyph instead of reading the spinner's own cell, so a
-// font or spinner change would have left the rectangles behind.
+// A working agent shows the braille spinner; every other state shows the hollow
+// rectangle traced by those dots. They only read as one system while the
+// rectangle is derived from the glyph's real ink instead of from a visually
+// similar box someone guessed by eye.
 //
-// So this lints the contract, not the numbers: --mark-size/--mark-w/--mark-h
-// are declared once, and every renderer of the spinner AND every static state
-// reads them rather than restating a length. What the marks actually PAINT is a
-// separate question this cannot answer. That is statusMark.render.test.mjs.
+// So this lints the contract, not the numbers: type, cell, measured ink box and
+// derived stroke are declared once, and every spinner/static renderer reads them.
+// What the marks actually PAINT is a separate question this cannot answer. That
+// is statusMark.render.test.mjs.
 //
 // Run with:  node test/statusMark.test.mjs
 import assert from 'node:assert/strict';
@@ -41,8 +39,11 @@ const LENGTH = /(?:^|[\s:])-?\d*\.?\d+(?:px|em|rem|%)/;
 
 console.log('the cell is declared once');
 
-check('--mark-size, --mark-w and --mark-h are declared exactly once each', () => {
-  for (const name of ['--mark-size', '--mark-w', '--mark-h']) {
+check('the type, cell and measured path values are declared exactly once each', () => {
+  for (const name of [
+    '--mark-size', '--mark-w', '--mark-h',
+    '--mark-ink-x', '--mark-ink-y', '--mark-ink-w', '--mark-ink-h', '--mark-stroke',
+  ]) {
     const declarations = [...css.matchAll(new RegExp(`${name}\\s*:`, 'g'))].length;
     assert.equal(declarations, 1, `${name} is declared ${declarations} times`);
   }
@@ -105,32 +106,30 @@ check('no state rule restates a length for its box', () => {
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these restate the box: ${offenders.join(', ')}`);
 });
-check('the mark inside the cell only fills it', () => {
-  for (const r of stateRules.filter((x) => /::before/.test(x.selector))) {
-    for (const [, , value] of r.body.matchAll(/(?:^|;|\s)(width|height)\s*:\s*([^;]+)/g)) {
-      assert.equal(value.trim(), '100%', `${r.selector} sizes the mark to ${value.trim()}`);
-    }
-  }
+check('working fills the shared cell', () => {
+  const working = rules.find((r) => r.selector === '.status.working::before' && /width\s*:\s*100%/.test(r.body));
+  assert.ok(working, 'working does not fill the shared cell');
+  assert.match(working.body, /height\s*:\s*100%/);
 });
-check('the four states are unique braille glyphs, never boxes', () => {
-  const expected = { working: '⠋', waiting: '⠿', idle: '⠶', stopped: '⠤' };
-  const animated = new Set(['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧']);
-  const seen = new Set();
-  for (const [state, glyph] of Object.entries(expected)) {
-    const own = rules.find((r) => r.selector === `.status.${state}::before`);
-    assert.ok(own, `no pseudo-element for ${state}`);
-    assert.match(own.body, new RegExp(`content:\\s*['"]${glyph}['"]`), `${state} does not use ${glyph}`);
-    seen.add(glyph);
-
-    if (state !== 'working') assert.ok(!animated.has(glyph), `${state} can look identical to a working frame`);
-
-    const bodies = stateRules.filter((r) => r.selector.includes(`.status.${state}`) && /::before/.test(r.selector))
-      .map((r) => r.body).join('\n');
-    for (const [, prop, value] of bodies.matchAll(/(?:^|;)\s*(background|border(?:-[\w-]+)?|box-shadow)\s*:\s*([^;]+)/g)) {
-      assert.equal(value.trim(), 'none', `${state} paints ${prop}: ${value.trim()}`);
-    }
+check('every non-working state uses one measured hollow rectangle', () => {
+  const statics = rules.filter((r) => ['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));
+  assert.equal(statics.length, 1, `found ${statics.length} shared static path rules`);
+  const body = statics[0].body;
+  for (const [prop, variable] of [
+    ['left', '--mark-ink-x'], ['top', '--mark-ink-y'],
+    ['width', '--mark-ink-w'], ['height', '--mark-ink-h'],
+  ]) {
+    assert.match(body, new RegExp(`${prop}\\s*:\\s*var\\(${variable}\\)`), `${prop} does not read ${variable}`);
   }
-  assert.equal(seen.size, 4, 'two states share a glyph');
+  assert.match(body, /content\s*:\s*['"]{2}/, 'the static path is still a glyph');
+  assert.match(body, /border\s*:\s*var\(--mark-stroke\)\s+solid\s+currentColor/, 'the path does not use the derived dot stroke');
+  assert.match(body, /background\s*:\s*none/, 'the path has a fill');
+  assert.match(body, /border-radius\s*:\s*0/, 'the path is rounded');
+});
+check('no non-working state overrides that rectangle with its own shape', () => {
+  const offenders = rules.filter((r) => /\.status\.(waiting|idle|stopped)::before/.test(r.selector))
+    .filter((r) => !['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));
+  assert.deepEqual(offenders.map((r) => r.selector), []);
 });
 
 console.log('\nand the plain colour dot is left alone');
@@ -157,7 +156,7 @@ check('the states that are not working carry no animation', () => {
   }
 });
 check('working runs the same animation the rest of the app runs', () => {
-  const w = rules.find((r) => r.selector === '.status.working::before');
+  const w = rules.find((r) => r.selector === '.status.working::before' && /animation:/.test(r.body));
   assert.ok(w, 'no `.status.working::before` rule');
   assert.match(w.body, /animation:\s*ov-spin/, 'working does not use ov-spin');
 });


### PR DESCRIPTION
Follow-up to #82 for the operator's status-mark feedback: non-working states should read as the working braille spinner's completed path, and that mark must render identically in every surface that consumes it.

## What changed

The working sequence remains `⠋⠙⠹⠸⠼⠴⠦⠧`. Waiting, idle and stopped draw the same square-cornered hollow rectangle over the six-dot extent:

| state | shape | treatment |
| --- | --- | --- |
| working | moving braille perimeter | accent |
| waiting | completed hollow path | accent |
| idle | completed hollow path | muted |
| stopped | completed hollow path | muted at 50% opacity |

That is intentionally one static silhouette. Waiting, idle and stopped are not shape-distinguishable in grayscale; they use the requested accent / muted / dim treatment and surrounding state text where present.

## Context parity

#84 places the same `.status` inside `.ph-title`, whose text is weight 600. Before this revision the mark inherited that weight: the pane-title `⠋` rendered **6.00 × 5.875px / 16.34px² alpha area**, versus **5.50 × 5.375px / 10.04px²** at weight 400 in the sidebar and reader. That confirms the operator's heavier, incompletely-disappearing dots were a real font-weight change, not a second mark implementation.

The shared contract now includes `--mark-weight: 400`. Every renderer owns its family, 12.5px size, weight, and line-height, so a 600- or 700-weight parent cannot change it. This covers state marks, Overview progress/group marks, and the reader's working mark.

The cell was centred before, but its ink was not. The natural braille ink sits 0.90625px above the cell centre; the 600-weight 12px pane title's x-height centre is another 0.5px below that centre. I chose optical alignment to the adjacent x-height rather than box-only alignment: moving and static marks receive the same **1.40625px downward correction**. The render test measures the header baseline/x-height and pins their centres within 0.2px.

## Measured geometry

With bundled `GeistMono.woff2` at 12.5px in Chromium, rasterised at 16× and measured at alpha ≥ 16:

- six-dot `⠿` ink: **5.50 × 8.8125px**
- one dot: **1.875 × 1.875px**
- natural ink origin: **1.8125px left, 1.25px top**
- optically corrected rendered origin: **1.8125px left, 2.65625px top**

Chromium quantises CSS border widths to whole CSS pixels: `1.875px` paints as `1px`, so the path uses the nearest paintable stroke, **2px**. If the bundled font fails and a fallback has different braille metrics, the animated glyph can drift relative to the path; the path deliberately remains tied to the shipped font's measurement.

The base `.status` rule remains untouched. Usage provider dots and Settings ready dots remain ordinary 8 × 8 caller-coloured dots. No #84/header component code or Sidebar markup is changed here.

## Verification

- `npm test` — green.
- `npm run test:render` — green. It embeds the bundled font, re-measures the ink, reproduces normal/700-weight/600-weight contexts, proves all marks compute to weight 400, checks shared working/static geometry, measures pane-title x-height alignment, exercises the reader/Overview spinner variants, and pins the bare-dot regressions.
- `npm run build` — green.
- Built app exercised in light and dark themes with working/waiting/idle/stopped on real sidebar rows, real Overview tiles/list cards, and a local pane-title fixture reproducing #84's mono 600-weight centred container.
- Normal animation remains `ov-spin` in the before and after builds; the captures use reduced motion only to hold one comparable frame.

**[Before/after parity sheet — both themes, all three surfaces in each frame →](https://lvwerra-agent-artifacts.static.hf.space/pr87-braille-status-marks.html)**
