### PR TITLE
Settings → API log: the calls agents make, as a list and as lanes

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -232,8 +232,20 @@ const resolveOperationOrigin = (raw, req) => {
   const remoteSession = store.list().find((s) => s.remote?.name === name);
   return remoteSession ? { id: `remote:${name}`, type: 'remote', name, cli: remoteSession.remote?.peer?.harness || 'remote' } : null;
 };
+// Who the call was aimed at. Every route that acts on one session names it in
+// the path; resolving the NAME here, at write time, is the difference between an
+// audit trail that still reads in a month and one full of ids whose sessions
+// have since been renamed or deleted.
+const TARGET_ROUTES = /^\/api\/(?:agents|sessions|trace|files)\/([^/]+)/;
+const resolveOperationTarget = (req) => {
+  const id = (req.path.match(TARGET_ROUTES) || [])[1];
+  if (!id) return null;
+  const s = store.get(id);
+  return s ? { id: s.id, name: s.name, cli: s.cli } : { id };
+};
 app.use(operationMiddleware({
   resolveOrigin: resolveOperationOrigin,
+  resolveTarget: resolveOperationTarget,
   // Test servers explicitly opt out so old endpoint-focused fixtures do not
   // have to pretend to be the operator. Production never sets this switch.
   allowMissing: process.env.AM_ALLOW_MISSING_ORIGIN === '1',
@@ -1360,7 +1372,7 @@ digest for one agent. Read \`state\` before you do anything:
 ### Watch instead of asking
 \`\`\`sh
 curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/tail?lines=120" | jq -r .text
-curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15"
+curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15&from=$AM_ID"
 \`\`\`
 \`tail\` returns that agent's screen and scrollback — exactly what a human would
 see in its pane. \`wait\` BLOCKS until the agent has held one of \`state\`
@@ -1374,13 +1386,17 @@ see in its pane. \`wait\` BLOCKS until the agent has held one of \`state\`
   covers a whole job; on expiry it answers \`{matched:false,timedOut:true}\` and
   you reissue. That is the shape of the API, not a failure.
 
+\`wait\` is read-only, so \`from=$AM_ID\` is optional on it — pass it anyway. It
+is what lets Settings → API log draw the arrow back from the agent you waited on
+to you; without it the log knows the wait finished but not who was watching.
+
 Because of both, the correct form is a background loop rather than a call:
 reissue until it matches, started the way your harness runs a command in the
 background (Claude Code: \`run_in_background\`), so you stay free meanwhile and
 are woken once, when the peer is genuinely finished.
 
 \`\`\`sh
-( until curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15" \\
+( until curl -s "http://localhost:\${AM_PORT:-${PORT}}/api/agents/$ID/wait?timeout=300&settle=15&from=$AM_ID" \\
         > /tmp/wait-$ID.json \\
      && jq -e '.matched or .state == "gone" or has("error")' /tmp/wait-$ID.json >/dev/null
   do sleep 2; done ) >/dev/null 2>&1 &

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -15,59 +15,59 @@ const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
 const LOGGED_READS = [/^\/api\/agents\/[^/]+\/wait$/];
 const shouldLog = (req) => MUTATING.has(req.method)
   || (req.method === 'GET' && LOGGED_READS.some((re) => re.test(req.path)));
+// The body is stored WHOLE, on the operator's instruction: "just store all the
+// full api calls. why this arbitrary compression." So there is no allowlist of
+// routes, no size cap, and nothing is replaced by a summary of itself. The one
+// thing still withheld is a credential — that is not compression, it is not
+// writing secrets into a file that lives on the bucket.
+//
+// Above this length a string is stored as {present, chars, sha256, text} rather
+// than as a bare string. Nothing is lost either way: this only decides whether
+// the checksum travels beside the value, and `chars` is what the log's compact
+// list column reads.
 const MAX_TEXT = 500;
-// Prompt text IS kept, on the operator's instruction: a log that can say who
-// asked whom but never what they asked answers half the question. Only the
-// routes that carry a prompt are unwrapped this way — a file write goes through
-// the same summariser and its body stays a checksum, because "store the
-// prompts" is not "store every byte that ever crossed the API".
-const PROMPT_ROUTES = [
-  /^\/api\/agents$/,                          // spawn: the body IS the seed prompt
-  /^\/api\/sessions$/,                        // same, as a `prompt` field
-  /^\/api\/agents\/[^/]+\/prompt$/,
-  /^\/api\/sessions\/[^/]+\/input$/,
-  /^\/api\/remote\/[^/]+\/messages$/,        // the same act, for a remote agent
-];
-const carriesPrompt = (req) => req && PROMPT_ROUTES.some((re) => re.test(req.path));
-// A prompt is normally a screenful. This is not a cap on what an agent may send,
-// only on what the audit file keeps verbatim: past it the text is cut and says
-// so, while chars and sha256 still describe the whole thing.
-const MAX_PROMPT = 64 * 1024;
-const MAX_DEPTH = 5;
+// A backstop against a cyclic object, not a limit on how much is kept: a request
+// body is the output of a JSON or text parser and cannot contain a cycle, but
+// JSON.stringify throwing here would lose the whole entry.
+const MAX_DEPTH = 20;
+// How far back a read will go looking for complete records. One enormous entry
+// must not hide the log, and reading a whole year of it must not exhaust memory.
+const MAX_TAIL = 256 * 1024 * 1024;
 const SENSITIVE_KEY = /(authorization|credential|password|secret|subscription|token|endpoint|private.?key)/i;
 const CONTENT_KEY = /(body|content|data|prompt|text)/i;
 
 const digest = (value) => crypto.createHash('sha256').update(value).digest('hex');
 
-function textSummary(value, keepText = false) {
-  const summary = { present: value.length > 0, chars: value.length, sha256: digest(value) };
-  // sha256 stays even with the text beside it: equal checksums are how you spot
-  // the same prompt being sent again, which is what a schedule looks like.
-  if (!keepText) return summary;
-  return value.length > MAX_PROMPT
-    ? { ...summary, text: value.slice(0, MAX_PROMPT), truncated: true }
-    : { ...summary, text: value };
+// The value, plus the two things worth having beside it: sha256, because equal
+// checksums are how a repeated prompt or a scheduled job shows up, and chars,
+// because that is what the list column reads without touching the text.
+function textSummary(value) {
+  return { present: value.length > 0, chars: value.length, sha256: digest(value), text: value };
 }
 
 /**
- * Keep the parameters needed to reconstruct an operation without turning the
- * audit trail into a second store for prompts, file contents, or credentials.
+ * The call as it was made, whole, with a checksum attached to anything long
+ * enough to want one. Credentials are the single exception and are replaced by
+ * `[redacted]` wherever they appear.
  */
-export function summarizePayload(value, key = '', depth = 0, keepText = false) {
+export function summarizePayload(value, key = '', depth = 0) {
   if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
-  if (Buffer.isBuffer(value)) return { bytes: value.length, sha256: digest(value) };
+  // No route here parses a raw body today, but if one ever does, keep the bytes
+  // rather than a description of them.
+  if (Buffer.isBuffer(value)) {
+    return { bytes: value.length, sha256: digest(value), base64: value.toString('base64') };
+  }
   if (typeof value === 'string') {
-    // A credential is never kept, prompt route or not.
     if (SENSITIVE_KEY.test(key)) return '[redacted]';
-    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value, keepText);
+    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value);
     return value;
   }
   if (depth >= MAX_DEPTH) return '[max-depth]';
-  if (Array.isArray(value)) return value.slice(0, 100).map((v) => summarizePayload(v, key, depth + 1, keepText));
+  if (Array.isArray(value)) return value.map((v) => summarizePayload(v, key, depth + 1));
   if (typeof value === 'object') {
     const out = {};
-    for (const [k, v] of Object.entries(value).slice(0, 100)) {
-      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1, keepText);
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1);
     }
     return out;
   }
@@ -163,7 +163,7 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
         method: req.method,
         path: req.path,
         query: cleanQuery(req.query),
-        request: summarizePayload(req.body, 'body', 0, carriesPrompt(req)),
+        request: summarizePayload(req.body, 'body'),
         status: res.statusCode,
         ok: res.statusCode < 400,
         durationMs: Date.now() - started,
@@ -182,16 +182,24 @@ export function readOperations(limit = 200, before = null) {
   try {
     fd = fs.openSync(OPERATIONS_FILE, 'r');
     const size = fs.fstatSync(fd).size;
-    // A bounded tail keeps this endpoint cheap even after years of operations.
-    // Four MiB comfortably holds the maximum 1,000 compact records in normal use.
-    const start = Math.max(0, size - 4 * 1024 * 1024);
-    const buf = Buffer.alloc(size - start);
-    fs.readSync(fd, buf, 0, buf.length, start);
-    let text = buf.toString('utf8');
-    if (start > 0) text = text.slice(Math.max(0, text.indexOf('\n') + 1));
-    const rows = text.split('\n').filter(Boolean).flatMap((line) => {
-      try { return [JSON.parse(line)]; } catch { return []; }
-    });
+    // A bounded tail keeps this endpoint cheap after years of operations. But an
+    // entry is now as big as the call it records — a file write can be eight
+    // megabytes on one line — so a fixed window is not enough: it could contain
+    // no COMPLETE line at all and the log would read as empty. Grow it until
+    // there are enough whole records, or until the ceiling says stop.
+    let rows = [];
+    for (let window = 4 * 1024 * 1024; ; window *= 4) {
+      const start = Math.max(0, size - window);
+      const buf = Buffer.alloc(size - start);
+      fs.readSync(fd, buf, 0, buf.length, start);
+      let text = buf.toString('utf8');
+      // the first line is almost certainly cut in half by the window
+      if (start > 0) text = text.slice(Math.max(0, text.indexOf('\n') + 1));
+      rows = text.split('\n').filter(Boolean).flatMap((line) => {
+        try { return [JSON.parse(line)]; } catch { return []; }
+      });
+      if (rows.length >= take || start === 0 || window >= MAX_TAIL) break;
+    }
     // Sort, do not merely reverse. A record is appended when its response
     // finishes, but `at` is when the request STARTED — and a `wait` can block
     // for five minutes, so it lands in the file after calls that began later and

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -102,6 +102,13 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
     }
 
     if (origin) req.operationOrigin = origin;
+    // BEFORE next(), not at response time: the handler for a delete removes the
+    // session from the store and only then answers, so resolving this later
+    // recorded `{id}` for a session whose name and cli had just been thrown
+    // away — the one operation where the roster can never fill them back in.
+    // A request-time snapshot also gives a rename the name it had when the call
+    // arrived, which is the state the entry is describing.
+    const target = resolveTarget ? resolveTarget(req) : null;
     const started = Date.now();
     const operationId = crypto.randomUUID();
     let responseBody;
@@ -125,10 +132,10 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
         id: operationId,
         at: new Date(started).toISOString(),
         origin,
-        // Who it was done TO, resolved at write time. The id is in the path
-        // already, but a name read back later is the name the session has
-        // NOW — renamed or deleted, and the audit trail stops making sense.
-        ...(resolveTarget ? (() => { const t = resolveTarget(req); return t ? { target: t } : {}; })() : {}),
+        // Who it was done TO, snapshotted above. The id is in the path already,
+        // but a name read back later is the name the session has NOW — renamed
+        // or deleted, and the audit trail stops making sense.
+        ...(target ? { target } : {}),
         method: req.method,
         path: req.path,
         query: cleanQuery(req.query),
@@ -161,9 +168,17 @@ export function readOperations(limit = 200, before = null) {
     const rows = text.split('\n').filter(Boolean).flatMap((line) => {
       try { return [JSON.parse(line)]; } catch { return []; }
     });
+    // Sort, do not merely reverse. A record is appended when its response
+    // finishes, but `at` is when the request STARTED — and a `wait` can block
+    // for five minutes, so it lands in the file after calls that began later and
+    // finished sooner. Reversing append order therefore returned rows out of
+    // chronological order, which put an old wait above newer calls in the log
+    // and, because the map derives its x from rank, could run its time axis
+    // backwards. Ties keep newest-appended first, which is what reversing did.
     return rows
       .filter((row) => !before || row.at < before)
       .reverse()
+      .sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0))
       .slice(0, take);
   } catch {
     return [];

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -6,6 +6,15 @@ import { DATA_DIR } from './config.js';
 export const OPERATIONS_FILE = path.join(DATA_DIR, 'operations.jsonl');
 
 const MUTATING = new Set(['POST', 'PUT', 'PATCH', 'DELETE']);
+// Reads worth auditing. A GET is normally none of this log's business — it
+// changes nothing — but `wait` is the one read that IS an event between two
+// agents: A blocked on B until B stopped working. Without it the log records
+// work being handed out and nothing ever coming back, which is exactly half of
+// "who called whom". Deliberately NOT here: `tail`, which every open pane polls
+// constantly and which says nothing a resolved wait does not already say.
+const LOGGED_READS = [/^\/api\/agents\/[^/]+\/wait$/];
+const shouldLog = (req) => MUTATING.has(req.method)
+  || (req.method === 'GET' && LOGGED_READS.some((re) => re.test(req.path)));
 const MAX_TEXT = 500;
 const MAX_DEPTH = 5;
 const SENSITIVE_KEY = /(authorization|credential|password|secret|subscription|token|endpoint|private.?key)/i;
@@ -73,14 +82,18 @@ const cleanQuery = (query) => {
  * unknown. It may derive an identity from a protocol route (remote agents do
  * this for backwards compatibility with already-running polling loops).
  */
-export function operationMiddleware({ resolveOrigin, allowMissing = false } = {}) {
+export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing = false } = {}) {
   return (req, res, next) => {
-    if (!req.path.startsWith('/api/') || !MUTATING.has(req.method)) return next();
+    if (!req.path.startsWith('/api/') || !shouldLog(req)) return next();
 
     const raw = requestOrigin(req);
     let origin = resolveOrigin ? resolveOrigin(raw, req) : (raw ? { id: raw, type: 'unknown' } : null);
     if (!origin && allowMissing) origin = { id: 'test', type: 'test' };
-    if (!origin) {
+    // A logged READ is never refused for want of an origin. `wait` is documented
+    // as read-only and every watch loop running right now calls it without
+    // `?from=`; rejecting those would break them the moment this ships. An
+    // unattributed wait still records that someone finished waiting on B.
+    if (!origin && MUTATING.has(req.method)) {
       return res.status(400).json({
         error: raw
           ? `unknown origin '${raw}'`
@@ -88,7 +101,7 @@ export function operationMiddleware({ resolveOrigin, allowMissing = false } = {}
       });
     }
 
-    req.operationOrigin = origin;
+    if (origin) req.operationOrigin = origin;
     const started = Date.now();
     const operationId = crypto.randomUUID();
     let responseBody;
@@ -101,11 +114,21 @@ export function operationMiddleware({ resolveOrigin, allowMissing = false } = {}
     const record = () => {
       if (recorded) return;
       recorded = true;
+      // A wait is a polling loop: only the call that RESOLVED is an event. The
+      // ones that timed out say "still working", which the log already implies,
+      // and logging them would multiply the entries by however long the job ran.
+      // Same for a wait the caller abandoned (no body) or one whose target had
+      // already gone: nothing came back, so there is nothing to draw.
+      if (!MUTATING.has(req.method) && !(responseBody && responseBody.matched === true)) return;
       append({
         version: 1,
         id: operationId,
         at: new Date(started).toISOString(),
         origin,
+        // Who it was done TO, resolved at write time. The id is in the path
+        // already, but a name read back later is the name the session has
+        // NOW — renamed or deleted, and the audit trail stops making sense.
+        ...(resolveTarget ? (() => { const t = resolveTarget(req); return t ? { target: t } : {}; })() : {}),
         method: req.method,
         path: req.path,
         query: cleanQuery(req.query),

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -16,34 +16,58 @@ const LOGGED_READS = [/^\/api\/agents\/[^/]+\/wait$/];
 const shouldLog = (req) => MUTATING.has(req.method)
   || (req.method === 'GET' && LOGGED_READS.some((re) => re.test(req.path)));
 const MAX_TEXT = 500;
+// Prompt text IS kept, on the operator's instruction: a log that can say who
+// asked whom but never what they asked answers half the question. Only the
+// routes that carry a prompt are unwrapped this way — a file write goes through
+// the same summariser and its body stays a checksum, because "store the
+// prompts" is not "store every byte that ever crossed the API".
+const PROMPT_ROUTES = [
+  /^\/api\/agents$/,                          // spawn: the body IS the seed prompt
+  /^\/api\/sessions$/,                        // same, as a `prompt` field
+  /^\/api\/agents\/[^/]+\/prompt$/,
+  /^\/api\/sessions\/[^/]+\/input$/,
+  /^\/api\/remote\/[^/]+\/messages$/,        // the same act, for a remote agent
+];
+const carriesPrompt = (req) => req && PROMPT_ROUTES.some((re) => re.test(req.path));
+// A prompt is normally a screenful. This is not a cap on what an agent may send,
+// only on what the audit file keeps verbatim: past it the text is cut and says
+// so, while chars and sha256 still describe the whole thing.
+const MAX_PROMPT = 64 * 1024;
 const MAX_DEPTH = 5;
 const SENSITIVE_KEY = /(authorization|credential|password|secret|subscription|token|endpoint|private.?key)/i;
 const CONTENT_KEY = /(body|content|data|prompt|text)/i;
 
 const digest = (value) => crypto.createHash('sha256').update(value).digest('hex');
 
-function textSummary(value) {
-  return { present: value.length > 0, chars: value.length, sha256: digest(value) };
+function textSummary(value, keepText = false) {
+  const summary = { present: value.length > 0, chars: value.length, sha256: digest(value) };
+  // sha256 stays even with the text beside it: equal checksums are how you spot
+  // the same prompt being sent again, which is what a schedule looks like.
+  if (!keepText) return summary;
+  return value.length > MAX_PROMPT
+    ? { ...summary, text: value.slice(0, MAX_PROMPT), truncated: true }
+    : { ...summary, text: value };
 }
 
 /**
  * Keep the parameters needed to reconstruct an operation without turning the
  * audit trail into a second store for prompts, file contents, or credentials.
  */
-export function summarizePayload(value, key = '', depth = 0) {
+export function summarizePayload(value, key = '', depth = 0, keepText = false) {
   if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
   if (Buffer.isBuffer(value)) return { bytes: value.length, sha256: digest(value) };
   if (typeof value === 'string') {
+    // A credential is never kept, prompt route or not.
     if (SENSITIVE_KEY.test(key)) return '[redacted]';
-    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value);
+    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value, keepText);
     return value;
   }
   if (depth >= MAX_DEPTH) return '[max-depth]';
-  if (Array.isArray(value)) return value.slice(0, 100).map((v) => summarizePayload(v, key, depth + 1));
+  if (Array.isArray(value)) return value.slice(0, 100).map((v) => summarizePayload(v, key, depth + 1, keepText));
   if (typeof value === 'object') {
     const out = {};
     for (const [k, v] of Object.entries(value).slice(0, 100)) {
-      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1);
+      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1, keepText);
     }
     return out;
   }
@@ -139,7 +163,7 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
         method: req.method,
         path: req.path,
         query: cleanQuery(req.query),
-        request: summarizePayload(req.body, 'body'),
+        request: summarizePayload(req.body, 'body', 0, carriesPrompt(req)),
         status: res.statusCode,
         ok: res.statusCode < 400,
         durationMs: Date.now() - started,

--- a/server/test/operations.test.mjs
+++ b/server/test/operations.test.mjs
@@ -20,6 +20,13 @@ const middleware = operationMiddleware({
   resolveOrigin: (raw) => raw === 'operator'
     ? { id: 'operator', type: 'operator', name: 'test operator' }
     : raw === 'agent-1' ? { id: raw, type: 'agent', name: 'agent one', cli: 'codex' } : null,
+  // The manager resolves the session named in the path; here, anything called
+  // s-* exists and everything else does not.
+  resolveTarget: (req) => {
+    const id = (req.path.match(/^\/api\/(?:agents|sessions)\/([^/]+)/) || [])[1];
+    if (!id) return null;
+    return id.startsWith('s-') ? { id, name: `name of ${id}`, cli: 'claude' } : { id };
+  },
 });
 
 class Response extends EventEmitter {
@@ -69,6 +76,50 @@ try {
   check('plain-text agent prompts are summarized too', rows[3]?.request?.present === true && rows[3]?.request?.chars === 26);
   check('origin is separate from the recorded query', rows[3]?.origin?.id === 'agent-1' && !('from' in (rows[3]?.query || {})));
   check('query parameters needed to replay the operation remain', rows[3]?.query?.cli === 'codex');
+
+  // The one read this log cares about. A `wait` is how one agent watches
+  // another, so it is the only GET recorded — and only when it RESOLVED, since
+  // a wait that timed out is a polling artefact, not an event.
+  console.log('\nthe wait that came back');
+  const before = readOperations(50).length;
+  invoke({ method: 'GET', path: '/api/agents/s-target/wait', query: { from: 'agent-1' } },
+    (_req, res) => res.json({ id: 's-target', state: 'waiting', matched: true, waited: 143 }));
+  invoke({ method: 'GET', path: '/api/agents/s-target/wait', query: { from: 'agent-1' } },
+    (_req, res) => res.json({ id: 's-target', state: 'working', matched: false, timedOut: true }));
+  invoke({ method: 'GET', path: '/api/agents/s-target/wait' },
+    (_req, res) => res.json({ id: 's-target', state: 'idle', matched: true, waited: 4 }));
+  let tailed = false;
+  invoke({ method: 'GET', path: '/api/agents/s-target/tail' }, (_req, res) => { tailed = true; res.json({ text: '' }); });
+  let rostered = false;
+  invoke({ method: 'GET', path: '/api/agents' }, (_req, res) => { rostered = true; res.json({ agents: [] }); });
+
+  const waits = readOperations(50).filter((r) => r.method === 'GET');
+  check('a resolved wait is recorded', waits.length === 2, `${waits.length} GET rows`);
+  check('a wait that only timed out is not', !waits.some((r) => r.result?.matched === false));
+  check('tail is never logged — every open pane polls it', tailed && !waits.some((r) => r.path.endsWith('/tail')));
+  check('nor is the roster, or any other read', rostered && readOperations(50).length === before + 2);
+
+  // `wait` is documented read-only and every watch loop running today calls it
+  // without ?from=. Refusing those would break them the moment this ships.
+  const anonymous = waits.find((r) => !r.origin);
+  check('an unattributed wait is accepted, not 400ed', !!anonymous);
+  check('and still records who it was waiting ON', anonymous?.target?.id === 's-target');
+  const attributed = waits.find((r) => r.origin?.id === 'agent-1');
+  check('an attributed wait keeps both ends', attributed?.origin?.id === 'agent-1' && attributed?.target?.name === 'name of s-target');
+  check('a wait is worth its duration, not just its timestamp', typeof attributed?.durationMs === 'number');
+
+  console.log('\nwho it was done to');
+  invoke({ path: '/api/sessions/s-42/input', query: { from: 'agent-1' }, body: { text: 'go' } },
+    (_req, res) => res.json({ ok: true }));
+  invoke({ path: '/api/sessions/ghost-9/input', query: { from: 'agent-1' }, body: { text: 'go' } },
+    (_req, res) => res.status(404).json({ error: 'not found' }));
+  const [ghost, named] = readOperations(2);
+  check('the target name is resolved at write time, not read time', named?.target?.name === 'name of s-42');
+  check('a target that no longer exists still records its id', ghost?.target?.id === 'ghost-9' && !ghost?.target?.name);
+
+  console.log('\nand the guard that has to keep holding');
+  const stillRefused = invoke({ path: '/api/groups', body: { name: 'nope' } }, () => {});
+  check('a mutating call with no origin is still refused', stillRefused.statusCode === 400);
 } finally {
   fs.rmSync(TMP, { recursive: true, force: true });
 }

--- a/server/test/operations.test.mjs
+++ b/server/test/operations.test.mjs
@@ -81,7 +81,14 @@ try {
   check('credentials are redacted', rows[1]?.request?.token === '[redacted]');
   check('session creation with a prompt records presence and size',
     rows[2]?.request?.prompt?.present === true && rows[2]?.request?.prompt?.chars === 27);
-  check('prompt content is not copied into the audit log', rows[2]?.request?.prompt?.sha256 && !JSON.stringify(rows[2]).includes('flaky test'));
+  // This assertion used to read "prompt content is not copied into the audit
+  // log". The operator asked for the opposite — a log that can say who asked
+  // whom but never what they asked answers half the question — so the rule is
+  // now: the prompt is kept, and everything that was never a prompt is not.
+  check('a prompt is kept as text, on the operator\'s instruction',
+    rows[2]?.request?.prompt?.text === 'Investigate the flaky test.');
+  check('with its checksum beside it, so a repeated prompt is still spottable',
+    rows[2]?.request?.prompt?.sha256?.length === 64);
   check('plain-text agent prompts are summarized too', rows[3]?.request?.present === true && rows[3]?.request?.chars === 26);
   check('origin is separate from the recorded query', rows[3]?.origin?.id === 'agent-1' && !('from' in (rows[3]?.query || {})));
   check('query parameters needed to replay the operation remain', rows[3]?.query?.cli === 'codex');
@@ -125,6 +132,33 @@ try {
   const [ghost, named] = readOperations(2);
   check('the target name is resolved at write time, not read time', named?.target?.name === 'name of s-42');
   check('a target that no longer exists still records its id', ghost?.target?.id === 'ghost-9' && !ghost?.target?.name);
+
+  console.log('\nprompts are kept, everything else is still a checksum');
+  invoke({ path: '/api/agents/s-target/prompt', query: { from: 'agent-1' }, body: 'Investigate the flaky test in web/.' },
+    (_req, res) => res.json({ ok: true }));
+  const [prompted] = readOperations(1);
+  check('a prompt is stored as text', prompted?.request?.text === 'Investigate the flaky test in web/.');
+  check('and still carries its checksum, which is how a repeat is spotted',
+    prompted?.request?.sha256?.length === 64 && prompted?.request?.chars === 35,
+    `chars ${prompted?.request?.chars}`);
+  invoke({ path: '/api/sessions/s-42/input', query: { from: 'agent-1' }, body: { text: 'run the tests' } },
+    (_req, res) => res.json({ ok: true }));
+  check('a prompt nested in a field is kept too', readOperations(1)[0]?.request?.text?.text === 'run the tests');
+  invoke({ method: 'PUT', path: '/api/files/f-1/write', query: { from: 'agent-1' }, body: 'x'.repeat(4000) },
+    (_req, res) => res.json({ ok: true }));
+  const [written] = readOperations(1);
+  check('a file body is NOT — storing prompts is not storing every byte',
+    written?.request?.text === undefined && written?.request?.chars === 4000);
+  invoke({ path: '/api/agents/s-target/prompt', query: { from: 'agent-1' }, body: 'y'.repeat(70 * 1024) },
+    (_req, res) => res.json({ ok: true }));
+  const [huge] = readOperations(1);
+  check('an enormous prompt is cut and says so, with the full size still recorded',
+    huge?.request?.truncated === true && huge?.request?.text?.length === 64 * 1024 && huge?.request?.chars === 70 * 1024);
+  invoke({ path: '/api/sessions', query: { from: 'agent-1' }, body: { cli: 'claude', prompt: 'seed', token: 'hunter2' } },
+    (_req, res) => res.status(201).json({ id: 's-new' }));
+  const [seeded] = readOperations(1);
+  check('a seed prompt is kept', seeded?.request?.prompt?.text === 'seed');
+  check('and a credential beside it is still redacted', seeded?.request?.token === '[redacted]');
 
   console.log('\ndeleting the thing being audited');
   // The real route removes the session from the store and only then answers, so

--- a/server/test/operations.test.mjs
+++ b/server/test/operations.test.mjs
@@ -20,14 +20,23 @@ const middleware = operationMiddleware({
   resolveOrigin: (raw) => raw === 'operator'
     ? { id: 'operator', type: 'operator', name: 'test operator' }
     : raw === 'agent-1' ? { id: raw, type: 'agent', name: 'agent one', cli: 'codex' } : null,
-  // The manager resolves the session named in the path; here, anything called
-  // s-* exists and everything else does not.
+  // Stands in for the manager's store: a session exists until something deletes
+  // it. A resolver that always answers would hide the case this has to cover.
   resolveTarget: (req) => {
     const id = (req.path.match(/^\/api\/(?:agents|sessions)\/([^/]+)/) || [])[1];
     if (!id) return null;
-    return id.startsWith('s-') ? { id, name: `name of ${id}`, cli: 'claude' } : { id };
+    const known = sessions.get(id);
+    return known ? { id, ...known } : { id };
   },
 });
+
+// The fake store the resolver reads. Handlers below delete from it mid-request,
+// which is what the real delete route does before it answers.
+const sessions = new Map([
+  ['s-target', { name: 'name of s-target', cli: 'claude' }],
+  ['s-42', { name: 'name of s-42', cli: 'claude' }],
+  ['s-doomed', { name: 'deleted-agent', cli: 'codex' }],
+]);
 
 class Response extends EventEmitter {
   statusCode = 200;
@@ -116,6 +125,46 @@ try {
   const [ghost, named] = readOperations(2);
   check('the target name is resolved at write time, not read time', named?.target?.name === 'name of s-42');
   check('a target that no longer exists still records its id', ghost?.target?.id === 'ghost-9' && !ghost?.target?.name);
+
+  console.log('\ndeleting the thing being audited');
+  // The real route removes the session from the store and only then answers, so
+  // a target resolved from the response handler finds nothing left. This is the
+  // one operation where the roster can never fill the name back in afterwards.
+  invoke({ method: 'DELETE', path: '/api/sessions/s-doomed', query: { from: 'operator' } },
+    (_req, res) => { sessions.delete('s-doomed'); res.json({ ok: true }); });
+  const [deleted] = readOperations(1);
+  check('a delete keeps the name of what it deleted',
+    deleted?.target?.name === 'deleted-agent' && deleted?.target?.cli === 'codex',
+    JSON.stringify(deleted?.target));
+  check('and the session really was gone before the response', !sessions.has('s-doomed'));
+  invoke({ path: '/api/sessions/never-existed/input', query: { from: 'operator' }, body: { text: 'x' } },
+    (_req, res) => res.json({ ok: true }));
+  const [noSuchTarget] = readOperations(1);
+  check('a genuinely unknown target is still recorded as a bare id',
+    noSuchTarget?.target?.id === 'never-existed' && !noSuchTarget?.target?.name);
+
+  console.log('\nchronology, when a wait outlives the calls it overlaps');
+  // A record carries the time the request STARTED but is written when it
+  // finishes. A wait blocks for up to 300s, so it is appended after calls that
+  // began later — and `readOperations` used to just reverse the file.
+  const slowWait = { method: 'GET', path: '/api/agents/s-target/wait', query: { from: 'agent-1' }, headers: {}, body: undefined };
+  const waitRes = new Response();
+  middleware(slowWait, waitRes, () => {});                   // starts first…
+  await new Promise((r) => setTimeout(r, 25));
+  invoke({ path: '/api/sessions/s-42/input', query: { from: 'agent-1' }, body: { text: 'meanwhile' } },
+    (_req, res) => res.json({ ok: true }));                  // …a later call finishes first…
+  await new Promise((r) => setTimeout(r, 25));
+  waitRes.json({ id: 's-target', state: 'waiting', matched: true, waited: 0 });  // …and the wait resolves last
+
+  const feed = readOperations(50);
+  const iWait = feed.findIndex((r) => r.method === 'GET' && r.result?.waited === 0);
+  const iMeanwhile = feed.findIndex((r) => r.request?.text?.chars === 9);
+  check('the wait was appended last but is listed after the call it overlapped',
+    iWait > iMeanwhile && iMeanwhile >= 0, `wait at ${iWait}, overlapping call at ${iMeanwhile}`);
+  check('so every row is in order, newest first',
+    feed.every((r, i) => i === 0 || feed[i - 1].at >= r.at));
+  check('and the wait still carries how long it blocked',
+    feed[iWait]?.durationMs >= 40, `${feed[iWait]?.durationMs}ms`);
 
   console.log('\nand the guard that has to keep holding');
   const stillRefused = invoke({ path: '/api/groups', body: { name: 'nope' } }, () => {});

--- a/server/test/operations.test.mjs
+++ b/server/test/operations.test.mjs
@@ -133,7 +133,7 @@ try {
   check('the target name is resolved at write time, not read time', named?.target?.name === 'name of s-42');
   check('a target that no longer exists still records its id', ghost?.target?.id === 'ghost-9' && !ghost?.target?.name);
 
-  console.log('\nprompts are kept, everything else is still a checksum');
+  console.log('\nthe body is kept whole, whatever route it came in on');
   invoke({ path: '/api/agents/s-target/prompt', query: { from: 'agent-1' }, body: 'Investigate the flaky test in web/.' },
     (_req, res) => res.json({ ok: true }));
   const [prompted] = readOperations(1);
@@ -144,21 +144,41 @@ try {
   invoke({ path: '/api/sessions/s-42/input', query: { from: 'agent-1' }, body: { text: 'run the tests' } },
     (_req, res) => res.json({ ok: true }));
   check('a prompt nested in a field is kept too', readOperations(1)[0]?.request?.text?.text === 'run the tests');
+  // This used to assert the opposite — that only prompt-carrying routes kept
+  // their text. The operator asked for the allowlist gone: "just store all the
+  // full api calls. why this arbitrary compression."
   invoke({ method: 'PUT', path: '/api/files/f-1/write', query: { from: 'agent-1' }, body: 'x'.repeat(4000) },
     (_req, res) => res.json({ ok: true }));
   const [written] = readOperations(1);
-  check('a file body is NOT — storing prompts is not storing every byte',
-    written?.request?.text === undefined && written?.request?.chars === 4000);
+  check('a file write body is kept too — no route allowlist any more',
+    written?.request?.text === 'x'.repeat(4000) && written?.request?.chars === 4000);
+  // …and this asserted a 64 KB cut. There is no cap now.
   invoke({ path: '/api/agents/s-target/prompt', query: { from: 'agent-1' }, body: 'y'.repeat(70 * 1024) },
     (_req, res) => res.json({ ok: true }));
   const [huge] = readOperations(1);
-  check('an enormous prompt is cut and says so, with the full size still recorded',
-    huge?.request?.truncated === true && huge?.request?.text?.length === 64 * 1024 && huge?.request?.chars === 70 * 1024);
+  check('nothing is truncated, however big',
+    huge?.request?.text?.length === 70 * 1024 && huge?.request?.truncated === undefined,
+    `kept ${huge?.request?.text?.length} of ${70 * 1024}`);
+  check('with the checksum of the whole thing beside it',
+    huge?.request?.sha256?.length === 64 && huge?.request?.chars === 70 * 1024);
   invoke({ path: '/api/sessions', query: { from: 'agent-1' }, body: { cli: 'claude', prompt: 'seed', token: 'hunter2' } },
     (_req, res) => res.status(201).json({ id: 's-new' }));
   const [seeded] = readOperations(1);
   check('a seed prompt is kept', seeded?.request?.prompt?.text === 'seed');
   check('and a credential beside it is still redacted', seeded?.request?.token === '[redacted]');
+
+  // One eight-megabyte line must not hide everything behind it: the tail window
+  // grows until it holds whole records rather than half of one.
+  console.log('\nreading past an enormous entry');
+  invoke({ method: 'PUT', path: '/api/files/f-2/write', query: { from: 'agent-1' }, body: 'z'.repeat(6 * 1024 * 1024) },
+    (_req, res) => res.json({ ok: true }));
+  invoke({ path: '/api/agents/s-target/prompt', query: { from: 'agent-1' }, body: 'after the big one' },
+    (_req, res) => res.json({ ok: true }));
+  const past = readOperations(20);
+  check('the entries behind it are still readable', past.length >= 5, `${past.length} rows`);
+  check('including the giant one itself',
+    past.some((r) => r.request?.chars === 6 * 1024 * 1024));
+  check('and the one after it', past[0]?.request?.text === 'after the big one');
 
   console.log('\ndeleting the thing being audited');
   // The real route removes the session from the store and only then answers, so

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -50,7 +50,7 @@ function autoGrid(n: number): GridSpec {
   return { cols: 3, rows: 3 };
 }
 
-type SettingsPage = 'general' | 'usage' | 'skills' | 'cron';
+type SettingsPage = 'general' | 'usage' | 'skills' | 'cron' | 'apilog';
 const ROOT_PATH = '.';
 const WARM_TERMINAL_LIMIT = 12;
 const normalizePath = (p?: string | null) => (p && p.trim() ? p : ROOT_PATH);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -674,3 +674,27 @@ export const saveSkill = (name: string, content: string) =>
   fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'PUT', headers: { 'content-type': 'text/plain' }, body: content }).then(json);
 export const deleteSkill = (name: string) =>
   fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'DELETE' }).then(json);
+
+// ---- the API log (Settings → API log) ----
+// Written by operationMiddleware: every mutating call, plus the one read that is
+// an event between two agents — a `wait` that resolved. Payloads are summarised
+// at write time, never stored: a prompt is {present, chars, sha256} and nothing
+// else, so this view can say who asked whom and how long the ask was, never what
+// it said.
+export interface OperationSummary { present?: boolean; chars?: number; sha256?: string; bytes?: number; }
+export interface Operation {
+  id: string;
+  at: string;
+  origin: { id: string; type: string; name?: string; cli?: string } | null;
+  target?: { id: string; name?: string; cli?: string };
+  method: string;
+  path: string;
+  query?: Record<string, unknown>;
+  request?: unknown;
+  status: number;
+  ok: boolean;
+  durationMs: number;
+  result?: unknown;
+}
+export const getOperations = (limit = 500): Promise<{ operations: Operation[]; generatedAt: string }> =>
+  fetch(`/api/operations?limit=${limit}`).then(json);

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -65,7 +65,15 @@ const created = (op: api.Operation): { id: string; name: string } | null => {
 export const isWait = (op: api.Operation) => op.method === 'GET' && /\/wait$/.test(op.path);
 const isPrompt = (op: api.Operation) => /\/(prompt|input)$/.test(op.path);
 
-/** What the Payload column says. Text length, never text. */
+/** The prompt as sent, when the log kept it. Prompt routes store the text
+ *  beside its checksum; everything else is still summarised, so this is null for
+ *  a file write and for any call that never carried a prompt. */
+export function promptText(op: api.Operation): string | null {
+  const sum = textSummary(op.request) as (api.OperationSummary & { text?: string }) | null;
+  return typeof sum?.text === 'string' ? sum.text : null;
+}
+
+/** What the Payload column says: how long the ask was. The words are in the card. */
 function payloadOf(op: api.Operation): { text: string; sha?: string } {
   if (isWait(op)) {
     const state = (op.result as { state?: string } | undefined)?.state;
@@ -130,6 +138,7 @@ export default function ApiLog() {
   const rows = useMemo(() => (ops || []).filter(
     (op) => withOperator || op.origin?.type !== 'operator',
   ), [ops, withOperator]);
+  // how many calls the checkbox is holding back, so ticking it is an informed act
   const hidden = (ops || []).length - rows.length;
   const failures = rows.filter((op) => !op.ok).length;
 
@@ -156,17 +165,15 @@ export default function ApiLog() {
           {/* the failure count was a filter chip; it is more useful as a fact */}
           {failures > 0 && <span className="al-fails"> · {failures} failed</span>}
         </span>
+        <label className="al-check">
+          <input type="checkbox" checked={withOperator} onChange={(e) => setWithOperator(e.target.checked)} />
+          show user calls{hidden ? <span className="al-check-n"> ({hidden})</span> : null}
+        </label>
         <div className="seg al-view">
           <button className={view === 'list' ? 'on' : ''} onClick={() => setView('list')}>List</button>
           <button className={view === 'map' ? 'on' : ''} onClick={() => setView('map')}>Map</button>
         </div>
         <button className="btn-ghost al-refresh" onClick={load}>Refresh</button>
-      </div>
-
-      <div className="al-filters">
-        <button className={`al-chip${withOperator ? ' on' : ''}`} onClick={() => setWithOperator((v) => !v)}>
-          {withOperator ? 'Including your own calls' : `Your own calls hidden${hidden ? ` (${hidden})` : ''}`}
-        </button>
       </div>
 
       {error && <div className="s-warn">{error}</div>}
@@ -230,7 +237,16 @@ const FOOT = 40;       // axis + legend, both inside the frame
 const MAX_LANES = 14;
 const MAX_MARKS = 60;
 
+const ZOOMS = [1, 1.5, 2, 3, 4, 6];
+
 function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, string> }) {
+  // Two ways to lay out the same calls. RANKED spaces events evenly, which is
+  // what makes a sparse trace readable — a night of nothing does not eat the
+  // plot. REAL TIME places them by the clock, which is the only way to see that
+  // three prompts went out in the same second. Neither is a substitute for the
+  // other, so both exist and ranked is the default.
+  const [byClock, setByClock] = useState(false);
+  const [zoom, setZoom] = useState(1);
   // Hovering previews an entry; CLICKING keeps it. Both are needed: the card is
   // fixed below the plot and its JSON scrolls, so clearing on the mark's
   // mouseleave meant the pointer could never reach the card — the lower half of
@@ -279,10 +295,14 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
       if (isWait(op) && op.durationMs > 0) events.push({ t: t + op.durationMs, id: op.id, end: true });
     }
     events.sort((a, b) => a.t - b.t);
+    const t0 = events.length ? events[0].t : 0;
+    const t1 = events.length ? events[events.length - 1].t : 1;
     const xStart = new Map<string, number>();
     const xResolved = new Map<string, number>();
     events.forEach((e, i) => {
-      const x = events.length < 2 ? 0.5 : i / (events.length - 1);
+      const x = byClock
+        ? (t1 === t0 ? 0.5 : (e.t - t0) / (t1 - t0))
+        : (events.length < 2 ? 0.5 : i / (events.length - 1));
       (e.end ? xResolved : xStart).set(e.id, x);
     });
     const marks = recent.map((op) => ({
@@ -311,7 +331,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
       to: events.length ? new Date(events[events.length - 1].t).toISOString() : '',
       dropped: Math.max(0, rows.length - MAX_MARKS),
     };
-  }, [rows, names]);
+  }, [rows, names, byClock]);
 
   if (!lanes.length) return <div className="s-muted al-empty">Nothing to draw yet.</div>;
 
@@ -323,8 +343,25 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
 
   return (
     <div className="al-map">
+      <div className="al-mapbar">
+        <div className="seg al-scale">
+          <button className={byClock ? '' : 'on'} onClick={() => setByClock(false)}>even</button>
+          <button className={byClock ? 'on' : ''} onClick={() => setByClock(true)}>real time</button>
+        </div>
+        {/* Zoom is horizontal only: it widens the drawing inside a frame that
+            already scrolls sideways, so the lane cap and the 30px spacing are
+            untouched and nothing can overlap vertically at any level. */}
+        <div className="seg al-zoom">
+          <button disabled={zoom === ZOOMS[0]} onClick={() => setZoom((z) => ZOOMS[Math.max(0, ZOOMS.indexOf(z) - 1)])} aria-label="Zoom out">−</button>
+          <button onClick={() => setZoom(1)} className="al-zoom-lvl">{zoom}×</button>
+          <button disabled={zoom === ZOOMS[ZOOMS.length - 1]} onClick={() => setZoom((z) => ZOOMS[Math.min(ZOOMS.length - 1, ZOOMS.indexOf(z) + 1)])} aria-label="Zoom in">+</button>
+        </div>
+        <span className="al-scale-note">
+          {byClock ? 'spaced by the clock — zoom to open up a burst' : 'evenly spaced, one step per event'}
+        </span>
+      </div>
       <div className="al-mapwrap">
-        <svg viewBox={`0 0 ${width} ${height}`} role="img"
+        <svg viewBox={`0 0 ${width} ${height}`} style={{ width: `${100 * zoom}%` }} role="img"
           aria-label="Swimlanes: one lane per agent, prompts drawn from caller to target, resolved waits back the other way, and a lane drawn faint until the agent is created.">
           <defs>
             <marker id="al-ar" viewBox="0 0 8 8" refX="6.5" refY="4" markerWidth="4.5" markerHeight="4.5" orient="auto">
@@ -436,6 +473,7 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
       </div>
     );
   }
+  const text = promptText(op);
   const body = {
     at: op.at,
     call: `${op.method} ${op.path}`,
@@ -445,7 +483,7 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
     took: took(op.durationMs),
     ...(created(op) ? { created: created(op) } : {}),
     ...(op.query && Object.keys(op.query).length ? { query: op.query } : {}),
-    ...(op.request === undefined ? {} : { request: op.request }),
+    ...(op.request === undefined ? {} : { request: withoutText(op.request) }),
     ...(op.result === undefined ? {} : { result: op.result }),
   };
   return (
@@ -457,13 +495,40 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
         <span className="al-card-took">{took(op.durationMs)}</span>
         {pinned && <button type="button" className="al-card-x" onClick={onClose} aria-label="Release this entry">✕</button>}
       </div>
+      {text !== null && (
+        <div className="al-prompt">
+          <div className="al-prompt-lbl">prompt as sent</div>
+          <pre className="al-prompt-body">{text}</pre>
+        </div>
+      )}
       <pre className="al-json">{json(body)}</pre>
       <div className="al-card-foot">
-        prompt text is not stored — {'{'}present, chars, sha256{'}'} only
+        {text === null
+          ? 'no prompt on this call — bodies that are not prompts stay summarised'
+          : 'stored with the entry; the checksum beside it is what makes a repeated prompt visible'}
         {!pinned && <span className="al-card-hint"> · click the call to keep this open</span>}
       </div>
     </div>
   );
+}
+
+/** The prompt is shown as itself, above; JSON-escaped into one line it is
+ *  unreadable. Its length and checksum stay in the JSON. */
+function withoutText(request: unknown): unknown {
+  if (!request || typeof request !== 'object') return request;
+  const strip = (v: Record<string, unknown>) => {
+    const { text, ...rest } = v;
+    return typeof text === 'string' ? rest : v;
+  };
+  const top = request as Record<string, unknown>;
+  if (typeof top.text === 'string' && typeof top.chars === 'number') return strip(top);
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(top)) {
+    out[k] = v && typeof v === 'object' && typeof (v as Record<string, unknown>).text === 'string'
+      ? strip(v as Record<string, unknown>)
+      : v;
+  }
+  return out;
 }
 
 /** JSON with the keys tinted. Small enough not to want a highlighter. */

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -18,7 +18,7 @@
 // something, when, and how big the ask was — never what it said. Equal
 // checksums mean identical prompts, which is what a repeating job produces, so
 // repeats are marked rather than hidden.
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../api';
 
 type View = 'list' | 'map';
@@ -231,7 +231,25 @@ const MAX_LANES = 14;
 const MAX_MARKS = 60;
 
 function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, string> }) {
-  const [hover, setHover] = useState<api.Operation | null>(null);
+  // Hovering previews an entry; CLICKING keeps it. Both are needed: the card is
+  // fixed below the plot and its JSON scrolls, so clearing on the mark's
+  // mouseleave meant the pointer could never reach the card — the lower half of
+  // a long entry could not be read, scrolled or copied. A short grace period
+  // carries the pointer across the gap, and a click pins the entry so it
+  // survives the pointer going anywhere at all.
+  const [sel, setSel] = useState<{ op: api.Operation; pinned: boolean } | null>(null);
+  const hideTimer = useRef<number>();
+  useEffect(() => () => window.clearTimeout(hideTimer.current), []);
+  const preview = (op: api.Operation) => {
+    window.clearTimeout(hideTimer.current);
+    setSel((cur) => (cur?.pinned ? cur : { op, pinned: false }));
+  };
+  const release = () => {
+    window.clearTimeout(hideTimer.current);
+    hideTimer.current = window.setTimeout(() => setSel((cur) => (cur?.pinned ? cur : null)), 220);
+  };
+  const pin = (op: api.Operation) => { window.clearTimeout(hideTimer.current); setSel({ op, pinned: true }); };
+  const hover = sel?.op ?? null;
 
   const { lanes, marks, born, from, to, dropped } = useMemo(() => {
     const recent = rows.slice(0, MAX_MARKS).slice().reverse();  // oldest first, left to right
@@ -245,16 +263,36 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     for (const op of recent) { bump(made, originLane(op)); bump(got, other(op)); }
     const byCount = (m: Map<string, number>) => [...m].sort((a, b) => b[1] - a[1]).map(([n]) => n);
     const lanes = [...byCount(made), ...byCount(got).filter((n) => !made.has(n))].slice(0, MAX_LANES);
-    // x is the call's RANK, not its clock position: real traffic arrives in
-    // bursts, and spacing by time collapses a burst into one unreadable column
-    // while leaving the quiet hours as empty space. The axis still says what
-    // period is on screen.
-    const xs = new Map<string, number>();
-    const marks = recent.map((op, i) => {
-      const x = recent.length < 2 ? 0.5 : i / (recent.length - 1);
-      xs.set(op.id, x);
-      return { op, x, a: lanes.indexOf(originLane(op)), b: lanes.indexOf(other(op)) };
-    }).filter((m) => m.a >= 0 || m.b >= 0);
+    // x is RANK, not clock position: real traffic arrives in bursts, and spacing
+    // by time collapses a burst into one unreadable column while leaving the
+    // quiet hours as empty space. The axis still says what period is on screen.
+    //
+    // The rank is over EVENTS, not calls, and a wait is two events — issued, and
+    // resolved. That is what makes a five-minute wait occupy five minutes' worth
+    // of the picture even when nothing else happens while it blocks: snapping its
+    // resolution to the nearest other call, as this did first, gave a wait in
+    // quiet traffic no span at all, which is the ordinary shape of waiting.
+    const events: Array<{ t: number; id: string; end?: boolean }> = [];
+    for (const op of recent) {
+      const t = new Date(op.at).getTime();
+      events.push({ t, id: op.id });
+      if (isWait(op) && op.durationMs > 0) events.push({ t: t + op.durationMs, id: op.id, end: true });
+    }
+    events.sort((a, b) => a.t - b.t);
+    const xStart = new Map<string, number>();
+    const xResolved = new Map<string, number>();
+    events.forEach((e, i) => {
+      const x = events.length < 2 ? 0.5 : i / (events.length - 1);
+      (e.end ? xResolved : xStart).set(e.id, x);
+    });
+    const marks = recent.map((op) => ({
+      op,
+      // a wait is DRAWN where it resolved; its span reaches back to where it began
+      x: xResolved.get(op.id) ?? xStart.get(op.id) ?? 0.5,
+      x0: xResolved.has(op.id) ? xStart.get(op.id) : undefined,
+      a: lanes.indexOf(originLane(op)),
+      b: lanes.indexOf(other(op)),
+    })).filter((m) => m.a >= 0 || m.b >= 0);
     // When a lane came into being, if we watched it happen. Before that its line
     // is drawn faint: the agent did not exist, and a solid line all the way to
     // the left edge said it had been there the whole time.
@@ -263,25 +301,14 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
       const c = created(op);
       if (c && !born.has(c.name)) born.set(c.name, x);
     }
-    // A wait BLOCKS, and that is the interesting thing about it. Its `at` is
-    // when it STARTED — which is where its rank puts it — and it resolved
-    // durationMs later. So the resolution is drawn where that moment falls in
-    // the sequence, and the stretch in between is the wait itself: a five-minute
-    // block reads as five minutes of the picture rather than as a point.
-    const endX = (op: api.Operation, own: number) => {
-      const ended = new Date(op.at).getTime() + (op.durationMs || 0);
-      let x = own;
-      for (const m of marks) if (new Date(m.op.at).getTime() <= ended) x = Math.max(x, m.x);
-      // resolved after everything else on screen: run to the right edge
-      return ended > new Date(marks[marks.length - 1].op.at).getTime() ? 1 : x;
-    };
     return {
       lanes,
-      marks: marks.map((m) => (isWait(m.op) ? { ...m, x0: m.x, x: endX(m.op, m.x) } : m)) as
-        Array<{ op: api.Operation; x: number; a: number; b: number; x0?: number }>,
+      marks,
       born,
-      from: recent.length ? recent[0].at : '',
-      to: recent.length ? recent[recent.length - 1].at : '',
+      // The axis spans the EVENTS on screen, so a wait that resolved after the
+      // last request still ends inside the frame rather than off it.
+      from: events.length ? new Date(events[0].t).toISOString() : '',
+      to: events.length ? new Date(events[events.length - 1].t).toISOString() : '',
       dropped: Math.max(0, rows.length - MAX_MARKS),
     };
   }, [rows, names]);
@@ -330,7 +357,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
               return (
                 <circle key={op.id} cx={px} cy={laneY(lane)} r={on ? 3.4 : 2}
                   className={`al-dot${cls}${on ? ' on' : ''}`}
-                  onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}>
+                  onMouseEnter={() => preview(op)} onMouseLeave={release} onClick={() => pin(op)}>
                   <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
                 </circle>
               );
@@ -338,7 +365,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
             const y1 = laneY(src) + (dst > src ? 4 : -4);
             const y2 = laneY(dst) + (dst > src ? -6 : 6);
             return (
-              <g key={op.id} onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}
+              <g key={op.id} onMouseEnter={() => preview(op)} onMouseLeave={release} onClick={() => pin(op)}
                 className={`al-arrowg${on ? ' on' : ''}`}>
                 <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
                 {/* how long the caller was blocked, on the caller's own lane */}
@@ -378,7 +405,14 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
       {/* Under the plot, not floating over it: a card that follows the cursor
           covers the very lanes you are reading, and clips against a frame that
           scrolls. This one is always the same size and in the same place. */}
-      <HoverCard op={hover} names={names} />
+      <HoverCard
+        op={hover}
+        pinned={!!sel?.pinned}
+        names={names}
+        onEnter={() => window.clearTimeout(hideTimer.current)}
+        onLeave={release}
+        onClose={() => setSel(null)}
+      />
     </div>
   );
 }
@@ -387,11 +421,18 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
  *  who, what it hit, the status and how long it took. The log's request/result
  *  are already summaries — this shows them as they are stored rather than
  *  paraphrasing them into a sentence. */
-function HoverCard({ op, names }: { op: api.Operation | null; names: Map<string, string> }) {
+function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
+  op: api.Operation | null;
+  pinned: boolean;
+  names: Map<string, string>;
+  onEnter: () => void;
+  onLeave: () => void;
+  onClose: () => void;
+}) {
   if (!op) {
     return (
       <div className="al-card al-card-idle">
-        Hover a call for the whole entry — who, what it hit, its status, how long it took.
+        Hover a call for the whole entry — who, what it hit, its status, how long it took. Click one to keep it here.
       </div>
     );
   }
@@ -408,16 +449,18 @@ function HoverCard({ op, names }: { op: api.Operation | null; names: Map<string,
     ...(op.result === undefined ? {} : { result: op.result }),
   };
   return (
-    <div className="al-card">
+    <div className={`al-card${pinned ? ' pinned' : ''}`} onMouseEnter={onEnter} onMouseLeave={onLeave}>
       <div className="al-card-head">
         <span className={`al-meth${isWait(op) ? ' back' : ''}`}>{op.method}</span>
         <span className="al-card-path">{op.path}</span>
         <span className={`al-st ${statusClass(op)}`}>{op.status}</span>
         <span className="al-card-took">{took(op.durationMs)}</span>
+        {pinned && <button type="button" className="al-card-x" onClick={onClose} aria-label="Release this entry">✕</button>}
       </div>
       <pre className="al-json">{json(body)}</pre>
       <div className="al-card-foot">
         prompt text is not stored — {'{'}present, chars, sha256{'}'} only
+        {!pinned && <span className="al-card-hint"> · click the call to keep this open</span>}
       </div>
     </div>
   );

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -249,8 +249,6 @@ const FOOT = 40;       // axis + legend, both inside the frame
 const MAX_LANES = 14;
 const MAX_MARKS = 60;
 
-const ZOOMS = [1, 1.5, 2, 3, 4, 6];
-
 function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, string> }) {
   // Two ways to lay out the same calls. RANKED spaces events evenly, which is
   // what makes a sparse trace readable — a night of nothing does not eat the
@@ -258,7 +256,16 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   // three prompts went out in the same second. Neither is a substitute for the
   // other, so both exist and ranked is the default.
   const [byClock, setByClock] = useState(false);
-  const [zoom, setZoom] = useState(1);
+  // The window you are looking at, in domain units [0,1] of all the data. null
+  // is "everything". Drag horizontally across the plot to set it — the brush
+  // every charting library has — double-click or the button to clear it.
+  const [win, setWin] = useState<{ a: number; b: number } | null>(null);
+  const [brush, setBrush] = useState<{ from: number; to: number } | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const dragRef = useRef<{ from: number; moved: boolean } | null>(null);
+  // A drag that happened to start on a mark must not also select it: the click
+  // arrives after the pointer is up, so it has to be swallowed once.
+  const swallowClick = useRef(false);
   // Hovering previews an entry; CLICKING keeps it. Both are needed: the card is
   // fixed below the plot and its JSON scrolls, so clearing on the mark's
   // mouseleave meant the pointer could never reach the card — the lower half of
@@ -269,6 +276,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   const hideTimer = useRef<number>();
   useEffect(() => () => window.clearTimeout(hideTimer.current), []);
   const preview = (op: api.Operation) => {
+    if (dragRef.current) return;      // dragging out a window, not reading an entry
     window.clearTimeout(hideTimer.current);
     setSel((cur) => (cur?.pinned ? cur : { op, pinned: false }));
   };
@@ -276,10 +284,14 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     window.clearTimeout(hideTimer.current);
     hideTimer.current = window.setTimeout(() => setSel((cur) => (cur?.pinned ? cur : null)), 220);
   };
-  const pin = (op: api.Operation) => { window.clearTimeout(hideTimer.current); setSel({ op, pinned: true }); };
+  const pin = (op: api.Operation) => {
+    if (swallowClick.current) { swallowClick.current = false; return; }
+    window.clearTimeout(hideTimer.current);
+    setSel({ op, pinned: true });
+  };
   const hover = sel?.op ?? null;
 
-  const { lanes, marks, born, from, to, dropped } = useMemo(() => {
+  const { lanes, marks, born, axis, dropped } = useMemo(() => {
     const recent = rows.slice(0, MAX_MARKS).slice().reverse();  // oldest first, left to right
     // Lanes: everything that CALLS above everything that is only called. Then a
     // prompt points down the picture and a resolved wait points back up it,
@@ -333,14 +345,24 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
       const c = created(op);
       if (c && !born.has(c.name)) born.set(c.name, x);
     }
+    // x → time, for labelling any point of the axis (including a brushed edge
+    // that falls between two events). In real time this is a straight line; in
+    // ranked mode it is piecewise, one segment per event.
+    const axis: Array<{ x: number; t: number }> = [];
+    events.forEach((e, i) => {
+      const x = byClock
+        ? (t1 === t0 ? 0.5 : (e.t - t0) / (t1 - t0))
+        : (events.length < 2 ? 0.5 : i / (events.length - 1));
+      if (!axis.length || axis[axis.length - 1].x !== x) axis.push({ x, t: e.t });
+    });
     return {
       lanes,
       marks,
       born,
-      // The axis spans the EVENTS on screen, so a wait that resolved after the
-      // last request still ends inside the frame rather than off it.
-      from: events.length ? new Date(events[0].t).toISOString() : '',
-      to: events.length ? new Date(events[events.length - 1].t).toISOString() : '',
+      // The axis spans the EVENTS on screen — so a wait that resolved after the
+      // last request still ends inside the frame — and `axis` is what turns any
+      // point of it back into a time, for the labels and the brush readout.
+      axis,
       dropped: Math.max(0, rows.length - MAX_MARKS),
     };
   }, [rows, names, byClock]);
@@ -350,7 +372,68 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   const width = 760;
   const height = TOP + lanes.length * LANE_H + FOOT;
   const laneY = (i: number) => TOP + i * LANE_H + 6;
-  const xOf = (t: number) => LEFT + t * (width - LEFT - RIGHT);
+  const PLOT = width - LEFT - RIGHT;
+  // Everything is placed in DOMAIN units and then mapped through the window, so
+  // zooming is one function rather than a special case in every mark.
+  const lo = win ? win.a : 0;
+  const hi = win ? win.b : 1;
+  const inWin = (t: number) => t >= lo - 1e-9 && t <= hi + 1e-9;
+  const xOf = (t: number) => LEFT + ((t - lo) / (hi - lo)) * PLOT;
+  const clampX = (t: number) => LEFT + Math.min(1, Math.max(0, (t - lo) / (hi - lo))) * PLOT;
+  // A time for any point on the axis, so a brushed edge can be named.
+  const timeAt = (t: number) => {
+    if (!axis.length) return 0;
+    if (t <= axis[0].x) return axis[0].t;
+    for (let i = 1; i < axis.length; i++) {
+      if (t <= axis[i].x) {
+        const span = axis[i].x - axis[i - 1].x || 1;
+        return axis[i - 1].t + ((t - axis[i - 1].x) / span) * (axis[i].t - axis[i - 1].t);
+      }
+    }
+    return axis[axis.length - 1].t;
+  };
+  const clock = (ms: number) => HHMMSS(new Date(ms).toISOString());
+  // A wait counts as visible when any part of the stretch it blocked for is in
+  // the window, so zooming into the middle of a five-minute wait still shows it.
+  const visible = marks.filter((m) => inWin(m.x) || (m.x0 !== undefined && m.x0 <= hi && m.x >= lo));
+  const shown = visible.length;
+
+  // Brushing is MOUSE (and pen) only. A horizontal drag on a phone is how you
+  // scroll — the frame scrolls sideways and the page scrolls down — so touch is
+  // left alone entirely rather than fighting it for the gesture.
+  const domainAt = (clientX: number) => {
+    const box = svgRef.current?.getBoundingClientRect();
+    if (!box) return 0;
+    // through the SVG's own box, so a frame scrolled sideways needs no correction
+    const svgX = ((clientX - box.left) / box.width) * width;
+    return lo + Math.min(1, Math.max(0, (svgX - LEFT) / PLOT)) * (hi - lo);
+  };
+  const onDown = (e: React.PointerEvent<SVGSVGElement>) => {
+    if (e.pointerType === 'touch' || e.button !== 0) return;
+    dragRef.current = { from: domainAt(e.clientX), moved: false };
+    svgRef.current?.setPointerCapture(e.pointerId);
+  };
+  const onMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    const d = dragRef.current;
+    if (!d) return;
+    const to = domainAt(e.clientX);
+    // a few pixels of slop, so a click on a mark stays a click
+    if (!d.moved && Math.abs(to - d.from) * PLOT < 5) return;
+    d.moved = true;
+    setBrush({ from: d.from, to });
+  };
+  const onUp = (e: React.PointerEvent<SVGSVGElement>) => {
+    const d = dragRef.current;
+    dragRef.current = null;
+    setBrush(null);
+    swallowClick.current = !!d?.moved;
+    if (!d?.moved) return;
+    const to = domainAt(e.clientX);
+    const a = Math.min(d.from, to);
+    const b = Math.max(d.from, to);
+    // a window narrower than a couple of pixels is a slip, not an intention
+    if ((b - a) * PLOT > 4) setWin({ a, b });
+  };
 
 
   return (
@@ -360,20 +443,30 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
           <button className={byClock ? '' : 'on'} onClick={() => setByClock(false)}>even</button>
           <button className={byClock ? 'on' : ''} onClick={() => setByClock(true)}>real time</button>
         </div>
-        {/* Zoom is horizontal only: it widens the drawing inside a frame that
-            already scrolls sideways, so the lane cap and the 30px spacing are
-            untouched and nothing can overlap vertically at any level. */}
-        <div className="seg al-zoom">
-          <button disabled={zoom === ZOOMS[0]} onClick={() => setZoom((z) => ZOOMS[Math.max(0, ZOOMS.indexOf(z) - 1)])} aria-label="Zoom out">−</button>
-          <button onClick={() => setZoom(1)} className="al-zoom-lvl">{zoom}×</button>
-          <button disabled={zoom === ZOOMS[ZOOMS.length - 1]} onClick={() => setZoom((z) => ZOOMS[Math.min(ZOOMS.length - 1, ZOOMS.indexOf(z) + 1)])} aria-label="Zoom in">+</button>
-        </div>
-        <span className="al-scale-note">
-          {byClock ? 'spaced by the clock — zoom to open up a burst' : 'evenly spaced, one step per event'}
-        </span>
+        {win ? (
+          <>
+            <button className="btn-ghost al-reset" onClick={() => setWin(null)}>reset zoom</button>
+            <span className="al-scale-note al-window">
+              {clock(timeAt(win.a))} → {clock(timeAt(win.b))} · {shown} of {marks.length} calls
+            </span>
+          </>
+        ) : (
+          <span className="al-scale-note">
+            {byClock ? 'spaced by the clock' : 'evenly spaced, one step per event'} · drag across the plot to zoom
+          </span>
+        )}
       </div>
       <div className="al-mapwrap">
-        <svg viewBox={`0 0 ${width} ${height}`} style={{ width: `${100 * zoom}%` }} role="img"
+        <svg
+          ref={svgRef}
+          viewBox={`0 0 ${width} ${height}`}
+          className={`al-svg${brush ? ' brushing' : ''}`}
+          onPointerDown={onDown}
+          onPointerMove={onMove}
+          onPointerUp={onUp}
+          onPointerCancel={onUp}
+          onDoubleClick={() => setWin(null)}
+          role="img"
           aria-label="Swimlanes: one lane per agent, prompts drawn from caller to target, resolved waits back the other way, and a lane drawn faint until the agent is created.">
           <defs>
             <marker id="al-ar" viewBox="0 0 8 8" refX="6.5" refY="4" markerWidth="4.5" markerHeight="4.5" orient="auto">
@@ -388,17 +481,23 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
             return (
               <g key={name}>
                 <text x="2" y={laneY(i) - 5} className={`al-lane-lbl${b !== undefined ? ' new' : ''}`}>{name}</text>
-                {b !== undefined && <line x1="2" y1={laneY(i)} x2={xOf(b)} y2={laneY(i)} className="al-lane unborn" />}
-                <line x1={b === undefined ? 2 : xOf(b)} y1={laneY(i)} x2={width - 4} y2={laneY(i)} className="al-lane" />
+                {/* faint before the agent existed, solid after — clipped to the
+                    window, so zooming past the birth shows a solid lane and
+                    zooming before it shows a dashed one. */}
+                {b !== undefined && b > lo && <line x1={LEFT} y1={laneY(i)} x2={clampX(b)} y2={laneY(i)} className="al-lane unborn" />}
+                {b !== undefined && b > lo && <line x1="2" y1={laneY(i)} x2={LEFT} y2={laneY(i)} className="al-lane unborn" />}
+                {(b === undefined || b <= hi) && (
+                  <line x1={b === undefined || b <= lo ? 2 : clampX(b)} y1={laneY(i)} x2={width - 4} y2={laneY(i)} className="al-lane" />
+                )}
               </g>
             );
           })}
-          {marks.map(({ op, x, x0, a, b }) => {
+          {visible.map(({ op, x, x0, a, b }) => {
             const back = isWait(op);
             const isNew = !!created(op);
             const src = back ? (b >= 0 ? b : a) : a;
             const dst = back ? a : b;
-            const px = xOf(x);
+            const px = clampX(x);
             const on = hover?.id === op.id;
             const cls = `${back ? ' back' : ''}${op.ok ? '' : ' bad'}${isNew ? ' new' : ''}`;
             if (src < 0 || dst < 0 || src === dst) {
@@ -419,7 +518,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
                 <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
                 {/* how long the caller was blocked, on the caller's own lane */}
                 {back && x0 !== undefined && x0 < x && (
-                  <line x1={xOf(x0)} y1={laneY(dst)} x2={px} y2={laneY(dst)} className="al-held" />
+                  <line x1={clampX(x0)} y1={laneY(dst)} x2={px} y2={laneY(dst)} className="al-held" />
                 )}
                 <line x1={px} y1={y1} x2={px} y2={y2}
                   className={`al-arrow${cls}`}
@@ -434,9 +533,29 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
               </g>
             );
           })}
-          {/* axis and legend, both inside the frame */}
-          {from && <text x="2" y={height - 22} className="al-axis">{`${DAY(from)} ${HHMMSS(from).slice(0, 5)} →`}</text>}
-          {to && <text x={width - 4} y={height - 22} textAnchor="end" className="al-axis">{HHMMSS(to).slice(0, 5)}</text>}
+          {/* what is being dragged out right now */}
+          {brush && (
+            <g className="al-brushg">
+              <rect
+                x={clampX(Math.min(brush.from, brush.to))}
+                y={TOP - 8}
+                width={Math.max(1, Math.abs(clampX(brush.to) - clampX(brush.from)))}
+                height={lanes.length * LANE_H + 10}
+                className="al-brush"
+              />
+              <text x={clampX(Math.min(brush.from, brush.to)) + 3} y={TOP - 11} className="al-brush-lbl">
+                {clock(timeAt(Math.min(brush.from, brush.to)))} → {clock(timeAt(Math.max(brush.from, brush.to)))}
+              </text>
+            </g>
+          )}
+          {/* axis and legend, both inside the frame. The ends follow the window,
+              so a zoomed plot says which slice of time it is showing. */}
+          <text x="2" y={height - 22} className="al-axis">
+            {`${DAY(new Date(timeAt(lo)).toISOString())} ${clock(timeAt(lo)).slice(0, 5)} →`}
+          </text>
+          <text x={width - 4} y={height - 22} textAnchor="end" className="al-axis">
+            {clock(timeAt(hi)).slice(0, 5)}
+          </text>
           <g className="al-key">
             <line x1="2" y1={height - 7} x2="18" y2={height - 7} className="al-arrow" markerEnd="url(#al-ar)" />
             <text x="22" y={height - 4}>prompt</text>

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -77,7 +77,15 @@ function payloadOf(op: api.Operation): { text: string; sha?: string } {
 const statusClass = (op: api.Operation) =>
   (op.ok ? 'ok' : op.status >= 500 ? 'bad' : 'warn');
 
-const who = (op: api.Operation) => op.origin?.name || op.origin?.id || '—';
+/** For the MAP: the caller's lane, or nothing. These have to be different. A
+ *  `wait` may arrive with no origin — the server keeps that path working for
+ *  the watch loops already running — and the em dash is a display fallback, not
+ *  an agent. Treating it as one added a lane called "—" and drew a return arrow
+ *  into it, inventing a caller the log never knew. Unattributed means a mark on
+ *  the lane of whoever was waited ON, which is the one end that IS known. */
+const originLane = (op: api.Operation) => op.origin?.name || op.origin?.id || '';
+/** For the Who column: something readable, even when nobody was attributed. */
+const who = (op: api.Operation) => originLane(op) || '—';
 /** The id of whoever the call acted on. `target` is written into the log from
  *  this version on; entries recorded before it have the id in the path, which is
  *  worth digging out so the map is not empty on the day this ships. */
@@ -237,7 +245,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     const made = new Map<string, number>();
     const got = new Map<string, number>();
     const bump = (m: Map<string, number>, name: string) => name && m.set(name, (m.get(name) || 0) + 1);
-    for (const op of recent) { bump(made, who(op)); bump(got, whom(op, names)); }
+    for (const op of recent) { bump(made, originLane(op)); bump(got, whom(op, names)); }
     const byCount = (m: Map<string, number>) => [...m].sort((a, b) => b[1] - a[1]).map(([n]) => n);
     const callers = byCount(made);
     const lanes = [...callers, ...byCount(got).filter((n) => !made.has(n))].slice(0, MAX_LANES);
@@ -250,7 +258,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     const marks = recent.map((op, i) => ({
       op,
       x: recent.length < 2 ? 0.5 : i / (recent.length - 1),
-      a: lanes.indexOf(who(op)),
+      a: lanes.indexOf(originLane(op)),
       b: lanes.indexOf(whom(op, names)),
     })).filter((m) => m.a >= 0 || m.b >= 0);
     void t0; void t1;

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -22,7 +22,6 @@ import { useEffect, useMemo, useState } from 'react';
 import * as api from '../api';
 
 type View = 'list' | 'map';
-type Kind = 'fail' | 'prompt' | 'file';
 
 const HHMMSS = (iso: string) => new Date(iso).toLocaleTimeString([], { hour12: false });
 const DAY = (iso: string) => new Date(iso).toLocaleDateString([], { day: 'numeric', month: 'short' });
@@ -54,6 +53,15 @@ function textSummary(value: unknown): api.OperationSummary | null {
 }
 
 const isFileRoute = (p: string) => p.startsWith('/api/files') || p.startsWith('/api/skills');
+/** A create names nothing in its path — the session it made is in the RESULT.
+ *  Without this the call drew as a dot on the caller's lane and the agent it
+ *  brought into being appeared to have been there all along. */
+const created = (op: api.Operation): { id: string; name: string } | null => {
+  if (op.method !== 'POST' || !op.ok) return null;
+  if (op.path !== '/api/agents' && op.path !== '/api/sessions') return null;
+  const r = op.result as { id?: string; name?: string } | undefined;
+  return r?.id ? { id: r.id, name: r.name || r.id } : null;
+};
 export const isWait = (op: api.Operation) => op.method === 'GET' && /\/wait$/.test(op.path);
 const isPrompt = (op: api.Operation) => /\/(prompt|input)$/.test(op.path);
 
@@ -103,9 +111,11 @@ export default function ApiLog() {
   const [names, setNames] = useState<Map<string, string>>(new Map());
   const [error, setError] = useState('');
   const [view, setView] = useState<View>('list');
-  const [origin, setOrigin] = useState('');            // '' = everyone
-  const [kinds, setKinds] = useState<Kind[]>([]);
-  const [q, setQ] = useState('');
+  // The operator's own clicks are most of the log and none of the story: this
+  // view is for what the AGENTS did to each other. Off by default, and the only
+  // filter — the chips and the path search that used to sit here made a screen
+  // of controls for a screen of rows.
+  const [withOperator, setWithOperator] = useState(false);
 
   const load = () => api.getOperations(500)
     .then((d) => { setOps(d.operations); setError(''); })
@@ -117,21 +127,11 @@ export default function ApiLog() {
       .catch(() => {});
   }, []);
 
-  const origins = useMemo(() => {
-    const seen = new Map<string, string>();
-    for (const op of ops || []) if (op.origin) seen.set(op.origin.id, op.origin.name || op.origin.id);
-    return [...seen].sort((a, b) => a[1].localeCompare(b[1]));
-  }, [ops]);
-
-  const failures = (ops || []).filter((op) => !op.ok).length;
-  const toggle = (k: Kind) => setKinds((ks) => (ks.includes(k) ? ks.filter((x) => x !== k) : [...ks, k]));
-
-  const rows = useMemo(() => (ops || []).filter((op) => {
-    if (origin && op.origin?.id !== origin) return false;
-    if (q && !op.path.toLowerCase().includes(q.toLowerCase())) return false;
-    if (!kinds.length) return true;
-    return kinds.some((k) => (k === 'fail' ? !op.ok : k === 'prompt' ? isPrompt(op) : isFileRoute(op.path)));
-  }), [ops, origin, q, kinds]);
+  const rows = useMemo(() => (ops || []).filter(
+    (op) => withOperator || op.origin?.type !== 'operator',
+  ), [ops, withOperator]);
+  const hidden = (ops || []).length - rows.length;
+  const failures = rows.filter((op) => !op.ok).length;
 
   // Identical prompts have identical checksums. Counting them is the only thing
   // the log can honestly say about repetition, and it is enough to spot a job
@@ -145,14 +145,17 @@ export default function ApiLog() {
     return n;
   }, [rows]);
 
-  const span = ops && ops.length
-    ? `${DAY(ops[ops.length - 1].at)}–${DAY(ops[0].at)}`
-    : '';
+  const span = rows.length ? `${DAY(rows[rows.length - 1].at)}–${DAY(rows[0].at)}` : '';
 
   return (
     <div className="al">
       <div className="al-head">
-        <span className="al-count">{ops ? `${ops.length} calls` : 'loading…'}{span ? ` · ${span}` : ''}</span>
+        <span className="al-count">
+          {ops ? `${rows.length} call${rows.length === 1 ? '' : 's'}` : 'loading…'}
+          {span ? ` · ${span}` : ''}
+          {/* the failure count was a filter chip; it is more useful as a fact */}
+          {failures > 0 && <span className="al-fails"> · {failures} failed</span>}
+        </span>
         <div className="seg al-view">
           <button className={view === 'list' ? 'on' : ''} onClick={() => setView('list')}>List</button>
           <button className={view === 'map' ? 'on' : ''} onClick={() => setView('map')}>Map</button>
@@ -161,17 +164,9 @@ export default function ApiLog() {
       </div>
 
       <div className="al-filters">
-        <button className={`al-chip${origin ? '' : ' on'}`} onClick={() => setOrigin('')}>Everyone</button>
-        {origins.map(([id, name]) => (
-          <button key={id} className={`al-chip${origin === id ? ' on' : ''}`} onClick={() => setOrigin(id)}>{name}</button>
-        ))}
-        <span className="al-gap" />
-        <button className={`al-chip${kinds.includes('fail') ? ' on' : ''}`} onClick={() => toggle('fail')}>
-          Only failures ({failures})
+        <button className={`al-chip${withOperator ? ' on' : ''}`} onClick={() => setWithOperator((v) => !v)}>
+          {withOperator ? 'Including your own calls' : `Your own calls hidden${hidden ? ` (${hidden})` : ''}`}
         </button>
-        <button className={`al-chip${kinds.includes('prompt') ? ' on' : ''}`} onClick={() => toggle('prompt')}>Prompts</button>
-        <button className={`al-chip${kinds.includes('file') ? ' on' : ''}`} onClick={() => toggle('file')}>Files</button>
-        <input className="al-find mono" placeholder="path contains…" value={q} onChange={(e) => setQ(e.target.value)} />
       </div>
 
       {error && <div className="s-warn">{error}</div>}
@@ -225,46 +220,66 @@ function LogTable({ rows, repeats, names }: {
 // ---- the map ----------------------------------------------------------------
 // Geometry follows the approved mock: a labelled hairline per lane, arrows
 // drawn between lanes, a dot on the lane the call was made from.
-const LANE_H = 46;
-const TOP = 26;
-const LEFT = 108;      // room for the longest lane label
-const RIGHT = 26;
-const MAX_LANES = 12;
-const MAX_MARKS = 48;
+// Denser than the mock: at a real pane width its 46px lanes left the plot mostly
+// empty, and the point of the picture is to hold a lot of calls at once.
+const LANE_H = 30;
+const TOP = 18;
+const LEFT = 104;      // room for the longest lane label
+const RIGHT = 20;
+const FOOT = 40;       // axis + legend, both inside the frame
+const MAX_LANES = 14;
+const MAX_MARKS = 60;
 
 function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, string> }) {
   const [hover, setHover] = useState<api.Operation | null>(null);
 
-  const { lanes, marks, from, to, dropped } = useMemo(() => {
+  const { lanes, marks, born, from, to, dropped } = useMemo(() => {
     const recent = rows.slice(0, MAX_MARKS).slice().reverse();  // oldest first, left to right
     // Lanes: everything that CALLS above everything that is only called. Then a
     // prompt points down the picture and a resolved wait points back up it,
-    // which is the whole claim the legend makes. Sorting by traffic alone put
-    // targets above their callers and the two directions stopped meaning
-    // anything.
+    // which is the whole claim the legend makes.
     const made = new Map<string, number>();
     const got = new Map<string, number>();
     const bump = (m: Map<string, number>, name: string) => name && m.set(name, (m.get(name) || 0) + 1);
-    for (const op of recent) { bump(made, originLane(op)); bump(got, whom(op, names)); }
+    const other = (op: api.Operation) => created(op)?.name || whom(op, names);
+    for (const op of recent) { bump(made, originLane(op)); bump(got, other(op)); }
     const byCount = (m: Map<string, number>) => [...m].sort((a, b) => b[1] - a[1]).map(([n]) => n);
-    const callers = byCount(made);
-    const lanes = [...callers, ...byCount(got).filter((n) => !made.has(n))].slice(0, MAX_LANES);
-    const t0 = recent.length ? new Date(recent[0].at).getTime() : 0;
-    const t1 = recent.length ? new Date(recent[recent.length - 1].at).getTime() : 1;
+    const lanes = [...byCount(made), ...byCount(got).filter((n) => !made.has(n))].slice(0, MAX_LANES);
     // x is the call's RANK, not its clock position: real traffic arrives in
     // bursts, and spacing by time collapses a burst into one unreadable column
     // while leaving the quiet hours as empty space. The axis still says what
     // period is on screen.
-    const marks = recent.map((op, i) => ({
-      op,
-      x: recent.length < 2 ? 0.5 : i / (recent.length - 1),
-      a: lanes.indexOf(originLane(op)),
-      b: lanes.indexOf(whom(op, names)),
-    })).filter((m) => m.a >= 0 || m.b >= 0);
-    void t0; void t1;
+    const xs = new Map<string, number>();
+    const marks = recent.map((op, i) => {
+      const x = recent.length < 2 ? 0.5 : i / (recent.length - 1);
+      xs.set(op.id, x);
+      return { op, x, a: lanes.indexOf(originLane(op)), b: lanes.indexOf(other(op)) };
+    }).filter((m) => m.a >= 0 || m.b >= 0);
+    // When a lane came into being, if we watched it happen. Before that its line
+    // is drawn faint: the agent did not exist, and a solid line all the way to
+    // the left edge said it had been there the whole time.
+    const born = new Map<string, number>();
+    for (const { op, x } of marks) {
+      const c = created(op);
+      if (c && !born.has(c.name)) born.set(c.name, x);
+    }
+    // A wait BLOCKS, and that is the interesting thing about it. Its `at` is
+    // when it STARTED — which is where its rank puts it — and it resolved
+    // durationMs later. So the resolution is drawn where that moment falls in
+    // the sequence, and the stretch in between is the wait itself: a five-minute
+    // block reads as five minutes of the picture rather than as a point.
+    const endX = (op: api.Operation, own: number) => {
+      const ended = new Date(op.at).getTime() + (op.durationMs || 0);
+      let x = own;
+      for (const m of marks) if (new Date(m.op.at).getTime() <= ended) x = Math.max(x, m.x);
+      // resolved after everything else on screen: run to the right edge
+      return ended > new Date(marks[marks.length - 1].op.at).getTime() ? 1 : x;
+    };
     return {
       lanes,
-      marks,
+      marks: marks.map((m) => (isWait(m.op) ? { ...m, x0: m.x, x: endX(m.op, m.x) } : m)) as
+        Array<{ op: api.Operation; x: number; a: number; b: number; x0?: number }>,
+      born,
       from: recent.length ? recent[0].at : '',
       to: recent.length ? recent[recent.length - 1].at : '',
       dropped: Math.max(0, rows.length - MAX_MARKS),
@@ -274,77 +289,149 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   if (!lanes.length) return <div className="s-muted al-empty">Nothing to draw yet.</div>;
 
   const width = 760;
-  const height = TOP + lanes.length * LANE_H + 34;
-  const laneY = (i: number) => TOP + i * LANE_H + 8;
+  const height = TOP + lanes.length * LANE_H + FOOT;
+  const laneY = (i: number) => TOP + i * LANE_H + 6;
   const xOf = (t: number) => LEFT + t * (width - LEFT - RIGHT);
+
 
   return (
     <div className="al-map">
       <div className="al-mapwrap">
         <svg viewBox={`0 0 ${width} ${height}`} role="img"
-          aria-label="Swimlanes: one lane per agent, prompts drawn from caller to target and resolved waits back the other way.">
+          aria-label="Swimlanes: one lane per agent, prompts drawn from caller to target, resolved waits back the other way, and a lane drawn faint until the agent is created.">
           <defs>
-            <marker id="al-ar" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <marker id="al-ar" viewBox="0 0 8 8" refX="6.5" refY="4" markerWidth="4.5" markerHeight="4.5" orient="auto">
               <path d="M0 0 L8 4 L0 8 z" fill="var(--accent)" />
             </marker>
-            <marker id="al-arb" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+            <marker id="al-arb" viewBox="0 0 8 8" refX="6.5" refY="4" markerWidth="4.5" markerHeight="4.5" orient="auto">
               <path d="M0 0 L8 4 L0 8 z" fill="var(--muted)" />
             </marker>
           </defs>
-          {lanes.map((name, i) => (
-            <g key={name}>
-              <text x="2" y={laneY(i) - 6} className="al-lane-lbl">{name}</text>
-              <line x1="2" y1={laneY(i)} x2={width - 4} y2={laneY(i)} className="al-lane" />
-            </g>
-          ))}
-          {marks.map(({ op, x, a, b }) => {
+          {lanes.map((name, i) => {
+            const b = born.get(name);
+            return (
+              <g key={name}>
+                <text x="2" y={laneY(i) - 5} className={`al-lane-lbl${b !== undefined ? ' new' : ''}`}>{name}</text>
+                {b !== undefined && <line x1="2" y1={laneY(i)} x2={xOf(b)} y2={laneY(i)} className="al-lane unborn" />}
+                <line x1={b === undefined ? 2 : xOf(b)} y1={laneY(i)} x2={width - 4} y2={laneY(i)} className="al-lane" />
+              </g>
+            );
+          })}
+          {marks.map(({ op, x, x0, a, b }) => {
             const back = isWait(op);
-            // A wait is attention coming BACK: it is drawn from the agent that
-            // was waited on to the one that waited.
+            const isNew = !!created(op);
             const src = back ? (b >= 0 ? b : a) : a;
             const dst = back ? a : b;
             const px = xOf(x);
             const on = hover?.id === op.id;
+            const cls = `${back ? ' back' : ''}${op.ok ? '' : ' bad'}${isNew ? ' new' : ''}`;
             if (src < 0 || dst < 0 || src === dst) {
               const lane = src >= 0 ? src : dst;
               return (
-                <circle key={op.id} cx={px} cy={laneY(lane)} r={on ? 4 : 2.6}
-                  className={`al-dot${back ? ' back' : ''}${op.ok ? '' : ' bad'}${on ? ' on' : ''}`}
+                <circle key={op.id} cx={px} cy={laneY(lane)} r={on ? 3.4 : 2}
+                  className={`al-dot${cls}${on ? ' on' : ''}`}
                   onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}>
                   <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
                 </circle>
               );
             }
-            const y1 = laneY(src) + (dst > src ? 5 : -5);
-            const y2 = laneY(dst) + (dst > src ? -7 : 7);
+            const y1 = laneY(src) + (dst > src ? 4 : -4);
+            const y2 = laneY(dst) + (dst > src ? -6 : 6);
             return (
               <g key={op.id} onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}
                 className={`al-arrowg${on ? ' on' : ''}`}>
                 <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
+                {/* how long the caller was blocked, on the caller's own lane */}
+                {back && x0 !== undefined && x0 < x && (
+                  <line x1={xOf(x0)} y1={laneY(dst)} x2={px} y2={laneY(dst)} className="al-held" />
+                )}
                 <line x1={px} y1={y1} x2={px} y2={y2}
-                  className={`al-arrow${back ? ' back' : ''}${op.ok ? '' : ' bad'}`}
+                  className={`al-arrow${cls}`}
                   markerEnd={`url(#${back ? 'al-arb' : 'al-ar'})`} />
-                <circle cx={px} cy={laneY(src)} r="2.6" className={`al-dot${back ? ' back' : ''}${op.ok ? '' : ' bad'}`} />
-                {/* a hit area wider than a 1.6px line, or nothing is hoverable */}
+                <circle cx={px} cy={laneY(src)} r="2" className={`al-dot${cls}`} />
+                {/* a create ends on a lane that did not exist a moment ago: an
+                    open mark says "this one begins here" where a filled dot
+                    would just be one more call */}
+                {isNew && <circle cx={px} cy={laneY(dst)} r="3.2" className="al-birth" />}
+                {/* a hit area wider than a 1px line, or nothing is hoverable */}
                 <line x1={px} y1={y1} x2={px} y2={y2} className="al-hit" />
               </g>
             );
           })}
-          {from && <text x="2" y={height - 8} className="al-axis">{`${DAY(from)} ${HHMMSS(from).slice(0, 5)} →`}</text>}
-          {to && <text x={width - 4} y={height - 8} textAnchor="end" className="al-axis">{HHMMSS(to).slice(0, 5)}</text>}
+          {/* axis and legend, both inside the frame */}
+          {from && <text x="2" y={height - 22} className="al-axis">{`${DAY(from)} ${HHMMSS(from).slice(0, 5)} →`}</text>}
+          {to && <text x={width - 4} y={height - 22} textAnchor="end" className="al-axis">{HHMMSS(to).slice(0, 5)}</text>}
+          <g className="al-key">
+            <line x1="2" y1={height - 7} x2="18" y2={height - 7} className="al-arrow" markerEnd="url(#al-ar)" />
+            <text x="22" y={height - 4}>prompt</text>
+            <line x1="72" y1={height - 7} x2="88" y2={height - 7} className="al-arrow back" markerEnd="url(#al-arb)" />
+            <text x="92" y={height - 4}>wait, from where it started</text>
+            <line x1="228" y1={height - 7} x2="240" y2={height - 7} className="al-arrow new" markerEnd="url(#al-ar)" />
+            <circle cx="245" cy={height - 7} r="3.2" className="al-birth" />
+            <text x="252" y={height - 4}>created</text>
+            <line x1="304" y1={height - 7} x2="320" y2={height - 7} className="al-lane unborn" />
+            <text x="324" y={height - 4}>before it existed</text>
+            {dropped > 0 && <text x={width - 4} y={height - 4} textAnchor="end">newest {MAX_MARKS} of {rows.length}</text>}
+          </g>
         </svg>
       </div>
-      <div className="al-readout mono">
-        {hover
-          ? `${HHMMSS(hover.at)}  ${who(hover)}${whom(hover, names) ? ` → ${whom(hover, names)}` : ''}  ${hover.method} ${hover.path}  ${hover.status}  ${took(hover.durationMs)}  ${payloadOf(hover).text}`
-          : 'Hover a line for its time, status and payload.'}
+      {/* Under the plot, not floating over it: a card that follows the cursor
+          covers the very lanes you are reading, and clips against a frame that
+          scrolls. This one is always the same size and in the same place. */}
+      <HoverCard op={hover} names={names} />
+    </div>
+  );
+}
+
+/** The whole call, pretty-printed, plus the metadata that is not in the body:
+ *  who, what it hit, the status and how long it took. The log's request/result
+ *  are already summaries — this shows them as they are stored rather than
+ *  paraphrasing them into a sentence. */
+function HoverCard({ op, names }: { op: api.Operation | null; names: Map<string, string> }) {
+  if (!op) {
+    return (
+      <div className="al-card al-card-idle">
+        Hover a call for the whole entry — who, what it hit, its status, how long it took.
       </div>
-      <div className="al-legend">
-        <span><i className="al-key" /> prompt (caller → target)</span>
-        <span><i className="al-key back" /> wait resolved (target → caller)</span>
-        <span><i className="al-key dot" /> the call&apos;s own lane</span>
-        {dropped > 0 && <span className="s-muted">newest {MAX_MARKS} of {rows.length} drawn</span>}
+    );
+  }
+  const body = {
+    at: op.at,
+    call: `${op.method} ${op.path}`,
+    from: op.origin ? `${op.origin.name || op.origin.id}${op.origin.type ? ` (${op.origin.type})` : ''}` : null,
+    to: whom(op, names) || created(op)?.name || null,
+    status: op.status,
+    took: took(op.durationMs),
+    ...(created(op) ? { created: created(op) } : {}),
+    ...(op.query && Object.keys(op.query).length ? { query: op.query } : {}),
+    ...(op.request === undefined ? {} : { request: op.request }),
+    ...(op.result === undefined ? {} : { result: op.result }),
+  };
+  return (
+    <div className="al-card">
+      <div className="al-card-head">
+        <span className={`al-meth${isWait(op) ? ' back' : ''}`}>{op.method}</span>
+        <span className="al-card-path">{op.path}</span>
+        <span className={`al-st ${statusClass(op)}`}>{op.status}</span>
+        <span className="al-card-took">{took(op.durationMs)}</span>
+      </div>
+      <pre className="al-json">{json(body)}</pre>
+      <div className="al-card-foot">
+        prompt text is not stored — {'{'}present, chars, sha256{'}'} only
       </div>
     </div>
   );
+}
+
+/** JSON with the keys tinted. Small enough not to want a highlighter. */
+function json(value: unknown) {
+  return JSON.stringify(value, null, 2).split('\n').map((line, i) => {
+    const m = line.match(/^(\s*)"([^"]+)":\s?(.*)$/);
+    return (
+      <span key={i}>
+        {m ? <>{m[1]}<span className="al-k">{m[2]}</span>: {m[3]}</> : line}
+        {'\n'}
+      </span>
+    );
+  });
 }

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -13,11 +13,12 @@
 //          reason reads are logged at all; without it the picture shows work
 //          going out and nothing ever coming back.
 //
-// What this cannot show, by design: the log stores {present, chars, sha256} for
-// prompt text and never the text. So this answers who asked whom to do
-// something, when, and how big the ask was — never what it said. Equal
-// checksums mean identical prompts, which is what a repeating job produces, so
-// repeats are marked rather than hidden.
+// The log stores each call WHOLE — body included, on the operator's instruction —
+// with credentials the one thing withheld. So this can answer who asked whom to
+// do what, when, and in their own words. Equal checksums still mean identical
+// prompts, which is what a repeating job produces, so repeats are marked; and
+// because an entry is now as big as the call it records, the card decides how
+// much of a body to paint rather than trying to paint all of it.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../api';
 
@@ -65,9 +66,8 @@ const created = (op: api.Operation): { id: string; name: string } | null => {
 export const isWait = (op: api.Operation) => op.method === 'GET' && /\/wait$/.test(op.path);
 const isPrompt = (op: api.Operation) => /\/(prompt|input)$/.test(op.path);
 
-/** The prompt as sent, when the log kept it. Prompt routes store the text
- *  beside its checksum; everything else is still summarised, so this is null for
- *  a file write and for any call that never carried a prompt. */
+/** The body as sent. Every route's body is kept now, so this is the prompt for a
+ *  prompt, the file for a write, and null only when the call carried no body. */
 export function promptText(op: api.Operation): string | null {
   const sum = textSummary(op.request) as (api.OperationSummary & { text?: string }) | null;
   return typeof sum?.text === 'string' ? sum.text : null;
@@ -84,8 +84,11 @@ function payloadOf(op: api.Operation): { text: string; sha?: string } {
   const sum = textSummary(op.request);
   if (!sum || !sum.chars) return { text: '—' };
   const what = isFileRoute(op.path) ? 'file' : isPrompt(op) ? 'prompt' : 'body';
+  // KB rather than a character count once it stops being something you read
   return {
-    text: isFileRoute(op.path) ? `${what} · ${KB(sum.chars)}` : `${what} · ${sum.chars.toLocaleString()} chars`,
+    text: isFileRoute(op.path) || sum.chars > 100_000
+      ? `${what} · ${KB(sum.chars)}`
+      : `${what} · ${sum.chars.toLocaleString()} chars`,
     sha: sum.sha256,
   };
 }
@@ -112,6 +115,13 @@ const whom = (op: api.Operation, names?: Map<string, string>) => {
   return op.target?.name || (id && names?.get(id)) || id;
 };
 
+// What the CARD is willing to paint. The log stores whole bodies now — a file
+// write is megabytes on one line — and a <pre> with five million characters in
+// it locks the tab. Nothing is truncated on disk; this is only how much of it
+// the viewer draws at once, and it says when it is holding some back.
+const SHOW_CHARS = 20_000;
+const clip = (text: string) => (text.length > SHOW_CHARS ? text.slice(0, SHOW_CHARS) : text);
+
 export default function ApiLog() {
   const [ops, setOps] = useState<api.Operation[] | null>(null);
   // id → name for sessions that still exist, so an older entry whose target was
@@ -125,7 +135,9 @@ export default function ApiLog() {
   // of controls for a screen of rows.
   const [withOperator, setWithOperator] = useState(false);
 
-  const load = () => api.getOperations(500)
+  // 200, not 500: entries carry their whole body now, so a page of them is
+  // measured in megabytes rather than kilobytes.
+  const load = () => api.getOperations(200)
     .then((d) => { setOps(d.operations); setError(''); })
     .catch(() => setError('could not read the log'));
   useEffect(() => { load(); }, []);
@@ -497,8 +509,15 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
       </div>
       {text !== null && (
         <div className="al-prompt">
-          <div className="al-prompt-lbl">prompt as sent</div>
-          <pre className="al-prompt-body">{text}</pre>
+          <div className="al-prompt-lbl">
+            body as sent
+            {text.length > SHOW_CHARS && (
+              <span className="al-clipped">
+                {' '}· showing the first {SHOW_CHARS.toLocaleString()} of {text.length.toLocaleString()} characters
+              </span>
+            )}
+          </div>
+          <pre className="al-prompt-body">{clip(text)}</pre>
         </div>
       )}
       <pre className="al-json">{json(body)}</pre>
@@ -517,7 +536,10 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
 function withoutText(request: unknown): unknown {
   if (!request || typeof request !== 'object') return request;
   const strip = (v: Record<string, unknown>) => {
-    const { text, ...rest } = v;
+    const { text, base64, ...rest } = v;
+    // base64 of an upload is not readable and not small; its bytes and checksum
+    // are in the entry, and the file itself is on disk.
+    if (typeof base64 === 'string') return { ...rest, base64: `[${base64.length.toLocaleString()} chars]` };
     return typeof text === 'string' ? rest : v;
   };
   const top = request as Record<string, unknown>;

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -1,0 +1,342 @@
+// Settings → API log: what the agents actually did to each other.
+//
+// Two views over /api/operations, which the manager already writes for every
+// call that changes something (plus, since this feature, the one read that is an
+// event between two agents — a `wait` that resolved).
+//
+//   list — one call per LINE. Not per row: per line. A wrapped row halves how
+//          many calls fit on a screen, so every cell is nowrap/ellipsis and the
+//          path is the one column allowed to take the remaining width.
+//   map  — one lane per agent, time left to right, and the calls drawn BETWEEN
+//          the lanes: a prompt is an arrow from caller to target, a resolved
+//          wait is an arrow back the other way. That return arrow is the whole
+//          reason reads are logged at all; without it the picture shows work
+//          going out and nothing ever coming back.
+//
+// What this cannot show, by design: the log stores {present, chars, sha256} for
+// prompt text and never the text. So this answers who asked whom to do
+// something, when, and how big the ask was — never what it said. Equal
+// checksums mean identical prompts, which is what a repeating job produces, so
+// repeats are marked rather than hidden.
+import { useEffect, useMemo, useState } from 'react';
+import * as api from '../api';
+
+type View = 'list' | 'map';
+type Kind = 'fail' | 'prompt' | 'file';
+
+const HHMMSS = (iso: string) => new Date(iso).toLocaleTimeString([], { hour12: false });
+const DAY = (iso: string) => new Date(iso).toLocaleDateString([], { day: 'numeric', month: 'short' });
+
+/** 6ms · 576ms · 18.4s · 4m 18s — always three glyphs of information, never more. */
+export function took(ms: number): string {
+  if (!Number.isFinite(ms)) return '—';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const m = Math.floor(ms / 60_000);
+  return `${m}m ${String(Math.round((ms % 60_000) / 1000)).padStart(2, '0')}s`;
+}
+
+const KB = (chars: number) => (chars < 1024 ? `${chars} B` : `${(chars / 1024).toFixed(1)} KB`);
+
+/** The summariser stores text as {present, chars, sha256} — sometimes as the
+ *  whole body (a prompt), sometimes one field inside it (`input` wraps it in
+ *  `text`). Find it either way; anything else has no payload worth a column. */
+function textSummary(value: unknown): api.OperationSummary | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.chars === 'number') return v as api.OperationSummary;
+  for (const inner of Object.values(v)) {
+    if (inner && typeof inner === 'object' && typeof (inner as api.OperationSummary).chars === 'number') {
+      return inner as api.OperationSummary;
+    }
+  }
+  return null;
+}
+
+const isFileRoute = (p: string) => p.startsWith('/api/files') || p.startsWith('/api/skills');
+export const isWait = (op: api.Operation) => op.method === 'GET' && /\/wait$/.test(op.path);
+const isPrompt = (op: api.Operation) => /\/(prompt|input)$/.test(op.path);
+
+/** What the Payload column says. Text length, never text. */
+function payloadOf(op: api.Operation): { text: string; sha?: string } {
+  if (isWait(op)) {
+    const state = (op.result as { state?: string } | undefined)?.state;
+    return { text: `resolved · ${state || 'finished'}` };
+  }
+  const bytes = (op.result as { bytes?: number } | undefined)?.bytes;
+  if (typeof bytes === 'number') return { text: `upload · ${KB(bytes)}` };
+  const sum = textSummary(op.request);
+  if (!sum || !sum.chars) return { text: '—' };
+  const what = isFileRoute(op.path) ? 'file' : isPrompt(op) ? 'prompt' : 'body';
+  return {
+    text: isFileRoute(op.path) ? `${what} · ${KB(sum.chars)}` : `${what} · ${sum.chars.toLocaleString()} chars`,
+    sha: sum.sha256,
+  };
+}
+
+const statusClass = (op: api.Operation) =>
+  (op.ok ? 'ok' : op.status >= 500 ? 'bad' : 'warn');
+
+const who = (op: api.Operation) => op.origin?.name || op.origin?.id || '—';
+/** The id of whoever the call acted on. `target` is written into the log from
+ *  this version on; entries recorded before it have the id in the path, which is
+ *  worth digging out so the map is not empty on the day this ships. */
+const TARGET_IN_PATH = /^\/api\/(?:agents|sessions|trace|files)\/([^/]+)/;
+const targetId = (op: api.Operation) => op.target?.id || (op.path.match(TARGET_IN_PATH) || [])[1] || '';
+const whom = (op: api.Operation, names?: Map<string, string>) => {
+  const id = targetId(op);
+  return op.target?.name || (id && names?.get(id)) || id;
+};
+
+export default function ApiLog() {
+  const [ops, setOps] = useState<api.Operation[] | null>(null);
+  // id → name for sessions that still exist, so an older entry whose target was
+  // never recorded still draws with a name rather than an id.
+  const [names, setNames] = useState<Map<string, string>>(new Map());
+  const [error, setError] = useState('');
+  const [view, setView] = useState<View>('list');
+  const [origin, setOrigin] = useState('');            // '' = everyone
+  const [kinds, setKinds] = useState<Kind[]>([]);
+  const [q, setQ] = useState('');
+
+  const load = () => api.getOperations(500)
+    .then((d) => { setOps(d.operations); setError(''); })
+    .catch(() => setError('could not read the log'));
+  useEffect(() => { load(); }, []);
+  useEffect(() => {
+    api.getTree()
+      .then((t) => setNames(new Map(t.sessions.map((s) => [s.id, s.name]))))
+      .catch(() => {});
+  }, []);
+
+  const origins = useMemo(() => {
+    const seen = new Map<string, string>();
+    for (const op of ops || []) if (op.origin) seen.set(op.origin.id, op.origin.name || op.origin.id);
+    return [...seen].sort((a, b) => a[1].localeCompare(b[1]));
+  }, [ops]);
+
+  const failures = (ops || []).filter((op) => !op.ok).length;
+  const toggle = (k: Kind) => setKinds((ks) => (ks.includes(k) ? ks.filter((x) => x !== k) : [...ks, k]));
+
+  const rows = useMemo(() => (ops || []).filter((op) => {
+    if (origin && op.origin?.id !== origin) return false;
+    if (q && !op.path.toLowerCase().includes(q.toLowerCase())) return false;
+    if (!kinds.length) return true;
+    return kinds.some((k) => (k === 'fail' ? !op.ok : k === 'prompt' ? isPrompt(op) : isFileRoute(op.path)));
+  }), [ops, origin, q, kinds]);
+
+  // Identical prompts have identical checksums. Counting them is the only thing
+  // the log can honestly say about repetition, and it is enough to spot a job
+  // that fires the same text on a schedule.
+  const repeats = useMemo(() => {
+    const n = new Map<string, number>();
+    for (const op of rows) {
+      const sha = payloadOf(op).sha;
+      if (sha) n.set(sha, (n.get(sha) || 0) + 1);
+    }
+    return n;
+  }, [rows]);
+
+  const span = ops && ops.length
+    ? `${DAY(ops[ops.length - 1].at)}–${DAY(ops[0].at)}`
+    : '';
+
+  return (
+    <div className="al">
+      <div className="al-head">
+        <span className="al-count">{ops ? `${ops.length} calls` : 'loading…'}{span ? ` · ${span}` : ''}</span>
+        <div className="seg al-view">
+          <button className={view === 'list' ? 'on' : ''} onClick={() => setView('list')}>List</button>
+          <button className={view === 'map' ? 'on' : ''} onClick={() => setView('map')}>Map</button>
+        </div>
+        <button className="btn-ghost al-refresh" onClick={load}>Refresh</button>
+      </div>
+
+      <div className="al-filters">
+        <button className={`al-chip${origin ? '' : ' on'}`} onClick={() => setOrigin('')}>Everyone</button>
+        {origins.map(([id, name]) => (
+          <button key={id} className={`al-chip${origin === id ? ' on' : ''}`} onClick={() => setOrigin(id)}>{name}</button>
+        ))}
+        <span className="al-gap" />
+        <button className={`al-chip${kinds.includes('fail') ? ' on' : ''}`} onClick={() => toggle('fail')}>
+          Only failures ({failures})
+        </button>
+        <button className={`al-chip${kinds.includes('prompt') ? ' on' : ''}`} onClick={() => toggle('prompt')}>Prompts</button>
+        <button className={`al-chip${kinds.includes('file') ? ' on' : ''}`} onClick={() => toggle('file')}>Files</button>
+        <input className="al-find mono" placeholder="path contains…" value={q} onChange={(e) => setQ(e.target.value)} />
+      </div>
+
+      {error && <div className="s-warn">{error}</div>}
+      {view === 'list'
+        ? <LogTable rows={rows} repeats={repeats} names={names} />
+        : <LogMap rows={rows} names={names} />}
+      {ops && !rows.length && !error && <div className="s-muted al-empty">No calls match.</div>}
+    </div>
+  );
+}
+
+function LogTable({ rows, repeats, names }: {
+  rows: api.Operation[]; repeats: Map<string, number>; names: Map<string, string>;
+}) {
+  return (
+    <div className="al-tblwrap">
+      <table className="al-tbl">
+        <thead>
+          <tr>
+            <th>Time</th><th>Who</th><th className="grow">Call</th>
+            <th>Status</th><th className="num">Took</th><th>Payload</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((op) => {
+            const pay = payloadOf(op);
+            const n = pay.sha ? repeats.get(pay.sha) || 0 : 0;
+            return (
+              <tr key={op.id} title={`${op.at}${whom(op, names) ? ` → ${whom(op, names)}` : ''}`}>
+                <td className="al-time">{HHMMSS(op.at)}</td>
+                <td className="al-who">{who(op)}</td>
+                <td className="grow">
+                  <span className={`al-meth${isWait(op) ? ' back' : ''}`}>{op.method}</span>{' '}
+                  <span className="al-path">{op.path}</span>
+                </td>
+                <td className={`al-st ${statusClass(op)}`}>{op.status}</td>
+                <td className="num">{took(op.durationMs)}</td>
+                <td className="al-pay">
+                  {pay.text}
+                  {n > 1 && <span className="al-rep" title={`${n} calls with this exact payload — ${pay.sha}`}> ×{n}</span>}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---- the map ----------------------------------------------------------------
+// Geometry follows the approved mock: a labelled hairline per lane, arrows
+// drawn between lanes, a dot on the lane the call was made from.
+const LANE_H = 46;
+const TOP = 26;
+const LEFT = 108;      // room for the longest lane label
+const RIGHT = 26;
+const MAX_LANES = 12;
+const MAX_MARKS = 48;
+
+function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, string> }) {
+  const [hover, setHover] = useState<api.Operation | null>(null);
+
+  const { lanes, marks, from, to, dropped } = useMemo(() => {
+    const recent = rows.slice(0, MAX_MARKS).slice().reverse();  // oldest first, left to right
+    // Lanes: everything that CALLS above everything that is only called. Then a
+    // prompt points down the picture and a resolved wait points back up it,
+    // which is the whole claim the legend makes. Sorting by traffic alone put
+    // targets above their callers and the two directions stopped meaning
+    // anything.
+    const made = new Map<string, number>();
+    const got = new Map<string, number>();
+    const bump = (m: Map<string, number>, name: string) => name && m.set(name, (m.get(name) || 0) + 1);
+    for (const op of recent) { bump(made, who(op)); bump(got, whom(op, names)); }
+    const byCount = (m: Map<string, number>) => [...m].sort((a, b) => b[1] - a[1]).map(([n]) => n);
+    const callers = byCount(made);
+    const lanes = [...callers, ...byCount(got).filter((n) => !made.has(n))].slice(0, MAX_LANES);
+    const t0 = recent.length ? new Date(recent[0].at).getTime() : 0;
+    const t1 = recent.length ? new Date(recent[recent.length - 1].at).getTime() : 1;
+    // x is the call's RANK, not its clock position: real traffic arrives in
+    // bursts, and spacing by time collapses a burst into one unreadable column
+    // while leaving the quiet hours as empty space. The axis still says what
+    // period is on screen.
+    const marks = recent.map((op, i) => ({
+      op,
+      x: recent.length < 2 ? 0.5 : i / (recent.length - 1),
+      a: lanes.indexOf(who(op)),
+      b: lanes.indexOf(whom(op, names)),
+    })).filter((m) => m.a >= 0 || m.b >= 0);
+    void t0; void t1;
+    return {
+      lanes,
+      marks,
+      from: recent.length ? recent[0].at : '',
+      to: recent.length ? recent[recent.length - 1].at : '',
+      dropped: Math.max(0, rows.length - MAX_MARKS),
+    };
+  }, [rows, names]);
+
+  if (!lanes.length) return <div className="s-muted al-empty">Nothing to draw yet.</div>;
+
+  const width = 760;
+  const height = TOP + lanes.length * LANE_H + 34;
+  const laneY = (i: number) => TOP + i * LANE_H + 8;
+  const xOf = (t: number) => LEFT + t * (width - LEFT - RIGHT);
+
+  return (
+    <div className="al-map">
+      <div className="al-mapwrap">
+        <svg viewBox={`0 0 ${width} ${height}`} role="img"
+          aria-label="Swimlanes: one lane per agent, prompts drawn from caller to target and resolved waits back the other way.">
+          <defs>
+            <marker id="al-ar" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+              <path d="M0 0 L8 4 L0 8 z" fill="var(--accent)" />
+            </marker>
+            <marker id="al-arb" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+              <path d="M0 0 L8 4 L0 8 z" fill="var(--muted)" />
+            </marker>
+          </defs>
+          {lanes.map((name, i) => (
+            <g key={name}>
+              <text x="2" y={laneY(i) - 6} className="al-lane-lbl">{name}</text>
+              <line x1="2" y1={laneY(i)} x2={width - 4} y2={laneY(i)} className="al-lane" />
+            </g>
+          ))}
+          {marks.map(({ op, x, a, b }) => {
+            const back = isWait(op);
+            // A wait is attention coming BACK: it is drawn from the agent that
+            // was waited on to the one that waited.
+            const src = back ? (b >= 0 ? b : a) : a;
+            const dst = back ? a : b;
+            const px = xOf(x);
+            const on = hover?.id === op.id;
+            if (src < 0 || dst < 0 || src === dst) {
+              const lane = src >= 0 ? src : dst;
+              return (
+                <circle key={op.id} cx={px} cy={laneY(lane)} r={on ? 4 : 2.6}
+                  className={`al-dot${back ? ' back' : ''}${op.ok ? '' : ' bad'}${on ? ' on' : ''}`}
+                  onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}>
+                  <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
+                </circle>
+              );
+            }
+            const y1 = laneY(src) + (dst > src ? 5 : -5);
+            const y2 = laneY(dst) + (dst > src ? -7 : 7);
+            return (
+              <g key={op.id} onMouseEnter={() => setHover(op)} onMouseLeave={() => setHover(null)}
+                className={`al-arrowg${on ? ' on' : ''}`}>
+                <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
+                <line x1={px} y1={y1} x2={px} y2={y2}
+                  className={`al-arrow${back ? ' back' : ''}${op.ok ? '' : ' bad'}`}
+                  markerEnd={`url(#${back ? 'al-arb' : 'al-ar'})`} />
+                <circle cx={px} cy={laneY(src)} r="2.6" className={`al-dot${back ? ' back' : ''}${op.ok ? '' : ' bad'}`} />
+                {/* a hit area wider than a 1.6px line, or nothing is hoverable */}
+                <line x1={px} y1={y1} x2={px} y2={y2} className="al-hit" />
+              </g>
+            );
+          })}
+          {from && <text x="2" y={height - 8} className="al-axis">{`${DAY(from)} ${HHMMSS(from).slice(0, 5)} →`}</text>}
+          {to && <text x={width - 4} y={height - 8} textAnchor="end" className="al-axis">{HHMMSS(to).slice(0, 5)}</text>}
+        </svg>
+      </div>
+      <div className="al-readout mono">
+        {hover
+          ? `${HHMMSS(hover.at)}  ${who(hover)}${whom(hover, names) ? ` → ${whom(hover, names)}` : ''}  ${hover.method} ${hover.path}  ${hover.status}  ${took(hover.durationMs)}  ${payloadOf(hover).text}`
+          : 'Hover a line for its time, status and payload.'}
+      </div>
+      <div className="al-legend">
+        <span><i className="al-key" /> prompt (caller → target)</span>
+        <span><i className="al-key back" /> wait resolved (target → caller)</span>
+        <span><i className="al-key dot" /> the call&apos;s own lane</span>
+        {dropped > 0 && <span className="s-muted">newest {MAX_MARKS} of {rows.length} drawn</span>}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -2,17 +2,19 @@ import { useEffect, useState } from 'react';
 import { isPassive, isRemote, type Cli } from '../types';
 import * as api from '../api';
 import SkillsEditor from './SkillsEditor';
+import ApiLog from './ApiLog';
 import UsagePanel from './UsagePanel';
 import CronSettings from './CronSettings';
 import { SunGlyph, MoonGlyph, RefreshGlyph, InfoGlyph } from './icons';
 import Logo from './Logo';
 
-type Page = 'general' | 'usage' | 'skills' | 'cron';
+type Page = 'general' | 'usage' | 'skills' | 'cron' | 'apilog';
 const PAGES: { id: Page; label: string }[] = [
   { id: 'general', label: 'General' },
   { id: 'usage', label: 'Usage' },
   { id: 'skills', label: 'Skills' },
   { id: 'cron', label: 'Cron' },
+  { id: 'apilog', label: 'API log' },
 ];
 
 interface Info { dataDir?: string; home?: string; spaceId?: string | null; spaceHost?: string | null; engine?: string; ghostty?: boolean; canRelaunch?: boolean; secrets?: string[]; bucketUnverified?: boolean; }
@@ -774,6 +776,18 @@ export default function SettingsView({
           <div className="settings-page wide">
             <h2>Usage</h2>
             <UsagePanel />
+          </div>
+        )}
+
+        {page === 'apilog' && (
+          <div className="settings-page wide">
+            <h2>API log</h2>
+            <p className="s-help">
+              Every call that changed something, plus the waits that resolved — who asked whom to do
+              what, and when. Prompt text is never stored, only its length and a checksum, so this
+              says who prompted whom and how long the prompt was, never what it said.
+            </p>
+            <ApiLog />
           </div>
         )}
 

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -784,8 +784,8 @@ export default function SettingsView({
             <h2>API log</h2>
             <p className="s-help">
               Every call that changed something, plus the waits that resolved — who asked whom to do
-              what, and when. Prompt text is never stored, only its length and a checksum, so this
-              says who prompted whom and how long the prompt was, never what it said.
+              what, when, and in their own words: each entry keeps the call whole, body included.
+              Credentials are the exception and are never written here.
             </p>
             <ApiLog />
           </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1447,11 +1447,18 @@ a.btn-ghost { text-decoration: none; }
 .al-map { display: flex; flex-direction: column; gap: 8px; }
 .al-mapbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .al-scale button, .al-zoom button { padding: 3px 9px; font-size: 11px; }
-.al-zoom button { min-width: 26px; }
-.al-zoom-lvl { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.al-reset { padding: 3px 9px; font-size: 11px; }
+.al-window { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
 .al-scale-note { font-size: 11px; color: var(--muted); }
 .al-mapwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); padding: 6px; }
-.al-map svg { display: block; width: 100%; min-width: 620px; height: auto; }
+/* Drag horizontally to zoom into a slice of the axis. `col-resize` is the
+   cursor every charting brush uses; on a touch device none of this applies —
+   see the pointerType check in ApiLog.tsx — so the frame keeps its own
+   sideways scroll and the page keeps scrolling down. */
+.al-map svg { display: block; width: 100%; min-width: 620px; height: auto; cursor: col-resize; }
+.al-svg.brushing { user-select: none; }
+.al-brush { fill: color-mix(in srgb, var(--accent) 14%, transparent); stroke: var(--accent); stroke-width: 1; }
+.al-brush-lbl { font-family: var(--font-mono); font-size: 8px; fill: var(--accent); }
 .al-lane { stroke: var(--border); stroke-width: 1; }
 /* before the agent existed: barely there, so the line cannot claim it did */
 .al-lane.unborn { stroke: var(--border); stroke-width: 1; stroke-dasharray: 2 4; opacity: 0.45; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1405,12 +1405,12 @@ a.btn-ghost { text-decoration: none; }
 .al-fails { color: var(--danger); }
 .al-view { margin-left: auto; }
 .al-refresh { padding: 4px 9px; font-size: 11.5px; }
-.al-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+/* one plain control, on the same line as the buttons */
+.al-check { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--text); cursor: pointer; margin-left: 10px; }
+.al-check input { margin: 0; accent-color: var(--accent); }
+.al-check-n { color: var(--muted); font-family: var(--font-mono); font-size: 11px; }
 /* A filter is a chip: bordered, quiet until it is on, and never a coloured pill
    sitting in a data row — the rows themselves carry no badges at all. */
-.al-chip { padding: 4px 9px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--muted); font: inherit; font-size: 11.5px; cursor: pointer; white-space: nowrap; }
-.al-chip:hover { border-color: var(--border-strong); color: var(--text); }
-.al-chip.on { border-color: var(--accent); color: var(--text); font-weight: 600; background: color-mix(in srgb, var(--accent) 10%, transparent); }
 .al-empty { padding: 14px 2px; }
 
 /* ONE CALL PER LINE. Every cell is nowrap and clips; the path is the only
@@ -1445,6 +1445,11 @@ a.btn-ghost { text-decoration: none; }
 
 /* the map */
 .al-map { display: flex; flex-direction: column; gap: 8px; }
+.al-mapbar { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.al-scale button, .al-zoom button { padding: 3px 9px; font-size: 11px; }
+.al-zoom button { min-width: 26px; }
+.al-zoom-lvl { font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.al-scale-note { font-size: 11px; color: var(--muted); }
 .al-mapwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); padding: 6px; }
 .al-map svg { display: block; width: 100%; min-width: 620px; height: auto; }
 .al-lane { stroke: var(--border); stroke-width: 1; }
@@ -1485,9 +1490,16 @@ a.btn-ghost { text-decoration: none; }
 /* the marks are clickable, and the whole point of the card is that you can
    reach into it — so nothing here opts out of pointer events */
 .al-arrowg, .al-dot { cursor: pointer; }
-.al-json { margin: 0; max-height: 210px; overflow: auto; white-space: pre; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45; color: var(--text); }
+/* NOT scrollable, and not capped: a 210px window over 411px of JSON was a card
+   whose second half could not be read at all. The page scrolls instead. */
+.al-json { margin: 0; white-space: pre-wrap; word-break: break-word; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45; color: var(--text); }
 .al-json .al-k { color: var(--accent); }
 .al-card-foot { font-size: 9.5px; color: var(--muted); border-top: 1px solid var(--border); padding-top: 5px; }
+/* the prompt as sent: its own block, because JSON-escaping a paragraph onto one
+   line makes it unreadable. Selectable, wrapped, and never truncated here. */
+.al-prompt { display: flex; flex-direction: column; gap: 3px; }
+.al-prompt-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); }
+.al-prompt-body { margin: 0; padding: 7px 9px; background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--r-sm); font-family: var(--font-mono); font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--text); }
 
 /* settings: skills editor */
 .settings-page.wide { max-width: 980px; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1499,6 +1499,7 @@ a.btn-ghost { text-decoration: none; }
    line makes it unreadable. Selectable, wrapped, and never truncated here. */
 .al-prompt { display: flex; flex-direction: column; gap: 3px; }
 .al-prompt-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); }
+.al-clipped { color: var(--muted); text-transform: none; letter-spacing: 0; }
 .al-prompt-body { margin: 0; padding: 7px 9px; background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--r-sm); font-family: var(--font-mono); font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--text); }
 
 /* settings: skills editor */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1464,7 +1464,6 @@ a.btn-ghost { text-decoration: none; }
 .al-dot.back { fill: var(--muted); }
 .al-dot.bad { fill: var(--danger); }
 .al-hit { stroke: transparent; stroke-width: 10; }
-.al-arrowg { cursor: default; }
 /* a slight lift on hover, not a thickening — the card carries the detail */
 .al-arrowg.on .al-arrow { stroke-width: 1.6; }
 .al-arrowg.on .al-held { opacity: 0.45; }
@@ -1479,6 +1478,13 @@ a.btn-ghost { text-decoration: none; }
 .al-card-head { display: flex; align-items: baseline; gap: 7px; font-family: var(--font-mono); font-size: 11px; }
 .al-card-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .al-card-took { color: var(--muted); margin-left: auto; white-space: nowrap; }
+.al-card.pinned { border-color: var(--accent); }
+.al-card-x { border: none; background: none; color: var(--muted); cursor: pointer; font-size: 11px; padding: 0 2px; line-height: 1; }
+.al-card-x:hover { color: var(--text); }
+.al-card-hint { color: var(--muted); opacity: 0.8; }
+/* the marks are clickable, and the whole point of the card is that you can
+   reach into it — so nothing here opts out of pointer events */
+.al-arrowg, .al-dot { cursor: pointer; }
 .al-json { margin: 0; max-height: 210px; overflow: auto; white-space: pre; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45; color: var(--text); }
 .al-json .al-k { color: var(--accent); }
 .al-card-foot { font-size: 9.5px; color: var(--muted); border-top: 1px solid var(--border); padding-top: 5px; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1398,6 +1398,76 @@ a.btn-ghost { text-decoration: none; }
   .skiprestore { align-self: flex-start; }
 }
 
+/* ---- settings: API log (docs: the approved cron-and-api-log mock) ---- */
+.al { display: flex; flex-direction: column; gap: 12px; margin-top: 10px; }
+.al-head { display: flex; align-items: center; gap: 10px; }
+.al-count { font-family: var(--font-mono); font-size: 11.5px; color: var(--muted); }
+.al-view { margin-left: auto; }
+.al-refresh { padding: 4px 9px; font-size: 11.5px; }
+.al-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+.al-gap { flex: 1 0 12px; }
+/* A filter is a chip: bordered, quiet until it is on, and never a coloured pill
+   sitting in a data row — the rows themselves carry no badges at all. */
+.al-chip { padding: 4px 9px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--muted); font: inherit; font-size: 11.5px; cursor: pointer; white-space: nowrap; }
+.al-chip:hover { border-color: var(--border-strong); color: var(--text); }
+.al-chip.on { border-color: var(--accent); color: var(--text); font-weight: 600; background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.al-find { flex: 1; min-width: 130px; padding: 4px 8px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--text); font-size: 11.5px; }
+.al-find:focus { outline: none; border-color: var(--accent); }
+.al-empty { padding: 14px 2px; }
+
+/* ONE CALL PER LINE. Every cell is nowrap and clips; the path is the only
+   column that may take the slack (max-width:0 + width:100% is what makes a
+   table cell shrink-to-fit-the-rest rather than push the row wide). Wrapping
+   would halve how many calls a screen holds, which is the whole point of it. */
+.al-tblwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); }
+.al-tbl { border-collapse: collapse; width: 100%; font-family: var(--font-mono); font-size: 11.5px; font-variant-numeric: tabular-nums; }
+/* A floor, so a narrow pane scrolls the table sideways instead of crushing the
+   Call column — which is the one column worth reading — down to two letters.
+   The row stays one line either way; that is the rule this is protecting. */
+.al-tbl { min-width: 640px; }
+.al-tbl th { text-align: left; padding: 7px 10px; background: var(--panel-2); border-bottom: 1px solid var(--border); font-size: 10px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--muted); font-weight: 600; white-space: nowrap; }
+.al-tbl td { padding: 5px 10px; border-bottom: 1px solid var(--border); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.al-tbl tr:last-child td { border-bottom: none; }
+.al-tbl td.grow, .al-tbl th.grow { max-width: 0; width: 100%; }
+.al-tbl td.num, .al-tbl th.num { text-align: right; }
+.al-tbl tbody tr:hover { background: var(--panel-2); }
+.al-time { color: var(--muted); }
+.al-who { max-width: 130px; overflow: hidden; text-overflow: ellipsis; }
+.al-meth { font-weight: 700; color: var(--accent); }
+/* the one logged read: attention coming back, not work going out */
+.al-meth.back { color: var(--muted); }
+.al-path { color: var(--text); }
+/* colour the text in the column, never a badge around it */
+.al-st { font-weight: 600; }
+.al-st.ok { color: var(--go); }
+.al-st.warn { color: #9a6212; }
+.al-st.bad { color: var(--danger); }
+.al-pay { color: var(--muted); max-width: 190px; overflow: hidden; text-overflow: ellipsis; }
+.al-rep { color: var(--accent); font-weight: 600; }
+
+/* the map */
+.al-map { display: flex; flex-direction: column; gap: 8px; }
+.al-mapwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); padding: 8px; }
+.al-map svg { display: block; width: 100%; min-width: 620px; height: auto; }
+.al-lane { stroke: var(--border); stroke-width: 1; }
+.al-lane-lbl { font-family: var(--font-mono); font-size: 9px; fill: var(--muted); }
+.al-axis { font-family: var(--font-mono); font-size: 8px; fill: var(--muted); }
+.al-arrow { stroke: var(--accent); stroke-width: 1.6; }
+.al-arrow.back { stroke: var(--muted); stroke-dasharray: 3 3; }
+/* a call that failed is worth seeing in the shape, not only in the list */
+.al-arrow.bad { stroke: var(--danger); }
+.al-dot.bad { fill: var(--danger); }
+.al-dot { fill: var(--accent); }
+.al-dot.back { fill: var(--muted); }
+.al-hit { stroke: transparent; stroke-width: 11; }
+.al-arrowg { cursor: default; }
+.al-arrowg.on .al-arrow { stroke-width: 2.6; }
+.al-readout { font-size: 11px; color: var(--muted); min-height: 16px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.al-legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 11.5px; color: var(--muted); }
+.al-legend i.al-key { display: inline-block; width: 16px; height: 0; border-top: 2px solid var(--accent); vertical-align: middle; margin-right: 5px; }
+.al-legend i.al-key.back { border-top-style: dashed; border-color: var(--muted); }
+.al-legend i.al-key.dot { width: 6px; height: 6px; border: none; border-radius: 50%; background: var(--accent); }
+
 /* settings: skills editor */
 .settings-page.wide { max-width: 980px; }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1402,17 +1402,15 @@ a.btn-ghost { text-decoration: none; }
 .al { display: flex; flex-direction: column; gap: 12px; margin-top: 10px; }
 .al-head { display: flex; align-items: center; gap: 10px; }
 .al-count { font-family: var(--font-mono); font-size: 11.5px; color: var(--muted); }
+.al-fails { color: var(--danger); }
 .al-view { margin-left: auto; }
 .al-refresh { padding: 4px 9px; font-size: 11.5px; }
 .al-filters { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; }
-.al-gap { flex: 1 0 12px; }
 /* A filter is a chip: bordered, quiet until it is on, and never a coloured pill
    sitting in a data row — the rows themselves carry no badges at all. */
 .al-chip { padding: 4px 9px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--muted); font: inherit; font-size: 11.5px; cursor: pointer; white-space: nowrap; }
 .al-chip:hover { border-color: var(--border-strong); color: var(--text); }
 .al-chip.on { border-color: var(--accent); color: var(--text); font-weight: 600; background: color-mix(in srgb, var(--accent) 10%, transparent); }
-.al-find { flex: 1; min-width: 130px; padding: 4px 8px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel); color: var(--text); font-size: 11.5px; }
-.al-find:focus { outline: none; border-color: var(--accent); }
 .al-empty { padding: 14px 2px; }
 
 /* ONE CALL PER LINE. Every cell is nowrap and clips; the path is the only
@@ -1447,26 +1445,43 @@ a.btn-ghost { text-decoration: none; }
 
 /* the map */
 .al-map { display: flex; flex-direction: column; gap: 8px; }
-.al-mapwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); padding: 8px; }
+.al-mapwrap { overflow-x: auto; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); padding: 6px; }
 .al-map svg { display: block; width: 100%; min-width: 620px; height: auto; }
 .al-lane { stroke: var(--border); stroke-width: 1; }
+/* before the agent existed: barely there, so the line cannot claim it did */
+.al-lane.unborn { stroke: var(--border); stroke-width: 1; stroke-dasharray: 2 4; opacity: 0.45; }
 .al-lane-lbl { font-family: var(--font-mono); font-size: 9px; fill: var(--muted); }
+.al-lane-lbl.new { fill: var(--accent); }
 .al-axis { font-family: var(--font-mono); font-size: 8px; fill: var(--muted); }
-.al-arrow { stroke: var(--accent); stroke-width: 1.6; }
+/* slim: at 1px an arrow marks a moment instead of shouting about it */
+.al-arrow { stroke: var(--accent); stroke-width: 1; }
 .al-arrow.back { stroke: var(--muted); stroke-dasharray: 3 3; }
-/* a call that failed is worth seeing in the shape, not only in the list */
 .al-arrow.bad { stroke: var(--danger); }
-.al-dot.bad { fill: var(--danger); }
+.al-arrow.new { stroke-width: 1.5; }
+/* the stretch a caller spent blocked, on the caller's own lane */
+.al-held { stroke: var(--muted); stroke-width: 3; opacity: 0.28; stroke-linecap: round; }
 .al-dot { fill: var(--accent); }
 .al-dot.back { fill: var(--muted); }
-.al-hit { stroke: transparent; stroke-width: 11; }
+.al-dot.bad { fill: var(--danger); }
+.al-hit { stroke: transparent; stroke-width: 10; }
 .al-arrowg { cursor: default; }
-.al-arrowg.on .al-arrow { stroke-width: 2.6; }
-.al-readout { font-size: 11px; color: var(--muted); min-height: 16px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.al-legend { display: flex; flex-wrap: wrap; gap: 14px; font-size: 11.5px; color: var(--muted); }
-.al-legend i.al-key { display: inline-block; width: 16px; height: 0; border-top: 2px solid var(--accent); vertical-align: middle; margin-right: 5px; }
-.al-legend i.al-key.back { border-top-style: dashed; border-color: var(--muted); }
-.al-legend i.al-key.dot { width: 6px; height: 6px; border: none; border-radius: 50%; background: var(--accent); }
+/* a slight lift on hover, not a thickening — the card carries the detail */
+.al-arrowg.on .al-arrow { stroke-width: 1.6; }
+.al-arrowg.on .al-held { opacity: 0.45; }
+.al-key text { font-family: var(--font-mono); font-size: 8px; fill: var(--muted); }
+/* the moment a lane begins */
+.al-birth { fill: var(--panel); stroke: var(--accent); stroke-width: 1.4; }
+
+/* the hover card: the call as it is stored, plus what the body does not say */
+.al-card { background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md);
+  padding: 8px 10px; display: flex; flex-direction: column; gap: 6px; min-height: 74px; }
+.al-card-idle { color: var(--muted); font-size: 11.5px; justify-content: center; }
+.al-card-head { display: flex; align-items: baseline; gap: 7px; font-family: var(--font-mono); font-size: 11px; }
+.al-card-path { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.al-card-took { color: var(--muted); margin-left: auto; white-space: nowrap; }
+.al-json { margin: 0; max-height: 210px; overflow: auto; white-space: pre; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.45; color: var(--text); }
+.al-json .al-k { color: var(--accent); }
+.al-card-foot { font-size: 9.5px; color: var(--muted); border-top: 1px solid var(--border); padding-top: 5px; }
 
 /* settings: skills editor */
 .settings-page.wide { max-width: 980px; }

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -44,6 +44,17 @@ const wait = (i, watcher, watched, ms) => ({
   status: 200, ok: true, durationMs: ms,
   result: { id: watched, state: 'waiting', matched: true, waited: Math.round(ms / 1000) },
 });
+// A wait the server accepted with no `?from=`: read-only, so it is never
+// refused, and every watch loop running today calls it that way. Nobody is
+// attributed, so there is no caller to draw an arrow from.
+// Its target is an agent nothing else in the fixture touches, so the mark it
+// leaves can only have come from this entry.
+const anonymousWait = {
+  id: 'w0', at: at(2), method: 'GET', path: '/api/agents/lonely/wait',
+  origin: null, target: { id: 'lonely', name: 'lonely', cli: 'claude' },
+  status: 200, ok: true, durationMs: 12000,
+  result: { id: 'lonely', state: 'waiting', matched: true, waited: 12 },
+};
 // Two identical prompts (same checksum) — what a repeating job looks like.
 const operations = [
   wait(9, 'manager', 'builder', 258000),
@@ -57,6 +68,7 @@ const operations = [
     target: { id: 'files-5', name: 'files-5' },
     request: { present: true, chars: 8400, sha256: 'sha-file' },
     status: 200, ok: true, durationMs: 41, result: { ok: true } },
+  anonymousWait,
 ];
 
 const stub = path.join(tmp, 'api-stub.ts');
@@ -145,18 +157,25 @@ try {
   const page = await open(1200);
   const list = await page.evaluate(() => {
     const cells = [...document.querySelectorAll('.al-tbl tbody tr')].map((r) => [...r.children].map((c) => c.textContent.trim()));
-    return { first: cells[0], repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()) };
+    return {
+      first: cells[0],
+      repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()),
+      whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
+    };
   });
   console.log('what a row says');
   check('a resolved wait reads as one, with the time it blocked for',
     () => assert.deepEqual(list.first.slice(2), ['GET /api/agents/builder/wait', '200', '4m 18s', 'resolved · waiting']));
   check('identical prompts are marked as repeats, since the text itself is never stored',
     () => assert.deepEqual(list.repeats, ['×2', '×2']));
+  check('an unattributed call still reads as a row, with an em dash for who',
+    () => assert.ok(list.whos.includes('—'), list.whos.join(', ')));
 
   await page.click('.al-view button:nth-child(2)');
   await page.waitForSelector('.al-map svg');
   const map = await page.evaluate(() => {
     const labels = [...document.querySelectorAll('.al-lane-lbl')];
+    const dotLanes = [...document.querySelectorAll('circle.al-dot')].map((c) => Number(c.getAttribute('cy')));
     const lanes = labels.map((t) => t.textContent);
     // Which lane an endpoint sits on: the arrow stops a few px short of the
     // hairline, so snap to the nearest lane label.
@@ -170,7 +189,7 @@ try {
       dst: lanes[laneAt(Number(l.getAttribute('y2')))],
       dashed: !!getComputedStyle(l).strokeDasharray && getComputedStyle(l).strokeDasharray !== 'none',
     }));
-    return { lanes, arrows };
+    return { lanes, arrows, dotLanes: dotLanes.map((y) => lanes[laneAt(y)]) };
   });
   console.log('\nthe map');
   check('callers are laid out above the agents they call',
@@ -191,6 +210,19 @@ try {
     });
   check('a failed call is visible in the shape too',
     () => assert.ok(map.arrows.some((a) => a.bad)));
+
+  // The em dash in the Who column is a display fallback, not an agent. Giving it
+  // a lane invented a caller the log never knew and drew a return arrow into it.
+  check('an unattributed wait does not invent a caller lane',
+    () => assert.ok(!map.lanes.includes('—'), map.lanes.join(' < ')));
+  check('nor an arrow to one',
+    () => assert.ok(!map.arrows.some((a) => a.src === '—' || a.dst === '—'), JSON.stringify(map.arrows)));
+  check('it is a mark on the lane of whoever was waited on',
+    () => {
+      assert.ok(map.lanes.includes('lonely'), map.lanes.join(' < '));
+      assert.ok(map.dotLanes.includes('lonely'), `dots on: ${map.dotLanes.join(', ')}`);
+      assert.ok(!map.arrows.some((a) => a.src === 'lonely' || a.dst === 'lonely'), 'and no arrow to or from it');
+    });
   await page.close();
 } finally {
   await browser.close();

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -113,6 +113,16 @@ const quietWait = {
 };
 operations.push({ ...prompt(599, 'watcher', 'quiet-1', 64), target: { id: 'quiet-1', name: 'quiet', cli: 'claude' } });
 operations.push(quietWait);
+// The log keeps whole bodies now, so the viewer has to cope with one this big.
+// Nothing is cut on disk; the card decides how much of it to paint.
+const HUGE = 'q'.repeat(400_000);
+operations.push({
+  id: 'big', at: at(601), method: 'PUT', path: '/api/files/files-9/write',
+  origin: { id: 'manager', type: 'agent', name: 'manager' },
+  target: { id: 'files-9', name: 'files-9' },
+  request: { present: true, chars: HUGE.length, sha256: 'sha-huge', text: HUGE },
+  status: 200, ok: true, durationMs: 88, result: { ok: true, size: HUGE.length },
+});
 
 operations.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));  // the endpoint's own order
 
@@ -243,16 +253,29 @@ try {
       repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()),
       whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
       newest: document.querySelector('.al-tbl tbody tr')?.getAttribute('title')?.split(' ')[0],
+      big: (() => {
+        const row = [...document.querySelectorAll('.al-tbl tbody tr')]
+          .find((r) => r.textContent.includes('/api/files/files-9/write'));
+        return row ? { payload: row.children[5].textContent.trim(), height: row.getBoundingClientRect().height } : null;
+      })(),
     };
   });
   console.log('what a row says');
   check('a resolved wait reads as one, with the time it blocked for',
     () => assert.deepEqual(list.first.slice(2), ['GET /api/agents/builder/wait', '200', '4m 18s', 'resolved · waiting']));
-  check('and the newest row really is the newest', () => assert.equal(list.newest, at(600)));
-  check('identical prompts are marked as repeats, since the text itself is never stored',
+  check('and the newest row really is the newest', () => assert.equal(list.newest, operations[0].at));
+  check('identical prompts are marked as repeats — the checksum still earns its place',
     () => assert.deepEqual(list.repeats, ['×2', '×2']));
   check('an unattributed call still reads as a row, with an em dash for who',
     () => assert.ok(list.whos.includes('—'), list.whos.join(', ')));
+  // "just store all the full api calls" — so the VIEWER is what has to stay
+  // usable when one of them is 400 KB. The row says how big, on one line.
+  check('a 400 KB body is a size in the list, not an attempt to show it',
+    () => {
+      assert.ok(list.big, 'the big entry is missing from the list');
+      assert.match(list.big.payload, /^file · \d+(\.\d+)? KB$/, `payload: ${list.big.payload}`);
+      assert.ok(list.big.height < 30, `row is ${list.big.height}px tall`);
+    });
 
   await page.click('.al-view button:nth-child(2)');
   await page.waitForSelector('.al-map svg');
@@ -436,6 +459,28 @@ try {
   check('with the checksum still in the entry, which is what spots a repeat',
     () => assert.match(words.json, /sha256/));
   check('and it can be selected', () => assert.ok(words.selectable));
+
+  const painted = await page.evaluate(async () => {
+    for (const g of document.querySelectorAll('.al-arrowg, circle.al-dot')) {
+      g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+      g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 20));
+      if (/files-9/.test(document.querySelector('.al-card-path')?.textContent || '')) {
+        return {
+          drawn: document.querySelector('.al-prompt-body')?.textContent.length,
+          note: document.querySelector('.al-clipped')?.textContent,
+        };
+      }
+    }
+    return null;
+  });
+  check('a 400 KB body is not painted whole, and the card says how much it is holding back',
+    () => {
+      assert.ok(painted, 'never found the big entry in the map');
+      assert.ok(painted.drawn <= 20_000, `painted ${painted.drawn} characters`);
+      assert.match(painted.note || '', /400,000 characters/, `note: ${painted.note}`);
+    });
 
   // "i want an option to show things in real time, now it seems all actions are
   // equi-distant" — and then: "maybe we need a way to zoom in and zoom out"

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -98,6 +98,20 @@ const operations = [
     result: { id: 'poet-1', state: 'waiting', matched: true, waited: 258 } },
 ];
 
+// The case the first span implementation dropped: five minutes of blocking with
+// no other call in between, and nothing after it either. Snapping the resolution
+// to the nearest neighbouring call gave this no span at all — which is the
+// normal shape of waiting, not an edge case.
+const quietWait = {
+  id: 'wq', at: at(600), method: 'GET', path: '/api/agents/quiet-1/wait',
+  origin: { id: 'watcher', type: 'agent', name: 'watcher' },
+  target: { id: 'quiet-1', name: 'quiet', cli: 'claude' },
+  status: 200, ok: true, durationMs: 300000,
+  result: { id: 'quiet-1', state: 'waiting', matched: true, waited: 300 },
+};
+operations.push({ ...prompt(599, 'watcher', 'quiet-1', 64), target: { id: 'quiet-1', name: 'quiet', cli: 'claude' } });
+operations.push(quietWait);
+
 operations.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));  // the endpoint's own order
 
 const stub = path.join(tmp, 'api-stub.ts');
@@ -215,14 +229,16 @@ try {
   const list = await page.evaluate(() => {
     const cells = [...document.querySelectorAll('.al-tbl tbody tr')].map((r) => [...r.children].map((c) => c.textContent.trim()));
     return {
-      first: cells[0],
+      first: cells.find((c) => c[2].includes('/api/agents/builder/wait')) || cells[0],
       repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()),
       whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
+      newest: document.querySelector('.al-tbl tbody tr')?.getAttribute('title')?.split(' ')[0],
     };
   });
   console.log('what a row says');
   check('a resolved wait reads as one, with the time it blocked for',
     () => assert.deepEqual(list.first.slice(2), ['GET /api/agents/builder/wait', '200', '4m 18s', 'resolved · waiting']));
+  check('and the newest row really is the newest', () => assert.equal(list.newest, at(600)));
   check('identical prompts are marked as repeats, since the text itself is never stored',
     () => assert.deepEqual(list.repeats, ['×2', '×2']));
   check('an unattributed call still reads as a row, with an em dash for who',
@@ -233,6 +249,7 @@ try {
   const map = await page.evaluate(() => {
     const birth = document.querySelectorAll('circle.al-birth').length;
     const held = [...document.querySelectorAll('.al-held')].map((l) => Number(l.getAttribute('x2')) - Number(l.getAttribute('x1')));
+    const heldEnds = [...document.querySelectorAll('.al-held')].map((l) => Number(l.getAttribute('x2')));
     const unborn = [...document.querySelectorAll('.al-lane.unborn')].map((l) => Number(l.getAttribute('x2')));
     const labels = [...document.querySelectorAll('.al-lane-lbl')];
     const dotLanes = [...document.querySelectorAll('circle.al-dot')].map((c) => Number(c.getAttribute('cy')));
@@ -249,7 +266,7 @@ try {
       dst: lanes[laneAt(Number(l.getAttribute('y2')))],
       dashed: !!getComputedStyle(l).strokeDasharray && getComputedStyle(l).strokeDasharray !== 'none',
     }));
-    return { lanes, arrows, birth, held, unborn, dotLanes: dotLanes.map((y) => lanes[laneAt(y)]) };
+    return { lanes, arrows, birth, held, heldEnds, unborn, dotLanes: dotLanes.map((y) => lanes[laneAt(y)]) };
   });
   console.log('\nthe map');
   check('callers are laid out above the agents they call',
@@ -288,8 +305,18 @@ try {
   check('and that lane is drawn faint until it exists',
     () => assert.ok(map.unborn.some((x2) => x2 > 2), `unborn segments end at: ${map.unborn.join(', ')}`));
   // "in the wait, i think it should also be visible when the wait started"
-  check('a wait is a span from where it started, not a point',
-    () => assert.ok(map.held.some((w) => w > 4), `spans: ${map.held.join(', ')}`));
+  const timedWaits = operations.filter((o) => o.method === 'GET' && o.durationMs > 0 && o.origin);
+  check(`every one of the ${timedWaits.length} waits that blocked draws a span`,
+    () => {
+      assert.equal(map.held.length, timedWaits.length, `spans: ${map.held.join(', ')}`);
+      assert.ok(map.held.every((w) => w > 1), `widths: ${map.held.join(', ')}`);
+    });
+  check('including the five-minute one that blocked with nothing else going on',
+    () => {
+      // That wait is the newest thing in the fixture and resolved last, so its
+      // span has to run to the right edge of the plot — 760 wide, 20 of margin.
+      assert.ok(map.heldEnds.some((x2) => x2 >= 760 - 20 - 1), `span ends: ${map.heldEnds.join(', ')}`);
+    });
   check('it is a mark on the lane of whoever was waited on',
     () => {
       assert.ok(map.lanes.includes('lonely'), map.lanes.join(' < '));
@@ -329,6 +356,49 @@ try {
   check('still never the prompt text', () => assert.ok(!/"text":\s*"/.test(card.json)));
   check('and it sits below the plot rather than covering it',
     () => assert.equal(card.floating, 'static'));
+
+  // A card you cannot reach is a card you cannot read: the JSON is capped and
+  // scrollable, so the pointer has to be able to travel from the mark into it.
+  const reach = await page.evaluate(async () => {
+    const card = document.querySelector('.al-card');
+    const before = card.querySelector('.al-card-path').textContent;
+    // leave the mark the way a pointer does, then arrive on the card
+    document.querySelector('.al-arrowg').dispatchEvent(new MouseEvent('mouseout', { bubbles: true, relatedTarget: card }));
+    document.querySelector('.al-arrowg').dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+    card.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    card.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+    await new Promise((r) => setTimeout(r, 400));
+    const still = document.querySelector('.al-card-path')?.textContent;
+    const pre = document.querySelector('.al-json');
+    let scrolled = null;
+    if (pre) { pre.scrollTop = 40; scrolled = pre.scrollTop; }
+    return { before, still, idle: !!document.querySelector('.al-card-idle'), scrolled,
+      overflows: pre ? pre.scrollHeight > pre.clientHeight : null };
+  });
+  check('the entry survives the pointer moving onto the card',
+    () => { assert.equal(reach.still, reach.before); assert.ok(!reach.idle); });
+  check('and the JSON can actually be scrolled when it overflows',
+    () => assert.ok(!reach.overflows || reach.scrolled > 0, `overflows: ${reach.overflows}, scrollTop: ${reach.scrolled}`));
+
+  // …and a click keeps it, so the pointer can go anywhere without losing it.
+  const pinned = await page.evaluate(async () => {
+    const g = document.querySelector('.al-arrowg');
+    g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+    g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    const path = document.querySelector('.al-card-path')?.textContent;
+    g.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+    document.body.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 500));
+    return {
+      path,
+      still: document.querySelector('.al-card-path')?.textContent,
+      marked: !!document.querySelector('.al-card.pinned'),
+      hasClose: !!document.querySelector('.al-card-x'),
+    };
+  });
+  check('clicking a call pins the entry, and it says so',
+    () => { assert.equal(pinned.still, pinned.path); assert.ok(pinned.marked && pinned.hasClose); });
   await page.close();
 } finally {
   await browser.close();

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -30,11 +30,13 @@ const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-log-'));
 const bundle = path.join(tmp, 'app.js');
 
 const at = (s) => new Date(Date.UTC(2026, 7, 19, 21, 0, s)).toISOString();
+const PROMPT = 'Review the diff in web/ and\nreport anything that would break.';
 const prompt = (i, from, to, chars, ok = true) => ({
   id: `p${i}`, at: at(i), method: 'POST', path: `/api/agents/${to}/prompt`,
   origin: { id: from, type: 'agent', name: from },
   target: { id: to, name: to, cli: 'claude' },
-  request: { present: true, chars, sha256: `sha-${chars}` },
+  // as the log stores it now: the text, and the checksum that spots a repeat
+  request: { present: true, chars, sha256: `sha-${chars}`, text: PROMPT },
   status: ok ? 200 : 404, ok, durationMs: 303, result: { ok },
 });
 const wait = (i, watcher, watched, ms) => ({
@@ -70,7 +72,7 @@ const create = {
   id: 'c1', at: at(1), method: 'POST', path: '/api/agents',
   origin: { id: 'manager', type: 'agent', name: 'manager' },
   query: { cli: 'claude', name: 'poet' },
-  request: { present: true, chars: 88, sha256: 'seed' },
+  request: { present: true, chars: 88, sha256: 'seed', text: 'Write a poem about FUSE.' },
   status: 201, ok: true, durationMs: 452,
   result: { id: 'poet-1', name: 'poet', cli: 'claude', path: 'poet' },
 };
@@ -164,27 +166,35 @@ const open = async (width) => {
 try {
   const page0 = await open(1200);
   const filters = await page0.evaluate(() => {
-    const chips = [...document.querySelectorAll('.al-chip')];
+    const box = document.querySelector('.al-check input');
     return {
-      chips: chips.length,
-      label: chips[0]?.textContent.trim(),
+      isCheckbox: box?.type === 'checkbox',
+      checked: !!box?.checked,
+      inHeader: !!document.querySelector('.al-head .al-check'),
+      label: document.querySelector('.al-check')?.textContent.trim(),
       whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
       header: document.querySelector('.al-count')?.textContent.replace(/\s+/g, ' ').trim(),
       finds: document.querySelectorAll('.al-find').length,
     };
   });
   const mineCount = operations.filter((o) => o.origin?.type === 'operator').length;
-  console.log('the only filter there is');
-  check('one control, not a row of them', () => assert.equal(filters.chips, 1));
+  console.log('the only control there is');
+  check('a plain checkbox, unchecked, on the same line as the buttons',
+    () => {
+      assert.ok(filters.isCheckbox, 'not a checkbox');
+      assert.equal(filters.checked, false);
+      assert.ok(filters.inHeader, 'not on the header line');
+      assert.match(filters.label, /^show user calls/, `label: ${filters.label}`);
+    });
   check('and no path search either', () => assert.equal(filters.finds, 0));
-  check('the operator\'s own calls are hidden by default, and it says how many',
+  check('the user\'s own calls are out until it is ticked, and it says how many',
     () => {
       assert.ok(!filters.whos.includes('lvwerra'), `whos: ${filters.whos.join(', ')}`);
-      assert.match(filters.label, new RegExp(`hidden \\(${mineCount}\\)`), `label: ${filters.label}`);
+      assert.match(filters.label, new RegExp(`\\(${mineCount}\\)`), `label: ${filters.label}`);
     });
   check('the failure count survives as a fact rather than a filter',
     () => assert.match(filters.header, /1 failed/));
-  await page0.click('.al-chip');
+  await page0.click('.al-check input');
   await page0.waitForFunction(() => [...document.querySelectorAll('.al-who')].some((e) => e.textContent.trim() === 'lvwerra'));
   check('and one click brings them back', () => true);
   await page0.close();
@@ -377,8 +387,8 @@ try {
   });
   check('the entry survives the pointer moving onto the card',
     () => { assert.equal(reach.still, reach.before); assert.ok(!reach.idle); });
-  check('and the JSON can actually be scrolled when it overflows',
-    () => assert.ok(!reach.overflows || reach.scrolled > 0, `overflows: ${reach.overflows}, scrollTop: ${reach.scrolled}`));
+  check('and the JSON is shown whole rather than in a scrolling window',
+    () => assert.equal(reach.overflows, false, 'the card clips its own content'));
 
   // …and a click keeps it, so the pointer can go anywhere without losing it.
   const pinned = await page.evaluate(async () => {
@@ -399,6 +409,74 @@ try {
   });
   check('clicking a call pins the entry, and it says so',
     () => { assert.equal(pinned.still, pinned.path); assert.ok(pinned.marked && pinned.hasClose); });
+
+  // "why arent the prompts not stored? or just not shown? we should change that"
+  const words = await page.evaluate(async () => {
+    // click marks until the card is showing a call that carried a prompt
+    for (const g of document.querySelectorAll('.al-arrowg')) {
+      g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+      g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+      g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 30));
+      if (/\/prompt$/.test(document.querySelector('.al-card-path')?.textContent || '')) break;
+    }
+    const body = document.querySelector('.al-prompt-body');
+    return {
+      path: document.querySelector('.al-card-path')?.textContent,
+      prompt: body?.textContent,
+      json: document.querySelector('.al-json')?.textContent,
+      selectable: body ? getComputedStyle(body).userSelect !== 'none' : null,
+    };
+  });
+  console.log('\nthe prompt itself');
+  check('is shown as it was sent, newlines and all',
+    () => { assert.match(words.path || '', /\/prompt$/, `card shows ${words.path}`); assert.equal(words.prompt, PROMPT); });
+  check('as its own block rather than escaped into the JSON',
+    () => assert.ok(!words.json.includes('\\n'), 'the JSON carries an escaped prompt'));
+  check('with the checksum still in the entry, which is what spots a repeat',
+    () => assert.match(words.json, /sha256/));
+  check('and it can be selected', () => assert.ok(words.selectable));
+
+  // "i want an option to show things in real time, now it seems all actions are
+  // equi-distant" — and then: "maybe we need a way to zoom in and zoom out"
+  const scaled = await page.evaluate(async () => {
+    // .al-arrowg only: the legend's swatches are .al-arrow too
+    const xs = () => [...document.querySelectorAll('.al-arrowg .al-arrow')].map((l) => Math.round(Number(l.getAttribute('x1'))));
+    const gaps = (a) => a.slice(1).map((v, i) => v - a[i]).filter((g) => g > 0);
+    const even = gaps([...new Set(xs())].sort((a, b) => a - b));
+    const svgWidth = () => document.querySelector('.al-map svg').style.width;
+    document.querySelectorAll('.al-scale button')[1].click();
+    await new Promise((r) => setTimeout(r, 120));
+    const clock = gaps([...new Set(xs())].sort((a, b) => a - b));
+    const before = svgWidth();
+    document.querySelector('.al-zoom button:last-child').click();
+    await new Promise((r) => setTimeout(r, 120));
+    return { even, clock, before, zoomed: svgWidth(), level: document.querySelector('.al-zoom-lvl')?.textContent };
+  });
+  console.log('\ntwo ways to lay out the same calls');
+  // Not every event draws an arrow, so consecutive arrows sit one OR SEVERAL
+  // steps apart. What separates the modes is the smallest gap: evenly spaced,
+  // it is the grid step and nothing can be closer; by the clock, calls a second
+  // apart land on top of each other — which is the whole reason zoom exists.
+  const evenStep = Math.min(...scaled.even);
+  const clockStep = Math.min(...scaled.clock);
+  check('evenly spaced by default — every gap a whole number of steps',
+    () => {
+      assert.ok(evenStep > 20, `step ${evenStep}px`);
+      assert.ok(scaled.even.every((g) => Math.abs(g / evenStep - Math.round(g / evenStep)) < 0.08),
+        `gaps: ${scaled.even.join(', ')}`);
+    });
+  check('and by the clock on demand, where a burst collapses and a quiet spell opens up',
+    () => {
+      assert.ok(clockStep < evenStep / 4, `clock step ${clockStep}px vs even ${evenStep}px`);
+      assert.ok(Math.max(...scaled.clock) > evenStep * 2, `widest clock gap ${Math.max(...scaled.clock)}px`);
+    });
+  check('zoom widens the drawing inside the frame that already scrolls',
+    () => {
+      assert.equal(scaled.before, '100%');
+      assert.equal(scaled.zoomed, '150%');
+      assert.equal(scaled.level, '1.5×');
+    });
   await page.close();
 } finally {
   await browser.close();

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -55,8 +55,29 @@ const anonymousWait = {
   status: 200, ok: true, durationMs: 12000,
   result: { id: 'lonely', state: 'waiting', matched: true, waited: 12 },
 };
+// The operator's own calls: most of a real log, and hidden by default because
+// this view is for what the AGENTS did to each other.
+const mine = (i) => ({
+  id: `m${i}`, at: at(20 + i), method: 'POST', path: '/api/sessions/shell-1/input',
+  origin: { id: 'lvwerra', type: 'operator', name: 'lvwerra' },
+  target: { id: 'shell-1', name: 'shell-1', cli: 'shell' },
+  request: { text: { present: true, chars: 30, sha256: `mine-${i}` } },
+  status: 200, ok: true, durationMs: 200, result: { ok: true },
+});
+// A create names nothing in its path: the session it made is in the result, and
+// the lane it brings into being must not look as though it was always there.
+const create = {
+  id: 'c1', at: at(1), method: 'POST', path: '/api/agents',
+  origin: { id: 'manager', type: 'agent', name: 'manager' },
+  query: { cli: 'claude', name: 'poet' },
+  request: { present: true, chars: 88, sha256: 'seed' },
+  status: 201, ok: true, durationMs: 452,
+  result: { id: 'poet-1', name: 'poet', cli: 'claude', path: 'poet' },
+};
 // Two identical prompts (same checksum) — what a repeating job looks like.
 const operations = [
+  mine(1), mine(2), mine(3),
+  create,
   wait(9, 'manager', 'builder', 258000),
   prompt(8, 'manager', 'builder', 1204),
   prompt(7, 'manager', 'ghost-1', 12, false),
@@ -69,7 +90,15 @@ const operations = [
     request: { present: true, chars: 8400, sha256: 'sha-file' },
     status: 200, ok: true, durationMs: 41, result: { ok: true } },
   anonymousWait,
+  // manager waits on the agent it just created; 258s of being blocked
+  { id: 'w9', at: at(2), method: 'GET', path: '/api/agents/poet-1/wait',
+    origin: { id: 'manager', type: 'agent', name: 'manager' },
+    target: { id: 'poet-1', name: 'poet', cli: 'claude' },
+    status: 200, ok: true, durationMs: 258000,
+    result: { id: 'poet-1', state: 'waiting', matched: true, waited: 258 } },
 ];
+
+operations.sort((a, b) => (a.at < b.at ? 1 : a.at > b.at ? -1 : 0));  // the endpoint's own order
 
 const stub = path.join(tmp, 'api-stub.ts');
 fs.writeFileSync(stub, `
@@ -119,6 +148,34 @@ const open = async (width) => {
 };
 
 try {
+  const page0 = await open(1200);
+  const filters = await page0.evaluate(() => {
+    const chips = [...document.querySelectorAll('.al-chip')];
+    return {
+      chips: chips.length,
+      label: chips[0]?.textContent.trim(),
+      whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
+      header: document.querySelector('.al-count')?.textContent.replace(/\s+/g, ' ').trim(),
+      finds: document.querySelectorAll('.al-find').length,
+    };
+  });
+  const mineCount = operations.filter((o) => o.origin?.type === 'operator').length;
+  console.log('the only filter there is');
+  check('one control, not a row of them', () => assert.equal(filters.chips, 1));
+  check('and no path search either', () => assert.equal(filters.finds, 0));
+  check('the operator\'s own calls are hidden by default, and it says how many',
+    () => {
+      assert.ok(!filters.whos.includes('lvwerra'), `whos: ${filters.whos.join(', ')}`);
+      assert.match(filters.label, new RegExp(`hidden \\(${mineCount}\\)`), `label: ${filters.label}`);
+    });
+  check('the failure count survives as a fact rather than a filter',
+    () => assert.match(filters.header, /1 failed/));
+  await page0.click('.al-chip');
+  await page0.waitForFunction(() => [...document.querySelectorAll('.al-who')].some((e) => e.textContent.trim() === 'lvwerra'));
+  check('and one click brings them back', () => true);
+  await page0.close();
+  console.log('');
+
   for (const width of [1200, 390]) {
     const page = await open(width);
     const m = await page.evaluate(() => {
@@ -174,6 +231,9 @@ try {
   await page.click('.al-view button:nth-child(2)');
   await page.waitForSelector('.al-map svg');
   const map = await page.evaluate(() => {
+    const birth = document.querySelectorAll('circle.al-birth').length;
+    const held = [...document.querySelectorAll('.al-held')].map((l) => Number(l.getAttribute('x2')) - Number(l.getAttribute('x1')));
+    const unborn = [...document.querySelectorAll('.al-lane.unborn')].map((l) => Number(l.getAttribute('x2')));
     const labels = [...document.querySelectorAll('.al-lane-lbl')];
     const dotLanes = [...document.querySelectorAll('circle.al-dot')].map((c) => Number(c.getAttribute('cy')));
     const lanes = labels.map((t) => t.textContent);
@@ -189,7 +249,7 @@ try {
       dst: lanes[laneAt(Number(l.getAttribute('y2')))],
       dashed: !!getComputedStyle(l).strokeDasharray && getComputedStyle(l).strokeDasharray !== 'none',
     }));
-    return { lanes, arrows, dotLanes: dotLanes.map((y) => lanes[laneAt(y)]) };
+    return { lanes, arrows, birth, held, unborn, dotLanes: dotLanes.map((y) => lanes[laneAt(y)]) };
   });
   console.log('\nthe map');
   check('callers are laid out above the agents they call',
@@ -217,12 +277,58 @@ try {
     () => assert.ok(!map.lanes.includes('—'), map.lanes.join(' < ')));
   check('nor an arrow to one',
     () => assert.ok(!map.arrows.some((a) => a.src === '—' || a.dst === '—'), JSON.stringify(map.arrows)));
+  // The operator's report: "create events are not shown … it's also not clear
+  // that the poet session didnt exist before that because the line already
+  // existed."
+  check('a create reaches the lane it brought into being',
+    () => {
+      assert.ok(map.arrows.some((a) => a.src === 'manager' && a.dst === 'poet'), JSON.stringify(map.arrows));
+      assert.ok(map.birth >= 1, `${map.birth} birth marks`);
+    });
+  check('and that lane is drawn faint until it exists',
+    () => assert.ok(map.unborn.some((x2) => x2 > 2), `unborn segments end at: ${map.unborn.join(', ')}`));
+  // "in the wait, i think it should also be visible when the wait started"
+  check('a wait is a span from where it started, not a point',
+    () => assert.ok(map.held.some((w) => w > 4), `spans: ${map.held.join(', ')}`));
   check('it is a mark on the lane of whoever was waited on',
     () => {
       assert.ok(map.lanes.includes('lonely'), map.lanes.join(' < '));
       assert.ok(map.dotLanes.includes('lonely'), `dots on: ${map.dotLanes.join(', ')}`);
       assert.ok(!map.arrows.some((a) => a.src === 'lonely' || a.dst === 'lonely'), 'and no arrow to or from it');
     });
+  // "a pretty view of the json when hovering so we could see the full call plus
+  // the metadata (duration, status)"
+  // mouse.move, not .hover(): the group's own box centre is empty space and
+  // Playwright reports the <svg> intercepting the click there.
+  const spot = await page.evaluate(() => {
+    const g = document.querySelector('.al-arrowg');
+    const r = g.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  });
+  await page.mouse.move(spot.x, spot.y);
+  await page.waitForFunction(() => !!document.querySelector('.al-json'), null, { timeout: 5000 });
+  const card = await page.evaluate(() => ({
+    method: document.querySelector('.al-card-head .al-meth')?.textContent.trim(),
+    path: document.querySelector('.al-card-path')?.textContent.trim(),
+    status: document.querySelector('.al-card-head .al-st')?.textContent.trim(),
+    tookText: document.querySelector('.al-card-took')?.textContent.trim(),
+    json: document.querySelector('.al-json')?.textContent,
+    keys: [...document.querySelectorAll('.al-json .al-k')].map((e) => e.textContent),
+    floating: getComputedStyle(document.querySelector('.al-card')).position,
+  }));
+  console.log('\nthe hover card');
+  check('shows the call, its status and how long it took',
+    () => {
+      assert.match(card.method, /^(POST|GET|PUT|DELETE)$/, `method: ${card.method}`);
+      assert.match(card.path, /^\/api\//, `path: ${card.path}`);
+      assert.match(card.status, /^\d{3}$/, `status: ${card.status}`);
+      assert.match(card.tookText, /^\d/, `took: ${card.tookText}`);
+    });
+  check('and the whole entry as JSON, with the metadata named',
+    () => ['at', 'call', 'from', 'to', 'status', 'took'].forEach((k) => assert.ok(card.keys.includes(k), `${k} missing from ${card.keys.join(', ')}`)));
+  check('still never the prompt text', () => assert.ok(!/"text":\s*"/.test(card.json)));
+  check('and it sits below the plot rather than covering it',
+    () => assert.equal(card.floating, 'static'));
   await page.close();
 } finally {
   await browser.close();

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -1,0 +1,201 @@
+// Settings → API log, in a real browser.
+//
+// Two rules here came from the operator and are the kind that decay silently,
+// so they are pinned rather than trusted:
+//
+//   1. ONE CALL PER LINE. A wrapped row halves how many calls fit on a screen.
+//      Every cell clips; the path is the only column allowed to take the slack,
+//      and below a certain width the table scrolls sideways instead of crushing
+//      it. Measured as row height, not as CSS.
+//   2. NO PILLS OR BADGES in a row. Status is coloured TEXT in its column — no
+//      border, no background, no chip.
+//
+// And one rule the map's legend claims, which is only true if the lanes are
+// ordered caller-above-target: a prompt goes from caller to target, a resolved
+// wait comes back the other way.
+//
+// Run with:  node test/apiLog.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-log-'));
+const bundle = path.join(tmp, 'app.js');
+
+const at = (s) => new Date(Date.UTC(2026, 7, 19, 21, 0, s)).toISOString();
+const prompt = (i, from, to, chars, ok = true) => ({
+  id: `p${i}`, at: at(i), method: 'POST', path: `/api/agents/${to}/prompt`,
+  origin: { id: from, type: 'agent', name: from },
+  target: { id: to, name: to, cli: 'claude' },
+  request: { present: true, chars, sha256: `sha-${chars}` },
+  status: ok ? 200 : 404, ok, durationMs: 303, result: { ok },
+});
+const wait = (i, watcher, watched, ms) => ({
+  id: `w${i}`, at: at(i), method: 'GET', path: `/api/agents/${watched}/wait`,
+  origin: { id: watcher, type: 'agent', name: watcher },
+  target: { id: watched, name: watched, cli: 'claude' },
+  status: 200, ok: true, durationMs: ms,
+  result: { id: watched, state: 'waiting', matched: true, waited: Math.round(ms / 1000) },
+});
+// Two identical prompts (same checksum) — what a repeating job looks like.
+const operations = [
+  wait(9, 'manager', 'builder', 258000),
+  prompt(8, 'manager', 'builder', 1204),
+  prompt(7, 'manager', 'ghost-1', 12, false),
+  wait(6, 'operator', 'manager', 61000),
+  prompt(5, 'operator', 'manager', 4096),
+  prompt(4, 'manager', 'builder', 1204),
+  { id: 'f1', at: at(3), method: 'PUT', path: '/api/files/files-5/write',
+    origin: { id: 'operator', type: 'operator', name: 'operator' },
+    target: { id: 'files-5', name: 'files-5' },
+    request: { present: true, chars: 8400, sha256: 'sha-file' },
+    status: 200, ok: true, durationMs: 41, result: { ok: true } },
+];
+
+const stub = path.join(tmp, 'api-stub.ts');
+fs.writeFileSync(stub, `
+export * from ${JSON.stringify(path.join(WEB, 'src/api.ts'))};
+export const getOperations = () => Promise.resolve(${JSON.stringify({ operations, generatedAt: at(9) })});
+export const getTree = () => Promise.resolve({ sessions: [], groups: [], order: [], hidden: [] });
+`);
+
+await build({
+  stdin: {
+    resolveDir: WEB,
+    loader: 'tsx',
+    contents: `
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import ApiLog from './src/components/ApiLog.tsx';
+      createRoot(document.getElementById('root')).render(
+        <div className="app settings"><div className="main settings-main">
+          <div className="settings-page wide"><ApiLog /></div>
+        </div></div>);
+    `,
+  },
+  outfile: bundle,
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  logLevel: 'error',
+  plugins: [{ name: 'stub-api', setup(b) { b.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub })); } }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const open = async (width) => {
+  const page = await browser.newPage({ viewport: { width, height: 900 } });
+  await page.setContent(`<style>${css}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  await page.waitForFunction(() => !!document.querySelector('.al-tbl tbody tr'));
+  return page;
+};
+
+try {
+  for (const width of [1200, 390]) {
+    const page = await open(width);
+    const m = await page.evaluate(() => {
+      const rows = [...document.querySelectorAll('.al-tbl tbody tr')];
+      const line = parseFloat(getComputedStyle(document.querySelector('.al-tbl')).fontSize) * 2.4;
+      const st = document.querySelector('.al-st');
+      const stStyle = getComputedStyle(st);
+      const main = document.querySelector('.settings-main');
+      return {
+        rows: rows.length,
+        tallest: Math.max(...rows.map((r) => r.getBoundingClientRect().height)),
+        line,
+        clipped: rows.every((r) => [...r.children].every((c) => getComputedStyle(c).whiteSpace === 'nowrap')),
+        badge: {
+          border: stStyle.borderTopWidth,
+          background: stStyle.backgroundColor,
+          radius: stStyle.borderTopLeftRadius,
+          colour: stStyle.color,
+        },
+        paneOverflow: main.scrollWidth > main.clientWidth,
+      };
+    });
+    console.log(`the list at ${width}px`);
+    check(`every one of the ${m.rows} rows is a single line`, () => assert.ok(m.tallest < m.line, `tallest ${m.tallest}px`));
+    check('and every cell clips rather than wraps', () => assert.ok(m.clipped));
+    check('status is coloured text, not a badge', () => assert.deepEqual(
+      { border: m.badge.border, background: m.badge.background, radius: m.badge.radius },
+      { border: '0px', background: 'rgba(0, 0, 0, 0)', radius: '0px' },
+    ));
+    check('…and it does carry a colour', () => assert.ok(!/rgba?\(0, 0, 0/.test(m.badge.colour), m.badge.colour));
+    check('the page itself never scrolls sideways', () => assert.ok(!m.paneOverflow));
+    await page.close();
+    console.log('');
+  }
+
+  const page = await open(1200);
+  const list = await page.evaluate(() => {
+    const cells = [...document.querySelectorAll('.al-tbl tbody tr')].map((r) => [...r.children].map((c) => c.textContent.trim()));
+    return { first: cells[0], repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()) };
+  });
+  console.log('what a row says');
+  check('a resolved wait reads as one, with the time it blocked for',
+    () => assert.deepEqual(list.first.slice(2), ['GET /api/agents/builder/wait', '200', '4m 18s', 'resolved · waiting']));
+  check('identical prompts are marked as repeats, since the text itself is never stored',
+    () => assert.deepEqual(list.repeats, ['×2', '×2']));
+
+  await page.click('.al-view button:nth-child(2)');
+  await page.waitForSelector('.al-map svg');
+  const map = await page.evaluate(() => {
+    const labels = [...document.querySelectorAll('.al-lane-lbl')];
+    const lanes = labels.map((t) => t.textContent);
+    // Which lane an endpoint sits on: the arrow stops a few px short of the
+    // hairline, so snap to the nearest lane label.
+    const laneYs = labels.map((t) => Number(t.getAttribute('y')));
+    const laneAt = (y) => laneYs.reduce((best, ly, i) => (Math.abs(ly - y) < Math.abs(laneYs[best] - y) ? i : best), 0);
+    const arrows = [...document.querySelectorAll('.al-arrow')].map((l) => ({
+      back: l.classList.contains('back'),
+      bad: l.classList.contains('bad'),
+      down: Number(l.getAttribute('y2')) > Number(l.getAttribute('y1')),
+      src: lanes[laneAt(Number(l.getAttribute('y1')))],
+      dst: lanes[laneAt(Number(l.getAttribute('y2')))],
+      dashed: !!getComputedStyle(l).strokeDasharray && getComputedStyle(l).strokeDasharray !== 'none',
+    }));
+    return { lanes, arrows };
+  });
+  console.log('\nthe map');
+  check('callers are laid out above the agents they call',
+    () => assert.ok(map.lanes.indexOf('manager') < map.lanes.indexOf('builder'), map.lanes.join(' < ')));
+  check('a prompt is an arrow from caller down to target',
+    () => assert.ok(map.arrows.some((a) => !a.back && a.down)));
+  check('a resolved wait is an arrow back the other way, dashed',
+    () => assert.ok(map.arrows.some((a) => a.back && !a.down && a.dashed)));
+  // The claim is about direction between the two agents, not about up and down
+  // on the screen: if A calls B and B also calls A, one of the pairs has to run
+  // the other way. What must hold is that the wait reverses its own prompt.
+  check('the wait reverses the prompt it answers — manager → builder, builder → manager',
+    () => {
+      const out = map.arrows.find((a) => !a.back && a.src === 'manager' && a.dst === 'builder');
+      const back = map.arrows.find((a) => a.back && a.src === 'builder' && a.dst === 'manager');
+      assert.ok(out && back, JSON.stringify(map.arrows));
+      assert.ok(out.down && !back.down, 'and with callers on top that reads as out and back');
+    });
+  check('a failed call is visible in the shape too',
+    () => assert.ok(map.arrows.some((a) => a.bad)));
+  await page.close();
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log(failed ? `\n${failed} failed` : '\napi-log: ok');
+process.exit(failed ? 1 : 0);

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -93,7 +93,7 @@ const operations = [
     status: 200, ok: true, durationMs: 41, result: { ok: true } },
   anonymousWait,
   // manager waits on the agent it just created; 258s of being blocked
-  { id: 'w9', at: at(2), method: 'GET', path: '/api/agents/poet-1/wait',
+  { id: 'w-poet', at: at(2), method: 'GET', path: '/api/agents/poet-1/wait',
     origin: { id: 'manager', type: 'agent', name: 'manager' },
     target: { id: 'poet-1', name: 'poet', cli: 'claude' },
     status: 200, ok: true, durationMs: 258000,
@@ -165,8 +165,12 @@ const check = (what, fn) => {
 };
 
 const browser = await chromium.launch(chromiumLaunchOptions());
+// A duplicate React key silently duplicates DOM nodes, which is how a fixture id
+// collision looked like a zoom bug for twenty minutes. Fail on it instead.
+const warnings = [];
 const open = async (width) => {
   const page = await browser.newPage({ viewport: { width, height: 900 } });
+  page.on('console', (m) => { if (m.type() === 'error' || m.type() === 'warning') warnings.push(m.text().slice(0, 120)); });
   await page.setContent(`<style>${css}</style><div id="root"></div>`);
   await page.addScriptTag({ path: bundle });
   await page.waitForFunction(() => !!document.querySelector('.al-tbl tbody tr'));
@@ -493,10 +497,7 @@ try {
     document.querySelectorAll('.al-scale button')[1].click();
     await new Promise((r) => setTimeout(r, 120));
     const clock = gaps([...new Set(xs())].sort((a, b) => a - b));
-    const before = svgWidth();
-    document.querySelector('.al-zoom button:last-child').click();
-    await new Promise((r) => setTimeout(r, 120));
-    return { even, clock, before, zoomed: svgWidth(), level: document.querySelector('.al-zoom-lvl')?.textContent };
+    return { even, clock, width: svgWidth() };
   });
   console.log('\ntwo ways to lay out the same calls');
   // Not every event draws an arrow, so consecutive arrows sit one OR SEVERAL
@@ -516,12 +517,107 @@ try {
       assert.ok(clockStep < evenStep / 4, `clock step ${clockStep}px vs even ${evenStep}px`);
       assert.ok(Math.max(...scaled.clock) > evenStep * 2, `widest clock gap ${Math.max(...scaled.clock)}px`);
     });
-  check('zoom widens the drawing inside the frame that already scrolls',
+  check('and the drawing still fits its frame in both — zoom is a window, not a stretch',
+    () => assert.equal(scaled.width, ''));
+
+  // "i meant more zooming into specific regions of the x-axis … drag
+  // horizontally a window to zoom in". Driven with a real mouse, not synthetic
+  // events, because pointer capture and the click that follows a drag are
+  // exactly what has to behave.
+  const { allMarks, fullAxisLeft } = await page.evaluate(() => ({
+    allMarks: document.querySelectorAll('.al-arrowg, circle.al-dot').length,
+    fullAxisLeft: document.querySelectorAll('.al-axis')[0]?.textContent,
+  }));
+  // release whatever the card tests pinned, so "the drag did not select" is
+  // about the drag rather than about leftover state
+  if (await page.$('.al-card-x')) await page.click('.al-card-x');
+  const plot = await page.evaluate(() => {
+    const box = document.querySelector('.al-map svg').getBoundingClientRect();
+    return { left: box.left, top: box.top, width: box.width, height: box.height };
+  });
+  const atFrac = (f) => plot.left + plot.width * f;
+  const midY = plot.top + plot.height * 0.35;
+  await page.mouse.move(atFrac(0.35), midY);
+  await page.mouse.down();
+  await page.mouse.move(atFrac(0.5), midY, { steps: 6 });
+  const midDrag = await page.evaluate(() => ({
+    brush: !!document.querySelector('.al-brush'),
+    label: document.querySelector('.al-brush-lbl')?.textContent,
+  }));
+  await page.mouse.move(atFrac(0.75), midY, { steps: 6 });
+  await page.mouse.up();
+  await page.waitForTimeout(150);
+  const zoomed = await page.evaluate(() => ({
+    brush: !!document.querySelector('.al-brush'),
+    window: document.querySelector('.al-window')?.textContent?.trim(),
+    reset: !!document.querySelector('.al-reset'),
+    marks: document.querySelectorAll('.al-arrowg, circle.al-dot').length,
+    axisLeft: document.querySelectorAll('.al-axis')[0]?.textContent,
+    pinned: !!document.querySelector('.al-card.pinned'),
+  }));
+  console.log('\ndrag across the plot to zoom');
+  check('the selection is drawn while dragging, with the range on it',
+    () => { assert.ok(midDrag.brush); assert.match(midDrag.label || '', /\d\d:\d\d:\d\d → \d\d:\d\d:\d\d/, `label: ${midDrag.label}`); });
+  check('releasing keeps that window, and says which one it is',
     () => {
-      assert.equal(scaled.before, '100%');
-      assert.equal(scaled.zoomed, '150%');
-      assert.equal(scaled.level, '1.5×');
+      assert.ok(!zoomed.brush, 'the selection rectangle stayed up');
+      assert.match(zoomed.window || '', /\d\d:\d\d:\d\d → \d\d:\d\d:\d\d · \d+ of \d+ calls/, `window: ${zoomed.window}`);
     });
+  check('there are fewer calls in view than before', () => assert.ok(zoomed.marks < allMarks, `${zoomed.marks} of ${allMarks}`));
+  check('the axis names the slice, not the whole run', () => assert.notEqual(zoomed.axisLeft, fullAxisLeft));
+  check('and a drag that started on a mark did not also select it', () => assert.ok(!zoomed.pinned));
+  check('there is a way back out', () => assert.ok(zoomed.reset));
+
+  await page.click('.al-reset');
+  await page.waitForTimeout(120);
+  const out = await page.evaluate(() => ({
+    marks: document.querySelectorAll('.al-arrowg, circle.al-dot').length,
+    window: !!document.querySelector('.al-window'),
+    axisLeft: document.querySelectorAll('.al-axis')[0]?.textContent,
+  }));
+  check('reset puts everything back', () => {
+    assert.equal(out.marks, allMarks, `${out.marks} marks after reset vs ${allMarks} before`);
+    assert.ok(!out.window);
+    assert.equal(out.axisLeft, fullAxisLeft);
+  });
+
+  // and again, cleared by double-click
+  await page.mouse.move(atFrac(0.3), midY);
+  await page.mouse.down();
+  await page.mouse.move(atFrac(0.6), midY, { steps: 6 });
+  await page.mouse.up();
+  await page.waitForTimeout(120);
+  const beforeDouble = await page.evaluate(() => !!document.querySelector('.al-window'));
+  await page.mouse.dblclick(atFrac(0.5), midY);
+  await page.waitForTimeout(120);
+  const afterDouble = await page.evaluate(() => !!document.querySelector('.al-window'));
+  check('double-click clears it too', () => { assert.ok(beforeDouble); assert.ok(!afterDouble); });
+  // A horizontal drag on a phone is how you scroll — the frame scrolls sideways
+  // and the page scrolls down — so brushing is mouse and pen only rather than
+  // competing for the gesture.
+  const touched = await page.evaluate(async () => {
+    const svg = document.querySelector('.al-map svg');
+    const box = svg.getBoundingClientRect();
+    const at = (f) => box.left + box.width * f;
+    const opts = (x) => ({ pointerType: 'touch', pointerId: 7, clientX: x, clientY: box.top + 20, bubbles: true, isPrimary: true });
+    svg.dispatchEvent(new PointerEvent('pointerdown', opts(at(0.3))));
+    svg.dispatchEvent(new PointerEvent('pointermove', opts(at(0.6))));
+    const during = !!document.querySelector('.al-brush');
+    svg.dispatchEvent(new PointerEvent('pointerup', opts(at(0.6))));
+    await new Promise((r) => setTimeout(r, 100));
+    return { during, zoomed: !!document.querySelector('.al-window'), touchAction: getComputedStyle(svg).touchAction };
+  });
+  check('a touch drag does not brush, and the page keeps its own scrolling',
+    () => {
+      assert.ok(!touched.during, 'a touch started a selection');
+      assert.ok(!touched.zoomed, 'a touch zoomed the axis');
+      assert.notEqual(touched.touchAction, 'none');
+    });
+
+  // A duplicate key silently duplicates DOM nodes — a fixture id collision once
+  // read exactly like a zoom bug. Nothing in the map should be warning.
+  check('and the map renders without React complaining',
+    () => assert.deepEqual(warnings, [], warnings.join(' // ')));
   await page.close();
 } finally {
   await browser.close();


### PR DESCRIPTION
Settings gains an **API log** tab: two views over `/api/operations`, built from the operator-approved mock at https://lvwerra-agent-artifacts.static.hf.space/cron-and-api-log.html (the API-log half of it; the cron half is a separate feature).

**Screens and the server-side evidence:** https://lvwerra-agent-artifacts.static.hf.space/api-log.html

## The half that was not free

`/api/operations` already recorded every call that changed something. It recorded **no reads at all** — `operations.js` gated on `MUTATING = POST|PUT|PATCH|DELETE`. Of the last 193 entries on this Space: 173 POST, 20 PUT, **0 GET**. `wait` is a GET, so the swimlane view's return arrows could not be drawn from the data: the picture would have shown work being handed out and nothing ever coming back.

Three changes in `server/src/operations.js`, all small:

1. **One allowlist.** `LOGGED_READS = [/^\/api\/agents\/[^/]+\/wait$/]` — that route and nothing else. Deliberately *not* `/tail`: every open pane polls it, so logging it multiplies the log by the polling rate and says nothing a resolved wait does not already say.
2. **One guard.** A `wait` is a polling loop, so only the call that **resolved** is an event. Entries where `matched !== true` are dropped — timeouts, waits the caller abandoned (no response body), and waits whose target had already gone. Without this, one watched job would write an entry per reissue for as long as it ran.
3. **Logged reads never require `?from=`.** `wait` is documented read-only and every watch loop running right now calls it without an origin; the middleware 400s mutating calls that lack one, so applying that rule to reads would have broken every running loop the moment this shipped. An unattributed wait is still recorded — it says someone finished waiting on B, which draws as a mark on B's lane rather than an arrow.

Mutating calls are untouched: no origin still means 400.

### And a `target` field

The entry shape gains `target: {id, name, cli}`, resolved at write time by a `resolveTarget` callback that index.js supplies (the session named in the path). The id was always in the path; the *name* is the thing that decays — read back a month later it is the name that session has now, if it still exists at all. `{id}` alone is recorded when the path names something the store does not know (a 404), which is itself worth seeing.

Entries written before this have no target, so the client digs the id out of the path and matches it against the roster. That is why the map is useful against the existing backlog rather than only against new traffic.

### One line of documentation

The environment skill's two `wait` snippets now pass `?from=$AM_ID`, with a sentence saying why: it is what turns an unattributed mark into a real arrow. No code depends on it.

## The two views

**List** (`web/src/components/ApiLog.tsx`). One call per **line** — the operator was explicit that a wrapped row halves what you can see. Every cell is nowrap/clip; the path column is the only one allowed to take the slack (`max-width: 0; width: 100%`); below ~640px the table scrolls sideways inside its own frame rather than crushing that column to two letters. No pills or badges: status is coloured text in its own column, the method is accent-coloured text, and a `wait` row's method is muted because it is the one call that came back rather than went out. Filters: origin chips, failures / prompts / files, and a path substring.

**Map.** One lane per agent, callers ordered above the agents they call, calls drawn between the lanes: a prompt is a solid arrow from caller to target, a resolved wait a dashed one back the other way, and a call with no distinct target is a dot on its own lane. Hovering reads out the same fields as the list row.

Two judgement calls worth reviewing:

- **x is the call's rank, not its clock position.** Real traffic arrives in bursts; spacing by wall-clock collapsed a burst into one unreadable column and left the quiet hours as whitespace. The axis still names the period on screen. The mock's own arrows are evenly spaced, so I read this as matching it, but it is a decision.
- **Lane order is callers-first.** Sorting lanes by traffic alone put targets above their callers, at which point "down is out, up is back" stopped being true and the legend was lying. Callers above targets makes the legend's claim visually true in the common case; where two agents call each other it cannot be, so the test asserts the *semantic* invariant (a wait reverses the prompt it answers) rather than "every dashed arrow points up".

Beyond the mock: a failed call draws in the danger colour in the map too, since a 404 prompt otherwise looks identical to one that landed. Say if that is unwanted.

## What it cannot say, by design

Prompt text is not stored — `{present, chars, sha256}` — and that is deliberate. The view says who prompted whom and how long the prompt was, never what it said. Identical checksums mean identical prompts, so repeats are marked `×N` in the payload column with the digest in the title; that is the only honest thing the log can say about a job that fires the same text on a schedule.

## Verified

- **Against a real server**, not fixtures: patched server on a temp `DATA_DIR`, one call of each kind. Attributed wait → logged with origin and target. Unattributed wait → logged, origin `null`, not 400ed. 3s timeout → not logged. `tail` → not logged. Roster GET → not logged. Writes → unchanged, now with a target. A wait held open for 9s recorded `durationMs: 9007`, which is the point of logging it at all.
- **Both views rendered** at 1200px and 390px against 210 entries pulled from this Space's live log: no pane overflow at either width, and **zero rows taller than one line**.
- `server/test/operations.test.mjs` extended (25 checks) covers all of the above at the middleware level, including that a mutating call with no origin is still refused.
- `web/test/apiLog.test.mjs` is new: row height measured rather than CSS trusted, the no-badge rule (the status cell must have no border, background or radius, and must carry a colour), the wait row's shape, the `×N` repeat marking, and the arrow directions.
- `web` typecheck, `npm test` (16 suites) and `npm run build`; `server npm test` (21 suites). Both suites pick the new files up automatically — #91 landed first, so there was no list to edit.

## What could regress

- **Log volume.** One entry per resolved wait, which is roughly one per prompt — the mock estimates about a third more entries, and that matches what I saw. `readOperations` already tails a bounded 4 MiB.
- **A watch loop that passes `?from=`** now attributes its waits. If an agent passes a *stale* id, `resolveOrigin` returns null and the entry records no origin rather than failing the call — the read path never rejects.
- **`resolveTarget` runs a `store.get` per logged call.** In-memory map lookup, on the response path, already inside a handler that did far more work.
- **The map is capped** at the newest 48 interactions and 12 lanes, and says so on screen when it drops any. Filters apply before the cap, so narrowing by origin walks further back.

