### PR TITLE
Move agent status onto CLI icon frames

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node ../scripts/run-suites.mjs",
-    "test:render": "node test/statusMark.render.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,7 +9,7 @@ import SettingsView from './components/SettingsView';
 import NewSession from './components/NewSession';
 import LayoutPicker from './components/LayoutPicker';
 import ShareDialog from './components/ShareDialog';
-import Logo from './components/Logo';
+import StateLogo from './components/StateLogo';
 import Overview from './components/Overview';
 import Locked from './components/Locked';
 import BackupBanner from './components/BackupBanner';
@@ -1122,8 +1122,7 @@ export default function App() {
               <div className="mchips">
                 {groupSessions.map((s, i) => (
                   <button key={s.id} className={`mchip${i === page ? ' on' : ''}`} title={s.name} onClick={() => setPage(i)}>
-                    <Logo cli={s.cli} size={13} tint={cliMap[s.cli]?.color} />
-                    <span className={`status ${s.state}`} />
+                    <StateLogo cli={s.cli} state={s.state} size={13} tint={cliMap[s.cli]?.color} />
                   </button>
                 ))}
               </div>

--- a/web/src/components/Locked.tsx
+++ b/web/src/components/Locked.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
+import type { SessionState } from '../types';
 import { SlidersGlyph, SunGlyph, GridGlyph, PlusGlyph, AmMark } from './icons';
 import Logo from './Logo';
+import StateLogo from './StateLogo';
 
 // A frozen, slightly dimmed replica of the real sidebar so the install page
 // looks like the product it unlocks. Pure decoration: no handlers, no state.
-type MockSession = { name: string; cli: string; tint: string; state: string };
+type MockSession = { name: string; cli: string; tint: string; state: SessionState };
 type MockItem = MockSession | { group: string; members: MockSession[] };
 const MOCK: MockItem[] = [
   { group: 'research', members: [
@@ -19,8 +21,7 @@ const MOCK: MockItem[] = [
 function MockRow({ s, nested }: { s: MockSession; nested?: boolean }) {
   return (
     <div className={`row session${nested ? ' nested' : ''}`}>
-      <span className={`status ${s.state}`} />
-      <Logo cli={s.cli} size={12} tint={s.tint} />
+      <StateLogo cli={s.cli} state={s.state} size={12} tint={s.tint} />
       <span className="name">{s.name}</span>
     </div>
   );
@@ -39,7 +40,6 @@ function MockSidebar() {
       </div>
       <div className="ov-fixed">
         <div className="row ov-row">
-          <span className="status ov-spacer" />
           <span className="ov-tile"><GridGlyph /></span>
           <span className="name">overview</span>
         </div>
@@ -63,10 +63,9 @@ function MockSidebar() {
         <span className="btn-ghost"><Logo cli="files" size={14} /> Files</span>
       </div>
       <div className="legend">
-        <span><span className="status working" /> working</span>
-        <span><span className="status waiting" /> your turn</span>
-        <span><span className="status idle" /> idle</span>
-        <span><span className="status stopped" /> stopped</span>
+        <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
+        <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
+        <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
       </div>
     </aside>
   );

--- a/web/src/components/Locked.tsx
+++ b/web/src/components/Locked.tsx
@@ -64,6 +64,7 @@ function MockSidebar() {
       </div>
       <div className="legend">
         <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
+        <span><StateLogo cli="shell" state="waiting" size={12} tint="var(--muted)" /> your turn</span>
         <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
         <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
       </div>

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -4,12 +4,18 @@ import { FolderGlyph, ListGlyph, RemoteGlyph } from './icons';
 const INVERT_DARK = new Set(['shell', 'opencode']);
 const INVERT_LIGHT = new Set(['hermes']);
 
+// A state frame must follow the tile exactly, so expose the two pieces of tile
+// geometry rather than making that component repeat Logo's sizing arithmetic.
+export const logoTilePadding = (size: number, tint?: string) =>
+  tint ? Math.max(3, Math.round(size * 0.18)) : 0;
+export const logoTileRadius = (size: number) => Math.max(4, Math.round(size * 0.28));
+
 export default function Logo({ cli, size = 18, tint }: { cli: string; size?: number; tint?: string }) {
   // `tint` (the CLI's brand color) wraps the glyph in a softly tinted tile so
   // rows/panes read as "Claude / Codex / Gemini" at a glance. `size` stays the
   // glyph size; the tile adds its own padding around it.
   const tile = tint
-    ? { padding: Math.max(3, Math.round(size * 0.18)), background: `color-mix(in srgb, ${tint} 13%, transparent)`, borderRadius: Math.max(4, Math.round(size * 0.28)) }
+    ? { padding: logoTilePadding(size, tint), background: `color-mix(in srgb, ${tint} 13%, transparent)`, borderRadius: logoTileRadius(size) }
     : undefined;
 
   // Files uses the same minimal folder glyph as the file tree.

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RemoteInfo, RemoteMessage, Session } from '../types';
 import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
-import Logo from './Logo';
+import StateLogo from './StateLogo';
 import { renderMarkdown } from '../lib/markdown';
 import { groupLabel, sessionTitle } from '../lib/sessionTitle';
 import { BackGlyph, CloseGlyph, StopGlyph, PlayGlyph, ShareGlyph, AckGlyph } from './icons';
@@ -222,8 +222,7 @@ export default function RemotePane({
               <BackGlyph />
             </button>
           )}
-          <Logo cli="remote" size={16} tint="#5ec2e0" />
-          <span className={`status ${state}`} title={stateLabel} />
+          <StateLogo cli="remote" state={state} size={16} tint="#5ec2e0" title={stateLabel} />
         </div>
         {editing ? (
           <input

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -840,6 +840,7 @@ export default function Sidebar({
 
       <div className="legend">
         <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
+        <span><StateLogo cli="shell" state="waiting" size={12} tint="var(--muted)" /> your turn</span>
         <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
         <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
         {archived.size > 0 && (

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
 import Logo from './Logo';
+import StateLogo from './StateLogo';
 import NewSession from './NewSession';
 import FolderPicker from './FolderPicker';
 import Attachments from './Attachments';
@@ -461,10 +462,12 @@ export default function Sidebar({
         onDoubleClick={(e) => { e.stopPropagation(); startEdit(ref, s.name); }}
         title={s.path ? `${s.name} · ${s.path}` : s.name}
       >
-        {/* The same three lights, but for a remote agent they mean connection,
-            not process: working / listening / not connected. */}
-        <span className={`status ${s.state}`} title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]} />
-        <Logo cli={s.cli} size={12} tint={colorOf[s.cli]} />
+        {/* State rides the CLI tile itself. For a remote agent it means
+            connection, not process: working / listening / not connected. */}
+        <StateLogo
+          cli={s.cli} state={s.state} size={12} tint={colorOf[s.cli]}
+          title={(isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state]}
+        />
         {editing ? (
           <input
             autoFocus className="rename" value={editName}
@@ -787,7 +790,7 @@ export default function Sidebar({
       {/* Overview: pinned above the tree with the row anatomy (tile · name) so
           it reads as clickable. It used to carry an "N waiting" count in a
           right slot; the rows directly below already show each of those agents
-          with its own state mark, so the number was a second, vaguer telling of
+          with state on its tile, so the number was a second, vaguer telling of
           what the list says exactly. */}
       <div className="ov-fixed">
         <div
@@ -795,7 +798,6 @@ export default function Sidebar({
           onClick={() => onActivate('overview')}
           title="All agents: digests, states, replies"
         >
-          <span className="status ov-spacer" />
           <span className="ov-tile"><GridGlyph /></span>
           <span className="name">overview</span>
         </div>
@@ -837,9 +839,9 @@ export default function Sidebar({
       </div>
 
       <div className="legend">
-        <span><span className="status working" /> working</span>
-        <span><span className="status waiting" /> idle</span>
-        <span><span className="status stopped" /> stopped</span>
+        <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
+        <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
+        <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
         {archived.size > 0 && (
           <label className="legend-arch" title="Sessions with no activity beyond the archive window (Settings)">
             <input type="checkbox" checked={showArchived} onChange={onToggleArchived} />

--- a/web/src/components/StateLogo.tsx
+++ b/web/src/components/StateLogo.tsx
@@ -1,0 +1,48 @@
+import type { SessionState } from '../types';
+import Logo, { logoTilePadding, logoTileRadius } from './Logo';
+
+/**
+ * The CLI tile and the agent state are one mark. The 96-unit path is divided
+ * into four exact 20 + 4 cells, so the working dash loop has no remainder (and
+ * therefore no visible jump) at the rounded rectangle's origin.
+ */
+export default function StateLogo({
+  cli, state, size = 18, tint, title,
+}: {
+  cli: string;
+  state: SessionState;
+  size?: number;
+  tint?: string;
+  title?: string;
+}) {
+  const padding = logoTilePadding(size, tint);
+  const frameSize = size + padding * 2;
+
+  return (
+    <span
+      className={`state-logo ${state}`}
+      style={{ width: frameSize, height: frameSize }}
+      title={title}
+    >
+      <Logo cli={cli} size={size} tint={tint} />
+      <svg
+        className="state-logo-frame"
+        viewBox={`0 0 ${frameSize} ${frameSize}`}
+        aria-hidden="true"
+      >
+        {state === 'working' && (
+          <rect
+            className="state-logo-track"
+            x="0.5" y="0.5" width={frameSize - 1} height={frameSize - 1}
+            rx={logoTileRadius(size)} pathLength="96"
+          />
+        )}
+        <rect
+          className={state === 'working' ? 'state-logo-run' : 'state-logo-static'}
+          x="0.5" y="0.5" width={frameSize - 1} height={frameSize - 1}
+          rx={logoTileRadius(size)} pathLength="96"
+        />
+      </svg>
+    </span>
+  );
+}

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -7,7 +7,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import '@xterm/xterm/css/xterm.css';
 import type { Cli, Session } from '../types';
 import { STATE_LABEL, isRemote } from '../types';
-import Logo from './Logo';
+import StateLogo from './StateLogo';
 import TraceInfo from './TraceInfo';
 import ConversationView from './conversation/ConversationView';
 import { isPassive } from '../types';
@@ -1105,7 +1105,10 @@ export default function TerminalPane({
               <BackGlyph />
             </button>
           )}
-          <Logo cli={session.cli} size={16} tint={tint} />
+          <StateLogo
+            cli={session.cli} state={session.state} size={16} tint={tint}
+            title={`${STATE_LABEL[session.state]} · ${conn}`}
+          />
           {/* Where the agent runs, beside what it is. It was on the right, in
               among the controls; it is not a control. Still hidden on a phone —
               moving it did not create room — where the `i` panel carries it
@@ -1129,9 +1132,6 @@ export default function TerminalPane({
             title={`${sessionTitle(session.name, groupName)} · ${pathLabel} · double-click to rename`}
             onDoubleClick={() => { setDraft(session.name); setEditing(true); }}
           >
-            {/* The state mark reads as part of the name now: what this agent is
-                doing, immediately left of who it is, both centred together. */}
-            <span className={`status ${session.state}`} title={`${STATE_LABEL[session.state]} · ${conn}`} />
             {group && <span className="ph-group">[{group}]</span>}
             <span className="ph-name">{session.name}</span>
           </span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -114,6 +114,20 @@ body {
 [data-theme='dark'] .cli-logo.inv-dark img { filter: invert(1); }
 [data-theme='light'] .cli-logo.inv-light img { filter: invert(1); }
 
+/* Agent state follows the CLI tile instead of occupying a second mark slot.
+   The 0.5px inset centres a 1px SVG stroke on the pixel boundary, so its top
+   and bottom edges paint at the same weight. Working uses four exact 20 + 4
+   cells on a normalised 96-unit perimeter: the final gap ends exactly where
+   the first dash starts, with no remainder to jump at the path origin. */
+.state-logo { position: relative; flex: none; display: inline-flex; color: var(--accent); }
+.state-logo-frame { position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%; overflow: visible; pointer-events: none; }
+.state-logo-frame rect { fill: none; stroke: currentColor; stroke-width: 1; vector-effect: non-scaling-stroke; stroke-linecap: butt; stroke-linejoin: round; }
+.state-logo-track { opacity: 0.22; }
+.state-logo-run { stroke-dasharray: 20 4; animation: state-logo-trace 0.92s linear infinite; }
+.state-logo.waiting, .state-logo.idle { color: var(--accent); }
+.state-logo.stopped { color: color-mix(in srgb, var(--muted) 50%, transparent); }
+@keyframes state-logo-trace { to { stroke-dashoffset: -24; } }
+
 /* header */
 .brand { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 13px 14px; border-bottom: 1px solid var(--border); }
 .brand .logo { display: flex; align-items: center; gap: 9px; flex: 1; min-width: 0; }
@@ -274,7 +288,6 @@ body {
 /* overview: pinned sidebar row (session-row anatomy) + cards view */
 .ov-fixed { padding: 5px 8px 6px; border-bottom: 1px solid var(--border); }
 .ov-row { cursor: pointer; padding-top: 6px; padding-bottom: 6px; }
-.ov-row .status.ov-spacer { visibility: hidden; }
 .ov-tile { flex: none; box-sizing: content-box; width: 12px; height: 12px; padding: 3px; border-radius: 4px; background: color-mix(in srgb, var(--accent) 14%, transparent); color: var(--accent); display: inline-flex; align-items: center; justify-content: center; }
 .ov-tile svg { width: 100%; height: 100%; display: block; }
 .ov-row .name { color: var(--text); }
@@ -521,10 +534,8 @@ body {
 .row.drop-before::after { top: -1px; }
 .row.drop-after::after { bottom: -1px; }
 .row.drop-on { background: var(--drop); outline: 1px solid var(--accent); outline-offset: -1px; }
-/* No size override here any more: the mark is em-based, so a sidebar row's own
-   type size already makes it a size down from a card's. See .status. */
 /* mono for THINGS (session names, counts), sans for commentary. Member names
-   speak in the muted voice — state (dot) and place (frame) carry the color. */
+   speak in the muted voice — the CLI tile's state frame carries the color. */
 .row .name { flex: 1; font-family: var(--font-mono); font-size: 11.5px; color: var(--muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
 .row.active .name, .row:hover .name { color: var(--text); }
 .row .rename { flex: 1; font: inherit; font-family: var(--font-mono); font-size: 11.5px; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
@@ -635,7 +646,7 @@ body {
 .controls .seg button { font-family: var(--font-mono); font-size: 11.5px; padding: 4px 8px; }
 
 .legend { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 12px; padding: 10px 16px; border-top: 1px solid var(--border); font-size: 10.5px; color: var(--muted); }
-.legend span { display: inline-flex; align-items: center; gap: 5px; }
+.legend > span { display: inline-flex; align-items: center; gap: 5px; }
 /* archived toggle: a quiet custom checkbox speaking the app's language */
 .legend-arch { position: relative; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
 .legend-arch input { position: absolute; inset: 0; opacity: 0; margin: 0; cursor: pointer; }
@@ -644,7 +655,7 @@ body {
 .legend-arch input:checked ~ .lbox { background: var(--accent); border-color: var(--accent); }
 .legend-arch input:checked ~ .lbox::after { content: ''; width: 5px; height: 2.5px; border-left: 1.5px solid var(--accent-fg); border-bottom: 1.5px solid var(--accent-fg); transform: rotate(-45deg) translateY(-1px); }
 /* archived rows/tiles: present but visibly parked */
-.row.archived .name, .row.archived .cli-logo { opacity: 0.45; }
+.row.archived .name, .row.archived .state-logo, .row.archived > .cli-logo { opacity: 0.45; }
 .ovt-tile.archived .ovt-head { opacity: 0.55; }
 .arch-note { font-size: 10.5px; color: var(--muted); font-style: italic; text-align: center; padding: 14px 12px 4px; margin-top: auto; }
 
@@ -812,9 +823,6 @@ body {
    server/reader-info.test.mjs — all four, in both views. */
 .pane-head .ph-btn::before { content: ''; position: absolute; inset: -4px -4px; }
 .pane-head .ph-path { min-width: 0; max-width: min(24vw, 220px); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500; }
-/* The state mark leads the name, inside the centred title: it never shrinks and
-   never wraps, so the name gives way first (see .ph-name). */
-.pane-head .ph-title > .status { flex: none; margin-right: 1px; }
 .pane-head .ph-title-input { width: 100%; text-align: center; font: inherit; font-family: var(--font-mono); font-weight: 600; padding: 1px 6px; border: 1px solid var(--accent); border-radius: var(--r-sm); background: var(--panel-2); color: var(--text); min-width: 0; }
 .pane-head .ph-close { justify-self: end; }
 /* The conversation's facts, behind one `i` in the pane header — the same place

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -118,12 +118,15 @@ body {
    The 0.5px inset centres a 1px SVG stroke on the pixel boundary, so its top
    and bottom edges paint at the same weight. Working uses four exact 20 + 4
    cells on a normalised 96-unit perimeter: the final gap ends exactly where
-   the first dash starts, with no remainder to jump at the path origin. */
+   the first dash starts, with no remainder to jump at the path origin.
+   Waiting uses sixteen exact 2 + 4 cells on that path: static points make
+   "your turn" distinct from both the long working segments and solid idle. */
 .state-logo { position: relative; flex: none; display: inline-flex; color: var(--accent); }
 .state-logo-frame { position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%; overflow: visible; pointer-events: none; }
 .state-logo-frame rect { fill: none; stroke: currentColor; stroke-width: 1; vector-effect: non-scaling-stroke; stroke-linecap: butt; stroke-linejoin: round; }
 .state-logo-track { opacity: 0.22; }
 .state-logo-run { stroke-dasharray: 20 4; animation: state-logo-trace 0.92s linear infinite; }
+.state-logo.waiting .state-logo-static { stroke-dasharray: 2 4; stroke-linecap: round; }
 .state-logo.waiting, .state-logo.idle { color: var(--accent); }
 .state-logo.stopped { color: color-mix(in srgb, var(--muted) 50%, transparent); }
 @keyframes state-logo-trace { to { stroke-dashoffset: -24; } }

--- a/web/test/stateLogo.render.test.mjs
+++ b/web/test/stateLogo.render.test.mjs
@@ -1,5 +1,4 @@
-// Browser proof for the selected icon-frame status at its two production sizes.
-// am-test: manual — needs Chromium; run with `npm run test:render`.
+// Browser proof for all four icon-frame states at the two production sizes.
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -24,6 +23,7 @@ await build({
       import StateLogo from './src/components/StateLogo.tsx';
       const States = ({ size }) => <>
         <StateLogo cli="codex" state="working" size={size} tint="#5eb6a6" />
+        <StateLogo cli="codex" state="waiting" size={size} tint="#5eb6a6" />
         <StateLogo cli="codex" state="idle" size={size} tint="#5eb6a6" />
         <StateLogo cli="codex" state="stopped" size={size} tint="#5eb6a6" />
       </>;
@@ -61,7 +61,8 @@ try {
           state: el.classList[1], box: [box.width, box.height],
           viewBox: svg.getAttribute('viewBox'), pathLength: rect.getAttribute('pathLength'),
           rect: [rect.x.baseVal.value, rect.y.baseVal.value, rect.width.baseVal.value, rect.height.baseVal.value],
-          stroke: rs.strokeWidth, dash: rs.strokeDasharray, animation: rs.animationName,
+          stroke: rs.strokeWidth, dash: rs.strokeDasharray, linecap: rs.strokeLinecap,
+          animation: rs.animationName,
           color: es.color, animations: el.getAnimations({ subtree: true }).length,
         };
       });
@@ -70,7 +71,7 @@ try {
 
     for (const [surface, size] of [['sidebar', 18], ['header', 22]]) {
       const states = result[surface];
-      assert.equal(states.length, 3);
+      assert.equal(states.length, 4);
       for (const mark of states) {
         assert.deepEqual(mark.box, [size, size], `${theme} ${surface} ${mark.state} box`);
         assert.equal(mark.viewBox, `0 0 ${size} ${size}`);
@@ -78,15 +79,22 @@ try {
         assert.deepEqual(mark.rect, [0.5, 0.5, size - 1, size - 1]);
         assert.equal(mark.stroke, '1px');
       }
-      assert.match(states[0].dash, /20px,? 4px/);
-      assert.equal(states[0].animation, 'state-logo-trace');
-      assert.equal(states[0].animations, 1);
-      for (const mark of states.slice(1)) {
+      const byState = Object.fromEntries(states.map((mark) => [mark.state, mark]));
+      assert.match(byState.working.dash, /20px,? 4px/);
+      assert.equal(byState.working.animation, 'state-logo-trace');
+      assert.equal(byState.working.animations, 1);
+      assert.match(byState.waiting.dash, /2px,? 4px/);
+      assert.equal(byState.waiting.linecap, 'round');
+      assert.equal(byState.idle.dash, 'none');
+      assert.equal(byState.stopped.dash, 'none');
+      for (const mark of [byState.waiting, byState.idle, byState.stopped]) {
         assert.equal(mark.animation, 'none');
         assert.equal(mark.animations, 0);
       }
-      assert.equal(states[0].color, states[1].color, `${theme} working and idle share accent`);
-      assert.notEqual(states[1].color, states[2].color, `${theme} stopped is muted`);
+      assert.equal(byState.working.color, byState.waiting.color, `${theme} working and waiting share accent`);
+      assert.equal(byState.waiting.color, byState.idle.color, `${theme} waiting and idle share accent hue`);
+      assert.notEqual(byState.idle.color, byState.stopped.color, `${theme} stopped is muted`);
+      assert.notEqual(byState.waiting.dash, byState.idle.dash, `${theme} your-turn and idle remain distinct`);
     }
     await page.close();
   }
@@ -95,4 +103,4 @@ try {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
-console.log('state-logo render: exact frame geometry and motion pass in both themes');
+console.log('state-logo render: four distinct states pass at both sizes and in both themes');

--- a/web/test/stateLogo.render.test.mjs
+++ b/web/test/stateLogo.render.test.mjs
@@ -1,0 +1,98 @@
+// Browser proof for the selected icon-frame status at its two production sizes.
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'state-logo-render-'));
+const bundle = path.join(tmp, 'app.js');
+
+await build({
+  stdin: {
+    resolveDir: WEB,
+    loader: 'tsx',
+    contents: `
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import StateLogo from './src/components/StateLogo.tsx';
+      const States = ({ size }) => <>
+        <StateLogo cli="codex" state="working" size={size} tint="#5eb6a6" />
+        <StateLogo cli="codex" state="idle" size={size} tint="#5eb6a6" />
+        <StateLogo cli="codex" state="stopped" size={size} tint="#5eb6a6" />
+      </>;
+      createRoot(document.getElementById('root')).render(<>
+        <div className="row session fixture-sidebar"><States size={12} /><span className="name">codex-1</span></div>
+        <div className="pane-head fixture-header">
+          <div className="ph-left"><States size={16} /></div>
+          <span className="ph-title"><span className="ph-name">codex-1</span></span>
+          <div className="ph-right" />
+        </div>
+      </>);
+    `,
+  },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+const browser = await chromium.launch(chromiumLaunchOptions());
+
+try {
+  for (const theme of ['light', 'dark']) {
+    const page = await browser.newPage({ viewport: { width: 700, height: 260 } });
+    await page.setContent(`<style>${css}</style><div id="root" data-theme="${theme}"></div>`);
+    await page.addScriptTag({ path: bundle });
+    await page.waitForSelector('.fixture-header .state-logo');
+
+    const result = await page.evaluate(() => {
+      const inspect = (surface) => [...document.querySelectorAll(`${surface} .state-logo`)].map((el) => {
+        const svg = el.querySelector('svg');
+        const rect = el.querySelector('rect:last-child');
+        const es = getComputedStyle(el);
+        const rs = getComputedStyle(rect);
+        const box = el.getBoundingClientRect();
+        return {
+          state: el.classList[1], box: [box.width, box.height],
+          viewBox: svg.getAttribute('viewBox'), pathLength: rect.getAttribute('pathLength'),
+          rect: [rect.x.baseVal.value, rect.y.baseVal.value, rect.width.baseVal.value, rect.height.baseVal.value],
+          stroke: rs.strokeWidth, dash: rs.strokeDasharray, animation: rs.animationName,
+          color: es.color, animations: el.getAnimations({ subtree: true }).length,
+        };
+      });
+      return { sidebar: inspect('.fixture-sidebar'), header: inspect('.fixture-header') };
+    });
+
+    for (const [surface, size] of [['sidebar', 18], ['header', 22]]) {
+      const states = result[surface];
+      assert.equal(states.length, 3);
+      for (const mark of states) {
+        assert.deepEqual(mark.box, [size, size], `${theme} ${surface} ${mark.state} box`);
+        assert.equal(mark.viewBox, `0 0 ${size} ${size}`);
+        assert.equal(mark.pathLength, '96');
+        assert.deepEqual(mark.rect, [0.5, 0.5, size - 1, size - 1]);
+        assert.equal(mark.stroke, '1px');
+      }
+      assert.match(states[0].dash, /20px,? 4px/);
+      assert.equal(states[0].animation, 'state-logo-trace');
+      assert.equal(states[0].animations, 1);
+      for (const mark of states.slice(1)) {
+        assert.equal(mark.animation, 'none');
+        assert.equal(mark.animations, 0);
+      }
+      assert.equal(states[0].color, states[1].color, `${theme} working and idle share accent`);
+      assert.notEqual(states[1].color, states[2].color, `${theme} stopped is muted`);
+    }
+    await page.close();
+  }
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('state-logo render: exact frame geometry and motion pass in both themes');

--- a/web/test/stateLogo.test.mjs
+++ b/web/test/stateLogo.test.mjs
@@ -1,88 +1,71 @@
-// The selected status study option makes the CLI tile itself the state mark:
-// working = a seamless four-cell loop, idle = accent frame, stopped = a very
-// quiet grey frame. This pins both the drawing contract and the three places
-// that opted into it; Overview deliberately keeps its existing marks.
+// Component behaviour for the icon-frame status. CSS differences are measured
+// in stateLogo.render.test.mjs; this suite pins the rendered structure and
+// geometry without depending on JSX attribute order or stylesheet source text.
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
+import { Children } from 'react';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
-import { createElement } from 'react';
-import { renderToStaticMarkup } from 'react-dom/server';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const SRC = path.join(HERE, '../src');
-const read = (file) => fs.readFileSync(path.join(SRC, file), 'utf8');
-const css = read('styles.css');
-
 const outDir = path.join(HERE, '../node_modules/.test-build');
 fs.mkdirSync(outDir, { recursive: true });
 const out = path.join(outDir, 'state-logo.mjs');
 await build({
-  entryPoints: [path.join(SRC, 'components/StateLogo.tsx')],
+  entryPoints: [path.join(HERE, '../src/components/StateLogo.tsx')],
   outfile: out, format: 'esm', bundle: true, jsx: 'automatic', logLevel: 'error',
   external: ['react', 'react/jsx-runtime'],
 });
 const { default: StateLogo } = await import(pathToFileURL(out).href);
 
-const render = (state, size = 12) => renderToStaticMarkup(createElement(StateLogo, {
-  cli: 'codex', state, size, tint: '#5eb6a6', title: state,
-}));
-const working = render('working');
-const idle = render('idle');
-const stopped = render('stopped');
+const STATES = ['working', 'waiting', 'idle', 'stopped'];
+const rendered = Object.fromEntries(STATES.map((state) => [state, StateLogo({
+  cli: 'codex', state, size: 12, tint: '#5eb6a6', title: state,
+})]));
 
-// Logo's 12px glyph + 3px shared tile padding = the production 18px sidebar
-// frame. The stroke is centred at .5 and reaches exactly 0..18 on every edge.
-assert.match(working, /^<span class="state-logo working" style="width:18px;height:18px"/);
-assert.match(working, /viewBox="0 0 18 18"/);
-assert.equal((working.match(/<rect/g) || []).length, 2, 'working needs a track and moving dashes');
-assert.match(working, /class="state-logo-track" x="0.5" y="0.5" width="17" height="17" rx="4" pathLength="96"/);
-assert.match(working, /class="state-logo-run" x="0.5" y="0.5" width="17" height="17" rx="4" pathLength="96"/);
-for (const [state, markup] of [['idle', idle], ['stopped', stopped]]) {
-  assert.equal((markup.match(/<rect/g) || []).length, 1, `${state} must be static`);
-  assert.match(markup, /class="state-logo-static"/);
-  assert.doesNotMatch(markup, /state-logo-(track|run)/);
+for (const state of STATES) {
+  const frame = rendered[state];
+  assert.equal(frame.props.className, `state-logo ${state}`);
+  assert.deepEqual(frame.props.style, { width: 18, height: 18 });
+  assert.equal(frame.props.title, state);
+
+  const [logo, svg] = Children.toArray(frame.props.children);
+  assert.equal(logo.props.cli, 'codex');
+  assert.equal(logo.props.size, 12);
+  assert.equal(logo.props.tint, '#5eb6a6');
+  assert.equal(svg.props.viewBox, '0 0 18 18');
+  assert.equal(svg.props['aria-hidden'], 'true');
+
+  const rects = Children.toArray(svg.props.children);
+  assert.equal(rects.length, state === 'working' ? 2 : 1);
+  for (const rect of rects) {
+    assert.equal(rect.props.x, '0.5');
+    assert.equal(rect.props.y, '0.5');
+    assert.equal(rect.props.width, 17);
+    assert.equal(rect.props.height, 17);
+    assert.equal(rect.props.rx, 4);
+    assert.equal(rect.props.pathLength, '96');
+  }
+  assert.equal(rects.at(-1).props.className,
+    state === 'working' ? 'state-logo-run' : 'state-logo-static');
 }
 
-assert.match(css, /\.state-logo-run\s*\{[^}]*stroke-dasharray:\s*20 4;[^}]*animation:\s*state-logo-trace 0\.92s linear infinite;/s);
-assert.match(css, /@keyframes state-logo-trace\s*\{\s*to\s*\{\s*stroke-dashoffset:\s*-24;/s);
-assert.match(css, /\.state-logo-frame rect\s*\{[^}]*stroke-width:\s*1;[^}]*vector-effect:\s*non-scaling-stroke;/s);
-assert.match(css, /\.state-logo\.waiting, \.state-logo\.idle\s*\{\s*color:\s*var\(--accent\);/s);
-assert.match(css, /\.state-logo\.stopped\s*\{\s*color:\s*color-mix\(in srgb, var\(--muted\) 50%, transparent\);/s);
+const workingRects = Children.toArray(
+  Children.toArray(rendered.working.props.children)[1].props.children,
+);
+assert.equal(workingRects[0].props.className, 'state-logo-track');
 
-// The frame and the tile consume one geometry function. A later logo padding
-// adjustment therefore cannot leave the state border behind.
-const logo = read('components/Logo.tsx');
-const stateLogo = read('components/StateLogo.tsx');
-assert.match(logo, /export const logoTilePadding/);
-assert.match(logo, /padding:\s*logoTilePadding\(size, tint\)/);
-assert.match(stateLogo, /logoTilePadding\(size, tint\)/);
-assert.match(stateLogo, /logoTileRadius\(size\)/);
+// The same component scales to the 22px pane-header tile. Inspecting the Logo
+// child as rendered proves both layers agree on the shared 3px padding rather
+// than pinning the helper's source spelling.
+const header = StateLogo({ cli: 'codex', state: 'idle', size: 16, tint: '#5eb6a6' });
+assert.deepEqual(header.props.style, { width: 22, height: 22 });
+const [headerLogo, headerSvg] = Children.toArray(header.props.children);
+const paintedLogo = headerLogo.type(headerLogo.props);
+assert.equal(paintedLogo.props.style.width, 16);
+assert.equal(paintedLogo.props.style.height, 16);
+assert.equal(paintedLogo.props.style.padding, 3);
+assert.equal(headerSvg.props.viewBox, '0 0 22 22');
 
-const sidebar = read('components/Sidebar.tsx');
-const terminal = read('components/TerminalPane.tsx');
-const remote = read('components/RemotePane.tsx');
-const locked = read('components/Locked.tsx');
-const overview = read('components/Overview.tsx');
-
-assert.match(sidebar, /<StateLogo[\s\S]*?cli=\{s\.cli\}[\s\S]*?state=\{s\.state\}[\s\S]*?size=\{12\}/);
-assert.match(terminal, /<StateLogo[\s\S]*?cli=\{session\.cli\}[\s\S]*?state=\{session\.state\}[\s\S]*?size=\{16\}/);
-assert.match(remote, /<StateLogo cli="remote" state=\{state\} size=\{16\}/);
-assert.match(locked, /<StateLogo cli=\{s\.cli\} state=\{s\.state\} size=\{12\}/);
-assert.doesNotMatch(terminal, /className=\{`status \$\{session\.state\}`\}/);
-assert.doesNotMatch(remote, /className=\{`status \$\{state\}`\}/);
-assert.doesNotMatch(sidebar, /status ov-spacer/);
-assert.doesNotMatch(locked, /status ov-spacer/);
-
-// Three legend examples, matching the selected working / idle / off study.
-for (const state of ['working', 'idle', 'stopped']) {
-  assert.match(sidebar, new RegExp(`<StateLogo cli="shell" state="${state}" size=\\{12\\}`));
-  assert.match(locked, new RegExp(`<StateLogo cli="shell" state="${state}" size=\\{12\\}`));
-}
-
-// This PR is intentionally scoped: Overview's denser cards keep their current
-// standalone state treatment.
-assert.match(overview, /className=\{`status \$\{s\.state\}`\}/);
-
-console.log('state-logo: geometry, states, and target surfaces agree');
+console.log('state-logo: four states share exact tile geometry without source-text pins');

--- a/web/test/stateLogo.test.mjs
+++ b/web/test/stateLogo.test.mjs
@@ -1,0 +1,88 @@
+// The selected status study option makes the CLI tile itself the state mark:
+// working = a seamless four-cell loop, idle = accent frame, stopped = a very
+// quiet grey frame. This pins both the drawing contract and the three places
+// that opted into it; Overview deliberately keeps its existing marks.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.join(HERE, '../src');
+const read = (file) => fs.readFileSync(path.join(SRC, file), 'utf8');
+const css = read('styles.css');
+
+const outDir = path.join(HERE, '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const out = path.join(outDir, 'state-logo.mjs');
+await build({
+  entryPoints: [path.join(SRC, 'components/StateLogo.tsx')],
+  outfile: out, format: 'esm', bundle: true, jsx: 'automatic', logLevel: 'error',
+  external: ['react', 'react/jsx-runtime'],
+});
+const { default: StateLogo } = await import(pathToFileURL(out).href);
+
+const render = (state, size = 12) => renderToStaticMarkup(createElement(StateLogo, {
+  cli: 'codex', state, size, tint: '#5eb6a6', title: state,
+}));
+const working = render('working');
+const idle = render('idle');
+const stopped = render('stopped');
+
+// Logo's 12px glyph + 3px shared tile padding = the production 18px sidebar
+// frame. The stroke is centred at .5 and reaches exactly 0..18 on every edge.
+assert.match(working, /^<span class="state-logo working" style="width:18px;height:18px"/);
+assert.match(working, /viewBox="0 0 18 18"/);
+assert.equal((working.match(/<rect/g) || []).length, 2, 'working needs a track and moving dashes');
+assert.match(working, /class="state-logo-track" x="0.5" y="0.5" width="17" height="17" rx="4" pathLength="96"/);
+assert.match(working, /class="state-logo-run" x="0.5" y="0.5" width="17" height="17" rx="4" pathLength="96"/);
+for (const [state, markup] of [['idle', idle], ['stopped', stopped]]) {
+  assert.equal((markup.match(/<rect/g) || []).length, 1, `${state} must be static`);
+  assert.match(markup, /class="state-logo-static"/);
+  assert.doesNotMatch(markup, /state-logo-(track|run)/);
+}
+
+assert.match(css, /\.state-logo-run\s*\{[^}]*stroke-dasharray:\s*20 4;[^}]*animation:\s*state-logo-trace 0\.92s linear infinite;/s);
+assert.match(css, /@keyframes state-logo-trace\s*\{\s*to\s*\{\s*stroke-dashoffset:\s*-24;/s);
+assert.match(css, /\.state-logo-frame rect\s*\{[^}]*stroke-width:\s*1;[^}]*vector-effect:\s*non-scaling-stroke;/s);
+assert.match(css, /\.state-logo\.waiting, \.state-logo\.idle\s*\{\s*color:\s*var\(--accent\);/s);
+assert.match(css, /\.state-logo\.stopped\s*\{\s*color:\s*color-mix\(in srgb, var\(--muted\) 50%, transparent\);/s);
+
+// The frame and the tile consume one geometry function. A later logo padding
+// adjustment therefore cannot leave the state border behind.
+const logo = read('components/Logo.tsx');
+const stateLogo = read('components/StateLogo.tsx');
+assert.match(logo, /export const logoTilePadding/);
+assert.match(logo, /padding:\s*logoTilePadding\(size, tint\)/);
+assert.match(stateLogo, /logoTilePadding\(size, tint\)/);
+assert.match(stateLogo, /logoTileRadius\(size\)/);
+
+const sidebar = read('components/Sidebar.tsx');
+const terminal = read('components/TerminalPane.tsx');
+const remote = read('components/RemotePane.tsx');
+const locked = read('components/Locked.tsx');
+const overview = read('components/Overview.tsx');
+
+assert.match(sidebar, /<StateLogo[\s\S]*?cli=\{s\.cli\}[\s\S]*?state=\{s\.state\}[\s\S]*?size=\{12\}/);
+assert.match(terminal, /<StateLogo[\s\S]*?cli=\{session\.cli\}[\s\S]*?state=\{session\.state\}[\s\S]*?size=\{16\}/);
+assert.match(remote, /<StateLogo cli="remote" state=\{state\} size=\{16\}/);
+assert.match(locked, /<StateLogo cli=\{s\.cli\} state=\{s\.state\} size=\{12\}/);
+assert.doesNotMatch(terminal, /className=\{`status \$\{session\.state\}`\}/);
+assert.doesNotMatch(remote, /className=\{`status \$\{state\}`\}/);
+assert.doesNotMatch(sidebar, /status ov-spacer/);
+assert.doesNotMatch(locked, /status ov-spacer/);
+
+// Three legend examples, matching the selected working / idle / off study.
+for (const state of ['working', 'idle', 'stopped']) {
+  assert.match(sidebar, new RegExp(`<StateLogo cli="shell" state="${state}" size=\\{12\\}`));
+  assert.match(locked, new RegExp(`<StateLogo cli="shell" state="${state}" size=\\{12\\}`));
+}
+
+// This PR is intentionally scoped: Overview's denser cards keep their current
+// standalone state treatment.
+assert.match(overview, /className=\{`status \$\{s\.state\}`\}/);
+
+console.log('state-logo: geometry, states, and target surfaces agree');


### PR DESCRIPTION
## Summary

- replaces the standalone status mark in sidebar session rows, mobile group chips, and pane headers with the selected status frame around the CLI tile
- uses an exact 96-unit perimeter for four distinct states: working is a seamless animated `20 + 4` four-cell loop, your-turn is a static dotted `2 + 4` loop, idle is a solid accent frame, and stopped is a 50%-muted solid frame
- updates both sidebar legends to show and name all four product states
- shares tile padding/radius geometry with `Logo`, so the border cannot drift from the icon tile

Design selection: https://lvwerra-agent-artifacts.static.hf.space/status-indicator-study-round2.html

The existing `.status` system remains intentionally: Overview still uses it on its three compact surfaces, and the bare form supplies the provider dot in `UsagePanel` and ready dot in `SettingsView`. The mobile group chips now use `StateLogo`; the Overview split is a deliberate scope boundary for this PR.

## Verification

- `cd web && npm test` — 15 suites passed, including the four-state Chromium render suite
- `cd web && npm run test:render` — existing status-mark checks plus icon-frame checks passed in light/dark at the 18px sidebar and 22px header sizes
- `cd web && npm run build` — passed

The render test pins the half-pixel 1px stroke geometry, both exactly tiled dash patterns, four visually distinct computed treatments, animation only on working, static waiting/idle/stopped frames, and both production sizes. The component unit test inspects rendered React structure and geometry without source-text or JSX-order assertions.