### PR TITLE
Overview state rides the CLI tile too

### DIFF
--- a/server/reader-info.test.mjs
+++ b/server/reader-info.test.mjs
@@ -211,19 +211,23 @@ try {
   const layout = await page.evaluate(() => ({
     pathInLeft: !!document.querySelector('.pane-head .ph-left .ph-path'),
     pathInRight: !!document.querySelector('.pane-head .ph-right .ph-path'),
-    statusInTitle: !!document.querySelector('.pane-head .ph-title .status'),
-    statusLeftOfName: (() => {
-      const dot = document.querySelector('.pane-head .ph-title .status');
+    // #92 moved state off a standalone dot and onto the CLI tile's frame, so it
+    // now leads the row from `.ph-left` rather than the centred title. The old
+    // shape of this assertion has been failing on main since that merged.
+    stateOnTile: !!document.querySelector('.pane-head .ph-left .state-logo'),
+    strayStatusDot: !!document.querySelector('.pane-head .status'),
+    stateLeadsRow: (() => {
+      const frame = document.querySelector('.pane-head .ph-left .state-logo');
       const name = document.querySelector('.pane-head .ph-name');
-      return !!dot && !!name && dot.getBoundingClientRect().right <= name.getBoundingClientRect().left + 1;
+      return !!frame && !!name && frame.getBoundingClientRect().right <= name.getBoundingClientRect().left + 1;
     })(),
     rightOrder: [...document.querySelectorAll('.pane-head .ph-right .ph-btn')]
       .map((b) => b.className.replace('ph-btn ', '').split(' ')[0]),
   }));
   check('the working directory sits with the agent icon, not with the controls',
     layout.pathInLeft && !layout.pathInRight, JSON.stringify(layout));
-  check('the state mark leads the centred name',
-    layout.statusInTitle && layout.statusLeftOfName, JSON.stringify(layout));
+  check('state rides the CLI tile at the head of the row, with no dot left behind',
+    layout.stateOnTile && layout.stateLeadsRow && !layout.strayStatusDot, JSON.stringify(layout));
   check('attach, search, info and close are one cluster in that order',
     JSON.stringify(layout.rightOrder) === JSON.stringify(['ph-image', 'ph-search', 'tinfo-btn', 'ph-close']),
     JSON.stringify(layout.rightOrder));

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties, ReactNode } from 'react';
 import * as api from '../api';
 import type { MetaSession, TraceTurn } from '../api';
 import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionState, Tree } from '../types';
-import { chipBuckets, isPassive, isRemote } from '../types';
+import { chipBuckets, isPassive, isRemote, STATE_LABEL, REMOTE_STATE_LABEL } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
 import { hiddenSessionIds } from '../lib/overviewHidden';
@@ -15,6 +15,7 @@ import {
 import type { PendingAttachment } from '../lib/attachments';
 import Attachments from './Attachments';
 import Logo from './Logo';
+import StateLogo from './StateLogo';
 import Composer from './conversation/Composer';
 import InputRequiredNotice from './conversation/InputRequiredNotice';
 import ExchangeView, { PendingExchange } from './conversation/Exchange';
@@ -62,6 +63,11 @@ const bucket = (state: SessionState): OverviewFilter =>
 const atWork = (m: MetaSession) =>
   m.state === 'working'
   || (!isRemote(m.cli) && m.state !== 'stopped' && !!m.digest?.running);
+
+// The same label rule the sidebar row uses: for a remote agent the frame means
+// connection, not process, so it must not borrow the local words.
+const stateTitle = (s: { cli: string; state: SessionState }) =>
+  (isRemote(s.cli) ? REMOTE_STATE_LABEL : STATE_LABEL)[s.state];
 
 /** How much of the conversation the card reads. Cheap: one page, from the end. */
 const CARD_TAIL = 120;
@@ -293,8 +299,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   return (
     <div className={`ov-card${windowed ? '' : ' ov-compact'}`}>
       <div className="ov-id" onClick={() => onOpen(s.id)} title="Open pane">
-        <span className={`status ${s.state}`} />
-        <Logo cli={s.cli} size={12} tint={color} />
+        <StateLogo cli={s.cli} state={s.state} size={12} tint={color} title={stateTitle(s)} />
         {group && <span className="ov-gtag mono">[{group}]</span>}
         <span className="ov-name mono">{s.name}</span>
         {ago && <span className="ov-ago">· {ago}</span>}
@@ -422,8 +427,7 @@ function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession; color
           width is available (the list card is wide enough to keep it inline). */}
       {group && <div className="ovt-gline mono">[{group}]</div>}
       <div className="ovt-head">
-        <span className={`status ${s.state}`} />
-        <Logo cli={s.cli} size={12} tint={color} />
+        <StateLogo cli={s.cli} state={s.state} size={12} tint={color} title={stateTitle(s)} />
         <span className="ovt-name mono">{s.name}</span>
         <span className="ovt-ago">{pending ? '' : fmtAgo(last)}</span>
       </div>
@@ -730,7 +734,10 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
             <span className="ov-sectitle">{g.name}</span>
             <span className="ov-secn mono">{shown.length}</span>
             <span className="ov-peek">
-              {shown.map(({ s }) => <span key={s.id} className={`status ${dataFor(s).state}`} />)}
+              {shown.map(({ s }) => (
+                <StateLogo key={s.id} frameOnly state={dataFor(s).state} size={12}
+                  title={`${s.name} · ${stateTitle({ cli: s.cli, state: dataFor(s).state })}`} />
+              ))}
             </span>
           </button>
           <div className="ov-drawer"><div className="ov-drawer-in">

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -443,14 +443,11 @@ body {
 .ovt-state { font-size: 10.5px; color: var(--muted); }
 .ovt-state.running { color: var(--accent); }
 .ovt-state.input { color: var(--accent); font-weight: 650; }
-.ovt-state.running::before {
-  content: '⠋'; display: inline-flex; align-items: center;
-  width: var(--mark-w); height: var(--mark-h);
-  font-family: var(--font-mono); font-size: var(--mark-size);
-  font-weight: var(--mark-weight); line-height: 1;
-  transform: translateY(var(--mark-optical-y));
-  animation: ov-spin 0.9s steps(1) infinite;
-}
+/* No spinner glyph here any more. The tile's frame is the animated thing now,
+   and a second ⠋ in the line below it meant one small tile carrying two motions
+   that say the same word. The line keeps the WORD, because it says things the
+   four-state frame cannot: `needs input`, `✓ done`, and `running` in the wider
+   digest sense (atWork) that a frame reading `waiting` does not cover. */
 .ovt-state.stopped { opacity: 0.7; }
 .ovt-group { position: relative; border: 1px solid var(--border); border-radius: 13px; padding: 12px 10px 10px; margin-top: 6px; }
 /* loose tiles align with tiles INSIDE group boxes (1px border + 10px padding),

--- a/web/test/stateLogo.test.mjs
+++ b/web/test/stateLogo.test.mjs
@@ -84,4 +84,24 @@ assert.equal(paintedLogo.props.style.height, 16);
 assert.equal(paintedLogo.props.style.padding, 3);
 assert.equal(headerSvg.props.viewBox, '0 0 22 22');
 
-console.log('state-logo: real tiles keep logos and 12px legend frames contain only the shared border');
+// Which surfaces have opted in. #92 shipped the frame to the sidebar, both pane
+// headers and the mock, and deliberately left Overview on the old standalone
+// mark; the operator has since asked for Overview too, so all three of its
+// state slots — card, tile and the group's peek strip — are frames now, and the
+// state-classed `.status` has no renderer left anywhere in the app.
+//
+// This one reads source rather than rendering, because Overview needs the whole
+// API surface to mount. It is written to survive reformatting: it counts and
+// looks for absence, never for an attribute order or a whole JSX line.
+const overview = fs.readFileSync(path.join(HERE, '../src/components/Overview.tsx'), 'utf8');
+const frames = (overview.match(/<StateLogo\b/g) || []).length;
+assert.ok(frames >= 3, `Overview should draw a frame in all three slots, found ${frames}`);
+assert.ok(/frameOnly/.test(overview), 'the group strip has no icon to frame, so it needs the frame-only form');
+for (const file of ['components/Overview.tsx', 'components/Sidebar.tsx', 'components/TerminalPane.tsx',
+  'components/RemotePane.tsx', 'components/Locked.tsx']) {
+  const text = fs.readFileSync(path.join(HERE, '../src', file), 'utf8');
+  assert.doesNotMatch(text, /className=\{?[`"']status [^`"']*\$\{/,
+    `${file} still renders a state-classed .status mark`);
+}
+
+console.log('state-logo: real tiles keep logos, 12px legend frames are border-only, and every state slot is a frame');

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -32,8 +32,8 @@ const embeddedFont = `@font-face {
 .parity-sidebar { display:flex; align-items:center; font-weight:400; }
 .parity-overview { display:flex; align-items:center; font-weight:700; }
 .mark-baseline { display:inline-block; width:0; height:0; padding:0; margin:0; }
-.status.working::before, .ov-busy::before, .cx-running::before,
-.ovt-state.running::before { animation:none !important; }`;
+.status.working::before, .ov-busy::before,
+.cx-running::before { animation:none !important; }`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -78,7 +78,6 @@ await page.setContent(`<style>${css}\n${embeddedFont}</style>
     <span class="ph-right"></span>
   </div>
   <div class="ov-busy" id="overview-busy">running</div>
-  <div class="ovt-state running" id="overview-group-working"></div>
   <div class="cx-running" id="reader-working">working</div>`);
 await page.evaluate(async () => {
   await document.fonts.load('12.5px "Geist Mono Test"', '⠿⠁');
@@ -173,7 +172,7 @@ const { marks, ink, optics } = await page.evaluate((ids) => {
   'working', 'waiting', 'idle', 'stopped', 'provider', 'ready',
   'sidebar-working', 'overview-working', 'overview-waiting',
   'header-working', 'header-waiting', 'overview-busy',
-  'overview-group-working', 'reader-working',
+  'reader-working',
 ]);
 await browser.close();
 
@@ -279,7 +278,7 @@ check('Overview and header static paths have identical geometry', () => {
   close(marks['overview-waiting'].left, marks['header-waiting'].left, 0.001);
 });
 for (const id of [
-  ...STATUS_WORKING, 'overview-busy', 'overview-group-working', 'reader-working',
+  ...STATUS_WORKING, 'overview-busy', 'reader-working',
 ]) {
   check(`${id} uses the same normal-weight, optically corrected spinner`, () => {
     assert.match(marks[id].content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);


### PR DESCRIPTION
> in the overview the spinning widget is still next to the icon, when it should be the animation around the icon like in the sidebar

**[Before/after, sizes and reduced-motion behaviour →](https://claude.ai/code/artifact/ace5f4a7-fe32-46e2-bf52-711d665e58f4)**

#92 shipped the frame to the sidebar, both pane headers and the install mock, and deliberately left Overview on the standalone mark — the argument being that Overview is denser. The operator has decided the other way, so all three of Overview's state slots move onto the tile:

- the card's row and the tile's head drop the separate mark; their plain `Logo` becomes a `StateLogo`
- the group's peek strip has no icon to frame, so it uses the **frame-only** form the sidebar and install legends already use

## Density was the objection, so here are the numbers

| | before | after |
|---|---|---|
| card / tile | 15×13 mark **+** 18×18 logo | **18×18 frame** |
| sidebar frame | 18×18 | 18×18 — unchanged, and identical |
| group strip mark | 15px wide | 12px frame-only |
| old marks left in Overview | 6 | **0** |

The frame is not a shrunken version of the sidebar's — it is the same object at the same size, and on the card and tile it replaces a mark *and* a logo that sat side by side, so those two rows get **narrower**. The strip's marks get smaller. No new size was invented: both come from `StateLogo`'s own `size` prop.

## The tile keeps its word and loses its spinner

`.ovt-state.running::before` drew an animated braille glyph in the line under the icon — so with the frame now animating a few pixels above it, one small tile carried two motions saying the same thing. The glyph is gone.

**The word stays**, because it says what a four-state frame cannot: `needs input`, `✓ done`, and `running` in the wider digest sense (`atWork`, which covers a session whose transcript is mid-task while its state reads `waiting`). In the sidebar the frame is all you get; on a tile the word still earns its place. Flagging the one consequence: in that `atWork`-but-not-`working` case the tile no longer animates at all — the accent word is the whole signal. Say if you would rather keep the glyph.

## The bare `.status` block, checked before touching

After this change `.status` is rendered **nowhere with a state class** — only bare, by the provider dots in `UsagePanel.tsx:92` and the ready dot in `SettingsView.tsx:358`. Both still work and both are still asserted in `statusMark.render.test.mjs` (`provider still shows rgb(214, 69, 69)`, `ready still shows rgb(46, 158, 91)`) — the pair I broke in #82 and do not intend to break again.

**The `.status.<state>` rules stay.** They look dead but are not: `statusMark.test.mjs` and `statusMark.render.test.mjs` measure `.status.working::before` as the *reference* for the spinner family that `.ov-busy` and `.cx-running` are checked against. Removing them means rewriting those two suites, which is a separate change. I left a note rather than a trap.

## Four states, both themes, no motion

All four stay distinguishable at Overview's sizes (the screenshots force real states through the API, so the working dash is genuine rather than a class swap). Under `prefers-reduced-motion` the working frame keeps `stroke-dasharray: 20px, 4px` with `animation-name: none` and **0** running animations, while waiting has no dash rect at all — so working is still dashed against waiting's solid when nothing may move.

## Tests

- `stateLogo.test.mjs` gains the assertion the brief asked for. The old declaration that Overview keeps the standalone mark **was already gone** — that suite was rewritten after my #92 review to pin structure rather than source text — so instead of editing it I added its opposite: every state slot is a frame, the strip uses the frame-only form, and no component renders a state-classed `.status`. Verified it fails if any one of the three sites is reverted.
- `statusMark.render.test.mjs` loses its `overview-group-working` fixture, which existed only to measure the tile spinner this removes.

## One thing that was already broken

`server/reader-info.test.mjs` asserted *"the state mark leads the centred name"* — the pane header's standalone dot. #92 moved that onto the tile, so **this has been failing on main since #92 merged**; I confirmed it fails identically with my changes stashed:

```
FAIL  the state mark leads the centred name  {"statusInTitle":false,"statusLeftOfName":false}
```

It now pins the arrangement #92 actually shipped (state on the tile, at the head of the row, no dot left behind). `npm run test:ui` goes from red to green — 74 checks.

Web suite: 15 suites. `npm run test:render`: all checks. `npm run test:ui`: all three suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)