### PR TITLE
Show attached files in the reader's immediate prompt

### DIFF
--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -9,10 +9,10 @@ import { rankSessions, sortLabel } from '../lib/overviewSort';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
 import {
-  defaultAttachmentPrompt, discardPendingAttachment, discardPendingAttachments,
+  buildPendingPrompt, discardPendingAttachment, discardPendingAttachments,
   pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
 } from '../lib/attachments';
-import type { PendingAttachment } from '../lib/attachments';
+import type { PendingAttachment, PendingPrompt } from '../lib/attachments';
 import Attachments from './Attachments';
 import Logo from './Logo';
 import Composer from './conversation/Composer';
@@ -152,7 +152,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   // Optimistic echo: the sent text becomes the prompt line the moment the
   // send succeeds — the digest round-trip (CLI writes transcript → rebuild →
   // poll) can take seconds, and a frozen card reads as "did that get lost?".
-  const [sent, setSent] = useState<{ text: string; at: number } | null>(null);
+  const [sent, setSent] = useState<(PendingPrompt & { at: number }) | null>(null);
   const [histIdx, setHistIdx] = useState(0); // digest fallback only: n-th answer back
   const [back, setBack] = useState(0);       // how many earlier turns are shown
   const [openWork, setOpenWork] = useState(false);
@@ -230,11 +230,12 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
     const batch = imagesRef.current;
     if ((!text && !batch.length) || sending) return;
     if (batch.some((image) => !image.attachment)) return;
-    const optimisticText = text || defaultAttachmentPrompt(batch.length);
+    const uploaded = batch.map((image) => image.attachment!);
+    const optimistic = buildPendingPrompt(s.cli, text, uploaded);
     setSending(true);
     setFailed(null);
     setDraft('');
-    setSent({ text: optimisticText, at: Date.now() });
+    setSent({ ...optimistic, at: Date.now() });
     setHistIdx(0);
     if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     try {
@@ -269,7 +270,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   }, [back, sent, running, latestX]);
 
   const ago = fmtAgo(Math.max(d?.lastAssistantTs || 0, d?.lastPromptTs || 0) || Date.parse(s.createdAt) || 0);
-  const promptText = sent ? sent.text : d?.lastPromptText || '';
+  const promptText = sent ? sent.displayText : d?.lastPromptText || '';
   const answerText = entry ? entry.answer : d?.lastAssistantText || '';
   const answerMd = entry ? entry.answerMd : d?.lastAssistantMd || '';
   // Chronological position: hist is newest-first, live text is the newest turn.
@@ -334,14 +335,14 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
             </div>
             {/* Optimistic echo: the digest round-trip can take seconds, and a
                 frozen card reads as "did that get lost?". */}
-            {justSent && sent && <PendingExchange text={sent.text} />}
+            {justSent && sent && <PendingExchange text={sent.displayText} />}
           </>
         ) : (
           /* No transcript to read yet (never started, or a harness with no
              trace): the digest still knows the last prompt and answer. */
           <>
             {promptText ? (
-              <div className="ov-prompt">{sent ? sent.text : (d?.lastPromptRaw || promptText)}</div>
+              <div className="ov-prompt">{sent ? sent.displayText : (d?.lastPromptRaw || promptText)}</div>
             ) : pending ? (
               <div className="ov-prompt-skel"><span className="skel" style={{ width: '70%' }} /></div>
             ) : (

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -20,10 +20,10 @@ import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
 import {
-  defaultAttachmentPrompt, discardPendingAttachment, discardPendingAttachments,
+  buildPendingPrompt, discardPendingAttachment, discardPendingAttachments,
   pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
 } from '../../lib/attachments';
-import type { PendingAttachment } from '../../lib/attachments';
+import type { PendingAttachment, PendingPrompt } from '../../lib/attachments';
 import { recallReading, rememberReading } from './readingPosition';
 import { useDraft } from './useDraft';
 import { fmtTok, splitExchanges } from './exchanges';
@@ -96,7 +96,7 @@ export default function ConversationView({
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
   const [sending, setSending] = useState(false);
   const [failed, setFailed] = useState<string | null>(null);
-  const [sent, setSent] = useState<{ text: string; at: number } | null>(null);
+  const [sent, setSent] = useState<(PendingPrompt & { at: number }) | null>(null);
   const allowAttachments = !isRemote(session.cli);
 
   useEffect(() => { attachmentsRef.current = attachments; }, [attachments]);
@@ -210,9 +210,10 @@ export default function ConversationView({
     const batch = attachmentsRef.current;
     if ((!text && !batch.length) || sending) return;
     if (batch.some((attachment) => !attachment.attachment)) return;
-    const optimisticText = text || defaultAttachmentPrompt(batch.length);
+    const uploaded = batch.map((attachment) => attachment.attachment!);
+    const optimistic = buildPendingPrompt(session.cli, text, uploaded);
     setSending(true); setFailed(null);
-    setDraft(''); setSent({ text: optimisticText, at: Date.now() });
+    setDraft(''); setSent({ ...optimistic, at: Date.now() });
     if (inputRef.current) { inputRef.current.style.height = 'auto'; inputRef.current.blur(); }
     stick.current = true;
     try {
@@ -562,7 +563,7 @@ export default function ConversationView({
               />
             </div>
           ))}
-          {sent && <PendingExchange text={sent.text} />}
+          {sent && <PendingExchange text={sent.displayText} />}
           {!exchanges.length && !sent && <div className="cxv-msg mono">nothing in this trace yet</div>}
           {!readOnly && session.inputRequired && (
             <InputRequiredNotice input={session.inputRequired} onOpenTerminal={() => writePaneMode('terminal')} />

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -141,8 +141,36 @@ export function discardPendingAttachments(sessionId: string, attachments: Pendin
   for (const attachment of attachments) discardPendingAttachment(sessionId, attachment);
 }
 
-export const defaultAttachmentPrompt = (count: number) =>
-  `Please inspect the attached file${count === 1 ? '' : 's'}.`;
+export interface PendingPrompt {
+  /** The operator's words (or the attachment-only fallback), used to recognise
+   *  the real transcript turn when it arrives. */
+  text: string;
+  /** What the optimistic exchange shows until that transcript turn arrives. */
+  displayText: string;
+}
+
+/**
+ * The server sends the prompt and its attachment paths as one string. Mirror
+ * that small presentation rule in the optimistic exchange so the first paint
+ * says exactly what was sent, without making transcript catch-up depend on a
+ * CLI retaining the path syntax verbatim.
+ */
+export function buildPendingPrompt(
+  cli: string,
+  text: string,
+  attachments: Pick<Attachment, 'kind' | 'path'>[],
+): PendingPrompt {
+  const onlyImages = attachments.length > 0 && attachments.every((attachment) => attachment.kind === 'image');
+  const prompt = String(text || '').trim() || (onlyImages
+    ? `Please inspect the attached screenshot${attachments.length === 1 ? '' : 's'}.`
+    : `Please inspect the attached file${attachments.length === 1 ? '' : 's'}.`);
+  if (!attachments.length) return { text: prompt, displayText: prompt };
+  const paths = attachments.map((attachment) => attachment.path);
+  const attachmentText = cli === 'gemini'
+    ? paths.map((filePath) => `@${JSON.stringify(filePath)}`).join('\n')
+    : `Attached files:\n${paths.map((filePath) => `- ${JSON.stringify(filePath)}`).join('\n')}`;
+  return { text: prompt, displayText: `${prompt}\n\n${attachmentText}` };
+}
 
 /** Upload in display order. Already-successful items are reused on retry. */
 export async function uploadPendingAttachments(

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -48,6 +48,14 @@ await build({
   external: ['react', 'react-dom', 'react/jsx-runtime'], plugins: [stubMarkdown],
 });
 const { PendingExchange, ExchangeView } = await import(pathToFileURL(out).href);
+const attachmentsOut = path.join(outDir, 'attachments.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/attachments.ts')],
+  outfile: attachmentsOut, format: 'esm', bundle: true, logLevel: 'error',
+});
+const { buildPendingPrompt } = await import(pathToFileURL(attachmentsOut).href);
+const { formatAttachmentDelivery } = await import(
+  pathToFileURL(path.join(HERE, '../../server/src/attachments.js')).href);
 // stepSummary decides whether a turn has a left half at all, so the two live in
 // the same check: no summary → the facts ride the working line.
 const exOut = path.join(outDir, 'exchanges-meta.mjs');
@@ -80,6 +88,46 @@ check('the prompt text is the prompt you sent',
   () => assert.match(html, />what changed in the deploy config\?</));
 check('a working line rides inside the same section',
   () => assert.match(html, /<div class="cx-running mono">working<\/div>\s*<\/section>/));
+
+console.log('\nand an attached prompt is complete on its first paint');
+const screenshot = { kind: 'image', path: '/state/attachments/reader/Screenshot 1.png' };
+const pendingPrompt = buildPendingPrompt('codex', 'compare this with the mock', [screenshot]);
+const attachedHtml = render(PendingExchange, { text: pendingPrompt.displayText });
+check('the optimistic exchange includes the Attached files line immediately', () => {
+  assert.match(attachedHtml, /compare this with the mock/);
+  assert.match(attachedHtml, /Attached files:/);
+  assert.match(attachedHtml, /Screenshot 1\.png/);
+});
+check('transcript catch-up still matches the operator text, not CLI path syntax',
+  () => assert.equal(pendingPrompt.text, 'compare this with the mock'));
+check('an attachment-only image uses the same screenshot fallback as the server',
+  () => assert.match(buildPendingPrompt('claude', '', [screenshot]).displayText,
+    /^Please inspect the attached screenshot\.\n\nAttached files:/));
+check('Gemini gets its actual @ path form rather than an invented Attached files label', () => {
+  const gemini = buildPendingPrompt('gemini', 'inspect it', [screenshot]).displayText;
+  assert.match(gemini, /\n\n@"\/state\/attachments\/reader\/Screenshot 1\.png"$/);
+  assert.doesNotMatch(gemini, /Attached files:/);
+});
+check('the optimistic formatter stays identical to the server delivery contract', () => {
+  const file = { kind: 'file', path: '/state/attachments/reader/notes from review.md' };
+  for (const cli of ['claude', 'codex', 'gemini', 'hermes']) {
+    for (const [text, attachments] of [['look here', [screenshot, file]], ['', [screenshot]], ['', [file]]]) {
+      assert.equal(
+        buildPendingPrompt(cli, text, attachments).displayText,
+        formatAttachmentDelivery(cli, text, attachments),
+        `${cli}: ${text || '(attachment only)'}`,
+      );
+    }
+  }
+});
+check('both optimistic send surfaces render the complete display text', () => {
+  const reader = fs.readFileSync(path.join(HERE, '../src/components/conversation/ConversationView.tsx'), 'utf8');
+  const overview = fs.readFileSync(path.join(HERE, '../src/components/Overview.tsx'), 'utf8');
+  assert.match(reader, /buildPendingPrompt\(session\.cli, text, uploaded\)/);
+  assert.match(reader, /<PendingExchange text=\{sent\.displayText\}/);
+  assert.match(overview, /buildPendingPrompt\(s\.cli, text, uploaded\)/);
+  assert.match(overview, /<PendingExchange text=\{sent\.displayText\}/);
+});
 
 console.log('\nand it has the shape of the turn it becomes a second later');
 // A real turn at the same moment the echo represents: asked, not yet answered.


### PR DESCRIPTION
## What changed

The reader's optimistic exchange now carries the uploaded attachment paths, so its first paint includes the same `Attached files:` block that the real transcript turn will show. Attachment-only image sends also use the server's `screenshot` wording, and Gemini keeps its existing `@"path"` form.

The same optimistic state is shared by the Overview conversation card, so that surface now stays consistent too.

## Why

This was a client-only gap, not transcript ordering. The server resolves the attachment IDs, formats the prompt plus paths into one string, and sends that string to the CLI in one `sendInput` call. The reader previously put only `text || defaultAttachmentPrompt(...)` into `sent`, rendered that incomplete echo immediately, and learned the paths only when the trace caught up a few seconds later.

The optimistic state keeps two values deliberately:

- `displayText`: the complete prompt and paths shown immediately.
- `text`: only the operator text/fallback used to recognize the real transcript turn. This avoids a duplicate echo if a CLI normalizes its attachment syntax in the trace.

## Verified

- Added regression coverage that renders the pending exchange and requires `Attached files:` plus the uploaded screenshot path on first paint.
- The client formatter is compared directly with the server's delivery formatter for Claude, Codex, Gemini, and Hermes; text+files, image-only, and file-only cases match.
- Both reader and Overview call sites are pinned to render `displayText`.
- `web`: typecheck, all 15 test suites, production build.
- `server`: attachment tests.
