### PR TITLE
Add durable cron jobs for scheduled prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,13 +108,14 @@ api.set_space_volumes(
 api.restart_space(space_id)
 ```
 
-Everything durable lives under `/data`: `sessions.json`, `groups.json`,
+Everything durable lives under `/data`: `sessions.json`, `groups.json`, `crons.json`,
 `workspaces/<path>/` (agent working dirs + shared `skills/`), and each
 CLI's closed state checkpoints under `/data/state`. Active harness state lives
 on local POSIX storage and is restored/checkpointed by
 [`scripts/agent-state.sh`](scripts/agent-state.sh); SQLite harnesses use online
 database backups rather than copying live WAL files. See
 [`docs/agent-state-checkpoints.md`](docs/agent-state-checkpoints.md).
+Scheduled prompts are documented in [`docs/cron-jobs.md`](docs/cron-jobs.md).
 
 ## Architecture
 

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -1,0 +1,117 @@
+# Cron jobs
+
+Cron jobs send ordinary Agent Manager prompts on a five-field cron schedule.
+They are durable configuration, not terminal processes: definitions and their
+last delivery result live in `DATA_DIR/crons.json` (the mounted bucket in a
+Space), while timers exist only in the current server process.
+
+The same feature is available in **Settings → Cron** and over HTTP. As with
+other mutating APIs, an agent passes `?from=$AM_ID`; the browser supplies the
+operator origin automatically.
+
+## Create and list
+
+```sh
+curl -sS --fail -X POST \
+  "http://localhost:${AM_PORT:-7860}/api/crons?from=$AM_ID" \
+  -H 'content-type: application/json' -d '{
+    "name": "nightly deploy check",
+    "agent": { "name": "nightly-index", "cli": "claude" },
+    "prompt": "Check last night’s deploy log and report regressions.",
+    "schedule": { "cron": "0 9 * * *", "tz": "Europe/Zurich" },
+    "runOnRestart": true
+  }'
+```
+
+The response is the stored job, including a generated `cron_…` id, `state`
+(`running` initially), and `next` as an ISO UTC instant. `schedule.tz` is a
+required IANA timezone; it is applied when calculating occurrences, including
+daylight-saving transitions. Expressions use exactly the conventional five
+fields: minute, hour, day of month, month, day of week.
+
+```sh
+curl -s "http://localhost:${AM_PORT:-7860}/api/crons" | jq .crons
+```
+
+Each listed job includes:
+
+```json
+{
+  "id": "cron_7f3a…",
+  "name": "nightly deploy check",
+  "agent": { "name": "nightly-index", "cli": "claude" },
+  "prompt": "…",
+  "schedule": { "cron": "0 9 * * *", "tz": "Europe/Zurich" },
+  "runOnRestart": true,
+  "state": "running",
+  "next": "2026-08-20T07:00:00.000Z",
+  "last": {
+    "at": "2026-08-19T07:00:00.000Z",
+    "status": "ok",
+    "durationMs": 83,
+    "trigger": "schedule"
+  }
+}
+```
+
+`last.status` reports whether Agent Manager delivered the prompt, or why it
+could not (for example, a CLI no longer installed on the Space). Its duration
+is delivery time, **not the agent task's runtime**. The supported CLIs do not
+provide one shared, trustworthy task-success signal, and an agent can accept
+overlapping prompts, so claiming task success here would be false.
+
+## Run, edit, stop, and delete
+
+```sh
+# Fire outside the schedule. 202 means accepted for delivery.
+curl -sS --fail -X POST \
+  "http://localhost:${AM_PORT:-7860}/api/crons/$ID/run?from=$AM_ID"
+
+# Stop keeps the definition and last result, but removes its next occurrence.
+curl -sS --fail -X PUT \
+  "http://localhost:${AM_PORT:-7860}/api/crons/$ID?from=$AM_ID" \
+  -H 'content-type: application/json' -d '{"state":"stopped"}'
+
+# Start again. PUT also accepts any of the create fields for editing.
+curl -sS --fail -X PUT \
+  "http://localhost:${AM_PORT:-7860}/api/crons/$ID?from=$AM_ID" \
+  -H 'content-type: application/json' -d '{"state":"running"}'
+
+curl -sS --fail -X DELETE \
+  "http://localhost:${AM_PORT:-7860}/api/crons/$ID?from=$AM_ID"
+```
+
+Manual Run now works for stopped jobs too; stopped governs future schedule
+fires, not whether the definition may be invoked explicitly.
+
+## Agent creation and identity
+
+At fire time Agent Manager looks for an existing session with the exact agent
+name. If found, it reuses that session; the job's `agent.cli` is only the type
+to use when creation is needed. If absent, the server synchronously creates one
+session in `workspaces/<slugged-agent-name>` before prompt delivery. Because
+lookup and creation happen without an asynchronous gap, two jobs firing for the
+same missing name cannot create two agents in this server process.
+
+The target sees a normal prompt prefixed with:
+
+```text
+[message from cron "nightly deploy check":]
+```
+
+Scheduled and restart fires enter the durable operations log with origin
+`{id: "cron:<job-id>", type: "cron", name: "<job-name>"}`. API calls that
+create, edit, manually run, or delete jobs retain the operator/agent identity
+that made the call.
+
+## Restart and overlap semantics
+
+On server start, every running job gets a newly calculated future occurrence.
+Persisted times that passed while the Space was asleep are not replayed. A
+running job with `runOnRestart: true` also fires once shortly after the server
+starts; this is one fresh invocation, independent of its next scheduled time.
+Stopped jobs do not run on restart.
+
+There is deliberately no overlap guard and no spend ceiling. If a target is
+already working, another prompt may land in its input and be handled mid-task.
+Use Stop or Delete when a schedule should no longer spend tokens.

--- a/docs/cron-jobs.md
+++ b/docs/cron-jobs.md
@@ -109,8 +109,9 @@ that made the call.
 On server start, every running job gets a newly calculated future occurrence.
 Persisted times that passed while the Space was asleep are not replayed. A
 running job with `runOnRestart: true` also fires once shortly after the server
-starts; this is one fresh invocation, independent of its next scheduled time.
-Stopped jobs do not run on restart.
+starts. If its next scheduled occurrence falls in that same short startup
+window, the scheduled occurrence substitutes for the restart fire so one boot
+cannot send the prompt twice. Stopped jobs do not run on restart.
 
 There is deliberately no overlap guard and no spend ceiling. If a target is
 already working, another prompt may land in its input and be handled mid-task.

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@coder/libghostty-vt-node": "0.1.0-beta.0",
+        "cron-parser": "^5.10.0",
         "express": "^4.19.2",
         "node-pty": "^1.0.0",
         "web-push": "^3.6.7",
@@ -205,6 +206,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
+    },
+    "node_modules/cron-parser": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.10.0.tgz",
+      "integrity": "sha512-izNAxJyRWUP8ljBoDSub5WyrVOUlT4SLGShswE7eoRBpp6QUsSycYxLBMJlbshgPBMcPT/nrfgjNY2918ayv2A==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.7.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "2.6.9",
@@ -607,6 +620,15 @@
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/math-intrinsics": {

--- a/server/package.json
+++ b/server/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@coder/libghostty-vt-node": "0.1.0-beta.0",
+    "cron-parser": "^5.10.0",
     "express": "^4.19.2",
     "node-pty": "^1.0.0",
     "web-push": "^3.6.7",

--- a/server/src/crons.js
+++ b/server/src/crons.js
@@ -126,6 +126,7 @@ function resetNext(job, now = new Date()) {
 
 export function init(now = new Date()) {
   for (const id of timers.keys()) clearTimer(id);
+  fireJob = null;
   try {
     const parsed = JSON.parse(fs.readFileSync(CRONS_FILE, 'utf8'));
     jobs = Array.isArray(parsed) ? parsed : [];
@@ -208,13 +209,24 @@ export function recordLast(id, last) {
 
 export function startScheduler(handler, { restartDelayMs = 1_500 } = {}) {
   fireJob = handler;
+  const restartAt = Date.now() + restartDelayMs;
+  // Capture the boot-time occurrence before arming it. By the restart callback
+  // it may already have fired and advanced `next`, which would hide the very
+  // collision this check prevents.
+  const restartJobs = jobs
+    .filter((job) => job.state === 'running' && job.runOnRestart)
+    .map((job) => ({ id: job.id, scheduledAt: Date.parse(job.next) }));
   for (const job of jobs) armExisting(job);
-  const restartJobs = jobs.filter((job) => job.state === 'running' && job.runOnRestart).map((job) => job.id);
   if (restartJobs.length) {
     const timer = setTimeout(() => {
-      for (const id of restartJobs) {
+      for (const { id, scheduledAt } of restartJobs) {
         const current = jobs.find((job) => job.id === id);
         if (!current || current.state !== 'running' || !current.runOnRestart) continue;
+        // One boot intent must not become two prompts. A scheduled occurrence
+        // within one restart-delay of the planned restart fire substitutes for
+        // it; this is startup de-duplication, not an overlap guard for ordinary
+        // runs. Use the captured time so this still holds if schedule fired first.
+        if (Number.isFinite(scheduledAt) && Math.abs(scheduledAt - restartAt) <= restartDelayMs) continue;
         Promise.resolve(fireJob(id, 'restart')).catch((e) =>
           console.error('[crons.restart]', id, e && e.message));
       }

--- a/server/src/crons.js
+++ b/server/src/crons.js
@@ -1,0 +1,224 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { CronExpressionParser } from 'cron-parser';
+import { DATA_DIR } from './config.js';
+
+export const CRONS_FILE = path.join(DATA_DIR, 'crons.json');
+const MAX_TIMER_MS = 2_147_000_000;
+const VALID_STATES = new Set(['running', 'stopped']);
+
+let jobs = [];
+let fireJob = null;
+const timers = new Map();
+
+const cleanText = (value, field, max = 160) => {
+  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} required`);
+  const text = value.trim();
+  if (text.length > max) throw new Error(`${field} is too long (max ${max} characters)`);
+  return text;
+};
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+function persist() {
+  try {
+    fs.mkdirSync(path.dirname(CRONS_FILE), { recursive: true });
+    const tmp = `${CRONS_FILE}.tmp`;
+    fs.writeFileSync(tmp, JSON.stringify(jobs, null, 2), { mode: 0o600 });
+    fs.renameSync(tmp, CRONS_FILE);
+  } catch (e) {
+    // A transient bucket/FUSE write must not take down the process that owns
+    // every live terminal. Match the session store's failure posture.
+    console.error('[crons.persist]', e && e.message);
+  }
+}
+
+export function validateSchedule(value, id = '') {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('schedule required');
+  const cron = cleanText(value.cron, 'schedule.cron', 120).replace(/\s+/g, ' ');
+  if (cron.split(' ').length !== 5) throw new Error('schedule.cron must use the standard five fields: minute hour day month weekday');
+  const tz = cleanText(value.tz, 'schedule.tz', 100);
+  try {
+    // Intl is the runtime authority for IANA zone names; cron-parser then
+    // applies that zone (including DST) when it advances the expression.
+    new Intl.DateTimeFormat('en', { timeZone: tz }).format(new Date());
+    CronExpressionParser.parse(cron, { tz, hashSeed: id || 'agent-manager-cron' }).next();
+  } catch (e) {
+    throw new Error(`invalid schedule: ${e && e.message ? e.message : e}`);
+  }
+  return { cron, tz };
+}
+
+export function nextOccurrence(schedule, after = new Date(), id = '') {
+  const valid = validateSchedule(schedule, id);
+  return CronExpressionParser.parse(valid.cron, {
+    currentDate: after,
+    tz: valid.tz,
+    hashSeed: id || 'agent-manager-cron',
+  }).next().toISOString();
+}
+
+function normalizeInput(input, existing = null) {
+  const src = input && typeof input === 'object' && !Array.isArray(input) ? input : {};
+  const merged = existing ? {
+    ...existing,
+    ...src,
+    agent: src.agent === undefined ? existing.agent : src.agent,
+    schedule: src.schedule === undefined ? existing.schedule : src.schedule,
+  } : src;
+  const agent = merged.agent;
+  if (!agent || typeof agent !== 'object' || Array.isArray(agent)) throw new Error('agent required');
+  const state = merged.state === undefined ? 'running' : merged.state;
+  if (!VALID_STATES.has(state)) throw new Error("state must be 'running' or 'stopped'");
+  const id = existing?.id || `cron_${crypto.randomBytes(5).toString('hex')}`;
+  return {
+    ...(existing || {}),
+    id,
+    name: cleanText(merged.name, 'name'),
+    agent: {
+      name: cleanText(agent.name, 'agent.name'),
+      cli: cleanText(agent.cli, 'agent.cli', 64),
+    },
+    prompt: cleanText(merged.prompt, 'prompt', 100_000),
+    schedule: validateSchedule(merged.schedule, id),
+    runOnRestart: merged.runOnRestart === true,
+    state,
+  };
+}
+
+function clearTimer(id) {
+  const timer = timers.get(id);
+  if (timer) clearTimeout(timer);
+  timers.delete(id);
+}
+
+function armExisting(job) {
+  clearTimer(job.id);
+  if (!fireJob || job.state !== 'running' || !job.next) return;
+  const target = Date.parse(job.next);
+  if (!Number.isFinite(target)) return;
+  const delay = target - Date.now();
+  const timer = setTimeout(() => {
+    timers.delete(job.id);
+    const current = jobs.find((candidate) => candidate.id === job.id);
+    if (!current || current.state !== 'running' || current.next !== job.next) return;
+    if (Date.now() + 250 < target) {
+      armExisting(current);
+      return;
+    }
+    // Advance before dispatch. If delivery is slow, fails, or overlaps another
+    // run, this occurrence is still consumed exactly once. Computing from now
+    // deliberately skips times missed while the process was unavailable.
+    current.next = nextOccurrence(current.schedule, new Date(Math.max(Date.now(), target)), current.id);
+    persist();
+    armExisting(current);
+    Promise.resolve(fireJob(current.id, 'schedule')).catch((e) =>
+      console.error('[crons.fire]', current.id, e && e.message));
+  }, Math.max(0, Math.min(MAX_TIMER_MS, delay)));
+  timer.unref?.();
+  timers.set(job.id, timer);
+}
+
+function resetNext(job, now = new Date()) {
+  job.next = job.state === 'running' ? nextOccurrence(job.schedule, now, job.id) : null;
+}
+
+export function init(now = new Date()) {
+  for (const id of timers.keys()) clearTimer(id);
+  try {
+    const parsed = JSON.parse(fs.readFileSync(CRONS_FILE, 'utf8'));
+    jobs = Array.isArray(parsed) ? parsed : [];
+  } catch {
+    jobs = [];
+  }
+  const valid = [];
+  for (const raw of jobs) {
+    try {
+      const job = normalizeInput(raw, raw && raw.id ? raw : null);
+      job.createdAt = raw.createdAt || now.toISOString();
+      job.updatedAt = raw.updatedAt || job.createdAt;
+      if (raw.last && typeof raw.last === 'object') job.last = raw.last;
+      resetNext(job, now); // stale persisted times are never replayed
+      valid.push(job);
+    } catch (e) {
+      console.error('[crons.load]', raw && raw.id, e && e.message);
+    }
+  }
+  jobs = valid;
+  persist();
+  return list();
+}
+
+export function list() {
+  return jobs.map(clone);
+}
+
+export function get(id) {
+  const job = jobs.find((candidate) => candidate.id === id);
+  return job ? clone(job) : null;
+}
+
+export function create(input, now = new Date()) {
+  const job = normalizeInput(input);
+  job.createdAt = now.toISOString();
+  job.updatedAt = job.createdAt;
+  resetNext(job, now);
+  jobs.push(job);
+  persist();
+  armExisting(job);
+  return clone(job);
+}
+
+export function update(id, patch, now = new Date()) {
+  const index = jobs.findIndex((job) => job.id === id);
+  if (index < 0) return null;
+  const before = jobs[index];
+  const job = normalizeInput(patch, before);
+  job.updatedAt = now.toISOString();
+  const scheduleChanged = job.schedule.cron !== before.schedule.cron || job.schedule.tz !== before.schedule.tz;
+  const resumed = before.state !== 'running' && job.state === 'running';
+  if (job.state !== 'running') job.next = null;
+  else if (scheduleChanged || resumed || !before.next) resetNext(job, now);
+  jobs[index] = job;
+  persist();
+  armExisting(job);
+  return clone(job);
+}
+
+export function remove(id) {
+  const before = jobs.length;
+  jobs = jobs.filter((job) => job.id !== id);
+  if (jobs.length === before) return false;
+  clearTimer(id);
+  persist();
+  return true;
+}
+
+export function recordLast(id, last) {
+  const job = jobs.find((candidate) => candidate.id === id);
+  if (!job) return null; // deleting a firing job must not recreate it
+  // Overlap is allowed. Completion order therefore need not be start order;
+  // never let an older, slower delivery replace the genuinely latest fire.
+  if (job.last && Date.parse(job.last.at) > Date.parse(last.at)) return clone(job);
+  job.last = clone(last);
+  persist();
+  return clone(job);
+}
+
+export function startScheduler(handler, { restartDelayMs = 1_500 } = {}) {
+  fireJob = handler;
+  for (const job of jobs) armExisting(job);
+  const restartJobs = jobs.filter((job) => job.state === 'running' && job.runOnRestart).map((job) => job.id);
+  if (restartJobs.length) {
+    const timer = setTimeout(() => {
+      for (const id of restartJobs) {
+        const current = jobs.find((job) => job.id === id);
+        if (!current || current.state !== 'running' || !current.runOnRestart) continue;
+        Promise.resolve(fireJob(id, 'restart')).catch((e) =>
+          console.error('[crons.restart]', id, e && e.message));
+      }
+    }, restartDelayMs);
+    timer.unref?.();
+  }
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,6 +17,7 @@ import * as groups from './groups.js';
 import * as order from './order.js';
 import * as demo from './demo.js';
 import * as hidden from './hidden.js';
+import * as crons from './crons.js';
 import {
   attach, agentInfo, deriveState, stop, stopAll, ensureRunning, sendInput, pasteInput, isRunning,
   waitForInputReady, capturePane, ghosttyReady, ghosttyError,
@@ -52,6 +53,7 @@ installSlowFsProbe();
 ensureDirs();
 refreshVersions();
 store.init();
+crons.init();
 pruneAttachmentDirs(store.list().map((session) => session.id))
   .catch((e) => console.error('[attachments.prune]', e && e.message));
 groups.init();
@@ -210,6 +212,10 @@ const resolveOperationOrigin = (raw, req) => {
     return { id: 'operator', type: 'operator', name: process.env.SPACE_AUTHOR_NAME || process.env.AM_USER || 'operator' };
   }
   if (raw) {
+    if (raw.startsWith('cron:')) {
+      const job = crons.get(raw.slice('cron:'.length));
+      if (job) return { id: raw, type: 'cron', name: job.name };
+    }
     const session = store.get(raw);
     if (session) return { id: session.id, type: 'agent', name: session.name, cli: session.cli };
     if (raw.startsWith('remote:')) {
@@ -1284,6 +1290,33 @@ To reconstruct recent manager operations (newest first):
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/operations?limit=100" | jq .operations
 \`\`\`
 
+### Schedule recurring prompts
+A cron job sends a normal prompt on a five-field cron schedule. It survives
+Space restarts in durable storage; if the named agent does not exist when it
+fires, the manager creates it in \`workspaces/<agent-name>\` first. The timezone
+is required because the Space clock is UTC. Create one with your own id so the
+operation log records who asked:
+
+\`\`\`sh
+curl -sS --fail -X POST "http://localhost:\${AM_PORT:-${PORT}}/api/crons?from=$AM_ID" \\
+  -H 'content-type: application/json' -d '{
+    "name":"weekday issue triage",
+    "agent":{"name":"triage","cli":"claude"},
+    "prompt":"Triage newly opened issues and report anything urgent.",
+    "schedule":{"cron":"0 9 * * 1-5","tz":"Europe/Zurich"},
+    "runOnRestart":true
+  }'
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/crons" | jq .crons
+\`\`\`
+
+Use \`POST /api/crons/$ID/run?from=$AM_ID\` to run now,
+\`PUT /api/crons/$ID?from=$AM_ID\` with \`{"state":"stopped"}\` (or
+\`"running"\`) to stop/start it, and \`DELETE /api/crons/$ID?from=$AM_ID\` to
+remove it. Run-on-restart is one fresh fire, never a replay of missed times.
+There is deliberately no overlap or spend guard: stop or delete jobs you no
+longer want. See \`docs/cron-jobs.md\` in the Agent Manager source for the full
+request and response shapes.
+
 Your session exports the port as \`$AM_PORT\` — read it rather than trusting a
 number you remember, and check it before you believe an empty answer: \`curl -s\`
 to a port nothing is listening on prints **nothing at all**, and in some agent
@@ -2207,6 +2240,128 @@ app.post('/api/sessions', (req, res) => {
   res.status(201).json({ ...s, running: false, state: 'stopped' });
 });
 
+// ---------- scheduled prompts (/api/crons) ----------
+//
+// A cron's agent type is only used when its named agent does not exist yet.
+// Existing names are deliberately reused (even if the session was created with
+// another CLI): the name is the idempotency key promised by the Settings form.
+const cronCliError = (cli) => {
+  const def = cliById(cli);
+  if (!def || !isAgentCli(cli) || isRemote(cli)) {
+    return `unknown agent type '${cli}' — use an agent from GET /api/clis (not shell, files, trace, or remote)`;
+  }
+  return null;
+};
+const cronAgentFolder = (name) => {
+  const readable = slugify(name);
+  if (readable) return readable;
+  // A perfectly valid display name can contain no ASCII characters. Do not
+  // collapse those agents into the workspaces root (or one shared `agent/`
+  // folder); a tiny deterministic suffix keeps the promised private folder.
+  let hash = 2_166_136_261;
+  for (const character of name) hash = Math.imul(hash ^ character.codePointAt(0), 16_777_619);
+  return `agent-${(hash >>> 0).toString(16).padStart(8, '0')}`;
+};
+
+function beginCronFire(job, trigger) {
+  const at = new Date();
+  const started = Date.now();
+  const fail = (error) => {
+    const message = String(error && error.message || error).slice(0, 500);
+    crons.recordLast(job.id, {
+      at: at.toISOString(), status: 'failed', durationMs: Date.now() - started, trigger, error: message,
+    });
+    return message;
+  };
+
+  try {
+    let session = store.list().find((candidate) => candidate.name === job.agent.name) || null;
+    let agentCreated = false;
+    if (!session) {
+      const invalid = cronCliError(job.agent.cli);
+      if (invalid) throw new Error(invalid);
+      const catalog = cliCatalog().find((candidate) => candidate.id === job.agent.cli);
+      if (!catalog?.available) throw new Error(`${cliById(job.agent.cli).label} is not installed on this Space`);
+      session = createSession({
+        name: job.agent.name,
+        cli: job.agent.cli,
+        // Cron-created agents own a predictable workspace. A second job with
+        // the same name sees the session synchronously and cannot create it
+        // again, even while the first prompt is still being delivered.
+        path: cronAgentFolder(job.agent.name),
+      });
+      if (!session) throw new Error('could not create the agent workspace');
+      if (session.error) throw new Error(session.error);
+      agentCreated = true;
+    }
+    if (!promptable(session) || isRemote(session.cli)) {
+      throw new Error(`the existing '${session.name}' session (${session.cli}) cannot receive scheduled prompts`);
+    }
+    const text = `[message from cron "${job.name}":] ${job.prompt}`;
+    const completion = deliver(session, { text }, `cron: ${job.name}`)
+      .then(() => {
+        crons.recordLast(job.id, {
+          at: at.toISOString(), status: 'ok', durationMs: Date.now() - started, trigger,
+        });
+      })
+      .catch((error) => { fail(error); });
+    return { agentCreated, completion };
+  } catch (error) {
+    const message = fail(error);
+    throw Object.assign(new Error(message), { statusCode: 409 });
+  }
+}
+
+const validateCronCli = (body) => {
+  const cli = body?.agent?.cli;
+  return typeof cli === 'string' ? cronCliError(cli.trim()) : null;
+};
+
+app.get('/api/crons', (_req, res) => res.json({ crons: crons.list() }));
+
+app.post('/api/crons', (req, res) => {
+  const cliError = validateCronCli(req.body);
+  if (cliError) return res.status(400).json({ error: cliError });
+  try {
+    const job = crons.create(req.body || {});
+    return res.status(201).json(job);
+  } catch (e) {
+    return res.status(400).json({ error: String(e.message || e) });
+  }
+});
+
+app.put('/api/crons/:id', (req, res) => {
+  if (!crons.get(req.params.id)) return res.status(404).json({ error: 'not found' });
+  const cliError = validateCronCli(req.body);
+  if (cliError) return res.status(400).json({ error: cliError });
+  try {
+    return res.json(crons.update(req.params.id, req.body || {}));
+  } catch (e) {
+    return res.status(400).json({ error: String(e.message || e) });
+  }
+});
+
+app.delete('/api/crons/:id', (req, res) => {
+  if (!crons.remove(req.params.id)) return res.status(404).json({ error: 'not found' });
+  return res.json({ ok: true });
+});
+
+app.post('/api/crons/:id/run', (req, res) => {
+  const job = crons.get(req.params.id);
+  if (!job) return res.status(404).json({ error: 'not found' });
+  const requested = String(req.query.trigger || '');
+  const trigger = req.operationOrigin?.type === 'cron' && (requested === 'schedule' || requested === 'restart')
+    ? requested : 'manual';
+  try {
+    const run = beginCronFire(job, trigger);
+    // 202 means the prompt was accepted for delivery, not that the agent's work
+    // has finished. `last` is updated when delivery itself succeeds or fails.
+    return res.status(202).json({ ok: true, agentCreated: run.agentCreated });
+  } catch (e) {
+    return res.status(e.statusCode || 409).json({ error: String(e.message || e) });
+  }
+});
+
 // Rename = display label only. Folders are never renamed or moved.
 app.put('/api/sessions/:id', (req, res) => {
   const name = (req.body || {}).name;
@@ -2789,4 +2944,16 @@ server.listen(PORT, () => {
   console.log(`Agent Manager :${PORT}  engine=libghostty${ghosttyReady() ? '' : ' (UNAVAILABLE)'}  data=${DATA_DIR}`);
   console.log('⚠  No authentication: this app trusts whoever can reach it.');
   console.log('   Keep this Space PRIVATE — a public instance gives anyone a shell + your logged-in agents.');
+  // Scheduled fires use the public cron-run route too. That keeps one execution
+  // path and gives the operations log a first-class `cron:<id>` origin instead
+  // of inventing a session that does not exist.
+  crons.startScheduler(async (id, trigger) => {
+    const response = await fetch(`http://127.0.0.1:${PORT}/api/crons/${encodeURIComponent(id)}/run?trigger=${trigger}`, {
+      method: 'POST', headers: { 'x-am-origin': `cron:${id}` },
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      throw new Error(body.error || `cron run returned HTTP ${response.status}`);
+    }
+  });
 });

--- a/server/test/cron-api.test.mjs
+++ b/server/test/cron-api.test.mjs
@@ -1,0 +1,139 @@
+// Cron API, durable boot behavior, scheduled identity, and same-name creation.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const PORT = 7902;
+const API = `http://127.0.0.1:${PORT}`;
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'am-cron-api-'));
+const bin = path.join(DATA_DIR, 'bin');
+fs.mkdirSync(bin, { recursive: true });
+const fakeClaude = path.join(bin, 'claude');
+fs.writeFileSync(fakeClaude, `#!/bin/sh
+printf '%s\\n' "$*" >> "$DATA_DIR/fake-claude.log"
+sleep 120
+`, { mode: 0o755 });
+
+const seed = (id, name) => ({
+  id, name,
+  agent: { name: 'shared-cron-agent', cli: 'claude' },
+  prompt: `Run ${name}.`,
+  schedule: { cron: '0 * * * *', tz: 'UTC' },
+  runOnRestart: true,
+  state: 'running',
+  createdAt: '2026-08-19T00:00:00.000Z',
+  updatedAt: '2026-08-19T00:00:00.000Z',
+});
+fs.writeFileSync(path.join(DATA_DIR, 'crons.json'), JSON.stringify([
+  seed('cron_boot_one', 'boot one'), seed('cron_boot_two', 'boot two'),
+]));
+
+let pass = 0; let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+const server = spawn('node', ['src/index.js'], {
+  env: {
+    ...BASE_ENV,
+    PATH: `${bin}:${BASE_ENV.PATH || ''}`,
+    PORT: String(PORT), DATA_DIR, HOME: path.join(DATA_DIR, 'home'),
+    CLAUDE_CONFIG_DIR: path.join(DATA_DIR, 'home', '.claude'),
+    AM_BASHRC: '/nonexistent',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let log = '';
+server.stdout.on('data', (chunk) => { log += chunk; });
+server.stderr.on('data', (chunk) => { log += chunk; });
+
+const api = async (route, init = {}) => {
+  const headers = new Headers(init.headers || {});
+  if (init.body && !headers.has('content-type')) headers.set('content-type', 'application/json');
+  if (init.method && init.method !== 'GET') headers.set('x-am-origin', 'operator');
+  const response = await fetch(`${API}${route}`, { ...init, headers });
+  const body = await response.json().catch(() => null);
+  return { status: response.status, body };
+};
+
+try {
+  for (let i = 0; i < 80; i++) {
+    if (await fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false)) break;
+    await sleep(250);
+  }
+
+  // Both boot jobs fire, but name lookup + synchronous creation gives them one
+  // shared agent. This is the race the feature must be idempotent across.
+  let sessions = [];
+  let operations = [];
+  for (let i = 0; i < 60; i++) {
+    sessions = (await api('/api/sessions')).body || [];
+    operations = (await api('/api/operations?limit=50')).body?.operations || [];
+    const cronOps = operations.filter((row) => row.origin?.type === 'cron');
+    if (sessions.length === 1 && cronOps.length >= 2) break;
+    await sleep(250);
+  }
+  check('two restart jobs naming one agent create exactly one session', sessions.length === 1, `sessions ${sessions.length}`);
+  check('the cron-created workspace follows workspaces/<agent-name>', sessions[0]?.path === 'shared-cron-agent', `path ${sessions[0]?.path}`);
+  const cronOps = operations.filter((row) => row.origin?.type === 'cron');
+  check('scheduled runs are attributed to cron identities in operations',
+    cronOps.length >= 2 && cronOps.every((row) => row.origin.id.startsWith('cron:') && row.origin.name.startsWith('boot')),
+    JSON.stringify(cronOps.map((row) => row.origin)));
+
+  let listed = await api('/api/crons');
+  for (let i = 0; i < 80 && !listed.body?.crons?.every((job) => job.last); i++) {
+    await sleep(250);
+    listed = await api('/api/crons');
+  }
+  check('GET lists both durable jobs', listed.status === 200 && listed.body?.crons?.length === 2);
+  check('run-on-restart records delivery outcomes', listed.body.crons.every((job) => job.last?.status === 'ok'),
+    JSON.stringify(listed.body.crons.map((job) => job.last)));
+
+  const manual = await api('/api/crons/cron_boot_one/run', { method: 'POST' });
+  check('Run now is accepted and reuses the agent', manual.status === 202 && manual.body?.agentCreated === false,
+    JSON.stringify(manual.body));
+
+  const stopped = await api('/api/crons/cron_boot_one', {
+    method: 'PUT', body: JSON.stringify({ state: 'stopped' }),
+  });
+  check('stop keeps the job and clears its next fire', stopped.status === 200 && stopped.body.state === 'stopped' && stopped.body.next === null);
+
+  const created = await api('/api/crons', {
+    method: 'POST', body: JSON.stringify({
+      name: 'Zurich morning', agent: { name: 'morning', cli: 'claude' }, prompt: 'Good morning.',
+      schedule: { cron: '0 9 * * 1-5', tz: 'Europe/Zurich' }, runOnRestart: false,
+    }),
+  });
+  check('POST stores the timezone and returns the next UTC instant',
+    created.status === 201 && created.body.schedule.tz === 'Europe/Zurich' && /Z$/.test(created.body.next),
+    JSON.stringify(created.body));
+
+  const invalid = await api('/api/crons', {
+    method: 'POST', body: JSON.stringify({
+      name: 'bad zone', agent: { name: 'bad', cli: 'claude' }, prompt: 'No.',
+      schedule: { cron: '0 9 * * *', tz: 'Moon/Sea' },
+    }),
+  });
+  check('invalid timezone is a readable 400', invalid.status === 400 && /invalid schedule/.test(invalid.body?.error || ''), JSON.stringify(invalid.body));
+
+  const deleted = await api('/api/crons/cron_boot_two', { method: 'DELETE' });
+  check('delete is distinct from stop and removes the job', deleted.status === 200
+    && !(await api('/api/crons')).body.crons.some((job) => job.id === 'cron_boot_two'));
+
+  const disk = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'crons.json'), 'utf8'));
+  check('the final state is on DATA_DIR, not local process memory',
+    disk.some((job) => job.id === 'cron_boot_one' && job.state === 'stopped')
+      && !disk.some((job) => job.id === 'cron_boot_two'));
+} catch (error) {
+  check(`suite threw: ${error && error.message}`, false, log.slice(-1200));
+} finally {
+  server.kill('SIGTERM');
+  await Promise.race([new Promise((resolve) => server.once('exit', resolve)), sleep(3000)]);
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/server/test/crons.test.mjs
+++ b/server/test/crons.test.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-crons-unit-'));
+process.env.DATA_DIR = root;
+const crons = await import('../src/crons.js');
+
+test.after(() => fs.rmSync(root, { recursive: true, force: true }));
+
+test('timezone is part of the calculation, including seasonal offsets', () => {
+  const schedule = { cron: '0 9 * * *', tz: 'Europe/Zurich' };
+  assert.equal(crons.nextOccurrence(schedule, new Date('2026-08-19T21:30:00Z'), 'daily'), '2026-08-20T07:00:00.000Z');
+  assert.equal(crons.nextOccurrence(schedule, new Date('2027-01-02T10:00:00Z'), 'daily'), '2027-01-03T08:00:00.000Z');
+});
+
+test('only five-field cron and real IANA timezones are accepted', () => {
+  assert.throws(() => crons.validateSchedule({ cron: '0 0 9 * * *', tz: 'UTC' }), /five fields/);
+  assert.throws(() => crons.validateSchedule({ cron: '0 9 * * *', tz: 'Moon\/Tranquility' }), /invalid schedule/);
+  assert.throws(() => crons.validateSchedule({ cron: '70 9 * * *', tz: 'UTC' }), /invalid schedule/);
+});
+
+test('jobs persist, stop without deletion, resume from now, and never replay stale next times', () => {
+  crons.init(new Date('2026-08-19T12:00:00Z'));
+  const job = crons.create({
+    name: 'daily index',
+    agent: { name: 'indexer', cli: 'claude' },
+    prompt: 'Refresh the index.',
+    schedule: { cron: '0 9 * * *', tz: 'UTC' },
+    runOnRestart: true,
+  }, new Date('2026-08-19T12:00:00Z'));
+  assert.equal(job.next, '2026-08-20T09:00:00.000Z');
+  assert.ok(fs.existsSync(path.join(root, 'crons.json')));
+
+  const stopped = crons.update(job.id, { state: 'stopped' }, new Date('2026-08-19T13:00:00Z'));
+  assert.equal(stopped.next, null);
+  assert.equal(stopped.prompt, 'Refresh the index.');
+  assert.equal(crons.list().length, 1);
+
+  const resumed = crons.update(job.id, { state: 'running' }, new Date('2026-08-21T10:00:00Z'));
+  assert.equal(resumed.next, '2026-08-22T09:00:00.000Z');
+
+  // Loading after downtime ignores the persisted Aug 22 occurrence and moves
+  // directly to the next future one. Missed occurrences are not catch-up work.
+  crons.init(new Date('2026-08-25T10:00:00Z'));
+  assert.equal(crons.get(job.id).next, '2026-08-26T09:00:00.000Z');
+});
+
+test('run on restart fires once for enabled running jobs, not stopped ones', async () => {
+  const running = crons.get(crons.list()[0].id);
+  assert.equal(running.runOnRestart, true);
+  const stopped = crons.create({
+    name: 'off', agent: { name: 'off-agent', cli: 'codex' }, prompt: 'No.',
+    schedule: { cron: '0 * * * *', tz: 'UTC' }, runOnRestart: true, state: 'stopped',
+  });
+  const fired = [];
+  crons.startScheduler((id, trigger) => { fired.push({ id, trigger }); }, { restartDelayMs: 5 });
+  await new Promise((resolve) => setTimeout(resolve, 40));
+  assert.deepEqual(fired, [{ id: running.id, trigger: 'restart' }]);
+  assert.equal(crons.get(stopped.id).state, 'stopped');
+});
+
+test('an older overlapping delivery cannot overwrite the newer last run', () => {
+  const id = crons.list()[0].id;
+  crons.recordLast(id, { at: '2026-08-25T12:02:00.000Z', status: 'ok', durationMs: 20 });
+  crons.recordLast(id, { at: '2026-08-25T12:01:00.000Z', status: 'failed', durationMs: 80_000, error: 'late failure' });
+  assert.equal(crons.get(id).last.status, 'ok');
+  assert.equal(crons.get(id).last.at, '2026-08-25T12:02:00.000Z');
+});

--- a/server/test/crons.test.mjs
+++ b/server/test/crons.test.mjs
@@ -69,3 +69,45 @@ test('an older overlapping delivery cannot overwrite the newer last run', () => 
   assert.equal(crons.get(id).last.status, 'ok');
   assert.equal(crons.get(id).last.at, '2026-08-25T12:02:00.000Z');
 });
+
+test('run on restart coalesces with a schedule due in the same startup window', () => {
+  for (const job of crons.list()) crons.remove(job.id);
+  const boot = Date.parse('2026-08-19T21:54:57.600Z'); // 2.4s before the minute
+  crons.init(new Date(boot));
+  const job = crons.create({
+    name: 'minute boundary', agent: { name: 'boundary', cli: 'claude' }, prompt: 'Once.',
+    schedule: { cron: '* * * * *', tz: 'UTC' }, runOnRestart: true,
+  }, new Date(boot));
+  assert.equal(Date.parse(job.next) - boot, 2_400);
+
+  const originalNow = Date.now;
+  const originalSetTimeout = globalThis.setTimeout;
+  const originalClearTimeout = globalThis.clearTimeout;
+  let now = boot;
+  let serial = 0;
+  const queued = [];
+  Date.now = () => now;
+  globalThis.setTimeout = (callback, delay = 0) => {
+    const timer = { id: ++serial, at: now + Number(delay), callback, canceled: false, unref() {} };
+    queued.push(timer);
+    return timer;
+  };
+  globalThis.clearTimeout = (timer) => { if (timer) timer.canceled = true; };
+  const fires = [];
+  try {
+    crons.startScheduler((id, trigger) => { fires.push({ id, trigger, at: now }); }, { restartDelayMs: 1_500 });
+    const end = boot + 2_500;
+    while (true) {
+      const due = queued.filter((timer) => !timer.canceled && timer.at <= end).sort((a, b) => a.at - b.at)[0];
+      if (!due) break;
+      due.canceled = true;
+      now = due.at;
+      due.callback();
+    }
+    assert.deepEqual(fires, [{ id: job.id, trigger: 'schedule', at: boot + 2_400 }]);
+  } finally {
+    Date.now = originalNow;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  }
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,7 +50,7 @@ function autoGrid(n: number): GridSpec {
   return { cols: 3, rows: 3 };
 }
 
-type SettingsPage = 'general' | 'usage' | 'skills';
+type SettingsPage = 'general' | 'usage' | 'skills' | 'cron';
 const ROOT_PATH = '.';
 const WARM_TERMINAL_LIMIT = 12;
 const normalizePath = (p?: string | null) => (p && p.trim() ? p : ROOT_PATH);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -120,6 +120,38 @@ export const getConfig = (): Promise<AmConfig> => fetch('/api/config').then(json
 export const saveConfig = (c: AmConfig) =>
   fetch('/api/config', { method: 'PUT', headers: HEADERS, body: JSON.stringify(c) }).then(json);
 
+// ---- durable scheduled prompts ----
+export type CronState = 'running' | 'stopped';
+export interface CronJob {
+  id: string;
+  name: string;
+  agent: { name: string; cli: string };
+  prompt: string;
+  schedule: { cron: string; tz: string };
+  runOnRestart: boolean;
+  state: CronState;
+  createdAt: string;
+  updatedAt: string;
+  next: string | null;
+  last?: {
+    at: string;
+    status: 'ok' | 'failed';
+    durationMs: number;
+    trigger?: 'schedule' | 'restart' | 'manual';
+    error?: string;
+  };
+}
+export type CronDraft = Pick<CronJob, 'name' | 'agent' | 'prompt' | 'schedule' | 'runOnRestart'>;
+export const getCrons = (): Promise<{ crons: CronJob[] }> => fetch('/api/crons').then(jsonOrError);
+export const createCron = (job: CronDraft): Promise<CronJob> =>
+  fetch('/api/crons', { method: 'POST', headers: HEADERS, body: JSON.stringify(job) }).then(jsonOrError);
+export const updateCron = (id: string, patch: Partial<CronDraft & { state: CronState }>): Promise<CronJob> =>
+  fetch(`/api/crons/${encodeURIComponent(id)}`, { method: 'PUT', headers: HEADERS, body: JSON.stringify(patch) }).then(jsonOrError);
+export const runCron = (id: string): Promise<{ ok: boolean; agentCreated: boolean }> =>
+  fetch(`/api/crons/${encodeURIComponent(id)}/run`, { method: 'POST' }).then(jsonOrError);
+export const deleteCron = (id: string): Promise<{ ok: boolean }> =>
+  fetch(`/api/crons/${encodeURIComponent(id)}`, { method: 'DELETE' }).then(jsonOrError);
+
 // ---- bucket backup: a Job on the Hub does the copying (docs/bucket-backup.md) ----
 export type BackupEvery = 'never' | '1h' | '3h' | '24h';
 export interface BackupStatus {

--- a/web/src/components/CronSettings.tsx
+++ b/web/src/components/CronSettings.tsx
@@ -281,9 +281,9 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
             <colgroup>
               <col className="cron-col-job" /><col className="cron-col-agent" /><col className="cron-col-type" />
               <col className="cron-col-interval" /><col className="cron-col-state" /><col className="cron-col-next" />
-              <col className="cron-col-last" /><col className="cron-col-actions" />
+              <col className="cron-col-last" /><col className="cron-col-actions" /><col className="cron-col-fill" />
             </colgroup>
-            <thead><tr><th>Job</th><th>Agent</th><th>Type</th><th>Interval</th><th>State</th><th>Next</th><th>Last run</th><th>Actions</th></tr></thead>
+            <thead><tr><th>Job</th><th>Agent</th><th>Type</th><th>Interval</th><th>State</th><th>Next</th><th>Last run</th><th>Actions</th><th className="cron-fill" aria-hidden="true" /></tr></thead>
             <tbody>{jobs.map((job) => {
               const type = clis.find((candidate) => candidate.id === job.agent.cli)?.label || job.agent.cli;
               const lastTitle = job.last
@@ -310,6 +310,7 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
                       if (editingId === job.id) reset();
                     })}>Delete</button>
                   </span></td>
+                  <td className="cron-fill" aria-hidden="true" />
                 </tr>
               );
             })}</tbody>

--- a/web/src/components/CronSettings.tsx
+++ b/web/src/components/CronSettings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent } from 'react';
 import * as api from '../api';
 import type { Cli, Session } from '../types';
 import Logo from './Logo';
@@ -35,6 +35,20 @@ const cronFor = (preset: Preset, time: string, weekday: string, custom: string) 
   if (preset === 'weekly') return `${minute} ${hour} * * ${weekday}`;
   return custom.trim().replace(/\s+/g, ' ');
 };
+const fieldsForCron = (cron: string): { preset: Preset; time: string; weekday: string; custom: string } => {
+  let match;
+  if (cron === '0 * * * *') return { preset: 'hourly', time: '09:00', weekday: '1', custom: cron };
+  if ((match = cron.match(/^(\d+) (\d+) \* \* 1-5$/))) {
+    return { preset: 'weekdays', time: `${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`, weekday: '1', custom: cron };
+  }
+  if ((match = cron.match(/^(\d+) (\d+) \* \* ([0-6])$/))) {
+    return { preset: 'weekly', time: `${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`, weekday: match[3], custom: cron };
+  }
+  if ((match = cron.match(/^(\d+) (\d+) \* \* \*$/))) {
+    return { preset: 'daily', time: `${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`, weekday: '1', custom: cron };
+  }
+  return { preset: 'custom', time: '09:00', weekday: '1', custom: cron };
+};
 const intervalName = (job: api.CronJob) => {
   const c = job.schedule.cron;
   let match;
@@ -65,6 +79,16 @@ const when = (iso: string | null, zone: string, now: number) => {
     }).format(new Date(value));
   } catch { return new Date(value).toLocaleString(); }
 };
+const compactWhen = (iso: string, zone: string) => {
+  const value = Date.parse(iso);
+  try {
+    const parts = new Intl.DateTimeFormat('en-GB', {
+      timeZone: zone, month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit', hourCycle: 'h23',
+    }).formatToParts(new Date(value));
+    const part = (type: Intl.DateTimeFormatPartTypes) => parts.find((candidate) => candidate.type === type)?.value || '';
+    return `${part('day')} ${part('month')} ${part('hour')}:${part('minute')}`;
+  } catch { return new Date(value).toISOString().slice(5, 16).replace('T', ' '); }
+};
 
 export default function CronSettings({ clis }: { clis: Cli[] }) {
   const agents = useMemo(() => clis.filter((cli) => !EXCLUDED_CLIS.has(cli.id)), [clis]);
@@ -74,6 +98,8 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
   const [busy, setBusy] = useState<string | null>(null);
   const [message, setMessage] = useState('');
   const [now, setNow] = useState(Date.now());
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const formRef = useRef<HTMLFormElement>(null);
   const [jobName, setJobName] = useState('');
   const [agentName, setAgentName] = useState('');
   const [cli, setCli] = useState('');
@@ -101,7 +127,7 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
     return () => { window.clearInterval(poll); window.clearInterval(clock); };
   }, []);
   useEffect(() => {
-    if (!agents.some((agent) => agent.id === cli && agent.available)) {
+    if (!cli || !agents.some((agent) => agent.id === cli)) {
       setCli(agents.find((agent) => agent.available)?.id || '');
     }
   }, [agents, cli]);
@@ -111,21 +137,39 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
   const selected = agents.find((agent) => agent.id === cli);
   const reset = () => {
     setJobName(''); setAgentName(''); setPrompt(''); setPreset('daily'); setTime('09:00');
-    setWeekday('1'); setCustom('0 9 * * *'); setTz(browserZone()); setRunOnRestart(true); setMessage('');
+    setWeekday('1'); setCustom('0 9 * * *'); setTz(browserZone()); setRunOnRestart(true);
+    setCli(agents.find((agent) => agent.available)?.id || ''); setEditingId(null); setMessage('');
   };
-  const create = async (event: FormEvent) => {
+  const edit = (job: api.CronJob) => {
+    const schedule = fieldsForCron(job.schedule.cron);
+    setEditingId(job.id); setJobName(job.name); setAgentName(job.agent.name); setCli(job.agent.cli);
+    setPrompt(job.prompt); setPreset(schedule.preset); setTime(schedule.time); setWeekday(schedule.weekday);
+    setCustom(schedule.custom); setTz(job.schedule.tz); setRunOnRestart(job.runOnRestart); setMessage('');
+    window.requestAnimationFrame(() => {
+      formRef.current?.scrollIntoView({ block: 'start' });
+      formRef.current?.querySelector<HTMLInputElement>('#cron-job-name')?.focus({ preventScroll: true });
+    });
+  };
+  const editFromKeyboard = (event: KeyboardEvent<HTMLTableRowElement>, job: api.CronJob) => {
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    edit(job);
+  };
+  const save = async (event: FormEvent) => {
     event.preventDefault();
     if (!jobName.trim() || !agentName.trim() || !cli || !prompt.trim() || !scheduleCron) return;
-    setBusy('create'); setMessage('');
+    const draft: api.CronDraft = {
+      name: jobName.trim(), agent: { name: agentName.trim(), cli }, prompt: prompt.trim(),
+      schedule: { cron: scheduleCron, tz: tz.trim() }, runOnRestart,
+    };
+    setBusy('save'); setMessage('');
     try {
-      await api.createCron({
-        name: jobName.trim(), agent: { name: agentName.trim(), cli }, prompt: prompt.trim(),
-        schedule: { cron: scheduleCron, tz: tz.trim() }, runOnRestart,
-      });
+      if (editingId) await api.updateCron(editingId, draft);
+      else await api.createCron(draft);
       reset();
       await load();
     } catch (error) {
-      setMessage(error instanceof Error ? error.message : 'Could not create the job.');
+      setMessage(error instanceof Error ? error.message : `Could not ${editingId ? 'update' : 'create'} the job.`);
     } finally { setBusy(null); }
   };
   const act = async (id: string, action: () => Promise<unknown>) => {
@@ -148,7 +192,7 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
 
   return (
     <>
-      <form className="cron-form" onSubmit={create}>
+      <form className="cron-form" onSubmit={save} ref={formRef}>
         <label htmlFor="cron-job-name">Job name</label>
         <div>
           <input id="cron-job-name" value={jobName} onChange={(event) => setJobName(event.target.value)} placeholder="nightly deploy check" required />
@@ -177,7 +221,9 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
               </button>
             ))}
           </div>
-          <p>{selected?.available ? 'Used only if the named agent must be created.' : 'Unavailable agent types cannot be selected.'}</p>
+          <p>{selected?.available
+            ? 'Used only if the named agent must be created.'
+            : editingId && selected ? 'This saved type is unavailable here; updating preserves it.' : 'Unavailable agent types cannot be selected.'}</p>
         </div>
 
         <label htmlFor="cron-prompt">Prompt</label>
@@ -221,7 +267,9 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
         </div>
 
         <div className="cron-form-actions">
-          <button className="btn-primary" type="submit" disabled={busy === 'create' || !selected?.available}>{busy === 'create' ? 'Creating…' : 'Create job'}</button>
+          <button className="btn-primary" type="submit" disabled={busy === 'save' || !selected || (!editingId && !selected.available)}>
+            {busy === 'save' ? (editingId ? 'Updating…' : 'Creating…') : (editingId ? 'Update job' : 'Create job')}
+          </button>
           <button className="btn-ghost" type="button" onClick={reset}>Cancel</button>
         </div>
       </form>
@@ -234,22 +282,34 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
       ) : (
         <div className="table-scroll cron-table-wrap">
           <table className="cron-table">
+            <colgroup>
+              <col className="cron-col-job" /><col className="cron-col-agent" /><col className="cron-col-type" />
+              <col className="cron-col-interval" /><col className="cron-col-state" /><col className="cron-col-next" />
+              <col className="cron-col-last" /><col className="cron-col-actions" />
+            </colgroup>
             <thead><tr><th>Job</th><th>Agent</th><th>Type</th><th>Interval</th><th>State</th><th>Next</th><th>Last run</th><th>Actions</th></tr></thead>
             <tbody>{jobs.map((job) => {
               const type = clis.find((candidate) => candidate.id === job.agent.cli)?.label || job.agent.cli;
               return (
-                <tr key={job.id}>
-                  <td>{job.name}</td>
-                  <td>{job.agent.name}</td>
-                  <td className="cron-dim">{type}</td>
-                  <td>{intervalName(job)} <span className="cron-dim">· {job.schedule.tz}{job.runOnRestart ? ' · on restart' : ''}</span></td>
+                <tr
+                  key={job.id} className={editingId === job.id ? 'editing' : ''} tabIndex={0}
+                  aria-selected={editingId === job.id}
+                  onClick={() => edit(job)} onKeyDown={(event) => editFromKeyboard(event, job)}
+                >
+                  <td title={job.name}>{job.name}</td>
+                  <td title={job.agent.name}>{job.agent.name}</td>
+                  <td className="cron-type" aria-label={type} title={type}><Logo cli={job.agent.cli} size={14} /></td>
+                  <td>{intervalName(job)}</td>
                   <td className={`cron-state ${job.state}`}>{job.state}</td>
                   <td className="cron-dim">{when(job.next, job.schedule.tz, now)}</td>
-                  <td title={job.last?.error || ''}>{job.last ? <><span className={`cron-last ${job.last.status}`}>{job.last.status}</span> <span className="cron-dim">{job.last.error || `${duration(job.last.durationMs)} · ${when(job.last.at, job.schedule.tz, now)}`}</span></> : <span className="cron-dim">—</span>}</td>
-                  <td><span className="cron-actions">
-                    <button disabled={busy === job.id} onClick={() => act(job.id, () => api.runCron(job.id))}>Run now</button>
-                    <button disabled={busy === job.id} onClick={() => act(job.id, () => api.updateCron(job.id, { state: job.state === 'running' ? 'stopped' : 'running' }))}>{job.state === 'running' ? 'Stop' : 'Start'}</button>
-                    <button className="danger" disabled={busy === job.id} onClick={() => act(job.id, () => api.deleteCron(job.id))}>Delete</button>
+                  <td title={job.last?.error || ''}>{job.last ? <><span className={`cron-last ${job.last.status}`}>{job.last.status}</span> <span className="cron-dim">{duration(job.last.durationMs)} · {compactWhen(job.last.at, job.schedule.tz)}</span></> : <span className="cron-dim">—</span>}</td>
+                  <td onClick={(event) => event.stopPropagation()} onKeyDown={(event) => event.stopPropagation()}><span className="cron-actions">
+                    <button className="btn-ghost" disabled={busy === job.id} onClick={() => act(job.id, () => api.runCron(job.id))}>Run now</button>
+                    <button className="btn-ghost" disabled={busy === job.id} onClick={() => act(job.id, () => api.updateCron(job.id, { state: job.state === 'running' ? 'stopped' : 'running' }))}>{job.state === 'running' ? 'Stop' : 'Start'}</button>
+                    <button className="btn-ghost danger" disabled={busy === job.id} onClick={() => act(job.id, async () => {
+                      await api.deleteCron(job.id);
+                      if (editingId === job.id) reset();
+                    })}>Delete</button>
                   </span></td>
                 </tr>
               );

--- a/web/src/components/CronSettings.tsx
+++ b/web/src/components/CronSettings.tsx
@@ -1,0 +1,262 @@
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import * as api from '../api';
+import type { Cli, Session } from '../types';
+import Logo from './Logo';
+
+type Preset = 'hourly' | 'daily' | 'weekdays' | 'weekly' | 'custom';
+const EXCLUDED_CLIS = new Set(['shell', 'files', 'trace', 'remote']);
+const DAYS = [
+  { value: '1', short: 'Mon', label: 'Monday' }, { value: '2', short: 'Tue', label: 'Tuesday' },
+  { value: '3', short: 'Wed', label: 'Wednesday' }, { value: '4', short: 'Thu', label: 'Thursday' },
+  { value: '5', short: 'Fri', label: 'Friday' }, { value: '6', short: 'Sat', label: 'Saturday' },
+  { value: '0', short: 'Sun', label: 'Sunday' },
+];
+
+const browserZone = () => {
+  try { return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'; } catch { return 'UTC'; }
+};
+const agentFolder = (value: string) => {
+  const readable = value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 40);
+  if (readable) return readable;
+  if (!value) return '<agent-name>';
+  let hash = 2_166_136_261;
+  for (const character of value) hash = Math.imul(hash ^ (character.codePointAt(0) || 0), 16_777_619);
+  return `agent-${(hash >>> 0).toString(16).padStart(8, '0')}`;
+};
+const timeParts = (time: string) => {
+  const [hour = '9', minute = '0'] = time.split(':');
+  return { hour: String(Number(hour)), minute: String(Number(minute)) };
+};
+const cronFor = (preset: Preset, time: string, weekday: string, custom: string) => {
+  const { hour, minute } = timeParts(time);
+  if (preset === 'hourly') return '0 * * * *';
+  if (preset === 'daily') return `${minute} ${hour} * * *`;
+  if (preset === 'weekdays') return `${minute} ${hour} * * 1-5`;
+  if (preset === 'weekly') return `${minute} ${hour} * * ${weekday}`;
+  return custom.trim().replace(/\s+/g, ' ');
+};
+const intervalName = (job: api.CronJob) => {
+  const c = job.schedule.cron;
+  let match;
+  if (c === '0 * * * *') return 'hourly';
+  if ((match = c.match(/^(\d+) (\d+) \* \* \*$/))) return `every day ${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`;
+  if ((match = c.match(/^(\d+) (\d+) \* \* 1-5$/))) return `weekdays ${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`;
+  if ((match = c.match(/^(\d+) (\d+) \* \* ([0-6])$/))) {
+    const day = DAYS.find((candidate) => candidate.value === match[3])?.label || match[3];
+    return `${day}s ${match[2].padStart(2, '0')}:${match[1].padStart(2, '0')}`;
+  }
+  return c;
+};
+const duration = (ms: number) => {
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  return `${Math.floor(seconds / 60)}m ${String(seconds % 60).padStart(2, '0')}s`;
+};
+const when = (iso: string | null, zone: string, now: number) => {
+  if (!iso) return '—';
+  const value = Date.parse(iso);
+  const delta = value - now;
+  if (delta > 0 && delta < 60 * 60_000) return `in ${Math.max(1, Math.round(delta / 60_000))}m`;
+  if (delta > 0 && delta < 24 * 60 * 60_000) return `in ${Math.max(1, Math.round(delta / 3_600_000))}h`;
+  try {
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone: zone, weekday: 'short', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
+    }).format(new Date(value));
+  } catch { return new Date(value).toLocaleString(); }
+};
+
+export default function CronSettings({ clis }: { clis: Cli[] }) {
+  const agents = useMemo(() => clis.filter((cli) => !EXCLUDED_CLIS.has(cli.id)), [clis]);
+  const [jobs, setJobs] = useState<api.CronJob[]>([]);
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [message, setMessage] = useState('');
+  const [now, setNow] = useState(Date.now());
+  const [jobName, setJobName] = useState('');
+  const [agentName, setAgentName] = useState('');
+  const [cli, setCli] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [preset, setPreset] = useState<Preset>('daily');
+  const [time, setTime] = useState('09:00');
+  const [weekday, setWeekday] = useState('1');
+  const [custom, setCustom] = useState('0 9 * * *');
+  const [tz, setTz] = useState(browserZone);
+  const [runOnRestart, setRunOnRestart] = useState(true);
+
+  const load = async () => {
+    try {
+      const [cronData, tree] = await Promise.all([api.getCrons(), api.getTree()]);
+      setJobs(cronData.crons);
+      setSessions(tree.sessions);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not load cron jobs.');
+    } finally { setLoading(false); }
+  };
+  useEffect(() => {
+    load();
+    const poll = window.setInterval(load, 15_000);
+    const clock = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => { window.clearInterval(poll); window.clearInterval(clock); };
+  }, []);
+  useEffect(() => {
+    if (!agents.some((agent) => agent.id === cli && agent.available)) {
+      setCli(agents.find((agent) => agent.available)?.id || '');
+    }
+  }, [agents, cli]);
+
+  const scheduleCron = cronFor(preset, time, weekday, custom);
+  const existing = sessions.find((session) => session.name === agentName.trim());
+  const selected = agents.find((agent) => agent.id === cli);
+  const reset = () => {
+    setJobName(''); setAgentName(''); setPrompt(''); setPreset('daily'); setTime('09:00');
+    setWeekday('1'); setCustom('0 9 * * *'); setTz(browserZone()); setRunOnRestart(true); setMessage('');
+  };
+  const create = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!jobName.trim() || !agentName.trim() || !cli || !prompt.trim() || !scheduleCron) return;
+    setBusy('create'); setMessage('');
+    try {
+      await api.createCron({
+        name: jobName.trim(), agent: { name: agentName.trim(), cli }, prompt: prompt.trim(),
+        schedule: { cron: scheduleCron, tz: tz.trim() }, runOnRestart,
+      });
+      reset();
+      await load();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'Could not create the job.');
+    } finally { setBusy(null); }
+  };
+  const act = async (id: string, action: () => Promise<unknown>) => {
+    setBusy(id); setMessage('');
+    try {
+      await action();
+      await load();
+      window.setTimeout(load, 750); // delivery may finish just after a 202 Run-now response
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : 'The cron action failed.');
+    } finally { setBusy(null); }
+  };
+  const zones = useMemo(() => {
+    try {
+      const withValues = Intl as typeof Intl & { supportedValuesOf?: (key: 'timeZone') => string[] };
+      const values = withValues.supportedValuesOf?.('timeZone') || [];
+      return values.includes('UTC') ? values : ['UTC', ...values];
+    } catch { return ['UTC']; }
+  }, []);
+
+  return (
+    <>
+      <form className="cron-form" onSubmit={create}>
+        <label htmlFor="cron-job-name">Job name</label>
+        <div>
+          <input id="cron-job-name" value={jobName} onChange={(event) => setJobName(event.target.value)} placeholder="nightly deploy check" required />
+          <p>Names the job in this list, the operations log, and failures. It is separate from the agent.</p>
+        </div>
+
+        <label htmlFor="cron-agent-name">Agent name</label>
+        <div>
+          <input id="cron-agent-name" value={agentName} onChange={(event) => setAgentName(event.target.value)} placeholder="nightly-index" required />
+          <p>{existing
+            ? `Existing ${existing.name} session will be reused; its current ${existing.cli} type is kept.`
+            : `Created on first fire in workspaces/${agentFolder(agentName)}. An existing exact name is reused.`}</p>
+        </div>
+
+        <span className="cron-label" id="cron-cli-label">Agent type</span>
+        <div>
+          <div className="cron-clis" role="group" aria-labelledby="cron-cli-label">
+            {agents.map((agent) => (
+              <button
+                type="button" key={agent.id} className={cli === agent.id ? 'on' : ''}
+                disabled={!agent.available} aria-pressed={cli === agent.id}
+                title={agent.available ? agent.label : `${agent.label} is not installed on this Space`}
+                onClick={() => setCli(agent.id)}
+              >
+                <Logo cli={agent.id} size={13} /> {agent.label}
+              </button>
+            ))}
+          </div>
+          <p>{selected?.available ? 'Used only if the named agent must be created.' : 'Unavailable agent types cannot be selected.'}</p>
+        </div>
+
+        <label htmlFor="cron-prompt">Prompt</label>
+        <div>
+          <textarea id="cron-prompt" rows={4} value={prompt} onChange={(event) => setPrompt(event.target.value)} placeholder="Check last night’s deploy log…" required />
+          <p>Sent as a normal prompt. The agent keeps its conversation history between runs.</p>
+        </div>
+
+        <span className="cron-label" id="cron-schedule-label">Schedule</span>
+        <div>
+          <div className="seg cron-presets" role="group" aria-labelledby="cron-schedule-label">
+            {([
+              ['hourly', 'Hourly'], ['daily', 'Every day'], ['weekdays', 'Weekdays'], ['weekly', 'Weekly'], ['custom', 'Custom cron'],
+            ] as [Preset, string][]).map(([value, label]) => (
+              <button type="button" key={value} className={preset === value ? 'on' : ''} aria-pressed={preset === value} onClick={() => setPreset(value)}>{label}</button>
+            ))}
+          </div>
+          <div className="cron-schedule-fields">
+            {preset !== 'hourly' && preset !== 'custom' && (
+              <label>at <input type="time" value={time} onChange={(event) => setTime(event.target.value)} required /></label>
+            )}
+            {preset === 'weekly' && (
+              <label>on <select value={weekday} onChange={(event) => setWeekday(event.target.value)}>{DAYS.map((day) => <option value={day.value} key={day.value}>{day.label}</option>)}</select></label>
+            )}
+            {preset === 'custom' && (
+              <label className="cron-expression">cron <input className="mono" value={custom} onChange={(event) => setCustom(event.target.value)} placeholder="0 9 * * *" required /></label>
+            )}
+            <label className="cron-zone">timezone <input list="cron-timezones" value={tz} onChange={(event) => setTz(event.target.value)} required /></label>
+            <datalist id="cron-timezones">{zones.map((zone) => <option value={zone} key={zone} />)}</datalist>
+          </div>
+          <p><span className="mono">{scheduleCron || '—'}</span> · stored with <span className="mono">{tz || 'timezone required'}</span>; missed fires while the Space is down are not replayed.</p>
+        </div>
+
+        <span className="cron-label" id="cron-restart-label">Run on restart</span>
+        <div>
+          <div className="seg" role="group" aria-labelledby="cron-restart-label">
+            <button type="button" className={runOnRestart ? 'on' : ''} aria-pressed={runOnRestart} onClick={() => setRunOnRestart(true)}>Yes</button>
+            <button type="button" className={!runOnRestart ? 'on' : ''} aria-pressed={!runOnRestart} onClick={() => setRunOnRestart(false)}>No</button>
+          </div>
+          <p>Runs once when the app comes back. This is a fresh fire, not catch-up.</p>
+        </div>
+
+        <div className="cron-form-actions">
+          <button className="btn-primary" type="submit" disabled={busy === 'create' || !selected?.available}>{busy === 'create' ? 'Creating…' : 'Create job'}</button>
+          <button className="btn-ghost" type="button" onClick={reset}>Cancel</button>
+        </div>
+      </form>
+
+      {message && <div className="s-warn cron-message" role="alert">{message}</div>}
+
+      <h3>Scheduled jobs</h3>
+      {loading ? <div className="s-muted">Loading…</div> : jobs.length === 0 ? (
+        <div className="s-muted">No cron jobs yet.</div>
+      ) : (
+        <div className="table-scroll cron-table-wrap">
+          <table className="cron-table">
+            <thead><tr><th>Job</th><th>Agent</th><th>Type</th><th>Interval</th><th>State</th><th>Next</th><th>Last run</th><th>Actions</th></tr></thead>
+            <tbody>{jobs.map((job) => {
+              const type = clis.find((candidate) => candidate.id === job.agent.cli)?.label || job.agent.cli;
+              return (
+                <tr key={job.id}>
+                  <td>{job.name}</td>
+                  <td>{job.agent.name}</td>
+                  <td className="cron-dim">{type}</td>
+                  <td>{intervalName(job)} <span className="cron-dim">· {job.schedule.tz}{job.runOnRestart ? ' · on restart' : ''}</span></td>
+                  <td className={`cron-state ${job.state}`}>{job.state}</td>
+                  <td className="cron-dim">{when(job.next, job.schedule.tz, now)}</td>
+                  <td title={job.last?.error || ''}>{job.last ? <><span className={`cron-last ${job.last.status}`}>{job.last.status}</span> <span className="cron-dim">{job.last.error || `${duration(job.last.durationMs)} · ${when(job.last.at, job.schedule.tz, now)}`}</span></> : <span className="cron-dim">—</span>}</td>
+                  <td><span className="cron-actions">
+                    <button disabled={busy === job.id} onClick={() => act(job.id, () => api.runCron(job.id))}>Run now</button>
+                    <button disabled={busy === job.id} onClick={() => act(job.id, () => api.updateCron(job.id, { state: job.state === 'running' ? 'stopped' : 'running' }))}>{job.state === 'running' ? 'Stop' : 'Start'}</button>
+                    <button className="danger" disabled={busy === job.id} onClick={() => act(job.id, () => api.deleteCron(job.id))}>Delete</button>
+                  </span></td>
+                </tr>
+              );
+            })}</tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/CronSettings.tsx
+++ b/web/src/components/CronSettings.tsx
@@ -73,11 +73,7 @@ const when = (iso: string | null, zone: string, now: number) => {
   const delta = value - now;
   if (delta > 0 && delta < 60 * 60_000) return `in ${Math.max(1, Math.round(delta / 60_000))}m`;
   if (delta > 0 && delta < 24 * 60 * 60_000) return `in ${Math.max(1, Math.round(delta / 3_600_000))}h`;
-  try {
-    return new Intl.DateTimeFormat(undefined, {
-      timeZone: zone, weekday: 'short', month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit',
-    }).format(new Date(value));
-  } catch { return new Date(value).toLocaleString(); }
+  return compactWhen(iso, zone);
 };
 const compactWhen = (iso: string, zone: string) => {
   const value = Date.parse(iso);
@@ -290,19 +286,22 @@ export default function CronSettings({ clis }: { clis: Cli[] }) {
             <thead><tr><th>Job</th><th>Agent</th><th>Type</th><th>Interval</th><th>State</th><th>Next</th><th>Last run</th><th>Actions</th></tr></thead>
             <tbody>{jobs.map((job) => {
               const type = clis.find((candidate) => candidate.id === job.agent.cli)?.label || job.agent.cli;
+              const lastTitle = job.last
+                ? [duration(job.last.durationMs), job.last.error].filter(Boolean).join(' · ')
+                : '';
               return (
                 <tr
                   key={job.id} className={editingId === job.id ? 'editing' : ''} tabIndex={0}
                   aria-selected={editingId === job.id}
                   onClick={() => edit(job)} onKeyDown={(event) => editFromKeyboard(event, job)}
                 >
-                  <td title={job.name}>{job.name}</td>
-                  <td title={job.agent.name}>{job.agent.name}</td>
+                  <td className="cron-name" title={job.name}>{job.name}</td>
+                  <td className="cron-name" title={job.agent.name}>{job.agent.name}</td>
                   <td className="cron-type" aria-label={type} title={type}><Logo cli={job.agent.cli} size={14} /></td>
                   <td>{intervalName(job)}</td>
                   <td className={`cron-state ${job.state}`}>{job.state}</td>
                   <td className="cron-dim">{when(job.next, job.schedule.tz, now)}</td>
-                  <td title={job.last?.error || ''}>{job.last ? <><span className={`cron-last ${job.last.status}`}>{job.last.status}</span> <span className="cron-dim">{duration(job.last.durationMs)} · {compactWhen(job.last.at, job.schedule.tz)}</span></> : <span className="cron-dim">—</span>}</td>
+                  <td title={lastTitle}>{job.last ? <><span className={`cron-last ${job.last.status}`}>{job.last.status}</span> <span className="cron-dim">· {compactWhen(job.last.at, job.schedule.tz)}</span></> : <span className="cron-dim">—</span>}</td>
                   <td onClick={(event) => event.stopPropagation()} onKeyDown={(event) => event.stopPropagation()}><span className="cron-actions">
                     <button className="btn-ghost" disabled={busy === job.id} onClick={() => act(job.id, () => api.runCron(job.id))}>Run now</button>
                     <button className="btn-ghost" disabled={busy === job.id} onClick={() => act(job.id, () => api.updateCron(job.id, { state: job.state === 'running' ? 'stopped' : 'running' }))}>{job.state === 'running' ? 'Stop' : 'Start'}</button>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -3,14 +3,16 @@ import { isPassive, isRemote, type Cli } from '../types';
 import * as api from '../api';
 import SkillsEditor from './SkillsEditor';
 import UsagePanel from './UsagePanel';
+import CronSettings from './CronSettings';
 import { SunGlyph, MoonGlyph, RefreshGlyph, InfoGlyph } from './icons';
 import Logo from './Logo';
 
-type Page = 'general' | 'usage' | 'skills';
+type Page = 'general' | 'usage' | 'skills' | 'cron';
 const PAGES: { id: Page; label: string }[] = [
   { id: 'general', label: 'General' },
   { id: 'usage', label: 'Usage' },
   { id: 'skills', label: 'Skills' },
+  { id: 'cron', label: 'Cron' },
 ];
 
 interface Info { dataDir?: string; home?: string; spaceId?: string | null; spaceHost?: string | null; engine?: string; ghostty?: boolean; canRelaunch?: boolean; secrets?: string[]; bucketUnverified?: boolean; }
@@ -780,6 +782,14 @@ export default function SettingsView({
             <h2>Skills</h2>
             <p className="s-help">Reusable markdown/text skills. Saved skills are published as <span className="mono">SKILL.md</span> to every agent (Claude, Codex, Gemini, opencode, Hermes) and available in all new sessions. View renders markdown; Edit is plain text.</p>
             <SkillsEditor />
+          </div>
+        )}
+
+        {page === 'cron' && (
+          <div className="settings-page wide cron-page">
+            <h2>Cron</h2>
+            <p className="s-help cron-intro">Send a prompt to an agent on a schedule. Jobs persist across Space restarts; if the named agent does not exist when a job fires, it is created first.</p>
+            <CronSettings clis={clis} />
           </div>
         )}
       </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1432,16 +1432,16 @@ a.btn-ghost { text-decoration: none; }
 .cron-message { margin-top: 14px; }
 .cron-page h3 { margin-top: 24px; }
 .cron-table-wrap { margin-top: 8px; border-top: 1px solid var(--border); }
-.cron-table { width: 100%; min-width: 900px; border-collapse: collapse; table-layout: fixed; font-size: 11.5px; }
-.cron-col-job, .cron-col-agent { width: auto; }
-.cron-col-type { width: 42px; }
-.cron-col-interval { width: 130px; }
-.cron-col-state { width: 62px; }
-.cron-col-next { width: 82px; }
-.cron-col-last { width: 158px; }
-.cron-col-actions { width: 174px; }
-.cron-table th { padding: 7px 8px; border-bottom: 1px solid var(--border); color: var(--muted); font: 500 10px var(--font-mono); letter-spacing: 0.045em; text-align: left; text-transform: uppercase; white-space: nowrap; }
-.cron-table td { padding: 7px 8px; border-bottom: 1px solid var(--border); overflow: hidden; color: var(--text); font-family: var(--font-mono); text-overflow: ellipsis; vertical-align: middle; white-space: nowrap; }
+.cron-table { width: 100%; border-collapse: collapse; table-layout: auto; font-size: 11.5px; }
+/* The two unbounded names share whatever is left. Every other column takes its
+   intrinsic, one-line width, so state/date/action labels cannot be sacrificed
+   to a long name or to widths tuned for one particular viewport. */
+.cron-col-job, .cron-col-agent { width: 50%; }
+.cron-col-type, .cron-col-interval, .cron-col-state, .cron-col-next,
+.cron-col-last, .cron-col-actions { width: 1%; }
+.cron-table th { padding: 7px 5px; border-bottom: 1px solid var(--border); color: var(--muted); font: 500 10px var(--font-mono); letter-spacing: 0.045em; text-align: left; text-transform: uppercase; white-space: nowrap; }
+.cron-table td { padding: 7px 5px; border-bottom: 1px solid var(--border); color: var(--text); font-family: var(--font-mono); vertical-align: middle; white-space: nowrap; }
+.cron-table td.cron-name { max-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .cron-table tbody tr { cursor: pointer; }
 .cron-table tbody tr:hover, .cron-table tbody tr.editing { background: var(--panel-2); }
 .cron-table tbody tr:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
@@ -1452,7 +1452,7 @@ a.btn-ghost { text-decoration: none; }
 .cron-state.stopped { color: var(--muted); }
 .cron-last.failed { color: var(--danger); }
 .cron-actions { display: inline-flex; gap: 4px; white-space: nowrap; }
-.cron-actions .btn-ghost { padding: 4px 6px; border-radius: var(--r-sm); background: var(--panel); font: 500 10.5px var(--font-mono); }
+.cron-actions .btn-ghost { padding: 4px 5px; border-radius: var(--r-sm); background: var(--panel); font: 500 10.5px var(--font-mono); }
 .cron-actions .btn-ghost:disabled { cursor: wait; }
 
 @container (max-width: 560px) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1432,20 +1432,28 @@ a.btn-ghost { text-decoration: none; }
 .cron-message { margin-top: 14px; }
 .cron-page h3 { margin-top: 24px; }
 .cron-table-wrap { margin-top: 8px; border-top: 1px solid var(--border); }
-.cron-table { width: 100%; min-width: 960px; border-collapse: collapse; font-size: 11.5px; }
+.cron-table { width: 100%; min-width: 900px; border-collapse: collapse; table-layout: fixed; font-size: 11.5px; }
+.cron-col-job, .cron-col-agent { width: auto; }
+.cron-col-type { width: 42px; }
+.cron-col-interval { width: 130px; }
+.cron-col-state { width: 62px; }
+.cron-col-next { width: 82px; }
+.cron-col-last { width: 158px; }
+.cron-col-actions { width: 174px; }
 .cron-table th { padding: 7px 8px; border-bottom: 1px solid var(--border); color: var(--muted); font: 500 10px var(--font-mono); letter-spacing: 0.045em; text-align: left; text-transform: uppercase; white-space: nowrap; }
-.cron-table td { padding: 9px 8px; border-bottom: 1px solid var(--border); font-family: var(--font-mono); vertical-align: top; }
-.cron-table tbody tr:hover { background: var(--panel-2); }
-.cron-table td:nth-child(-n+3), .cron-table td:nth-child(5), .cron-table td:nth-child(6), .cron-table td:nth-child(8) { white-space: nowrap; }
+.cron-table td { padding: 7px 8px; border-bottom: 1px solid var(--border); overflow: hidden; color: var(--text); font-family: var(--font-mono); text-overflow: ellipsis; vertical-align: middle; white-space: nowrap; }
+.cron-table tbody tr { cursor: pointer; }
+.cron-table tbody tr:hover, .cron-table tbody tr.editing { background: var(--panel-2); }
+.cron-table tbody tr:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
+.cron-table tbody tr.editing { box-shadow: inset 2px 0 var(--accent); }
+.cron-type .cli-logo { display: flex; }
 .cron-dim { color: var(--muted); }
 .cron-state.running, .cron-last.ok { color: var(--go); }
 .cron-state.stopped { color: var(--muted); }
 .cron-last.failed { color: var(--danger); }
-.cron-actions { display: inline-flex; gap: 10px; white-space: nowrap; }
-.cron-actions button { padding: 0; border: 0; background: none; color: var(--accent); font: inherit; cursor: pointer; }
-.cron-actions button:hover:not(:disabled) { text-decoration: underline; text-underline-offset: 2px; }
-.cron-actions button.danger { color: var(--danger); }
-.cron-actions button:disabled { opacity: 0.4; cursor: wait; }
+.cron-actions { display: inline-flex; gap: 4px; white-space: nowrap; }
+.cron-actions .btn-ghost { padding: 4px 6px; border-radius: var(--r-sm); background: var(--panel); font: 500 10.5px var(--font-mono); }
+.cron-actions .btn-ghost:disabled { cursor: wait; }
 
 @container (max-width: 560px) {
   .cron-form { grid-template-columns: minmax(0, 1fr); row-gap: 5px; padding-left: 0; padding-right: 0; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1400,6 +1400,60 @@ a.btn-ghost { text-decoration: none; }
 
 /* settings: skills editor */
 .settings-page.wide { max-width: 980px; }
+
+/* settings: cron jobs — a labelled form followed by the operational table from
+   the approved mock. State is plain coloured text; controls are controls, never
+   status pills, so "running" cannot be mistaken for something clickable. */
+.cron-intro { max-width: 680px; margin: -8px 0 18px; }
+.cron-form { display: grid; grid-template-columns: 128px minmax(0, 1fr); column-gap: 20px; row-gap: 16px; padding: 16px 2px 20px; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); }
+.cron-form > label, .cron-label { padding-top: 8px; font-size: 13px; font-weight: 600; }
+.cron-form > div { min-width: 0; }
+.cron-form input, .cron-form textarea, .cron-form select { padding: 7px 9px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); color: var(--text); font: inherit; font-size: 12.5px; }
+.cron-form input:focus, .cron-form textarea:focus, .cron-form select:focus { outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); border-color: var(--accent); }
+.cron-form > div > input, .cron-form textarea { display: block; width: 100%; }
+.cron-form textarea { resize: vertical; min-height: 82px; line-height: 1.45; }
+.cron-form p { margin: 5px 0 0; color: var(--muted); font-size: 11.5px; line-height: 1.45; }
+.cron-clis { display: flex; flex-wrap: wrap; gap: 5px; }
+.cron-clis button { min-height: 30px; display: inline-flex; align-items: center; gap: 6px; padding: 5px 8px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--muted); font: 11.5px var(--font-mono); cursor: pointer; }
+.cron-clis button:hover:not(:disabled) { border-color: var(--border-strong); color: var(--text); }
+.cron-clis button.on { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 8%, var(--panel)); }
+.cron-clis button:disabled { opacity: 0.34; cursor: not-allowed; }
+.cron-presets { display: flex; flex-wrap: wrap; border: 0; border-radius: 0; overflow: visible; gap: 4px; }
+.cron-presets button { border: 1px solid var(--border); border-radius: var(--r-sm); padding: 5px 9px; }
+.cron-schedule-fields { display: flex; align-items: center; flex-wrap: wrap; gap: 8px 12px; margin-top: 9px; }
+.cron-schedule-fields label { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 11.5px; }
+.cron-schedule-fields input[type='time'] { width: 132px; font-family: var(--font-mono); }
+.cron-schedule-fields select { min-width: 112px; }
+.cron-schedule-fields .cron-expression { flex: 1 1 210px; }
+.cron-expression input { flex: 1; min-width: 140px; }
+.cron-schedule-fields .cron-zone { flex: 1 1 230px; }
+.cron-zone input { flex: 1; min-width: 160px; }
+.cron-form-actions { grid-column: 2; display: flex; gap: 8px; }
+.cron-message { margin-top: 14px; }
+.cron-page h3 { margin-top: 24px; }
+.cron-table-wrap { margin-top: 8px; border-top: 1px solid var(--border); }
+.cron-table { width: 100%; min-width: 960px; border-collapse: collapse; font-size: 11.5px; }
+.cron-table th { padding: 7px 8px; border-bottom: 1px solid var(--border); color: var(--muted); font: 500 10px var(--font-mono); letter-spacing: 0.045em; text-align: left; text-transform: uppercase; white-space: nowrap; }
+.cron-table td { padding: 9px 8px; border-bottom: 1px solid var(--border); font-family: var(--font-mono); vertical-align: top; }
+.cron-table tbody tr:hover { background: var(--panel-2); }
+.cron-table td:nth-child(-n+3), .cron-table td:nth-child(5), .cron-table td:nth-child(6), .cron-table td:nth-child(8) { white-space: nowrap; }
+.cron-dim { color: var(--muted); }
+.cron-state.running, .cron-last.ok { color: var(--go); }
+.cron-state.stopped { color: var(--muted); }
+.cron-last.failed { color: var(--danger); }
+.cron-actions { display: inline-flex; gap: 10px; white-space: nowrap; }
+.cron-actions button { padding: 0; border: 0; background: none; color: var(--accent); font: inherit; cursor: pointer; }
+.cron-actions button:hover:not(:disabled) { text-decoration: underline; text-underline-offset: 2px; }
+.cron-actions button.danger { color: var(--danger); }
+.cron-actions button:disabled { opacity: 0.4; cursor: wait; }
+
+@container (max-width: 560px) {
+  .cron-form { grid-template-columns: minmax(0, 1fr); row-gap: 5px; padding-left: 0; padding-right: 0; }
+  .cron-form > label, .cron-label { padding-top: 10px; }
+  .cron-form-actions { grid-column: 1; margin-top: 10px; }
+  .cron-schedule-fields { align-items: flex-start; flex-direction: column; }
+  .cron-schedule-fields .cron-expression, .cron-schedule-fields .cron-zone { flex: none; width: 100%; }
+}
 /* natural height — the settings page scrolls, not the preview */
 .skills { display: flex; gap: 14px; margin-top: 12px; align-items: flex-start; }
 .skills-list { width: 220px; flex: none; display: flex; flex-direction: column; gap: 4px; overflow-y: auto; border-right: 1px solid var(--border); padding-right: 10px; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1433,15 +1433,15 @@ a.btn-ghost { text-decoration: none; }
 .cron-page h3 { margin-top: 24px; }
 .cron-table-wrap { margin-top: 8px; border-top: 1px solid var(--border); }
 .cron-table { width: 100%; border-collapse: collapse; table-layout: auto; font-size: 11.5px; }
-/* The two unbounded names share whatever is left. Every other column takes its
-   intrinsic, one-line width, so state/date/action labels cannot be sacrificed
-   to a long name or to widths tuned for one particular viewport. */
-.cron-col-job, .cron-col-agent { width: 50%; }
-.cron-col-type, .cron-col-interval, .cron-col-state, .cron-col-next,
-.cron-col-last, .cron-col-actions { width: 1%; }
+/* Every data column takes its intrinsic one-line width. The final empty column
+   owns all surplus, keeping the useful columns grouped instead of stretching
+   Job and Agent across the table. */
+.cron-col-job, .cron-col-agent, .cron-col-type, .cron-col-interval,
+.cron-col-state, .cron-col-next, .cron-col-last, .cron-col-actions { width: 1%; }
+.cron-col-fill { width: auto; }
 .cron-table th { padding: 7px 5px; border-bottom: 1px solid var(--border); color: var(--muted); font: 500 10px var(--font-mono); letter-spacing: 0.045em; text-align: left; text-transform: uppercase; white-space: nowrap; }
 .cron-table td { padding: 7px 5px; border-bottom: 1px solid var(--border); color: var(--text); font-family: var(--font-mono); vertical-align: middle; white-space: nowrap; }
-.cron-table td.cron-name { max-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.cron-table .cron-fill { padding: 0; }
 .cron-table tbody tr { cursor: pointer; }
 .cron-table tbody tr:hover, .cron-table tbody tr.editing { background: var(--panel-2); }
 .cron-table tbody tr:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }

--- a/web/test/cronSettings.test.mjs
+++ b/web/test/cronSettings.test.mjs
@@ -17,7 +17,7 @@ const stub = path.join(tmp, 'api-stub.ts');
 fs.writeFileSync(stub, `
 export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
 let jobs = [{
-  id: 'cron_one', name: 'morning check with a deliberately long job name', agent: { name: 'triage agent with a deliberately long name', cli: 'codex' }, prompt: 'Check.',
+  id: 'cron_one', name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check.',
   schedule: { cron: '0 9 * * *', tz: 'Europe/Zurich' }, runOnRestart: true,
   state: 'running', createdAt: '2026-08-19T00:00:00Z', updatedAt: '2026-08-19T00:00:00Z',
   next: '2026-08-20T07:00:00Z', last: { at: '2026-08-19T07:00:00Z', status: 'ok', durationMs: 258 },
@@ -118,6 +118,21 @@ try {
   assert.equal(compactRow.buttonsFit, true, 'action labels are not clipped');
   assert.deepEqual(compactRow.buttonBorders, ['solid', 'solid', 'solid'], 'actions use button controls, not text links');
 
+  await page.setViewportSize({ width: 1200, height: 900 });
+  const contentFit = await firstRow.evaluate((row) => {
+    const cells = [...row.querySelectorAll('td')];
+    return cells.slice(0, 2).map((cell) => {
+      const range = document.createRange();
+      range.selectNodeContents(cell);
+      const textWidth = range.getBoundingClientRect().width;
+      const style = getComputedStyle(cell);
+      return cell.getBoundingClientRect().width - textWidth
+        - parseFloat(style.paddingLeft) - parseFloat(style.paddingRight);
+    });
+  });
+  assert.equal(contentFit.every((slack) => Math.abs(slack) < 1), true,
+    `wide Job and Agent columns hug their content (${contentFit.join(', ')}px surplus)`);
+
   const widths = [];
   for (const width of [1200, 980, 760, 390]) {
     await page.setViewportSize({ width, height: 900 });
@@ -129,22 +144,38 @@ try {
         width: window.innerWidth,
         overflow: wrap.scrollWidth - wrap.clientWidth,
         clipped: cells.map((cell) => cell.scrollWidth > cell.clientWidth),
+        ellipsis: cells.slice(0, 8).some((cell) => getComputedStyle(cell).textOverflow === 'ellipsis'),
+        filler: cells[8].getBoundingClientRect().width,
         actionFits: buttons.every((button) => button.scrollWidth <= button.clientWidth)
           && cells[7].scrollWidth <= cells[7].clientWidth,
       };
     }));
   }
-  for (const layout of widths.slice(0, 2)) {
-    assert.equal(layout.overflow, 0, `${layout.width}px viewport needs no table scrollbar`);
-  }
+  assert.equal(widths[0].overflow, 0, 'the wide table needs no scrollbar');
+  assert.equal(widths[0].filler > 0, true, 'wide surplus lands in the empty column after Actions');
   for (const layout of widths) {
-    assert.deepEqual(layout.clipped.slice(2), [false, false, false, false, false, false],
-      `${layout.width}px keeps every bounded column intact`);
+    assert.deepEqual(layout.clipped.slice(0, 8), [false, false, false, false, false, false, false, false],
+      `${layout.width}px truncates no data column`);
+    assert.equal(layout.ellipsis, false, `${layout.width}px applies no ellipsis treatment`);
     assert.equal(layout.actionFits, true, `${layout.width}px keeps every action usable`);
   }
-  assert.equal(widths.at(-1).overflow > 0, true, 'the genuinely narrow table owns its overflow');
-  assert.equal(widths.at(-1).clipped.slice(0, 2).some(Boolean), true,
-    'at the narrow limit a name gives before a bounded column or action');
+  assert.equal(widths.at(-1).overflow > 0, true, 'the genuinely narrow table scrolls rather than truncating');
+  const synchronizedScroll = await firstRow.evaluate((row) => {
+    const wrap = row.closest('.cron-table-wrap');
+    const header = row.closest('table').querySelector('th');
+    const cell = row.querySelector('td');
+    const before = { header: header.getBoundingClientRect().left, cell: cell.getBoundingClientRect().left };
+    wrap.scrollLeft = wrap.scrollWidth;
+    const after = { header: header.getBoundingClientRect().left, cell: cell.getBoundingClientRect().left };
+    return {
+      moved: before.header - after.header,
+      aligned: Math.abs((before.header - before.cell) - (after.header - after.cell)),
+      scrollLeft: wrap.scrollLeft,
+    };
+  });
+  assert.equal(synchronizedScroll.scrollLeft > 0, true, 'phone table can scroll to the Actions column');
+  assert.equal(synchronizedScroll.moved > 0, true, 'the header moves with horizontal scrolling');
+  assert.equal(synchronizedScroll.aligned < 0.5, true, 'header and body columns stay aligned while scrolling');
 
   await page.getByLabel('Job name', { exact: true }).fill('weekday digest');
   await page.getByLabel('Agent name', { exact: true }).fill('digest-agent');
@@ -164,8 +195,8 @@ try {
   const row = page.locator('.cron-table tbody tr').filter({ hasText: 'morning check' });
   await row.click();
   await page.getByRole('button', { name: 'Update job' }).waitFor();
-  assert.equal(await page.getByLabel('Job name', { exact: true }).inputValue(), 'morning check with a deliberately long job name');
-  assert.equal(await page.getByLabel('Agent name', { exact: true }).inputValue(), 'triage agent with a deliberately long name');
+  assert.equal(await page.getByLabel('Job name', { exact: true }).inputValue(), 'morning check');
+  assert.equal(await page.getByLabel('Agent name', { exact: true }).inputValue(), 'triage');
   assert.equal(await page.getByLabel('Prompt', { exact: true }).inputValue(), 'Check.');
   assert.equal(await page.locator('input[type="time"]').inputValue(), '09:00');
   assert.equal(await page.getByLabel('timezone').inputValue(), 'Europe/Zurich');
@@ -185,7 +216,7 @@ try {
   await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update' && call[2].prompt));
   const edited = await page.evaluate(() => window.__cronCalls.find((call) => call[0] === 'update' && call[2].prompt));
   assert.deepEqual(edited, ['update', 'cron_one', {
-    name: 'morning check with a deliberately long job name', agent: { name: 'triage agent with a deliberately long name', cli: 'codex' }, prompt: 'Check and summarize.',
+    name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check and summarize.',
     schedule: { cron: '15 10 * * 4', tz: 'Asia/Tokyo' }, runOnRestart: false,
   }], 'row selection round-trips every persisted field through PUT');
   assert.equal(await page.getByRole('button', { name: 'Create job' }).isVisible(), true, 'successful update returns the form to create mode');

--- a/web/test/cronSettings.test.mjs
+++ b/web/test/cronSettings.test.mjs
@@ -17,7 +17,7 @@ const stub = path.join(tmp, 'api-stub.ts');
 fs.writeFileSync(stub, `
 export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
 let jobs = [{
-  id: 'cron_one', name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check.',
+  id: 'cron_one', name: 'morning check with a deliberately long job name', agent: { name: 'triage agent with a deliberately long name', cli: 'codex' }, prompt: 'Check.',
   schedule: { cron: '0 9 * * *', tz: 'Europe/Zurich' }, runOnRestart: true,
   state: 'running', createdAt: '2026-08-19T00:00:00Z', updatedAt: '2026-08-19T00:00:00Z',
   next: '2026-08-20T07:00:00Z', last: { at: '2026-08-19T07:00:00Z', status: 'ok', durationMs: 258 },
@@ -114,9 +114,37 @@ try {
   assert.equal(compactRow.noWrap, true, 'every retained column is pinned to one line');
   assert.equal(compactRow.typeText, '', 'type column is icon-only');
   assert.equal(compactRow.interval, 'every day 09:00', 'interval omits timezone and restart detail');
-  assert.match(compactRow.last, /^ok 258ms · 19 Aug 09:00$/, 'last run uses the dense date');
+  assert.match(compactRow.last, /^ok · 19 Aug 09:00$/, 'last run keeps the complete dense date');
   assert.equal(compactRow.buttonsFit, true, 'action labels are not clipped');
   assert.deepEqual(compactRow.buttonBorders, ['solid', 'solid', 'solid'], 'actions use button controls, not text links');
+
+  const widths = [];
+  for (const width of [1200, 980, 760, 390]) {
+    await page.setViewportSize({ width, height: 900 });
+    widths.push(await firstRow.evaluate((row) => {
+      const wrap = row.closest('.cron-table-wrap');
+      const cells = [...row.querySelectorAll('td')];
+      const buttons = [...row.querySelectorAll('button')];
+      return {
+        width: window.innerWidth,
+        overflow: wrap.scrollWidth - wrap.clientWidth,
+        clipped: cells.map((cell) => cell.scrollWidth > cell.clientWidth),
+        actionFits: buttons.every((button) => button.scrollWidth <= button.clientWidth)
+          && cells[7].scrollWidth <= cells[7].clientWidth,
+      };
+    }));
+  }
+  for (const layout of widths.slice(0, 2)) {
+    assert.equal(layout.overflow, 0, `${layout.width}px viewport needs no table scrollbar`);
+  }
+  for (const layout of widths) {
+    assert.deepEqual(layout.clipped.slice(2), [false, false, false, false, false, false],
+      `${layout.width}px keeps every bounded column intact`);
+    assert.equal(layout.actionFits, true, `${layout.width}px keeps every action usable`);
+  }
+  assert.equal(widths.at(-1).overflow > 0, true, 'the genuinely narrow table owns its overflow');
+  assert.equal(widths.at(-1).clipped.slice(0, 2).some(Boolean), true,
+    'at the narrow limit a name gives before a bounded column or action');
 
   await page.getByLabel('Job name', { exact: true }).fill('weekday digest');
   await page.getByLabel('Agent name', { exact: true }).fill('digest-agent');
@@ -136,8 +164,8 @@ try {
   const row = page.locator('.cron-table tbody tr').filter({ hasText: 'morning check' });
   await row.click();
   await page.getByRole('button', { name: 'Update job' }).waitFor();
-  assert.equal(await page.getByLabel('Job name', { exact: true }).inputValue(), 'morning check');
-  assert.equal(await page.getByLabel('Agent name', { exact: true }).inputValue(), 'triage');
+  assert.equal(await page.getByLabel('Job name', { exact: true }).inputValue(), 'morning check with a deliberately long job name');
+  assert.equal(await page.getByLabel('Agent name', { exact: true }).inputValue(), 'triage agent with a deliberately long name');
   assert.equal(await page.getByLabel('Prompt', { exact: true }).inputValue(), 'Check.');
   assert.equal(await page.locator('input[type="time"]').inputValue(), '09:00');
   assert.equal(await page.getByLabel('timezone').inputValue(), 'Europe/Zurich');
@@ -157,7 +185,7 @@ try {
   await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update' && call[2].prompt));
   const edited = await page.evaluate(() => window.__cronCalls.find((call) => call[0] === 'update' && call[2].prompt));
   assert.deepEqual(edited, ['update', 'cron_one', {
-    name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check and summarize.',
+    name: 'morning check with a deliberately long job name', agent: { name: 'triage agent with a deliberately long name', cli: 'codex' }, prompt: 'Check and summarize.',
     schedule: { cron: '15 10 * * 4', tz: 'Asia/Tokyo' }, runOnRestart: false,
   }], 'row selection round-trips every persisted field through PUT');
   assert.equal(await page.getByRole('button', { name: 'Create job' }).isVisible(), true, 'successful update returns the form to create mode');

--- a/web/test/cronSettings.test.mjs
+++ b/web/test/cronSettings.test.mjs
@@ -1,0 +1,130 @@
+// The Cron Settings contract in a real browser: labelled controls, correct
+// request construction, distinct actions, plain-text state, and phone overflow.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cron-settings-'));
+const bundle = path.join(tmp, 'app.js');
+const stub = path.join(tmp, 'api-stub.ts');
+fs.writeFileSync(stub, `
+export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
+let jobs = [{
+  id: 'cron_one', name: 'morning check', agent: { name: 'triage', cli: 'claude' }, prompt: 'Check.',
+  schedule: { cron: '0 9 * * *', tz: 'Europe/Zurich' }, runOnRestart: true,
+  state: 'running', createdAt: '2026-08-19T00:00:00Z', updatedAt: '2026-08-19T00:00:00Z',
+  next: '2026-08-20T07:00:00Z', last: { at: '2026-08-19T07:00:00Z', status: 'ok', durationMs: 258 },
+}];
+window.__cronCalls = [];
+export const getCrons = () => Promise.resolve({ crons: structuredClone(jobs) });
+export const getTree = () => Promise.resolve({ order: [], groups: [], hidden: [], sessions: [] });
+export const createCron = (draft) => { window.__cronCalls.push(['create', structuredClone(draft)]); jobs.push({ ...draft, id: 'cron_new', state: 'running', next: '2026-08-21T07:00:00Z', createdAt: '', updatedAt: '' }); return Promise.resolve(jobs.at(-1)); };
+export const updateCron = (id, patch) => { window.__cronCalls.push(['update', id, structuredClone(patch)]); jobs = jobs.map((job) => job.id === id ? { ...job, ...patch, next: patch.state === 'stopped' ? null : job.next } : job); return Promise.resolve(jobs.find((job) => job.id === id)); };
+export const runCron = (id) => { window.__cronCalls.push(['run', id]); return Promise.resolve({ ok: true, agentCreated: false }); };
+export const deleteCron = (id) => { window.__cronCalls.push(['delete', id]); jobs = jobs.filter((job) => job.id !== id); return Promise.resolve({ ok: true }); };
+export const getConfig = () => Promise.resolve(null);
+export const getSecrets = () => Promise.resolve({ detected: [], notes: {} });
+export const backupStatus = () => Promise.resolve(null);
+export const checkUpdate = () => Promise.resolve({ ok: true });
+`);
+
+await build({
+  stdin: {
+    resolveDir: WEB, loader: 'tsx', contents: `
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import SettingsView from './src/components/SettingsView.tsx';
+      const clis = [
+        { id: 'shell', label: 'Shell', color: '#888', available: true },
+        { id: 'files', label: 'Files', color: '#888', available: true },
+        { id: 'trace', label: 'Trace', color: '#888', available: true },
+        { id: 'remote', label: 'Remote agent', color: '#888', available: true },
+        { id: 'claude', label: 'Claude Code', color: '#d97757', available: true },
+        { id: 'codex', label: 'Codex', color: '#5eb6a6', available: false },
+      ];
+      createRoot(document.getElementById('root')).render(
+        <SettingsView page="cron" onPage={() => {}} onClose={() => {}} theme="light"
+          onToggleTheme={() => {}} clis={clis} info={{ dataDir: '/data' }} />,
+      );
+    `,
+  },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+  plugins: [{ name: 'stub-api', setup(b) { b.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub })); } }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+const browser = await chromium.launch(chromiumLaunchOptions());
+try {
+  const page = await browser.newPage({ viewport: { width: 390, height: 900 } });
+  await page.setContent(`<style>${css}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  await page.waitForSelector('.cron-table tbody tr');
+
+  assert.equal(await page.getByRole('button', { name: 'Codex' }).isDisabled(), true,
+    'unavailable CLI remains visible but cannot be selected');
+  assert.equal(await page.locator('.cron-clis button').count(), 2,
+    'the picker is the CLI catalog minus shell/files/trace/remote');
+  for (const label of ['Job name', 'Agent name', 'Prompt']) {
+    assert.ok(await page.getByLabel(label, { exact: true }).count(), `${label} has an accessible label`);
+  }
+
+  const stateStyle = await page.locator('.cron-state').evaluate((element) => {
+    const style = getComputedStyle(element);
+    return { background: style.backgroundColor, radius: style.borderRadius, color: style.color };
+  });
+  assert.equal(stateStyle.background, 'rgba(0, 0, 0, 0)', 'state is text, not a badge fill');
+  assert.equal(stateStyle.radius, '0px', 'state is text, not a rounded pill');
+
+  const overflow = await page.evaluate(() => {
+    const main = document.querySelector('.settings-main');
+    const table = document.querySelector('.cron-table-wrap');
+    return {
+      page: main.scrollWidth - main.clientWidth,
+      table: table.scrollWidth - table.clientWidth,
+      stacked: document.querySelector('#cron-job-name').getBoundingClientRect().top
+        >= document.querySelector('label[for="cron-job-name"]').getBoundingClientRect().bottom,
+    };
+  });
+  assert.equal(overflow.page, 0, 'wide job table does not make the phone page scroll sideways');
+  assert.ok(overflow.table > 0, 'the table owns its horizontal overflow');
+  assert.equal(overflow.stacked, true, 'phone form control sits below its label');
+
+  await page.getByLabel('Job name', { exact: true }).fill('weekday digest');
+  await page.getByLabel('Agent name', { exact: true }).fill('digest-agent');
+  await page.getByLabel('Prompt', { exact: true }).fill('Summarize yesterday.');
+  await page.getByRole('button', { name: 'Weekdays' }).click();
+  await page.locator('input[type="time"]').fill('14:25');
+  await page.getByLabel('timezone').fill('America/New_York');
+  await page.getByRole('button', { name: 'No', exact: true }).click();
+  await page.getByRole('button', { name: 'Create job' }).click();
+  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'create'));
+  const created = await page.evaluate(() => window.__cronCalls.find((call) => call[0] === 'create')[1]);
+  assert.deepEqual(created, {
+    name: 'weekday digest', agent: { name: 'digest-agent', cli: 'claude' }, prompt: 'Summarize yesterday.',
+    schedule: { cron: '25 14 * * 1-5', tz: 'America/New_York' }, runOnRestart: false,
+  });
+
+  const row = page.locator('.cron-table tbody tr').filter({ hasText: 'morning check' });
+  await row.getByRole('button', { name: 'Run now' }).click();
+  await row.getByRole('button', { name: 'Stop' }).click();
+  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update'));
+  const actions = await page.evaluate(() => window.__cronCalls.map((call) => call[0]));
+  assert.ok(actions.includes('run') && actions.includes('update'), 'Run now and Stop are separate wired actions');
+  await row.getByRole('button', { name: 'Delete' }).click();
+  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'delete'));
+  assert.ok((await page.evaluate(() => window.__cronCalls)).some((call) => call[0] === 'delete' && call[1] === 'cron_one'));
+
+  await page.close();
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('cron settings: form, catalog, actions, state treatment, and phone overflow agree');

--- a/web/test/cronSettings.test.mjs
+++ b/web/test/cronSettings.test.mjs
@@ -17,7 +17,7 @@ const stub = path.join(tmp, 'api-stub.ts');
 fs.writeFileSync(stub, `
 export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
 let jobs = [{
-  id: 'cron_one', name: 'morning check', agent: { name: 'triage', cli: 'claude' }, prompt: 'Check.',
+  id: 'cron_one', name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check.',
   schedule: { cron: '0 9 * * *', tz: 'Europe/Zurich' }, runOnRestart: true,
   state: 'running', createdAt: '2026-08-19T00:00:00Z', updatedAt: '2026-08-19T00:00:00Z',
   next: '2026-08-20T07:00:00Z', last: { at: '2026-08-19T07:00:00Z', status: 'ok', durationMs: 258 },
@@ -96,6 +96,28 @@ try {
   assert.ok(overflow.table > 0, 'the table owns its horizontal overflow');
   assert.equal(overflow.stacked, true, 'phone form control sits below its label');
 
+  const firstRow = page.locator('.cron-table tbody tr').filter({ hasText: 'morning check' });
+  const compactRow = await firstRow.evaluate((row) => {
+    const cells = [...row.querySelectorAll('td')];
+    const buttons = [...row.querySelectorAll('button')];
+    return {
+      height: row.getBoundingClientRect().height,
+      noWrap: cells.every((cell) => getComputedStyle(cell).whiteSpace === 'nowrap'),
+      typeText: cells[2].textContent.trim(),
+      interval: cells[3].textContent.trim(),
+      last: cells[6].textContent.trim(),
+      buttonsFit: buttons.every((button) => button.scrollWidth <= button.clientWidth),
+      buttonBorders: buttons.map((button) => getComputedStyle(button).borderTopStyle),
+    };
+  });
+  assert.ok(compactRow.height < 40, `job row stays on one line at phone width (${compactRow.height}px)`);
+  assert.equal(compactRow.noWrap, true, 'every retained column is pinned to one line');
+  assert.equal(compactRow.typeText, '', 'type column is icon-only');
+  assert.equal(compactRow.interval, 'every day 09:00', 'interval omits timezone and restart detail');
+  assert.match(compactRow.last, /^ok 258ms · 19 Aug 09:00$/, 'last run uses the dense date');
+  assert.equal(compactRow.buttonsFit, true, 'action labels are not clipped');
+  assert.deepEqual(compactRow.buttonBorders, ['solid', 'solid', 'solid'], 'actions use button controls, not text links');
+
   await page.getByLabel('Job name', { exact: true }).fill('weekday digest');
   await page.getByLabel('Agent name', { exact: true }).fill('digest-agent');
   await page.getByLabel('Prompt', { exact: true }).fill('Summarize yesterday.');
@@ -112,9 +134,38 @@ try {
   });
 
   const row = page.locator('.cron-table tbody tr').filter({ hasText: 'morning check' });
+  await row.click();
+  await page.getByRole('button', { name: 'Update job' }).waitFor();
+  assert.equal(await page.getByLabel('Job name', { exact: true }).inputValue(), 'morning check');
+  assert.equal(await page.getByLabel('Agent name', { exact: true }).inputValue(), 'triage');
+  assert.equal(await page.getByLabel('Prompt', { exact: true }).inputValue(), 'Check.');
+  assert.equal(await page.locator('input[type="time"]').inputValue(), '09:00');
+  assert.equal(await page.getByLabel('timezone').inputValue(), 'Europe/Zurich');
+  assert.equal(await page.getByRole('button', { name: 'Every day' }).getAttribute('aria-pressed'), 'true');
+  assert.equal(await page.getByRole('button', { name: 'Yes', exact: true }).getAttribute('aria-pressed'), 'true');
+  assert.equal(await page.getByRole('button', { name: 'Codex' }).getAttribute('aria-pressed'), 'true');
+  assert.equal(await page.getByRole('button', { name: 'Update job' }).isDisabled(), false,
+    'an unavailable saved CLI is preserved without blocking edits to the other fields');
+
+  await page.getByLabel('Prompt', { exact: true }).fill('Check and summarize.');
+  await page.getByRole('button', { name: 'Weekly' }).click();
+  await page.locator('input[type="time"]').fill('10:15');
+  await page.locator('.cron-schedule-fields select').selectOption('4');
+  await page.getByLabel('timezone').fill('Asia/Tokyo');
+  await page.getByRole('button', { name: 'No', exact: true }).click();
+  await page.getByRole('button', { name: 'Update job' }).click();
+  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update' && call[2].prompt));
+  const edited = await page.evaluate(() => window.__cronCalls.find((call) => call[0] === 'update' && call[2].prompt));
+  assert.deepEqual(edited, ['update', 'cron_one', {
+    name: 'morning check', agent: { name: 'triage', cli: 'codex' }, prompt: 'Check and summarize.',
+    schedule: { cron: '15 10 * * 4', tz: 'Asia/Tokyo' }, runOnRestart: false,
+  }], 'row selection round-trips every persisted field through PUT');
+  assert.equal(await page.getByRole('button', { name: 'Create job' }).isVisible(), true, 'successful update returns the form to create mode');
+
   await row.getByRole('button', { name: 'Run now' }).click();
+  assert.equal(await page.getByRole('button', { name: 'Create job' }).isVisible(), true, 'an action click does not also select the row');
   await row.getByRole('button', { name: 'Stop' }).click();
-  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update'));
+  await page.waitForFunction(() => window.__cronCalls.some((call) => call[0] === 'update' && call[2].state));
   const actions = await page.evaluate(() => window.__cronCalls.map((call) => call[0]));
   assert.ok(actions.includes('run') && actions.includes('update'), 'Run now and Stop are separate wired actions');
   await row.getByRole('button', { name: 'Delete' }).click();


### PR DESCRIPTION
## What changed

- Added a durable cron store and scheduler backed by `DATA_DIR/crons.json`, with five-field cron parsing, IANA timezone/DST handling, future `next` calculation, stop/start/delete, Run now, and per-job Run on restart.
- Added the approved **Settings → Cron** form and job table: separate job/agent names, the existing `/api/clis` catalog and wording (pane/remote types excluded, unavailable types disabled), schedule presets plus custom cron, plain-text state, last delivery, and distinct Run now / Stop / Delete actions. Selecting a job reuses the form for a complete edit, including its timezone and restart setting.
- Kept each scheduled-job row to one line: Type is the agent icon, Interval is the schedule summary, Last run uses a compact timestamp, and the three actions use the app's small button treatment. The full details omitted from the table remain visible and editable after selecting the row.
- Added the documented API: `GET/POST /api/crons`, `PUT/DELETE /api/crons/:id`, and `POST /api/crons/:id/run`. The generated environment skill includes working curl examples, with the full contract in `docs/cron-jobs.md`.
- Scheduled fires go through the same run endpoint under a stable `cron:<job-id>` operations-log identity. The target receives `[message from cron "<job name>":]`.

This follows the operator-approved contract at https://lvwerra-agent-artifacts.static.hf.space/cron-and-api-log.html. The API-log UI shown on the second half of that study is not part of this cron feature.

## Behavior and decisions

- A missing target is synchronously created in `workspaces/<slugged-agent-name>` before delivery. Exact existing agent names are reused, so two jobs firing for the same missing name cannot create two sessions; the configured CLI is creation-only when a session already exists.
- On boot, stale persisted fire times are discarded and the next future occurrence is calculated. A running job with `runOnRestart` also fires once; stopped jobs do not. There is no missed-fire replay. If the scheduled occurrence is due inside the restart window, it substitutes for the restart fire so one boot intent cannot deliver twice.
- Overlap is deliberately allowed. Out-of-order completions cannot overwrite a newer `last` record.
- There are no overlap or cost guards, per the approved decision.
- No migration is needed. Existing sessions/config are untouched; an empty `crons.json` is created automatically on first boot of this version.

## One limitation / reviewer question

`last.status` is the result of **prompt delivery**, and `durationMs` is delivery time. It does not claim the agent's task succeeded or measure task runtime: the supported CLIs have no uniform trustworthy task-success signal, and overlapping prompts make terminal-idle inference ambiguous. The UI and docs state this honestly; if product intent was semantic task completion, that needs a separate adapter-level design rather than a guessed signal.

An exact existing name is reused even if that session's CLI differs from the job's creation CLI. That is the literal “existing name means reuse” behavior from the mock and keeps the name as the idempotency key; it is called out in the form and docs for review.

## Verification

- `cd server && npm test` — 23 suites passed.
- `cd web && npm test` — 16 suites passed.
- `cd web && npm run build` — TypeScript and production Vite build passed.
- New server coverage exercises timezone offsets, invalid schedules, durable restart loading, no missed replay, run-on-restart and startup coalescing, stop/start/delete, same-name concurrent boot fires, prompt delivery, operations-log cron identity, and out-of-order overlap completion.
- New Chromium coverage exercises the actual Cron Settings component at 390 px: catalog filtering, accessible labels, create/edit request construction, preservation of an unavailable saved CLI, schedule/timezone/restart round trips, independent Run now/Stop/Delete wiring, plain-text state treatment, one-line row geometry, unclipped button actions, stacked form, and table-owned horizontal scrolling.
