### PR TITLE
Close the hole between the back arrow and the agent logo

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -728,11 +728,13 @@ body {
    already reachable with a long enough agent name; putting the group in front
    of the name made it reachable at ordinary ones. With the floor the title is
    capped at what is actually free and ellipsises instead. */
-/* The vertical padding is a variable because .ph-back cancels it to reach the
-   header's full height without adding any (below). A bleed that restated the
-   number would drift the first time this padding changed — the same way a
-   hardcoded 14px against an 8px gutter gave the phone a sideways scroll. */
-.pane-head { --ph-pad-y: 7px; container-type: inline-size; display: grid; grid-template-columns: minmax(min-content, 1fr) minmax(0, auto) minmax(min-content, 1fr); align-items: center; gap: 9px; padding: var(--ph-pad-y) 11px; background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; flex: none; }
+/* Both paddings are variables because .ph-back is laid out against them: it
+   cancels the vertical one to reach the header's full height, and it spends the
+   horizontal one as its own left padding so its hit area fills the gutter. A
+   bleed that restated either number would drift the first time this padding
+   changed — the same way a hardcoded 14px against an 8px gutter gave the phone
+   a sideways scroll. */
+.pane-head { --ph-pad-y: 7px; --ph-pad-x: 11px; container-type: inline-size; display: grid; grid-template-columns: minmax(min-content, 1fr) minmax(0, auto) minmax(min-content, 1fr); align-items: center; gap: 9px; padding: var(--ph-pad-y) var(--ph-pad-x); background: var(--panel); border-bottom: 1px solid var(--border); font-size: 12px; flex: none; }
 .pane-head .ph-left { grid-column: 1; justify-self: start; display: inline-flex; align-items: center; gap: 7px; }
 .pane-head .ph-title { grid-column: 2; min-width: 0; max-width: 100%; display: inline-flex; align-items: center; justify-content: center; gap: 5px; font-family: var(--font-mono); font-weight: 600; white-space: nowrap; overflow: hidden; cursor: text; }
 /* `[Group] name` is one title in two parts, and the group is the only part that
@@ -754,8 +756,20 @@ body {
 /* The way back on a phone, left of the agent's logo. It stretches to the
    header's own height — cancelling that height's padding rather than adding any
    — because a taller header would hand straight back the row that dropping the
-   bar above it won (see .mbar). */
-.pane-head .ph-back { align-self: stretch; margin: calc(-1 * var(--ph-pad-y)) 1px calc(-1 * var(--ph-pad-y)) -5px; padding: 0 8px; }
+   bar above it won (see .mbar).
+   Horizontally it is all left: the padding it needs to stay a thumb-sized
+   target is spent on the side away from the logo, and cancelled by an equal
+   negative margin on the side facing it. So the hit area REACHES INTO the space
+   between arrow and logo instead of MAKING that space, and what you see is the
+   7px .ph-left already puts between every other pair in the row — not 16px.
+   The left margin gives the same treatment to the header's own gutter: the
+   target starts at the very edge of the pane, which is where a thumb reaching
+   across a phone arrives first. */
+.pane-head .ph-back {
+  align-self: stretch;
+  margin: calc(-1 * var(--ph-pad-y)) -8px calc(-1 * var(--ph-pad-y)) calc(-1 * var(--ph-pad-x));
+  padding: 0 8px 0 var(--ph-pad-x);
+}
 .pane-head .ph-back svg { width: 15px; height: 15px; }
 @container (max-width: 520px) {
   .pane-head .ph-path { display: none; }


### PR DESCRIPTION
> when there is a go back arrow on the window, it has a bit too much whitespace to the agent icon, can we reduce it a bit?

Follow-up to #75. It was **16px** — the arrow's 8px right padding, plus 1px of margin, plus the 7px `.ph-left` puts between every pair in that row. Every other pair in the header sits at 7px, so it read as a hole because it was one.

**[Screenshots, measurements and the hit-test →](https://claude.ai/code/artifact/c8aa92da-ce67-40b3-b90e-81378b2dfd40)**

## The padding did not go away

Taking it off the right would have been the one-line version, but that padding is what makes the arrow a thumb-sized target — #75 deliberately made it *taller* than the control it replaced, and a 23px-wide button on a phone would be a bad trade for tidier spacing.

So the padding moves to the side away from the logo, and the side facing the logo cancels its own with an equal negative margin:

```css
margin:  … -8px … calc(-1 * var(--ph-pad-x));
padding: 0  8px 0  var(--ph-pad-x);
```

The hit area **reaches into** the space between arrow and logo instead of **making** it. The left margin does the same to the header's own gutter, so the target starts at the very edge of the pane rather than 6px inside it — which is where a thumb reaching across a phone arrives first.

`--ph-pad-x` joins `--ph-pad-y` as a variable for the reason #75 made the first one: `.ph-back` is laid out *against* the header's padding, so a restated number drifts the moment that padding changes. The comment says so.

## Measured, at 320 and 390 (identical at both)

| | before | after |
| --- | --- | --- |
| gap, arrow to logo | 16px | **7px** |
| hit target | 31 × 36 | **34 × 36** |
| target's left edge | 6px inside the pane | **flush** |
| the arrow's own position | 14px | 11px |

The target is **larger**, not smaller — which was the constraint.

## Hit-tested rather than read off the CSS

`elementFromPoint` in a touch context (`hasTouch`, `isMobile`), after the change:

- ✅ centre of the button
- ✅ all four corners
- ✅ the pane's leading edge — dead space before, the target now
- ❌ the agent logo, and its left edge — still **not** the back button

That last one is the point of the overlap: it reaches into the gap without stealing the tap that belongs to the icon beside it.

## Desktop

Unaffected — it has no back arrow. Its header pixel-diff is 52px, which is **exactly** the number two runs of the *same* build produce, so it is the live status dot rather than this change. The phone headers differ by **0px** between identical runs, so the 7120px there is all signal.

Web and server suites green.

One thing worth flagging for whoever runs this next: I first measured against port 7803 and got nonsense (no arrow at all) because another agent's server already held it and mine had exited with `EADDRINUSE` into its log. The numbers above are from a verified-own instance — served bundle hash checked against `dist/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
