### PR TITLE
Reader: the tail is the paragraph rhythm, not a 30px reserve

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -380,6 +380,15 @@ pane with nothing to render (a shell) simply stays a terminal.
   `.markdown` turns that into a sideways drag because a scroller in one axis makes the other axis
   a scroller too. `overflow-x: hidden` on a parent is not the fix: it hides the symptom and clips
   content people need to read.
+- **The conversation ends the way it flows.** The scroller's bottom padding is `--cx-tail`, and it
+  is the same 12px that separates two paragraphs — so the last line clears the composer's border by
+  a paragraph's worth of space and no more. It used to be 30px, a number from when the reader's
+  bottom edge was the pane's rather than a border 30px away, which put 32px under the last line of
+  every conversation and read as one blank line too many. Nothing else contributes: the last
+  rendered block already gives up its margin (`.cx-md > :last-child`), and the tail holds no
+  elements — the empty-element shape of this bug (a spacer, a blank meta half, a working line with
+  nothing to say) was checked for and is not what this was. The phone narrows `--cx-gutter` and
+  restates no padding, so the two cannot drift apart.
 - **The reader fills the pane.** A fixed reading column left a gutter of nothing on each
   side while the prompt band still spanned the full width, so the two disagreed about where the
   conversation began. The pane is the measure: narrow the pane and the conversation narrows.

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -269,7 +269,12 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    hardcoded bleed against a padding that changes at a breakpoint drifts apart,
    and the band ends up wider than the scroller it sits in — which is exactly
    how the phone gained a sideways scroll: 14px of bleed, 8px of padding. */
-.cxv-body { --cx-gutter: 14px; flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; background: var(--panel); padding: 4px var(--cx-gutter) 30px; }
+/* The tail is the paragraph rhythm, not a reserve. 30px here — chosen when the
+   reader's bottom edge was the pane's, before a composer sat under it — put 32px
+   between the last line and the composer's border while the blocks above it are
+   12px apart, which reads as one blank line too many at the end of every
+   conversation. 12px makes the end of the flow spaced like the flow. */
+.cxv-body { --cx-gutter: 14px; --cx-tail: 12px; flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; background: var(--panel); padding: 4px var(--cx-gutter) var(--cx-tail); }
 .cxv-col { display: flex; flex-direction: column; min-width: 0; }
 .cxv-msg { font-size: 0.85em; color: var(--muted); padding: 6px 0; }
 /* The line above the oldest loaded exchange. Fixed height on purpose: it sits
@@ -324,7 +329,9 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
 
 /* ---------- phone ---------- */
 @media (max-width: 720px) {
-  .cxv-body { --cx-gutter: 8px; padding: 4px var(--cx-gutter) 24px; }
+  /* only the gutter narrows here: the padding itself is written once above, so a
+     phone cannot drift from the desktop tail the way it drifted from the bleed */
+  .cxv-body { --cx-gutter: 8px; }
   .cs-detail { font-size: 1em; }
 }
 

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -222,6 +222,40 @@ console.log('\nand nothing reserves the gutter for a control that cannot exist')
   });
 }
 
+console.log('\nand the end of the conversation is spaced like the conversation');
+// Reported from prod: "an additional newline at the end of the reader view".
+// It was not a margin and not an empty node — the last block already carries
+// `margin-bottom: 0` and the tail held no elements at all. It was `.cxv-body`'s
+// own bottom padding, 30px, chosen when the reader's bottom edge was the pane's
+// rather than a composer's border. These pin the three parts of the answer.
+{
+  const conv = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');
+  const shared = fs.readFileSync(path.join(HERE, '../src/styles.css'), 'utf8');
+  const rule = (css, sel) => { const i = css.indexOf(sel); return i < 0 ? null : css.slice(i, css.indexOf('}', i) + 1); };
+  check('the scroller pays its tail from a variable, not a number in the shorthand', () => {
+    const r = rule(conv, '.cxv-body {');
+    assert.ok(r, 'no .cxv-body rule');
+    assert.match(r, /--cx-tail:\s*12px/);
+    assert.match(r, /padding:\s*4px var\(--cx-gutter\) var\(--cx-tail\)/);
+  });
+  check('and that tail IS the paragraph rhythm, not a number that happens to be near it', () => {
+    const tail = (rule(conv, '.cxv-body {').match(/--cx-tail:\s*(\d+)px/) || [])[1];
+    const para = (rule(shared, '.markdown p {').match(/margin:\s*0 0 (\d+)px/) || [])[1];
+    assert.equal(tail, para, `tail ${tail}px vs paragraph spacing ${para}px — they must agree`);
+  });
+  check('the phone rule narrows the gutter and restates nothing else', () => {
+    const i = conv.indexOf('@media (max-width: 720px)');
+    const block = conv.slice(i, conv.indexOf('\n}', i));
+    const bodyRule = rule(block, '.cxv-body {');
+    assert.ok(bodyRule, 'the phone block should still set the gutter');
+    assert.match(bodyRule, /--cx-gutter:\s*8px/);
+    assert.doesNotMatch(bodyRule, /padding/, `a second padding here is how the phone drifts: ${bodyRule}`);
+  });
+  check('and the last rendered block still adds no margin of its own', () => {
+    assert.match(rule(conv, '.cx-md > :last-child {') || '', /margin-bottom:\s*0/);
+  });
+}
+
 console.log('\nand the CSS pair the nesting exists for is still a pair');
 const css = fs.readFileSync(path.join(HERE, '../src/conversation.css'), 'utf8');
 check('.cx pays out the gutter in em', () => assert.match(css, /\.cx\s*\{[^}]*padding:[^;]*1\.23em/));


### PR DESCRIPTION
> it seems like there is an additional newline at the end of the reader view. just a bit too much whitespace imo. can you have an agent confirm and fix?

**Confirmed.** **[Measured before/after →](https://claude.ai/code/artifact/a61eadea-fdf5-4fd3-aec6-099269efef0e)**

Scrolled to the end of a conversation that fills the pane, the space between the last line and the composer's border was **2.7× the spacing between the paragraphs above it**:

| | last line → composer | between paragraphs |
|---|---|---|
| desktop, before | **32px** | 12px |
| phone, before | **26px** | 12px |
| both, after | **14px** | 12px |

## What it was — and the three things it wasn't

You were right to point at `633d492`'s class of cause, so I checked those first and each is ruled out by measurement, not by reasoning:

- **Not an uncollapsed margin.** The last rendered block reports `margin-bottom: 0px` — `.cx-md > :last-child` already gives it up.
- **Not a trailing empty node from the renderer.** Nothing renders after the last paragraph at all: I enumerated every element whose box ends at or below it and the list is empty.
- **Not an element with no content.** No spacer, no blank pending exchange, no working line with nothing to say — the shape that caused both earlier reports (#88's empty head row, #85's blank meta half) is simply not present here.

It was **`.cxv-body`'s own bottom padding: `30px`** (24px on a phone), sitting in the same shorthand as the reading gutter:

```css
.cxv-body { --cx-gutter: 14px; … padding: 4px var(--cx-gutter) 30px; }
```

A number from when the reader's bottom edge *was* the pane's, before a composer sat under it with a border 30px away. So a margin fix would have been the wrong shape of fix — but so would trimming it by eye.

## The fix, and where the number comes from

`--cx-tail: 12px` — **the same 12px that separates two paragraphs** (`.markdown p { margin: 0 0 12px }`). The end of the flow is then spaced like the flow: 14px in total on both viewports, the tail plus `.cx`'s own 2px.

The phone rule restated the whole shorthand in order to narrow the gutter, and carried a different bottom (24px) as a side effect. With the tail a variable it has nothing left to restate — it narrows `--cx-gutter` and nothing else, which is the same drift this file already learned about with the prompt band's bleed in #71.

## The two things that must not break

- **It still opens on the last exchange with the newest content on screen** (#55/#59). At 1180px and at 390pt: `atBottom: 0`, last exchange fully visible, its answer on screen. Scrolling to the top and back returns to the end with the same 14px.
- **#78's needs-input band composes with it.** That band is not on main, so I merged `refs/pull/78/head` in locally to check (clean merge, nothing pushed). It sits last *inside* the scroller with margins `8px/2px`: 10px above it, and **14px** below — its own 2px plus the tail, carrying no reserve of its own. Before this change that state had 32px under the band too, so the band was not the thing holding the extra space.

## Pinned

In `web/test/pendingExchange.test.mjs`, where the reader's other CSS invariants live:

- the tail comes from `--cx-tail`, not a number in the shorthand;
- **its value equals `.markdown p`'s bottom margin** — the relationship, not the coincidence, so the two cannot drift apart silently;
- the phone rule restates no padding;
- and the last rendered block still gives up its own margin.

Mutation-checked: restoring the 30px tail fails two of those, restating the phone padding fails the third.

## Suites

Web green (143 checks), typecheck clean. `server/test/archive.test.mjs` and `resize.test.mjs` each failed in a full run and behave identically on **pristine main** under the same load: `archive` passes alone on both trees, and `resize` fails alone on both (2 failures, same assertions, with five other agents' servers running). Neither is related to this change, which is CSS in the reader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
