### PR TITLE
Env skill: make the wait-in-the-background shape copy-pasteable

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1327,17 +1327,42 @@ digest for one agent. Read \`state\` before you do anything:
 ### Watch instead of asking
 \`\`\`sh
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/tail?lines=120" | jq -r .text
-curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=120"   # blocks
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15"
 \`\`\`
 \`tail\` returns that agent's screen and scrollback — exactly what a human would
-see in its pane. \`wait\` blocks until it stops working (default: any of
-\`waiting,idle,stopped\`, \`timeout\` up to 300s) and answers
-\`{state, matched, timedOut}\`. Use \`wait\` instead of a \`sleep\` loop: long
-foreground sleeps can destabilize a session.
+see in its pane. \`wait\` BLOCKS until the agent has held one of \`state\`
+(default \`waiting,idle,stopped\`) for \`settle\` seconds, then answers
+\`{state, matched, waited}\`. Both knobs decide whether it works for you:
+
+- \`settle\` — seconds the state must HOLD (default 4, max 60). An agent goes
+  quiet between tool calls, so a bare match can fire in a gap in the middle of
+  the work and hand you half a result. Use 10–15 for a peer doing a real task.
+- \`timeout\` — seconds to block (default 60, **max 300**). One call rarely
+  covers a whole job; on expiry it answers \`{matched:false,timedOut:true}\` and
+  you reissue. That is the shape of the API, not a failure.
+
+Because of both, the correct form is a background loop rather than a call:
+reissue until it matches, started the way your harness runs a command in the
+background (Claude Code: \`run_in_background\`), so you stay free meanwhile and
+are woken once, when the peer is genuinely finished.
+
+\`\`\`sh
+( until curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15" \\
+        > /tmp/wait-$ID.json \\
+     && jq -e '.matched or .state == "gone" or has("error")' /tmp/wait-$ID.json >/dev/null
+  do sleep 2; done ) >/dev/null 2>&1 &
+\`\`\`
+When that exits, \`/tmp/wait-$ID.json\` holds the last answer: \`matched: true\`
+is finished, \`"state":"gone"\` means the session was deleted, \`error\` means the
+id is wrong. Read the file — do not start polling \`/api/agents\` instead. (The
+\`sleep 2\` costs nothing when \`wait\` is doing its job, and keeps the loop from
+spinning if the manager is briefly unreachable; it is inside the background
+subshell, so nothing of yours is blocked by it.)
 
 **This is the main pattern.** If you hand work to another agent, YOU watch it
-with \`tail\`/\`wait\`. It does not have to report back, and you must not sit in a
-loop asking it whether it's done.
+with \`tail\`/\`wait\` — start that loop as soon as you have its id. It does not
+have to report back, you must not sit in a loop asking it whether it's done, and
+never wait with \`sleep\`: long foreground sleeps can destabilize a session.
 
 ### Send an agent a prompt
 Send the text as the request **body** so quoting and newlines never bite you:
@@ -1379,6 +1404,11 @@ different one (the names are the \`group\` field in the roster), or \`group=none
 to leave it ungrouped. The prompt is required — it starts working on it
 immediately. Spawn one agent for one clearly separable job; several agents in
 one folder is fine, but this Space is a small CPU box, so don't build a fleet.
+
+The response carries the new agent's \`id\`. Capture it and start the background
+\`wait\` loop from **Watch instead of asking** right then: launching is the
+moment you choose how you will find out it finished, and nothing else will tell
+you.
 
 **Into a NEW group** — e.g. "start four agents in a group called taskforce".
 \`group=\` only ever selects a group that already exists; an unknown name is


### PR DESCRIPTION
The environment skill is generated from a template literal in `server/src/index.js` (`generateEnvSkillInner`), so this edits that template — not `/data/workspaces/skills/environment.md`, which is the rendered output and gets overwritten on every boot.

## Why the existing text did not work

"Watch instead of asking" already said the right thing — *"Use `wait` instead of a `sleep` loop"*, *"This is the main pattern"* — and it was still missed, by the operator, who then hand-rolled a poll. So this is not a volume problem. The section described the endpoint and left the reader to derive the shape, and three facts it never stated are exactly the ones that make that derivation come out wrong:

| what the reader hits | what the skill said | what happens |
| --- | --- | --- |
| `wait` blocks the caller | nothing | a coordinator that blocks for 300s is stuck, so the natural escape is the poll loop this section exists to prevent |
| `timeout` caps at 300s | "timeout up to 300s", in passing | one call against real work returns `timedOut`, and the reader concludes the endpoint does not work |
| `settle` exists | nothing at all | an agent drops to `waiting` in the gaps between tool calls; firing on that is how you act on half-finished work |

## What changed

**`### Watch instead of asking`** now documents both knobs (`settle`: default 4, max 60, what it protects against, 10–15 for a peer doing real work; `timeout`: default 60, **max 300**, and that expiry means reissue rather than failure), and gives the shape as a copy-pasteable background loop instead of leaving it to be derived:

```sh
( until curl -s ".../api/agents/$ID/wait?timeout=300&settle=15" \
        > /tmp/wait-$ID.json \
     && jq -e '.matched or .state == "gone" or has("error")' /tmp/wait-$ID.json >/dev/null
  do sleep 2; done ) >/dev/null 2>&1 &
```

Two details in there are deliberate and came out of running it:

- the condition also exits on `state: "gone"` and on an `error` body. A loop keyed only on `.matched` never terminates against a deleted session (`{"state":"gone","matched":false}`) or a mistyped id (404 `{"error":"not found"}`) — it just reissues forever.
- `sleep 2` in the loop body. When `wait` is working it costs nothing, because the call itself blocks for up to 300s. When the manager is briefly unreachable, `curl` fails instantly and without it the loop becomes a busy wait on a small CPU box. It is inside the background subshell, so it is not one of the long foreground sleeps the skill warns about.

The closing paragraph keeps **"This is the main pattern"** and absorbs the old `sleep` warning, so nothing was dropped.

**`### Launch a new agent`** gains three lines at the end of its first block, pointing at that loop. That is where a reader decides how to supervise, and the operator's report was specifically about launching agents — the section previously ended on group mechanics and never said "now watch it".

## Verified

The risk here is not the prose, it is the escaping: this is a JS template literal full of `` \` `` and `\${}`, and one stray backtick silently breaks the whole skill.

- **Rendered before and after.** Booted the server on a throwaway `DATA_DIR` on `origin/main` and on this branch, and diffed the two generated `environment.md` files (ports normalised). The diff is exactly these two changes and nothing else — so no escaping elsewhere in the ~19 KB template was disturbed. Code fences balanced (24, i.e. 12 pairs); no `\`` or `\${` artefacts survive into the output.
- **Ran the documented loop.** Against a stub that answers `timedOut` twice then `matched:true`: it reissued twice and exited with the final answer in the file. Against `{"state":"gone"}` and `{"error":"not found"}`: exited immediately (0s and 1s) rather than spinning. Against a dead port with the `sleep 2`: ~6 attempts in 12s instead of thousands.
- `node --check server/src/index.js`, and `server npm test` — 21 suites, green.

## What could regress

- Nothing executes this text, so the failure mode is a broken *skill file*, which the render-and-diff above is aimed squarely at. Worth a second pair of eyes on the escaping in the diff anyway.
- The section grew by roughly 20 lines in an already dense file. I traded that for removing the derivation step; if you would rather have it shorter, the two bullets explaining `settle` and `timeout` are the compressible part, not the snippet.
- `run_in_background` is named as the Claude Code way to background a command. Other harnesses are covered by the generic phrasing ("the way your harness runs a command in the background") plus the `&` in the snippet itself, which works anywhere.
