### PR TITLE
Use solid frames for waiting and idle states

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -118,16 +118,16 @@ body {
    The 0.5px inset centres a 1px SVG stroke on the pixel boundary, so its top
    and bottom edges paint at the same weight. Working uses four exact 20 + 4
    cells on a normalised 96-unit perimeter: the final gap ends exactly where
-   the first dash starts, with no remainder to jump at the path origin.
-   Waiting uses sixteen exact 2 + 4 cells on that path: static points make
-   "your turn" distinct from both the long working segments and solid idle. */
+   the first dash starts, with no remainder to jump at the path origin. The
+   other three states are solid frames: accent when waiting on the operator,
+   muted while idle, and the same muted hue dimmed further when stopped. */
 .state-logo { position: relative; flex: none; display: inline-flex; color: var(--accent); }
 .state-logo-frame { position: absolute; inset: 0; z-index: 1; width: 100%; height: 100%; overflow: visible; pointer-events: none; }
 .state-logo-frame rect { fill: none; stroke: currentColor; stroke-width: 1; vector-effect: non-scaling-stroke; stroke-linecap: butt; stroke-linejoin: round; }
 .state-logo-track { opacity: 0.22; }
 .state-logo-run { stroke-dasharray: 20 4; animation: state-logo-trace 0.92s linear infinite; }
-.state-logo.waiting .state-logo-static { stroke-dasharray: 2 4; stroke-linecap: round; }
-.state-logo.waiting, .state-logo.idle { color: var(--accent); }
+.state-logo.waiting { color: var(--accent); }
+.state-logo.idle { color: var(--muted); }
 .state-logo.stopped { color: color-mix(in srgb, var(--muted) 50%, transparent); }
 @keyframes state-logo-trace { to { stroke-dashoffset: -24; } }
 

--- a/web/test/stateLogo.render.test.mjs
+++ b/web/test/stateLogo.render.test.mjs
@@ -50,7 +50,7 @@ try {
     await page.addScriptTag({ path: bundle });
     await page.waitForSelector('.fixture-header .state-logo');
 
-    const result = await page.evaluate(() => {
+    const inspect = () => page.evaluate(() => {
       const inspect = (surface) => [...document.querySelectorAll(`${surface} .state-logo`)].map((el) => {
         const svg = el.querySelector('svg');
         const rect = el.querySelector('rect:last-child');
@@ -61,13 +61,13 @@ try {
           state: el.classList[1], box: [box.width, box.height],
           viewBox: svg.getAttribute('viewBox'), pathLength: rect.getAttribute('pathLength'),
           rect: [rect.x.baseVal.value, rect.y.baseVal.value, rect.width.baseVal.value, rect.height.baseVal.value],
-          stroke: rs.strokeWidth, dash: rs.strokeDasharray, linecap: rs.strokeLinecap,
-          animation: rs.animationName,
+          stroke: rs.strokeWidth, dash: rs.strokeDasharray, animation: rs.animationName,
           color: es.color, animations: el.getAnimations({ subtree: true }).length,
         };
       });
       return { sidebar: inspect('.fixture-sidebar'), header: inspect('.fixture-header') };
     });
+    const result = await inspect();
 
     for (const [surface, size] of [['sidebar', 18], ['header', 22]]) {
       const states = result[surface];
@@ -83,8 +83,7 @@ try {
       assert.match(byState.working.dash, /20px,? 4px/);
       assert.equal(byState.working.animation, 'state-logo-trace');
       assert.equal(byState.working.animations, 1);
-      assert.match(byState.waiting.dash, /2px,? 4px/);
-      assert.equal(byState.waiting.linecap, 'round');
+      assert.equal(byState.waiting.dash, 'none');
       assert.equal(byState.idle.dash, 'none');
       assert.equal(byState.stopped.dash, 'none');
       for (const mark of [byState.waiting, byState.idle, byState.stopped]) {
@@ -92,9 +91,31 @@ try {
         assert.equal(mark.animations, 0);
       }
       assert.equal(byState.working.color, byState.waiting.color, `${theme} working and waiting share accent`);
-      assert.equal(byState.waiting.color, byState.idle.color, `${theme} waiting and idle share accent hue`);
+      assert.notEqual(byState.waiting.color, byState.idle.color, `${theme} your-turn and idle colours differ`);
       assert.notEqual(byState.idle.color, byState.stopped.color, `${theme} stopped is muted`);
-      assert.notEqual(byState.waiting.dash, byState.idle.dash, `${theme} your-turn and idle remain distinct`);
+      const signatures = states.map((mark) => `${mark.dash}|${mark.animation}|${mark.color}`);
+      assert.equal(new Set(signatures).size, 4, `${theme} ${surface} has four distinct treatments`);
+    }
+
+    // Motion is only an enhancement. When the operator asks the OS to reduce
+    // it, working freezes as four long dashes and remains distinct from all
+    // three solid frames.
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await page.waitForTimeout(20);
+    const reduced = await inspect();
+    for (const surface of ['sidebar', 'header']) {
+      const states = reduced[surface];
+      const byState = Object.fromEntries(states.map((mark) => [mark.state, mark]));
+      assert.match(byState.working.dash, /20px,? 4px/);
+      assert.equal(byState.working.animation, 'none');
+      assert.equal(byState.working.animations, 0);
+      for (const mark of [byState.waiting, byState.idle, byState.stopped]) {
+        assert.equal(mark.dash, 'none');
+        assert.equal(mark.animation, 'none');
+        assert.equal(mark.animations, 0);
+      }
+      const signatures = states.map((mark) => `${mark.dash}|${mark.color}`);
+      assert.equal(new Set(signatures).size, 4, `${theme} reduced-motion ${surface} has four distinct treatments`);
     }
     await page.close();
   }
@@ -103,4 +124,4 @@ try {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
-console.log('state-logo render: four distinct states pass at both sizes and in both themes');
+console.log('state-logo render: four solid/dashed states stay distinct across sizes, themes and reduced motion');


### PR DESCRIPTION
## Summary

- removes the dotted waiting frame: waiting is now a solid accent line
- keeps idle visually separate as a solid muted line, with stopped using the same muted hue at 50% strength
- leaves working as the animated four-cell loop; under reduced motion it remains a static dashed frame
- keeps both existing four-state legends unchanged

The product still has four distinct states. This does not merge waiting and idle: “your turn” stays accent, while a merely idle agent is muted. If those states should ever become one, that should be an explicit product decision rather than an accidental styling collapse.

## Verification

- `cd web && npm test` — 15 suites passed
- `cd web && npm run test:render` — passed
- `cd web && npm run build` — passed

The Chromium test now requires four unique computed treatments at the 18px sidebar and 22px header sizes, in both themes. It repeats the assertion with reduced motion enabled, and fails if waiting/idle or idle/stopped collapse.