### PR TITLE
Reader: the middle of a turn is markdown too

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -128,9 +128,25 @@ Rules that keep this from becoming the ugly viewer in a small box:
 - **One left column, two meanings.** A tool reports its outcome there (`✓` / `✗`); everything
   else offers a disclosure triangle, greyed when there is nothing more to see. The fold control
   above uses the same column and the same triangle, so it reads as the head of the list.
-- **Expanding never repeats itself.** Text steps (thinking, an aside, a compaction) simply stop
-  being truncated — same font, same colour, more of it. Only a tool has genuinely *different*
-  material below: its input and what came back.
+- **Expanding never repeats itself.** A text step's one-line preview is the head row's whole
+  content while it is shut; opened, that row hands the text over and the step's body carries it
+  **rendered as markdown**. An agent writes an aside the way it writes an answer — headings, lists,
+  code spans, links — and for a long time only the answer was rendered, so the middle of a turn
+  showed its syntax raw (`## Plan`, `[the docs](https://…)`). The prose kinds — `note`, `think`,
+  `compact`, named by `proseOf()` — take the same path the answer does,
+  `highlightHtml(renderMarkdown(text), q)`, so a search term is still marked inside the rendered
+  blocks. Three consequences worth stating:
+    - **It renders in the body, not in the head row.** That row is a `<button>`; markdown carries
+      links and block elements, and neither is valid — or clickable — inside one.
+    - **The collapsed preview keeps its syntax.** `## Plan` says the message opens with a heading
+      and ` ``` ` says a code block is coming, which is more than `Plan` tells you, and stripping
+      it would mean a second markdown pass over a string that may be cut mid-token.
+    - **A cut message cannot take the panel with it.** These steps carry a `more` tail, so the text
+      can end mid-fence or mid-table; `marked` closes both itself and DOMPurify reparses what it
+      emits, so no unclosed block escapes to swallow what follows. Pinned in
+      `web/test/stepMarkdown.test.mjs`.
+  What must stay literal, stays literal: a tool's input is JSON, a shell's output and a tool result
+  are terminal bytes where two spaces mean two spaces, and an image is an image.
 - Consecutive calls to the same tool collapse (`✓ Read ×4  App.tsx, api.ts, +2`). The grouping
   logic exists — `ToolGroup` in `TracePane.tsx:86` — and gets reused, not rewritten.
 - **Thinking is one line** with a preview; system/harness turns are not shown at all in the card

--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -286,6 +286,19 @@ pane with nothing to render (a shell) simply stays a terminal.
   two runs of steps with the answer between them. Grouping runs over each side separately, so two
   `Read`s either side of the reply stay two rows rather than collapsing into `Read ×2` and erasing
   the sequence.
+- **One column, and only marks outside it.** The prompt's `❯`, a fold's `▸` and the working line's
+  spinner all hang in the gutter; the summary, the answer, the step rows and the word `working` all
+  start on the same text column. A mark that sits *inside* the column pushes its own row's text
+  sideways, which is what made a turn with no tool calls indent its `13s · 188 tok` by 19px — the
+  row reserved the gutter for a triangle that cannot exist in that state (`.cx-fold.flat` used to
+  pay `padding-left: 1.75em`). The cell is one number, `--cx-mark` on `.cx-meta`, read by both the
+  hang and the glyph's width so they cannot drift apart.
+- **A turn with nothing yet has no meta row.** No steps, no duration, no tokens means no left half,
+  and rendering the row anyway left an empty line above the working line — which read as the widget
+  sitting low, dropped rather than placed. In that state the turn's facts ride on the working line
+  itself, so there is one row instead of one and a half. The working line does not move for this:
+  it is the last row at the text column either way, before and after the first step arrives
+  (checked live, not inferred — the facts move up into the new meta row, the line stays put).
 - **One working line, and it is the last thing in the reader.** It carries what the agent is doing
   *now* (`working · Bash …`), so it belongs at the end of the rail it continues — putting it above
   the steps would report the present before the past, which is the same disorder as the bullet

--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -138,6 +138,14 @@ Rules that keep this from becoming the ugly viewer in a small box:
   blocks. Three consequences worth stating:
     - **It renders in the body, not in the head row.** That row is a `<button>`; markdown carries
       links and block elements, and neither is valid — or clickable — inside one.
+    - **An open `note` is two columns**, the disclosure gutter and the prose beside it. A note has
+      no label, so once its text moved to the body its head row held nothing but a triangle — and a
+      row whose only content is a triangle still takes a line, which read as *"it adds an empty line
+      at the beginning when expanded"*. Nothing was wrong with the rendering: no empty node, no
+      uncollapsed margin, and a leading newline in the source is dropped by markdown anyway (all
+      three are pinned in `stepMarkdown.test.mjs`). The blank line **was** the row. `think` and
+      `compact` keep the stacked layout, because their row says `thinking` or `context compacted`
+      and is therefore not an empty line.
     - **The collapsed preview keeps its syntax.** `## Plan` says the message opens with a heading
       and ` ``` ` says a code block is coming, which is more than `Plan` tells you, and stripping
       it would mean a second markdown pass over a string that may be cut mid-token.

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/settingsMobile.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test": "node test/stepMarkdown.test.mjs && node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/settingsMobile.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
     "test:render": "node test/statusMark.render.test.mjs",
     "preview": "vite preview"
   },

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -225,14 +225,38 @@ export function ExchangeView({
   // Naming the model on every turn is noise when it never changes; when it DOES
   // change mid-session that is worth a word, so say it only then.
   const model = x.model && x.model !== baseModel ? x.model : '';
+  // Which turn, when, and on what — the viewer's business. A card shows one
+  // turn, dated in its own header, so it says none of this. It is one fragment
+  // because two rows can carry it: the meta row normally, and the working line
+  // when the turn has nothing else to say yet.
+  const facts = (
+    <>
+      <span className="spacer" />
+      {model && <span className="cx-model">{model}</span>}
+      {/* Padded to the width of the total, in FIGURE spaces: the row is mono and
+          tabular, so one figure space is exactly one digit, and "turn  9/10"
+          lines up under "turn 10/10" instead of the whole right cluster stepping
+          left the moment a session passes nine turns. A plain space would
+          collapse in HTML. */}
+      <span className="cx-n">turn {padTurn(n ?? 0, total)}{total ? `/${total}` : ''}</span>
+      {x.startTs ? <span className="cx-time">{fmtClock(x.startTs)}</span> : null}
+    </>
+  );
+  const factsOnRunningRow = !summary && !!running && n != null;
 
   return (
     <section className={`cx${dim ? ' dim' : ''}`}>
       {prompt ? <div className="cx-prompt"><Hi text={prompt} q={q} /></div> : null}
 
       {/* Everything about the turn on ONE line, under the prompt: what the work
-          was on the left, which turn it is on the right. Nothing above. */}
-      {(summary || n != null) && (
+          was on the left, which turn it is on the right. Nothing above.
+          A turn that has not done anything yet has no left half — no steps, no
+          duration, no tokens — and rendering the row anyway left an empty line
+          above the `working` line, which is what read as the widget sitting
+          "weirdly low". In that state the facts ride on the working line itself,
+          so there is one row instead of one and a half. The working line does not
+          move: it is the last row either way, at the text column. */}
+      {(summary || (n != null && !factsOnRunningRow)) && (
       <div className="cx-meta mono">
         {steps.length > 0 ? (
           <button className={`cx-fold${isOpen ? ' on' : ''}`} onClick={toggle} title={isOpen ? 'Hide the work' : 'Show the work'}>
@@ -242,19 +266,7 @@ export function ExchangeView({
         ) : <span className="cx-fold flat">{summary}</span>}
         {/* Which turn, when, and on what — the viewer's business. A card shows one
             turn, dated in its own header, so it says none of this. */}
-        {n != null && (
-          <>
-            <span className="spacer" />
-            {model && <span className="cx-model">{model}</span>}
-            {/* Padded to the width of the total, in FIGURE spaces: the row is
-                mono and tabular, so one figure space is exactly one digit, and
-                "turn  9/10" lines up under "turn 10/10" instead of the whole
-                right cluster stepping left the moment a session passes nine
-                turns. A plain space would collapse in HTML. */}
-            <span className="cx-n">turn {padTurn(n, total)}{total ? `/${total}` : ''}</span>
-            {x.startTs ? <span className="cx-time">{fmtClock(x.startTs)}</span> : null}
-          </>
-        )}
+        {n != null && facts}
       </div>
       )}
       {isOpen && stepsBefore.length > 0 && (
@@ -278,6 +290,7 @@ export function ExchangeView({
       {running && (
         <div className="cx-running mono">
           working{latest && <span className="cx-running-at">· {latest}</span>}
+          {factsOnRunningRow && facts}
         </div>
       )}
     </section>

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from 'react';
 import type { TraceTurn } from '../../api';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { fmtClock, fmtDur, fmtTok, oneLine, stepSummary, stepText, stepsOf } from './exchanges';
+import { fmtClock, fmtDur, fmtTok, oneLine, proseOf, stepSummary, stepText, stepsOf } from './exchanges';
 import ToolCall from './ToolCall';
 
 const blocksOf = (t: TraceTurn | TraceTurn[] | null) =>
@@ -113,7 +113,23 @@ function StepRow({ s, q }: { s: Step; q?: string }) {
     : s.kind === 'shell' ? !!s.out.trim()
       : s.kind === 'image' ? true
         : full.trim().length > preview.length || more > 0;
-  const shown = open && full ? full : preview;
+  // Prose kinds — an aside, thinking out loud, a compaction — are markdown, and
+  // an agent writes them like markdown: headings, lists, code spans, links. Only
+  // the ANSWER used to be rendered, so the middle of a turn showed its syntax
+  // raw. It renders through the same path the answer takes, highlight and all.
+  //
+  // Not in the head row: that row is a <button>, and markdown carries links and
+  // block elements, neither of which is valid — or clickable — inside one. So the
+  // row keeps its one-line preview and the rendered prose goes in the body, the
+  // way every other expanded step already works (a tool's input, a shell's
+  // output). `shown` therefore stays the preview at every state.
+  const prose = proseOf(s);
+  const proseHtml = useMemo(
+    () => (open && prose.trim() ? highlightHtml(renderMarkdown(prose), q) : ''), [open, prose, q]);
+  // Open, the head row stops carrying the text: the rendered prose is below it,
+  // and the one-line preview above that would be the same words twice — once as
+  // syntax. Collapsed it is the row's whole content, so it stays.
+  const shown = proseHtml ? '' : preview;
 
   return (
     <div className={`cs${open ? ' open' : ''} ${s.kind}`}>
@@ -122,11 +138,17 @@ function StepRow({ s, q }: { s: Step; q?: string }) {
           ? <span className={`cs-mark ${s.failed ? 'bad' : 'ok'}`}>{s.failed ? '✗' : '✓'}</span>
           : <span className={`cs-tri${can ? '' : ' off'}`}>{open ? '▾' : '▸'}</span>}
         {label && <span className="cs-label mono">{label}</span>}
-        <span className={`cs-detail${open && full ? ' full' : ''}`}><Hi text={shown} q={q} /></span>
+        {shown ? <span className="cs-detail"><Hi text={shown} q={q} /></span> : <span className="cs-detail" />}
       </button>
       {open && (
         <div className="cs-body">
-          {/* the text already expanded above; only its cut tail is left to say */}
+          {/* Rendered, not raw. A truncated message can end mid-fence or
+              mid-table; marked closes both itself and DOMPurify reparses what it
+              emits, so a cut tail cannot leave an open block that swallows the
+              rest of the panel — pinned in test/stepMarkdown.test.mjs. */}
+          {proseHtml ? (
+            <div className="markdown cs-md" dangerouslySetInnerHTML={{ __html: proseHtml }} />
+          ) : null}
           {!!full && !!more && <div className="cs-more mono">…{moreLabel(more)}</div>}
           {s.kind === 'tools' && s.blocks.map((b, i) => (
             b.type === 'tool_use' ? (

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -114,6 +114,18 @@ export type Step =
   | { kind: 'image'; src: string }
   | { kind: 'compact'; text: string };
 
+/**
+ * The prose a step carries, or '' when it carries none.
+ *
+ * These three kinds are the agent writing for a reader — an aside, thinking out
+ * loud, a compaction summary — and it writes them in markdown, so the reader
+ * renders them. The others are not prose and must stay literal: a tool's input
+ * is JSON, a shell's output and a tool result are terminal bytes where two
+ * spaces mean two spaces, and an image is an image.
+ */
+export const proseOf = (s: Step): string =>
+  (s.kind === 'think' || s.kind === 'note' || s.kind === 'compact' ? s.text : '');
+
 // The one field of a tool call worth a line: what it acted on.
 const ARG_KEYS = ['file_path', 'path', 'notebook_path', 'command', 'pattern', 'glob', 'url', 'query', 'prompt', 'description', 'subagent_type'];
 const shortPath = (p: string) => {

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -25,8 +25,16 @@
 .cx-meta {
   display: flex; align-items: baseline; gap: 8px; min-width: 0;
   font-size: 0.85em; color: var(--muted);
+  /* the cell the fold's ▸ hangs in, so the summary starts on the text column —
+     one number, read by .cx-fold's negative margin and by the glyph's width */
+  --cx-mark: calc(1em + 5px);
 }
-.cx-meta .spacer { flex: 1; min-width: 4px; }
+/* the same spacer serves both rows that carry the turn's facts: the meta row,
+   and the working line when the turn has no meta row of its own yet */
+.cx-meta .spacer, .cx-running .spacer { flex: 1; min-width: 4px; }
+/* .cx-running has no `gap` on purpose — the spinner is a ::before flex item and
+   a gap would push `working` off the text column — so the facts space themselves */
+.cx-running .cx-model, .cx-running .cx-n, .cx-running .cx-time { flex: none; margin-left: 8px; }
 .cx-n, .cx-time, .cx-model { flex: none; font-variant-numeric: tabular-nums; }
 .cx-n { color: color-mix(in srgb, var(--accent) 65%, var(--muted)); }
 .cx-model { opacity: 0.8; }
@@ -49,14 +57,24 @@
 
 /* the fold control names what it hides — never a bare caret */
 .cx-fold {
-  display: inline-flex; align-items: baseline; gap: 6px; min-width: 0;
+  display: inline-flex; align-items: baseline; gap: 5px; min-width: 0;
   background: none; border: none; padding: 0; margin: 0;
+  /* the ▸ hangs in the gutter (see below), so the summary starts on the column */
+  margin-left: calc(-1 * var(--cx-mark));
   font: inherit; color: var(--muted); cursor: pointer; text-align: left;
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-/* the inset a folded row's ▸ takes up, so a flat summary starts at the same
-   column — in em, because the triangle is a glyph and grows with the text */
-.cx-fold.flat { cursor: default; padding-left: 1.75em; }
+/* The triangle hangs in the gutter, so the SUMMARY starts on the text column —
+   the same column as the prompt's words, the answer's words and the step rows'
+   text. §3.2's rule is that the prompt's ❯ is the only thing outside that
+   column, and a mark that pushes its own row's text sideways breaks it: a turn
+   with no tool calls has no triangle, so its summary used to start 19px right of
+   everything else (the operator: "they are a bit to the right because of the
+   whitespace where the uncollapse arrow would be"). Reserving the gutter for a
+   control that cannot exist in that state was the bug; now nothing reserves it,
+   because the mark is outside the column in both states. */
+.cx-fold .cs-tri { width: 1em; }
+.cx-fold.flat { cursor: default; margin-left: 0; }
 .cx-fold:hover { color: var(--text); }
 .cx-fold.on { color: var(--text); }
 /* the rail's triangle, borrowed into the smaller meta row: it steps down from
@@ -168,7 +186,10 @@
 .cx-note { font-size: 0.81em; color: var(--muted); padding-top: 4px; }
 
 .cx-running {
+  /* the spinner is a mark, so it hangs in the gutter with the other marks and
+     `working` starts on the text column rather than a cell's width right of it */
   display: flex; align-items: baseline; min-width: 0; font-size: 0.96em; color: var(--muted);
+  margin-left: calc(-1 * var(--mark-w));
 }
 .cx-running-at { margin-left: 7px; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; opacity: 0.85; }
 .cx-running::before {

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -92,12 +92,35 @@
   min-width: 0; flex: 1; font-size: 0.96em; color: var(--muted);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
-/* expanded in place: same font, same colour, just no longer cut */
-.cs-detail.full { white-space: pre-wrap; overflow: visible; text-overflow: clip; overflow-wrap: break-word; }
+/* No `.full` variant any more: a text step used to expand IN the head row, and
+   now the row hands its text to the body to be rendered (see .cs-md below), so
+   the detail is always the one truncated line. */
 .cs.note .cs-detail { color: var(--text); opacity: 0.78; }
 .cs-more { font-size: 0.77em; color: var(--muted); padding: 2px 0 0; }
 /* left inset = the rail column above it, so a body hangs under its own row */
 .cs-body { padding: 2px 0 6px 1em; }
+/* Prose inside a step — an aside, thinking, a compaction — is the same markdown
+   as an answer, one register quieter. A step is a row in a rail, so its headings
+   step down to something that reads as emphasis rather than as a title of the
+   page, and the margins are tight enough that a three-line aside does not
+   present itself as a reply. Same resets as .cx-md: the shared .markdown card
+   brings a border, a background and 14px, none of which belong in a rail. */
+.markdown.cs-md { flex: none; border: none; background: none; padding: 0; font-size: 0.96em; line-height: 1.5; }
+.cs-md > :first-child { margin-top: 0; }
+.cs-md > :last-child { margin-bottom: 0; }
+.cs-md p, .cs-md ul, .cs-md ol, .cs-md blockquote, .cs-md pre, .cs-md table { margin: 0 0 6px; }
+.cs-md ul, .cs-md ol { padding-left: 1.5em; }
+.cs-md h1, .cs-md h2, .cs-md h3, .cs-md h4 { margin: 7px 0 3px; line-height: 1.3; }
+.cs-md h1 { font-size: 1.15em; }
+.cs-md h2 { font-size: 1.08em; }
+.cs-md h3, .cs-md h4 { font-size: 1em; }
+.cs-md pre { font-size: 0.9em; }
+/* and each kind keeps the colour it had as plain text, or a rendered aside would
+   read as the agent's reply and rendered thinking would stop looking like
+   thinking (the same two colours .cs-detail and .cs-pre.think already use) */
+.cs.think .cs-md { color: color-mix(in srgb, #8b73c4 70%, var(--text)); }
+.cs.note .cs-md { color: var(--text); opacity: 0.85; }
+.cs.compact .cs-md { color: var(--muted); }
 .cs-pre {
   white-space: pre-wrap; word-break: break-word; margin: 3px 0; padding: 6px 8px;
   background: var(--panel-2); border-radius: var(--r-sm);

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -99,6 +99,21 @@
 .cs-more { font-size: 0.77em; color: var(--muted); padding: 2px 0 0; }
 /* left inset = the rail column above it, so a body hangs under its own row */
 .cs-body { padding: 2px 0 6px 1em; }
+/* An open note is TWO COLUMNS: the disclosure gutter, and the prose beside it.
+   A note has no label, so once its text moved to the body the head row had
+   nothing left in it — and a row whose only content is a 14px triangle still
+   takes a line, which is the "empty line at the beginning" it read as. Nothing
+   was wrong with the markdown: no empty node, no uncollapsed margin, no leading
+   newline in the source (markdown drops those anyway). The blank line WAS the
+   row. So the triangle now sits beside the first line it belongs to, and the
+   gutter it lives in is what you press to close the step again.
+   `think` and `compact` keep the stacked layout: their row says `thinking` or
+   `context compacted`, so it is not an empty line. */
+.cs.note.open { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: start; }
+.cs.note.open > .cs-head { grid-column: 1; width: auto; align-self: stretch; padding-right: 0; }
+.cs.note.open > .cs-head .cs-detail { display: none; }
+.cs.note.open > .cs-body { grid-column: 2; padding: 0 0 6px 0.45em; }
+
 /* Prose inside a step — an aside, thinking, a compaction — is the same markdown
    as an answer, one register quieter. A step is a row in a rail, so its headings
    step down to something that reads as emphasis rather than as a title of the

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -48,6 +48,15 @@ await build({
   external: ['react', 'react-dom', 'react/jsx-runtime'], plugins: [stubMarkdown],
 });
 const { PendingExchange, ExchangeView } = await import(pathToFileURL(out).href);
+// stepSummary decides whether a turn has a left half at all, so the two live in
+// the same check: no summary → the facts ride the working line.
+const exOut = path.join(outDir, 'exchanges-meta.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
+  outfile: exOut, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { stepSummary, stepsOf: stepsOfEx } = await import(pathToFileURL(exOut).href);
+const stepSummaryOf = (x) => stepSummary(x, stepsOfEx(x.steps));
 
 let failed = 0;
 const check = (what, fn) => {
@@ -145,6 +154,73 @@ check('and the padded cell is exactly as wide as the widest one', () => {
 });
 check('a session that never reaches ten pads nothing',
   () => assert.equal(turnCell(3, 9), 'turn 3/9'));
+
+console.log('\nand the meta row lines up in the two states that have no work');
+// Both reported from dev. A turn with nothing yet — no steps, no duration, no
+// tokens — used to render an empty meta row above the working line, which read
+// as the widget sitting "weirdly low"; and a finished turn with no tool calls
+// used to indent its summary into the gutter where the expand triangle would be,
+// for a triangle that cannot exist in that state.
+const emptyTurn = {
+  key: 'x9', at: 9, startTs: 1_700_000_000_000, endTs: 1_700_000_000_000, tokens: 0, toolCalls: 0,
+  prompt: { role: 'user', ts: 1_700_000_000_000, blocks: [{ type: 'text', text: 'now look at the packer' }] },
+  steps: [], answer: [],
+};
+const quietTurn = {
+  ...emptyTurn, key: 'x8', at: 8, endTs: 1_700_000_013_000, tokens: 188,
+  prompt: { role: 'user', ts: 1_700_000_000_000, blocks: [{ type: 'text', text: "that's nice" }] },
+  answer: [{ role: 'assistant', ts: 1_700_000_013_000, kind: 'final', blocks: [{ type: 'text', text: 'Quiet turn, then.' }] }],
+};
+check('a turn with nothing yet has no summary to show', () => {
+  assert.equal(stepSummaryOf(emptyTurn), '', 'an empty turn should summarise to nothing');
+});
+check('so while it works, the facts ride the working line and there is no empty row', () => {
+  const html = render(ExchangeView, { x: emptyTurn, n: 9, total: 9, running: true });
+  assert.ok(!html.includes('class="cx-meta'), 'no meta row should be rendered');
+  const run = html.slice(html.indexOf('cx-running'));
+  assert.match(run, /class="cx-n"/, 'the turn number should be on the working line');
+  assert.match(run, /class="cx-time"/, 'and the clock with it');
+});
+check('the working line is still the last thing in the turn', () => {
+  const html = render(ExchangeView, { x: emptyTurn, n: 9, total: 9, running: true });
+  assert.ok(html.lastIndexOf('cx-running') > html.lastIndexOf('cx-prompt'));
+});
+check('once there is a summary the facts are back on the meta row', () => {
+  const html = render(ExchangeView, { x: { ...emptyTurn, endTs: emptyTurn.startTs + 31_000, tokens: 4300 }, n: 9, total: 9, running: true });
+  const meta = html.slice(html.indexOf('cx-meta'), html.indexOf('cx-running'));
+  assert.match(meta, /class="cx-n"/, 'the facts belong to the meta row as soon as it exists');
+  const run = html.slice(html.indexOf('cx-running'));
+  assert.ok(!run.includes('class="cx-n"'), 'and not on the working line as well');
+});
+check('a finished turn with no tool calls says so with a flat fold', () => {
+  const html = render(ExchangeView, { x: quietTurn, n: 8, total: 9 });
+  assert.match(html, /class="cx-fold flat"/, 'no steps means nothing to unfold');
+  assert.match(html, /13s/);
+});
+
+console.log('\nand nothing reserves the gutter for a control that cannot exist');
+{
+  const css = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');
+  const rule = (sel) => { const i = css.indexOf(sel); return i < 0 ? null : css.slice(i, css.indexOf('}', i) + 1); };
+  check('a flat fold has no left padding at all', () => {
+    const r = rule('.cx-fold.flat {');
+    assert.ok(r, 'no .cx-fold.flat rule');
+    assert.doesNotMatch(r, /padding-left/, `a flat summary must start on the text column: ${r}`);
+  });
+  check('and an expandable one hangs its triangle by exactly the mark cell', () => {
+    assert.match(rule('.cx-fold {') || '', /margin-left:\s*calc\(-1 \* var\(--cx-mark\)\)/);
+    assert.match(rule('.cx-meta {') || '', /--cx-mark:/);
+  });
+  check('the facts on the working line are pushed right, like on the meta row', () => {
+    // the DOM assertions above pass whether or not this exists; without it the
+    // row renders "workingturn 3/301:02 PM", which only a screenshot shows
+    assert.match(rule('.cx-meta .spacer, .cx-running .spacer {') || '', /flex:\s*1/);
+    assert.match(rule('.cx-running .cx-model, .cx-running .cx-n, .cx-running .cx-time {') || '', /margin-left/);
+  });
+  check('the working line hangs its spinner the same way', () => {
+    assert.match(rule('.cx-running {') || '', /margin-left:\s*calc\(-1 \* var\(--mark-w\)\)/);
+  });
+}
 
 console.log('\nand the CSS pair the nesting exists for is still a pair');
 const css = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');

--- a/web/test/stepMarkdown.test.mjs
+++ b/web/test/stepMarkdown.test.mjs
@@ -1,0 +1,88 @@
+// Intermediate messages render as markdown — and a truncated one cannot take the
+// panel down with it.
+//
+// Only the ANSWER used to be rendered (`highlightHtml(renderMarkdown(answer))`),
+// so an agent's mid-turn message — which is written with headings, lists, code
+// spans and links like everything else it writes — was shown as raw syntax. The
+// prose kinds (`note`, `think`, `compact`) now take the same path.
+//
+// Two things are worth pinning rather than eyeballing:
+//   1. these messages carry a `more` tail, so `full` can end mid-fence or
+//      mid-table, and a renderer that emits an unclosed <pre> would swallow
+//      everything after it in the panel;
+//   2. the rendered prose must sit in the step's BODY, not in its head row —
+//      that row is a <button>, and links inside a button are neither valid nor
+//      clickable.
+// Run with:  node test/stepMarkdown.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { marked } from 'marked';
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+const balanced = (html, tag) =>
+  (html.match(new RegExp(`<${tag}[ >]`, 'g')) || []).length === (html.match(new RegExp(`</${tag}>`, 'g')) || []).length;
+
+console.log('a message cut mid-markdown still closes its blocks');
+for (const [what, md] of [
+  ['a fence cut open', 'The plan:\n\n```js\nconst rows = await db.all("SELECT 1")\nconst next = rows.map('],
+  ['a table cut mid-row', '| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 |'],
+  ['a list cut mid-item', '- read the generator\n- merge by `name`\n- cap the candid'],
+  ['a heading cut mid-word', '## Pla'],
+]) {
+  check(`${what} → balanced pre/code/table`, () => {
+    const html = marked.parse(md, { async: false });
+    for (const tag of ['pre', 'code', 'table', 'ul', 'ol']) {
+      assert.ok(balanced(html, tag), `${tag} left open by: ${what}`);
+    }
+  });
+}
+check('an unterminated code span stays literal rather than eating the rest', () => {
+  const html = marked.parse('I will edit `server/src/runner and then stop', { async: false });
+  assert.ok(!html.includes('<code>'), `expected no code element, got ${html}`);
+});
+
+// ---- which kinds are prose, and which must stay literal. This is the scope
+// decision itself, as a pure function — the browser is where the rendered output
+// and the search highlight over it are checked, because `highlightHtml` walks
+// text nodes with DOMParser and node has no DOM.
+const outDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const exOut = path.join(outDir, 'exchanges-md.mjs');
+await build({
+  entryPoints: [path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/components/conversation/exchanges.ts')],
+  outfile: exOut, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { proseOf, stepsOf } = await import(pathToFileURL(exOut).href);
+
+console.log('\nand only the agent\u2019s own prose goes through the renderer');
+const proseKinds = [
+  ['note', { kind: 'note', text: '## Plan\n\n- read `runner.js`' }, true],
+  ['think', { kind: 'think', text: 'weighing **poll** against `fs.watch`' }, true],
+  ['compact', { kind: 'compact', text: 'Context compacted. **Kept**: the plan.' }, true],
+  ['tools', { kind: 'tools', name: 'Read', count: 1, details: ['runner.js'], failed: false, blocks: [] }, false],
+  ['shell', { kind: 'shell', command: 'ls -la', out: 'total 4  -rw-r--r--' }, false],
+  ['image', { kind: 'image', src: 'data:image/png;base64,AA' }, false],
+];
+for (const [kind, step, isProse] of proseKinds) {
+  check(`${kind.padEnd(7)} ${isProse ? 'renders' : 'stays literal'}`,
+    () => assert.equal(proseOf(step) !== '', isProse));
+}
+check('a tool result is not prose either — two spaces there mean two spaces', () => {
+  const [step] = stepsOf([{ role: 'assistant', ts: 1, blocks: [
+    { type: 'tool_use', name: 'Bash', text: '{"command":"ls"}' },
+    { type: 'tool_result', text: 'a.md   b.md', failed: false },
+  ] }]);
+  assert.equal(proseOf(step), '', 'a tools step carries no prose');
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/stepMarkdown.test.mjs
+++ b/web/test/stepMarkdown.test.mjs
@@ -61,7 +61,55 @@ await build({
   entryPoints: [path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/components/conversation/exchanges.ts')],
   outfile: exOut, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { proseOf, stepsOf } = await import(pathToFileURL(exOut).href);
+const { proseOf, stepsOf, oneLine } = await import(pathToFileURL(exOut).href);
+
+console.log('\nand nothing is inserted at the top of a rendered message');
+// Reported from dev: "it seems to add an empty line at the beginning when
+// expanded". Three candidates were plausible and only one was true — the blank
+// line was the head ROW, which had handed its text to the body and still took a
+// line (fixed in CSS below). These pin the two candidates that were NOT the
+// cause, because a future renderer swap could make either one real:
+for (const [what, md] of [
+  ['a message that starts with a blank line', '\n\nAnswer to your question: **yes**.\n\nMore.'],
+  ['one that starts with blank lines and spaces', '   \n\n  Answer with an indent.'],
+  ['one that starts straight in', 'Answer to your question: **yes**.'],
+]) {
+  check(`${what} → no empty node at the top`, () => {
+    const html = marked.parse(md, { async: false });
+    assert.doesNotMatch(html, /^<p>\s*<\/p>/, `leading empty paragraph: ${html.slice(0, 60)}`);
+    assert.match(html.trim(), /^<(p|h[1-6]|ul|ol|pre|blockquote|table)[ >]/, `starts with something odd: ${html.slice(0, 60)}`);
+  });
+}
+check('and the collapsed preview trims it too, so the two agree', () => {
+  assert.equal(oneLine('\n\n  Answer to your question: yes.', 90), 'Answer to your question: yes.');
+});
+
+console.log('\nand an open note does not spend a line on an empty head row');
+// The actual cause: a note has no label, so once its text moved to the body the
+// head row held nothing but a triangle — and still took a line. Open, the step is
+// two columns, so the triangle sits beside the first line instead of above it.
+{
+  const css = fs.readFileSync(path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/conversation.css'), 'utf8');
+  const rule = (sel) => {
+    const i = css.indexOf(sel);
+    return i < 0 ? null : css.slice(i, css.indexOf('}', i) + 1);
+  };
+  check('.cs.note.open lays out in two columns', () => {
+    const r = rule('.cs.note.open {');
+    assert.ok(r, 'no .cs.note.open rule');
+    assert.match(r, /display:\s*grid/);
+    assert.match(r, /grid-template-columns:\s*auto/);
+  });
+  check('…with the emptied detail slot taken out of the flow', () => {
+    assert.match(rule('.cs.note.open > .cs-head .cs-detail {') || '', /display:\s*none/);
+  });
+  check('…and no top padding left above the first block', () => {
+    assert.match(rule('.cs.note.open > .cs-body {') || '', /padding:\s*0/);
+  });
+  check('a labelled prose step keeps the stacked layout — its row is not empty', () => {
+    assert.equal(rule('.cs.think.open {'), null, 'think should not have gained the grid');
+  });
+}
 
 console.log('\nand only the agent\u2019s own prose goes through the renderer');
 const proseKinds = [


### PR DESCRIPTION
> intermediate agent messages in the reader are not rendered as md although they come with md syntax.

**[Before/after captures →](https://claude.ai/code/artifact/a6e6f468-ecbd-4d07-a5db-fd31b242ea8e)**

**Stacked on [#85](https://github.com/huggingface/agent-manager/pull/85)** (`design/reader-order`), which restructures this same file — `StepRow` and the step rail. Base is that branch, not main, so this diff is only the markdown change; it needs #85 to land first, and GitHub will retarget it to main automatically when that happens.

## What was wrong

Only the answer was ever rendered — `highlightHtml(renderMarkdown(answer), q)` into `.markdown.cx-md` (`Exchange.tsx:181,221`). Everything the agent said on the way there is a `Step` of kind `note` / `think` / `compact`, rendered through `<Hi text={shown} q={q} />`: plain text plus search highlighting. So a mid-turn message arrived with headings, lists, code spans and links and was printed as syntax.

## What changed

`proseOf()` in `exchanges.ts` names the kinds that are the agent *writing for a reader* — `note`, `think`, `compact` — and `StepRow` sends those through the answer's own path. Everything else stays literal.

**It renders in the body, not in the head row.** That row is a `<button>`, and markdown carries links and block elements; neither is valid — or clickable — inside one. So the row keeps its one-line preview while shut, hands the text over when open, and the rendered prose sits in `.cs-body`, the way a tool's input and a shell's output already do.

That narrows the old rule rather than breaking it: "expanding never repeats itself" becomes *expanding never shows the same words twice* — which printing the syntax above a rendered copy would. I built it the other way first (preview kept above the rendered prose) and the duplication was the reason to change it; both variants are in the captures.

## The four things you flagged

| | |
|---|---|
| **1. highlighting** | Same path as the answer, `highlightHtml(renderMarkdown(text), q)` — the helper walks text nodes only, so tags survive. Searching “index” marks **2 hits inside the rendered prose**, parents `strong` and `p`: the bold survived and the mark went inside it. |
| **2. the preview** | **Stays raw**, deliberately. `## Plan` says the message opens with a heading and ` ``` ` says code is coming — `Plan` says less. Stripping would also mean a second markdown pass over a string that may be cut mid-token, i.e. a second renderer path to get wrong. |
| **3. truncation** | `marked` closes a cut fence, table or list itself, and DOMPurify reparses what it emits. Verified on a **27,603-char** message that the 20,000-char `VIEW_BLOCK_CAP` cuts *inside* a fence: the step renders, its `…+7,603 chars not retained` line follows, and every later step and answer still renders (`steps in the last exchange: 2, answers on screen: 3`, no page errors). |
| **4. scope** | In: `note`, `think`, `compact`. Out: a tool's input (JSON, and `ToolCall` already formats it), a shell's output and a tool result (terminal bytes — two spaces mean two spaces, and markdown would eat them), an image. |

Each kind also keeps the colour it had as plain text, so a rendered aside doesn't present itself as the reply and rendered thinking still looks like thinking. And the now-dead `.cs-detail.full` rule goes with the in-place expansion it styled.

## Verified

Measured on both builds against a fixture whose middle messages carry a heading, an ordered list, code spans, a link, a fenced block and a quote:

| | branch point (#85) | this branch |
|---|---|---|
| prose steps rendered | `markdown=false`, `tags=-` | `markdown=true`, `tags=h2,p,ol,li,code,strong,a,pre,blockquote` |
| head row when open | carries the whole message | one-line preview handed over |
| highlights inside prose | 0 | 2 |
| the cut message's row, 390pt | 332px tall | 281px — rendering is *shorter* than printing syntax |

`web/test/stepMarkdown.test.mjs` (new, wired into `npm test`) pins the two halves node can hold: truncated fences/tables/lists close and an unterminated code span stays literal; and `proseOf` answers which kinds render. Mutation-checked — letting shell output through the renderer fails it. The highlight-over-markdown path needs a DOM (`highlightHtml` uses `DOMParser`), so it is checked in the browser instead, and the number above is from that run rather than from a green tick.

Web suite and typecheck green; server suite green.

## Collisions

Trial-merged against **#84** (`feat/trace-share-and-reader-info`) at its current head: **one conflict, `web/package.json`** — the recurring `test` script line. Its branch now also carries `statusMark`, `fileWrapToggle` and `settingsMobile` suites plus a `test:render` script, so the resolution is to keep both lists and both scripts. `ConversationView.tsx` and `conversation.css` do **not** conflict: #84's work is the bar and the `i` panel, mine is `StepRow` and `.cs-md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
