### PR TITLE
Remove CLI icons from status legends

### DIFF
--- a/web/src/components/Locked.tsx
+++ b/web/src/components/Locked.tsx
@@ -63,10 +63,10 @@ function MockSidebar() {
         <span className="btn-ghost"><Logo cli="files" size={14} /> Files</span>
       </div>
       <div className="legend">
-        <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
-        <span><StateLogo cli="shell" state="waiting" size={12} tint="var(--muted)" /> your turn</span>
-        <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
-        <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
+        <span><StateLogo frameOnly state="working" size={12} /> working</span>
+        <span><StateLogo frameOnly state="waiting" size={12} /> your turn</span>
+        <span><StateLogo frameOnly state="idle" size={12} /> idle</span>
+        <span><StateLogo frameOnly state="stopped" size={12} /> stopped</span>
       </div>
     </aside>
   );

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -839,10 +839,10 @@ export default function Sidebar({
       </div>
 
       <div className="legend">
-        <span><StateLogo cli="shell" state="working" size={12} tint="var(--muted)" /> working</span>
-        <span><StateLogo cli="shell" state="waiting" size={12} tint="var(--muted)" /> your turn</span>
-        <span><StateLogo cli="shell" state="idle" size={12} tint="var(--muted)" /> idle</span>
-        <span><StateLogo cli="shell" state="stopped" size={12} tint="var(--muted)" /> stopped</span>
+        <span><StateLogo frameOnly state="working" size={12} /> working</span>
+        <span><StateLogo frameOnly state="waiting" size={12} /> your turn</span>
+        <span><StateLogo frameOnly state="idle" size={12} /> idle</span>
+        <span><StateLogo frameOnly state="stopped" size={12} /> stopped</span>
         {archived.size > 0 && (
           <label className="legend-arch" title="Sessions with no activity beyond the archive window (Settings)">
             <input type="checkbox" checked={showArchived} onChange={onToggleArchived} />

--- a/web/src/components/StateLogo.tsx
+++ b/web/src/components/StateLogo.tsx
@@ -1,21 +1,27 @@
 import type { SessionState } from '../types';
 import Logo, { logoTilePadding, logoTileRadius } from './Logo';
 
+type StateLogoProps = {
+  state: SessionState;
+  size?: number;
+  title?: string;
+} & (
+  | { frameOnly: true; cli?: never; tint?: never }
+  | { frameOnly?: false; cli: string; tint?: string }
+);
+
 /**
  * The CLI tile and the agent state are one mark. The 96-unit path is divided
  * into four exact 20 + 4 cells, so the working dash loop has no remainder (and
  * therefore no visible jump) at the rounded rectangle's origin.
  */
-export default function StateLogo({
-  cli, state, size = 18, tint, title,
-}: {
-  cli: string;
-  state: SessionState;
-  size?: number;
-  tint?: string;
-  title?: string;
-}) {
-  const padding = logoTilePadding(size, tint);
+export default function StateLogo(props: StateLogoProps) {
+  const { state, size = 18, title } = props;
+  // With a logo, `size` means glyph size and the shared tile padding completes
+  // the frame. With no logo there is no hidden glyph geometry, so it is the
+  // frame's outer size — exactly what a compact legend swatch needs.
+  const tint = props.frameOnly ? undefined : props.tint;
+  const padding = props.frameOnly ? 0 : logoTilePadding(size, tint);
   const frameSize = size + padding * 2;
 
   return (
@@ -24,7 +30,7 @@ export default function StateLogo({
       style={{ width: frameSize, height: frameSize }}
       title={title}
     >
-      <Logo cli={cli} size={size} tint={tint} />
+      {!props.frameOnly && <Logo cli={props.cli} size={size} tint={tint} />}
       <svg
         className="state-logo-frame"
         viewBox={`0 0 ${frameSize} ${frameSize}`}

--- a/web/test/stateLogo.render.test.mjs
+++ b/web/test/stateLogo.render.test.mjs
@@ -27,6 +27,12 @@ await build({
         <StateLogo cli="codex" state="idle" size={size} tint="#5eb6a6" />
         <StateLogo cli="codex" state="stopped" size={size} tint="#5eb6a6" />
       </>;
+      const Legend = () => <div className="legend fixture-legend">
+        <span><StateLogo frameOnly state="working" size={12} /> working</span>
+        <span><StateLogo frameOnly state="waiting" size={12} /> your turn</span>
+        <span><StateLogo frameOnly state="idle" size={12} /> idle</span>
+        <span><StateLogo frameOnly state="stopped" size={12} /> stopped</span>
+      </div>;
       createRoot(document.getElementById('root')).render(<>
         <div className="row session fixture-sidebar"><States size={12} /><span className="name">codex-1</span></div>
         <div className="pane-head fixture-header">
@@ -34,6 +40,7 @@ await build({
           <span className="ph-title"><span className="ph-name">codex-1</span></span>
           <div className="ph-right" />
         </div>
+        <Legend />
       </>);
     `,
   },
@@ -63,13 +70,18 @@ try {
           rect: [rect.x.baseVal.value, rect.y.baseVal.value, rect.width.baseVal.value, rect.height.baseVal.value],
           stroke: rs.strokeWidth, dash: rs.strokeDasharray, animation: rs.animationName,
           color: es.color, animations: el.getAnimations({ subtree: true }).length,
+          logos: el.querySelectorAll('.cli-logo').length,
         };
       });
-      return { sidebar: inspect('.fixture-sidebar'), header: inspect('.fixture-header') };
+      return {
+        sidebar: inspect('.fixture-sidebar'),
+        header: inspect('.fixture-header'),
+        legend: inspect('.fixture-legend'),
+      };
     });
     const result = await inspect();
 
-    for (const [surface, size] of [['sidebar', 18], ['header', 22]]) {
+    for (const [surface, size] of [['sidebar', 18], ['header', 22], ['legend', 12]]) {
       const states = result[surface];
       assert.equal(states.length, 4);
       for (const mark of states) {
@@ -95,6 +107,10 @@ try {
       assert.notEqual(byState.idle.color, byState.stopped.color, `${theme} stopped is muted`);
       const signatures = states.map((mark) => `${mark.dash}|${mark.animation}|${mark.color}`);
       assert.equal(new Set(signatures).size, 4, `${theme} ${surface} has four distinct treatments`);
+      for (const mark of states) {
+        assert.equal(mark.logos, surface === 'legend' ? 0 : 1,
+          `${theme} ${surface} ${mark.state} ${surface === 'legend' ? 'is frame-only' : 'keeps its CLI logo'}`);
+      }
     }
 
     // Motion is only an enhancement. When the operator asks the OS to reduce
@@ -103,7 +119,7 @@ try {
     await page.emulateMedia({ reducedMotion: 'reduce' });
     await page.waitForTimeout(20);
     const reduced = await inspect();
-    for (const surface of ['sidebar', 'header']) {
+    for (const surface of ['sidebar', 'header', 'legend']) {
       const states = reduced[surface];
       const byState = Object.fromEntries(states.map((mark) => [mark.state, mark]));
       assert.match(byState.working.dash, /20px,? 4px/);
@@ -124,4 +140,4 @@ try {
   fs.rmSync(tmp, { recursive: true, force: true });
 }
 
-console.log('state-logo render: four solid/dashed states stay distinct across sizes, themes and reduced motion');
+console.log('state-logo render: frame-only legend stays distinct while real tiles keep their logos');

--- a/web/test/stateLogo.test.mjs
+++ b/web/test/stateLogo.test.mjs
@@ -51,6 +51,22 @@ for (const state of STATES) {
     state === 'working' ? 'state-logo-run' : 'state-logo-static');
 }
 
+// The legend uses the same SVG renderer at a true 12px outer size, but carries
+// no fake CLI identity. Regular rows above still prove the default keeps Logo.
+for (const state of STATES) {
+  const frame = StateLogo({ frameOnly: true, state, size: 12 });
+  assert.deepEqual(frame.props.style, { width: 12, height: 12 });
+  const children = Children.toArray(frame.props.children);
+  assert.equal(children.length, 1, `${state} legend frame contains no Logo`);
+  const [svg] = children;
+  assert.equal(svg.type, 'svg');
+  assert.equal(svg.props.viewBox, '0 0 12 12');
+  for (const rect of Children.toArray(svg.props.children)) {
+    assert.equal(rect.props.width, 11);
+    assert.equal(rect.props.height, 11);
+  }
+}
+
 const workingRects = Children.toArray(
   Children.toArray(rendered.working.props.children)[1].props.children,
 );
@@ -68,4 +84,4 @@ assert.equal(paintedLogo.props.style.height, 16);
 assert.equal(paintedLogo.props.style.padding, 3);
 assert.equal(headerSvg.props.viewBox, '0 0 22 22');
 
-console.log('state-logo: four states share exact tile geometry without source-text pins');
+console.log('state-logo: real tiles keep logos and 12px legend frames contain only the shared border');


### PR DESCRIPTION
## Summary

- adds a frame-only mode to `StateLogo`; it reuses the exact SVG state renderer but omits the CLI logo and tile tint
- updates both the live sidebar and locked-screen legends to use 12px frame-only swatches
- keeps normal sidebar, mobile and pane-header tiles unchanged with their CLI logos inside

`frameOnly` is a distinct prop shape: it does not accept `cli` or `tint`, and its `size` is the frame’s outer size. This avoids carrying hidden shell geometry into a legend that is only explaining state.

## Verification

- `cd web && npm test` — 15 suites passed
- `cd web && npm run test:render` — passed
- `cd web && npm run build` — passed

The Chromium test renders all four 12px legend swatches in both themes and under reduced motion, requires four distinct treatments, and asserts they contain zero `.cli-logo` elements. The same test asserts the 18px sidebar and 22px header frames still contain their CLI logos.