### PR TITLE
Discover test suites instead of listing them by hand

### DIFF
--- a/scripts/run-suites.mjs
+++ b/scripts/run-suites.mjs
@@ -27,10 +27,19 @@
 // OPTING OUT. A suite that must not run in the default set says so in its own
 // header, on a line containing `am-test: manual` plus the reason. It is declared
 // where a reader will see it rather than by absence from a list somewhere else,
-// and every run prints what it skipped and why, so coverage cannot go quiet.
+// and every run prints what it skipped and why — on the failure path too, since
+// that is the moment someone is actually reading this output.
 //
-// Usage:  node ../scripts/run-suites.mjs [substring …]
-//         (a substring filters to matching suites — for running one by hand)
+// DISCOVERY IS TWO DEEP, ON PURPOSE: `test/` and the package root, so a
+// `test/fixtures/` directory is fixtures rather than a source of surprise runs.
+// A `*.test.mjs` anywhere below that is reported at the end of every run instead
+// of being ignored — a file that looks like a suite and never runs is the exact
+// failure this script exists to end, and it does not matter that the cause is a
+// subdirectory rather than a hand-edited list.
+//
+// Usage:  node ../scripts/run-suites.mjs [substring …] [--manual]
+//         a substring filters to matching suites — for running one by hand;
+//         --manual lets that filter reach the suites marked manual.
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -53,7 +62,10 @@ const listDir = (dir) => {
 // test/) at the front of the run.
 const found = [...listDir('test'), ...listDir('.')];
 
-const filters = process.argv.slice(2);
+const args = process.argv.slice(2);
+const wantManual = args.includes('--manual');
+const filters = args.filter((a) => !a.startsWith('--'));
+const matches = (file) => !filters.length || filters.some((f) => file.includes(f));
 const suites = [];
 const skipped = [];
 for (const file of found) {
@@ -65,17 +77,55 @@ for (const file of found) {
     fs.closeSync(fd);
   } catch { /* unreadable: let node report it */ }
   const manual = head.match(MANUAL);
-  if (manual) { skipped.push({ file, why: manual[1].trim() }); continue; }
-  if (filters.length && !filters.some((f) => file.includes(f))) continue;
+  // Named explicitly with --manual, a manual suite runs: the filter is the
+  // run-one-by-hand path, and the suites worth running by hand are mostly these.
+  if (manual && !(wantManual && filters.length && matches(file))) {
+    if (matches(file)) skipped.push({ file, why: manual[1].trim() });
+    continue;
+  }
+  if (!matches(file)) continue;
   suites.push(file);
 }
 
+// Anything that looks like a suite but sits below the two scanned depths.
+const stray = [];
+(function walk(dir, depth) {
+  let entries = [];
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+  for (const e of entries) {
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      if (['node_modules', '.git', 'dist', 'coverage'].includes(e.name)) continue;
+      walk(p, depth + 1);
+    } else if (e.name.endsWith('.test.mjs') && depth > 0 && path.dirname(p) !== 'test') {
+      stray.push(p);
+    }
+  }
+}('.', 0));
+
+const plural = (n) => `${n} suite${n === 1 ? '' : 's'}`;
+// Printed by BOTH exits. What did not run is most worth saying when something
+// failed, and that is exactly when an early `process.exit` used to swallow it.
+const report = () => {
+  for (const { file, why } of skipped) console.log(`  skipped ${file} — ${why || 'marked manual'}`);
+  for (const file of stray) {
+    console.log(`  NOT RUN ${file} — below \`test/\` and the package root, where discovery looks.`);
+    console.log('          Move it up, or mark it `am-test: manual` with a reason, or rename it.');
+  }
+};
+
 const pkg = path.basename(process.cwd());
 if (!suites.length) {
-  console.error(`no suites found in ${pkg}/${filters.length ? ` matching ${filters.join(', ')}` : ''}`);
+  // Blaming the filter here sends people looking for a typo when the file was
+  // found and deliberately excluded.
+  const manualOnly = skipped.length && filters.length;
+  console.error(manualOnly
+    ? `${pkg}/: ${plural(skipped.length)} matched ${filters.join(', ')}, all marked manual:`
+    : `no suites found in ${pkg}/${filters.length ? ` matching ${filters.join(', ')}` : ''}`);
+  report();
+  if (manualOnly) console.error(`Run one anyway with: npm test -- ${filters.join(' ')} --manual`);
   process.exit(1);
 }
-const plural = (n) => `${n} suite${n === 1 ? '' : 's'}`;
 console.log(`${pkg}: ${plural(suites.length)}\n`);
 
 for (const [i, file] of suites.entries()) {
@@ -85,10 +135,11 @@ for (const [i, file] of suites.entries()) {
   if (code !== 0) {
     console.error(`\n${file} FAILED (${r.signal ? `signal ${r.signal}` : `exit ${code}`})`);
     console.error(`${plural(i)} had passed before it; the rest were not started.`);
+    report();
     process.exit(code);
   }
   console.log('');
 }
 
 console.log(`${pkg}: ${plural(suites.length)} passed`);
-for (const { file, why } of skipped) console.log(`  skipped ${file} — ${why || 'marked manual'}`);
+report();

--- a/scripts/run-suites.mjs
+++ b/scripts/run-suites.mjs
@@ -1,0 +1,94 @@
+// Runs a package's test suites: every `*.test.mjs` in `test/`, then every one at
+// the package root, in that order, one at a time.
+//
+// WHY THIS EXISTS. Both package.json files used to carry the suite list by hand
+// —  `node a.test.mjs && node b.test.mjs && …` on one line. Every PR that added
+// a test edited that line, so any two such PRs conflicted by construction (six
+// times in the last few days), and the natural resolution — take one side —
+// silently drops the other PR's suite from the run. It stays green and nobody
+// notices the coverage is gone. Discovery removes the shared line: adding
+// `test/foo.test.mjs` is enough to make it run.
+//
+// SEQUENTIAL, DELIBERATELY. `node --test` would also discover these files, but
+// it runs them in PARALLEL by default, and several suites here start a real
+// server on a fixed port (migration on 7893, resize on 7895, trace-download on
+// 7898) or drive Chromium. Those ports do not collide today, but only because
+// whoever added each one picked a free number — nothing enforces it, and the
+// first suite that copies an existing PORT constant produces a flake that reads
+// as a product bug. This fleet has already lost time to exactly that symptom.
+// One at a time costs wall-clock and nothing else.
+//
+// EXIT SEMANTICS match the `&&` chain it replaces: the first failing suite stops
+// the run and its exit code is this process's exit code. That holds for both
+// kinds of file here — the standalone scripts that print their own results and
+// call process.exit, and the two `node:test` suites, which node exits non-zero
+// for when a test fails (verified, not assumed).
+//
+// OPTING OUT. A suite that must not run in the default set says so in its own
+// header, on a line containing `am-test: manual` plus the reason. It is declared
+// where a reader will see it rather than by absence from a list somewhere else,
+// and every run prints what it skipped and why, so coverage cannot go quiet.
+//
+// Usage:  node ../scripts/run-suites.mjs [substring …]
+//         (a substring filters to matching suites — for running one by hand)
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const MANUAL = /am-test:\s*manual\s*[—:-]?\s*(.*)/;
+const HEAD_BYTES = 4096;          // the marker belongs in the header, not line 900
+
+const listDir = (dir) => {
+  let names = [];
+  try { names = fs.readdirSync(dir); } catch { return []; }
+  return names
+    .filter((n) => n.endsWith('.test.mjs'))
+    .sort((a, b) => a.localeCompare(b, 'en'))
+    .map((n) => path.join(dir, n))
+    .filter((p) => fs.statSync(p).isFile());
+};
+
+// `test/` first, then the package root: the root files are the older ones, and
+// keeping them behind the directory keeps the common case (a new suite in
+// test/) at the front of the run.
+const found = [...listDir('test'), ...listDir('.')];
+
+const filters = process.argv.slice(2);
+const suites = [];
+const skipped = [];
+for (const file of found) {
+  let head = '';
+  try {
+    const fd = fs.openSync(file, 'r');
+    const buf = Buffer.alloc(HEAD_BYTES);
+    head = buf.subarray(0, fs.readSync(fd, buf, 0, HEAD_BYTES, 0)).toString('utf8');
+    fs.closeSync(fd);
+  } catch { /* unreadable: let node report it */ }
+  const manual = head.match(MANUAL);
+  if (manual) { skipped.push({ file, why: manual[1].trim() }); continue; }
+  if (filters.length && !filters.some((f) => file.includes(f))) continue;
+  suites.push(file);
+}
+
+const pkg = path.basename(process.cwd());
+if (!suites.length) {
+  console.error(`no suites found in ${pkg}/${filters.length ? ` matching ${filters.join(', ')}` : ''}`);
+  process.exit(1);
+}
+const plural = (n) => `${n} suite${n === 1 ? '' : 's'}`;
+console.log(`${pkg}: ${plural(suites.length)}\n`);
+
+for (const [i, file] of suites.entries()) {
+  console.log(`── [${i + 1}/${suites.length}] ${file}`);
+  const r = spawnSync(process.execPath, [file], { stdio: 'inherit' });
+  const code = r.status === null ? 1 : r.status;
+  if (code !== 0) {
+    console.error(`\n${file} FAILED (${r.signal ? `signal ${r.signal}` : `exit ${code}`})`);
+    console.error(`${plural(i)} had passed before it; the rest were not started.`);
+    process.exit(code);
+  }
+  console.log('');
+}
+
+console.log(`${pkg}: ${plural(suites.length)} passed`);
+for (const { file, why } of skipped) console.log(`  skipped ${file} — ${why || 'marked manual'}`);

--- a/server/mobile.test.mjs
+++ b/server/mobile.test.mjs
@@ -5,6 +5,7 @@
 // visual viewport is replaced with a controllable EventTarget so the keyboard
 // test covers both viewport height and iOS's non-zero offsetTop.
 //
+// am-test: manual — Chromium, a full web build and port 7896; `npm run test:mobile`.
 //   npm run test:mobile
 import fs from 'node:fs';
 import os from 'node:os';

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs",
     "test:screenshots": "node screenshot-input.test.mjs",
     "test:mobile": "node mobile.test.mjs",
-    "test": "node test/archive.test.mjs && node test/trace-download.test.mjs && node test/attachments.test.mjs && node state-checkpoint.test.mjs && node test/usage.test.mjs && node test/operations.test.mjs && node test/hidden.test.mjs && node test/slowfs.test.mjs && node test/spawn-group.test.mjs && node test/revive.test.mjs && node test/repin.test.mjs && node test/codex-repin.test.mjs && node test/opencode-resume.test.mjs && node test/input-required.test.mjs && node test/terminal-modes.test.mjs && node test/trace-tail.test.mjs && node test/trace-window.test.mjs && node migration.test.mjs && node resize.test.mjs"
+    "test": "node ../scripts/run-suites.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/reader-info.test.mjs
+++ b/server/reader-info.test.mjs
@@ -11,6 +11,7 @@
  *
  * Set READER_INFO_PUBLIC_DIR to a prebuilt web/dist to skip the build, and
  * READER_INFO_PORT to move off the default when suites run in parallel.
+ * am-test: manual — Chromium, a full web build and READER_INFO_PORT; `npm run test:ui`.
  */
 import fs from 'node:fs';
 import os from 'node:os';

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -12,6 +12,7 @@
  *   - the creation dialog has no redundant file picker.
  *
  * Set SCREENSHOT_PUBLIC_DIR to a prebuilt web/dist to skip the build.
+ * am-test: manual — Chromium, a full web build and SCREENSHOT_PORT; `npm run test:ui`.
  */
 import fs from 'node:fs';
 import os from 'node:os';

--- a/server/terminal-ui.test.mjs
+++ b/server/terminal-ui.test.mjs
@@ -7,6 +7,7 @@
  *   - ...without letting that lingering selection shadow Ctrl+C's SIGINT
  *
  * Set TERMUI_PUBLIC_DIR to a prebuilt web/dist to skip the build.
+ * am-test: manual — Chromium, a full web build and port 7897; `npm run test:ui`.
  */
 import fs from 'node:fs';
 import os from 'node:os';

--- a/web/package.json
+++ b/web/package.json
@@ -13,7 +13,7 @@
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
-    "test": "node test/stepMarkdown.test.mjs && node test/statusMark.test.mjs && node test/mobileBack.test.mjs && node test/pendingExchange.test.mjs && node test/composerAlign.test.mjs && node test/fileWrapToggle.test.mjs && node test/exchanges.test.mjs && node test/sessionTitle.test.mjs && node test/overviewSort.test.mjs && node test/drafts.test.mjs && node test/settingsMobile.test.mjs && node test/traceWindows.test.mjs && node test/sidebar-dnd.test.mjs",
+    "test": "node ../scripts/run-suites.mjs",
     "test:render": "node test/statusMark.render.test.mjs",
     "preview": "vite preview"
   },

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -6,8 +6,10 @@
 // mark, and a state pseudo-element never paints over the inline provider/CLI
 // colours carried by bare `.status` dots.
 //
-// Needs Chromium; run with:  node test/statusMark.render.test.mjs
-// (not in `npm test`, which stays browser-free — see package.json's test:render)
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+// Kept out of the default suite as its own script, unchanged by the discovery
+// change. (The note that used to sit here said `npm test` stays browser-free;
+// that stopped being true when traceWindows.test.mjs joined it.)
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';


### PR DESCRIPTION
`npm test` in each package now discovers its suites instead of running a list that has to be edited by hand.

## What changed

- **`scripts/run-suites.mjs`** (new, ~90 lines): runs `test/*.test.mjs` then `*.test.mjs` at the package root, alphabetically within each group, **one child process at a time**, stopping at the first failure and exiting with its code.
- **`web/package.json`, `server/package.json`**: `"test"` becomes `node ../scripts/run-suites.mjs`. One line each; nothing else in either file moved.
- **Five suite headers** gain an `am-test: manual — <reason>` line. That is the opt-out: the runner skips those files and prints each one with its reason at the end of every run.

No test file was moved, renamed, or edited beyond those header comments.

## Why not `node --test`

It would discover the same files, but it runs them **in parallel** by default. Suites here start real servers on fixed ports — `migration.test.mjs` 7893, `test/archive.test.mjs` 7894, `resize.test.mjs` 7895, `test/trace-download.test.mjs` 7898 — and several drive Chromium. Those three do not collide *today*, but only because whoever added each one happened to pick a free number; nothing enforces it, no test asserts it, and the next server suite that copies an existing `PORT` constant produces a flake that reads as a product bug. This fleet has already burned time chasing exactly that symptom. `--test-concurrency=1` would fix the concurrency but not the second problem: `node --test` wraps each file's stdout in TAP diagnostics, and these suites' own human-readable output (`ok  …`, `all checks passed`) is the thing you read when one fails. Sequential spawning keeps the output byte-for-byte what it is today.

## The things you asked me to check

**Exit semantics match the `&&` chain.** Verified both flavours of file, through `npm test`:

| throwaway suite | run stops? | `npm test` exit |
| --- | --- | --- |
| standalone script calling `process.exit(3)` | yes, at `[1/14]` | `3` |
| `node:test` file with one failing test | yes, at `[1/14]` | `1` |

Node exits non-zero for a `node:test` file run as a plain script, so the two kinds behave identically here — checked rather than assumed. The failure line names the file and says how many had passed before it and that the rest were not started.

**`web`'s `test:render` stays separate**, as its own script, unchanged. It needs Chromium *and* is the one suite whose subject is pixel rendering; I did not want to change coverage policy inside a build change. One correction though: its header said it was excluded because "`npm test` stays browser-free", and that has not been true since `traceWindows.test.mjs` joined the chain — `web npm test` already runs two Chromium suites (`traceWindows`, `settingsMobile`). I replaced that stale sentence with the marker and a note. **If the real reason was only browser-free-ness, this suite should probably just join the default set** — that is a call for you or the operator, not for this PR.

**Suites that were not in the chain.** I diffed every `*.test.mjs` on disk against both scripts before changing anything:

| file | status before | now |
| --- | --- | --- |
| `server/terminal-ui.test.mjs` | in `test:ui` | skipped, marked manual |
| `server/screenshot-input.test.mjs` | in `test:ui`, `test:screenshots` | skipped, marked manual |
| `server/reader-info.test.mjs` | in `test:ui` | skipped, marked manual |
| `server/mobile.test.mjs` | in `test:mobile` | skipped, marked manual |
| `web/test/statusMark.render.test.mjs` | in `test:render` | skipped, marked manual |
| **`server/test/backup.test.mjs`** | **in no script at all** | **runs** |
| **`server/test/backup-health.test.mjs`** | **in no script at all** | **runs** |

The last two are the interesting find. They arrived with the bucket-backup work (`0c0b094` #26 and `e721986` #34) and were never referenced by any npm script — 26 + 7 assertions that have been carried in the repo without ever running. They are `node:test` files, they pass, they take ~45ms between them, and they bind no ports and need no browser, so I included them. If you would rather land that separately, say so and I will pull them out behind a marker — but silently carrying them is how this PR's whole problem class started.

## Verified

- `web`: 13 suites, all pass — the same 13 the chain listed.
- `server`: 21 suites, all pass — the chain's 19 (including `test/archive.test.mjs`, which landed in #86 while this was open) plus the two backup suites.
- Added a throwaway `web/test/zzz-scratch.test.mjs`, ran `npm test`, watched it get picked up with no list edited; same again for a **root-level** `server/zzz-root-scratch.test.mjs`, since that is the other discovery branch. Both deleted.
- `npm run test:render` still passes; the four manual server suites still parse (`node --check`) and their scripts are untouched.

## What could regress

- **Order changed** from hand-ordered to alphabetical, so `state-checkpoint.test.mjs` now runs last rather than third, and web's browser suites are no longer last. Nothing here depends on order (every suite builds its own temp dirs) and both packages pass, but that is the change most likely to surprise.
- **A stray `*.test.mjs` now runs.** Leaving a scratch file in `test/` or a package root puts it in CI. The runner prints the count and every filename it runs, so it is visible rather than silent.
- **Marker false-positive:** any suite whose first 4 KB contains the string `am-test: manual` is skipped — including one that merely documents the convention. The skip list printed on every run is the guard.
- **`npm test -- foo`** now filters to suites whose path contains `foo` (handy for running one by hand). Previously the extra arg was appended to the last command in the chain and ignored.
- The runner uses only Node 20-compatible APIs (no `fs.globSync`), matching `server`'s `engines: >=20.19`.

## Rebased onto `d735b67`, and the conflict proved the point

This branch was cut at `77afeed`. #86 landed while it was open, adding `node test/archive.test.mjs` to the very line this PR deletes — the seventh conflict in the series, arriving during the fix for it. Resolution was to keep the runner; `test/archive.test.mjs` is discovered with no edit, and the server run goes 20 → 21 suites.

One thing worth reporting rather than hiding: on the first run after the rebase, `test/archive.test.mjs` failed under the runner (`exit 1`) while printing `22 passed, 0 failed`, then passed on every run since, alone and in the full suite. It binds a fixed port (7894) and another agent in this fleet is running the same suites against the same host, so the most likely cause is exactly the collision class this PR refuses to introduce — a suite that reports all-green and still exits non-zero because its server could not bind. I could not reproduce it in isolation, so I am flagging it rather than claiming it is understood. It is an argument for the sequential choice, not against it: parallelism would make that failure the normal case rather than a once-off.

## Collisions

`scripts/run-suites.mjs` is new, and the two `package.json` edits replace exactly the line that everything else conflicts on — so any open PR that adds a suite will conflict here **once**, and the resolution is always the same: keep this side and delete the incoming `&& node …` fragment, because the file it names is discovered anyway. That is what I did for #86 above. After this lands there is nothing left to conflict over.
