### PR TITLE
Reader: show the prompts typed while the agent was working

### DIFF
--- a/docs/conversation-view.md
+++ b/docs/conversation-view.md
@@ -435,6 +435,28 @@ pane with nothing to render (a shell) simply stays a terminal.
   history recall, a slash-command menu — and duplicated markup is how one surface quietly gets
   them and the other does not. `onPasteFiles` and `above` are the seam an attachment strip plugs
   into, so it arrives in both places at once or in neither.
+- **A prompt typed mid-turn is still a prompt.** Claude Code does not write one as a `user`
+  message: while the agent is working it records `{"type":"queue-operation","operation":"enqueue",
+  "content":"…"}`, and the text exists nowhere else until the queue is consumed. `queue-operation`
+  appeared nowhere in this repo, so every such prompt was invisible in the reader — permanently,
+  not late. Two of the operator's own prompts were lost that way.
+
+  The two consumption paths need opposite treatment, and they are distinguishable from the records
+  alone (which matters, because a window can hold the enqueue and not what follows it): `dequeue`
+  carries no text and pops the oldest queued prompt — the prompt arrives as an ordinary message
+  right after, so the queued copy stands down; `remove` names the text it takes out, and nothing
+  else will ever carry it, so that copy is what the reader shows. In the reference transcript that
+  split is 86 dequeues to 5 removes, and the 5 are exactly the prompts with no message anywhere.
+  A prompt still in the queue when the window ends is left to its message for the same reason.
+
+  It is shown where it was typed — inside the turn it interrupted, which means it opens a new
+  exchange there and the interrupted turn keeps only the work it had done so far. That is the
+  honest order: the operator typed it then, and the answer that follows usually addresses it. And
+  the band says **queued**, because the records cannot tell a prompt that was consumed from one
+  that was cancelled — so the reader states what it knows rather than implying the agent replied.
+  Harness noise is filtered exactly as it is for ordinary user text: one of those five removes is
+  an enqueued `<task-notification>`, and showing that as something the operator typed would be a
+  new bug in place of the old one.
 - **A half-typed reply is kept** (`drafts.ts`, `useDraft.ts`). Reported from a phone: start typing
   an answer, switch apps, come back, and the text is gone. The pane is not what loses it — App.tsx
   keeps a dozen panes warm, so an in-app trip to the session list already survived — the

--- a/server/package.json
+++ b/server/package.json
@@ -16,7 +16,7 @@
     "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs",
     "test:screenshots": "node screenshot-input.test.mjs",
     "test:mobile": "node mobile.test.mjs",
-    "test": "node ../scripts/run-suites.mjs"
+    "test": "node test/queued-prompts.test.mjs && node ../scripts/run-suites.mjs"
   },
   "engines": {
     "node": ">=20.19"

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1012,13 +1012,66 @@ async function* rangeJsonLines(file, range) {
 // same usage. parseClaude() above dedupes by dropping repeats; a viewer must
 // instead MERGE them, or half the assistant text disappears. So: first line for
 // an id creates the message and owns the usage, later lines append blocks.
+// A prompt typed while the agent is mid-turn is not written as a `user` message
+// at all. Claude Code queues it:
+//   {"type":"queue-operation","operation":"enqueue","content":"<the prompt>"}
+// and the text exists NOWHERE else until the queue is consumed. Two things then
+// happen, and they need opposite treatment:
+//   - `dequeue` (86 of 91 in the reference transcript): the prompt arrives as an
+//     ordinary user message afterwards, so the queued copy must give way to it
+//     or the reader shows the same prompt twice;
+//   - `remove` (5 of 91): it never arrives. The queue record is the only copy
+//     there will ever be — which is why those prompts were invisible in the
+//     reader, permanently, not late.
+// The two paths are distinguishable from the records alone, which matters
+// because a window can contain the enqueue and not the message that follows it:
+// `dequeue` carries no content and pops the oldest queued prompt (the real
+// message is coming, so the queued copy stands down), while `remove` names the
+// text it takes out (nothing else will carry it, so the queued copy is what the
+// reader gets). Text matching against later messages was the first attempt and
+// it double-rendered a prompt the operator had queued eight times in a loop:
+// the window held six enqueues and two of the messages.
+const queueKey = (s) => String(s || '').replace(/\s+/g, ' ').trim();
+// The same filter the rest of this file applies to user text: an enqueued
+// `<task-notification>` is the harness talking to itself, not something the
+// operator typed. One of the five removes in the reference transcript is exactly
+// that, and showing it as a prompt would be a new bug in place of the old one.
+const isHarnessText = (t) => t.startsWith('<') || t.startsWith('[Request interrupted');
+
 async function normalizeClaude(file, out, range) {
   const stitch = makeStitcher();
   const byMsgId = new Map();
+  const pending = [];   // queued prompts, oldest first, until dequeued or removed
   for await (const j of jsonLines(file, range)) {
     // These embed whole file contents; share.js drops them and so do we.
     if (j.type === 'file-history-snapshot' || j.type === 'file-history-delta') continue;
     if (j.isMeta || j.sourceToolUseID) continue;
+    if (j.type === 'queue-operation') {
+      const text = queueKey(j.content);
+      if (j.operation === 'enqueue') {
+        // Harness noise is not a prompt: one of the five removes in the
+        // reference transcript is an enqueued <task-notification>, and showing
+        // that as something the operator typed would be a new bug for an old one.
+        if (!text || isHarnessText(text)) continue;
+        const msg = {
+          role: 'user',
+          ts: j.timestamp ? Date.parse(j.timestamp) || undefined : undefined,
+          queued: true,
+          blocks: [textBlock('text', String(j.content))],
+        };
+        out.push(msg);
+        pending.push({ text, msg });
+        msg.superseded = true;   // until a `remove` proves it is the only copy
+      } else if (j.operation === 'dequeue') {
+        // popped into a request: the ordinary user message is on its way, and
+        // that one keeps the prompt. Positional, because dequeue names no text.
+        pending.shift();
+      } else if (j.operation === 'remove') {
+        const at = pending.findIndex((p) => p.text === text);
+        if (at >= 0) pending.splice(at, 1)[0].msg.superseded = false;
+      }
+      continue;
+    }
     if (j.type !== 'user' && j.type !== 'assistant') continue;
 
     const m = j.message;
@@ -1083,6 +1136,14 @@ async function normalizeClaude(file, out, range) {
       if (id) byMsgId.set(id, msg);
     }
   }
+  // Dropped at the end rather than never pushed: which path a queued prompt took
+  // is not known until its dequeue or remove has been read. Anything still
+  // pending when the window ends stays dropped — it is about to be dequeued, and
+  // the message that follows is the copy the reader should have.
+  if (out.messages.some((m) => m.superseded)) {
+    out.messages = out.messages.filter((m) => !m.superseded);
+  }
+  for (const m of out.messages) delete m.superseded;
 }
 
 // Codex — $CODEX_HOME/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl

--- a/server/test/queued-prompts.test.mjs
+++ b/server/test/queued-prompts.test.mjs
@@ -1,0 +1,154 @@
+// A prompt typed while the agent is mid-turn.
+//
+// Claude Code does not write it as a `user` message. It writes
+//   {"type":"queue-operation","operation":"enqueue","content":"<the prompt>"}
+// and then either `dequeue` (the prompt arrives as an ordinary user message
+// afterwards) or `remove` (it never does). Before this, `queue-operation`
+// appeared nowhere in the repo, so every mid-turn prompt was invisible in the
+// reader — permanently, not late. Two of the operator's own prompts were lost
+// that way, which is the regression nobody would notice coming back.
+//
+// Run with:  node test/queued-prompts.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { readTraceByPath } from '../src/traces.js';
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'am-queued-'));
+const norm = (s) => (s || '').replace(/\s+/g, ' ').trim();
+const textOf = (m) => norm((m.blocks || []).filter((b) => b.type === 'text').map((b) => b.text).join(' '));
+
+let clock = Date.UTC(2026, 7, 20, 8, 0, 0);
+const at = () => new Date((clock += 5000)).toISOString();
+const user = (text) => ({ type: 'user', timestamp: at(), cwd: '/w', message: { role: 'user', content: [{ type: 'text', text }] } });
+const assistant = (text) => ({ type: 'assistant', timestamp: at(), cwd: '/w', message: { id: `m${clock}`, role: 'assistant', model: 'claude-test', usage: { input_tokens: 10, output_tokens: 5 }, content: [{ type: 'text', text }] } });
+const tool = (name) => ({ type: 'assistant', timestamp: at(), cwd: '/w', message: { id: `t${clock}`, role: 'assistant', model: 'claude-test', content: [{ type: 'tool_use', id: `u${clock}`, name, input: { file_path: '/w/x.js' } }] } });
+const queue = (operation, content) => ({ type: 'queue-operation', operation, sessionId: 's', timestamp: at(), ...(content === undefined ? {} : { content }) });
+
+const write = (name, records) => {
+  const f = path.join(dir, `${name}.jsonl`);
+  fs.writeFileSync(f, `${records.map((r) => JSON.stringify(r)).join('\n')}\n`);
+  return f;
+};
+const read = async (f) => {
+  const page = await readTraceByPath(f, { limit: 500 });
+  return (page.turns || []);
+};
+
+// ---- the operator's case: queued, then removed, and never written as a message
+{
+  const f = write('removed', [
+    user('start the nightly job'),
+    tool('Bash'),
+    queue('enqueue', 'ok, now API feedback. the user should be excluded by default'),
+    queue('remove', 'ok, now API feedback. the user should be excluded by default'),
+    assistant('Done — the job is running.'),
+  ]);
+  const turns = await read(f);
+  const prompts = turns.filter((m) => m.role === 'user' && textOf(m));
+  check('a queued prompt that was removed is shown', () => {
+    assert.equal(prompts.length, 2, `expected the real prompt and the queued one, got ${prompts.map(textOf)}`);
+    assert.match(textOf(prompts[1]), /^ok, now API feedback/);
+  });
+  check('…and it says it was queued', () => assert.equal(prompts[1].queued, true));
+  check('…while an ordinary prompt does not', () => assert.equal(prompts[0].queued, undefined));
+  check('…and it keeps the time it was typed', () => assert.ok(prompts[1].ts > prompts[0].ts));
+}
+
+// ---- the common case: queued, dequeued, and the real message arrives
+{
+  const f = write('dequeued', [
+    user('start the nightly job'),
+    tool('Bash'),
+    queue('enqueue', 'and check the watcher after'),
+    queue('dequeue'),
+    user('and check the watcher after'),
+    assistant('Both done.'),
+  ]);
+  const prompts = (await read(f)).filter((m) => m.role === 'user' && textOf(m));
+  check('a dequeued prompt is shown once, by its real message', () => {
+    assert.equal(prompts.length, 2, `expected no duplicate, got ${prompts.map(textOf)}`);
+    assert.equal(textOf(prompts[1]), 'and check the watcher after');
+    assert.equal(prompts[1].queued, undefined, 'the real message should be the copy that survives');
+  });
+}
+
+// ---- two queued at once, one taken and one removed: order and pairing hold
+{
+  const f = write('both-paths', [
+    user('first'),
+    tool('Read'),
+    queue('enqueue', 'second, queued and taken'),
+    queue('enqueue', 'third, queued and removed'),
+    queue('dequeue'),
+    user('second, queued and taken'),
+    queue('remove', 'third, queued and removed'),
+    assistant('all three answered'),
+  ]);
+  const prompts = (await read(f)).filter((m) => m.role === 'user' && textOf(m));
+  check('the taken one comes from its message, the removed one from the queue', () => {
+    assert.deepEqual(prompts.map(textOf), ['first', 'third, queued and removed', 'second, queued and taken']);
+    assert.deepEqual(prompts.map((m) => !!m.queued), [false, true, false]);
+  });
+}
+
+// ---- the same words queued twice: FIFO, not "drop them all"
+{
+  const f = write('twice', [
+    user('go'),
+    queue('enqueue', 'same words'),
+    queue('enqueue', 'same words'),
+    queue('dequeue'),
+    user('same words'),
+    queue('remove', 'same words'),
+    assistant('ok'),
+  ]);
+  const prompts = (await read(f)).filter((m) => m.role === 'user' && textOf(m));
+  check('one copy survives per prompt, not none and not four', () => {
+    assert.equal(prompts.filter((m) => textOf(m) === 'same words').length, 2);
+    assert.equal(prompts.filter((m) => m.queued).length, 1);
+  });
+}
+
+// ---- harness noise must not become a prompt
+{
+  const f = write('noise', [
+    user('go'),
+    queue('enqueue', '<task-notification>\n<task-id>abc</task-id>\n</task-notification>'),
+    queue('remove', '<task-notification>\n<task-id>abc</task-id>\n</task-notification>'),
+    queue('enqueue', '[Request interrupted by user]'),
+    queue('remove', '[Request interrupted by user]'),
+    assistant('ok'),
+  ]);
+  const prompts = (await read(f)).filter((m) => m.role === 'user' && textOf(m));
+  check('an enqueued task-notification is not shown as something the operator typed', () => {
+    assert.equal(prompts.length, 1, `only the real prompt should be a prompt, got ${prompts.map((m) => textOf(m).slice(0, 24))}`);
+    assert.equal(textOf(prompts[0]), 'go');
+  });
+}
+
+// ---- still in the queue when the window ends: the message is coming, so wait
+{
+  const f = write('pending', [
+    user('go'),
+    tool('Bash'),
+    queue('enqueue', 'typed while it works, not taken yet'),
+  ]);
+  const prompts = (await read(f)).filter((m) => m.role === 'user' && textOf(m));
+  check('a prompt still in the queue is left to its message rather than shown twice', () => {
+    assert.equal(prompts.length, 1);
+    assert.equal(textOf(prompts[0]), 'go');
+  });
+}
+
+fs.rmSync(dir, { recursive: true, force: true });
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -490,6 +490,14 @@ export type TraceBlock =
 export interface TraceTurn {
   role: 'user' | 'assistant' | 'system';
   kind?: 'final' | 'update';
+  /**
+   * A prompt typed while the agent was mid-turn, read from Claude Code's queue
+   * records because it is written nowhere else (server/src/traces.js). The
+   * reader says so on the band: the records cannot tell a prompt that was
+   * consumed from one that was cancelled, so it reports what it knows — that
+   * this was typed and queued — rather than claiming it was answered.
+   */
+  queued?: boolean;
   ts?: number;
   model?: string;
   usage?: { in: number; out: number; cacheRead?: number };

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -246,7 +246,15 @@ export function ExchangeView({
 
   return (
     <section className={`cx${dim ? ' dim' : ''}`}>
-      {prompt ? <div className="cx-prompt"><Hi text={prompt} q={q} /></div> : null}
+      {prompt ? (
+        <div className="cx-prompt">
+          <Hi text={prompt} q={q} />
+          {/* Read from a queue record rather than a message: it was typed while
+              the agent was working. Labelled because those records cannot say
+              whether it was then consumed or cancelled — see TraceTurn.queued. */}
+          {x.prompt?.queued ? <span className="cx-queued mono" title="Typed while the agent was working, so it waited in the queue">queued</span> : null}
+        </div>
+      ) : null}
 
       {/* Everything about the turn on ONE line, under the prompt: what the work
           was on the left, which turn it is on the right. Nothing above.

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -50,6 +50,11 @@
   font-size: 1em; font-weight: 550; color: var(--text);
   white-space: pre-wrap; overflow-wrap: break-word;
 }
+/* the queue marker: a quiet aside on the band, not a second voice */
+.cx-queued {
+  margin-left: 7px; padding: 0 4px; border: 1px solid var(--border); border-radius: var(--r-sm);
+  font-size: 0.78em; font-weight: 500; color: var(--muted); vertical-align: 1px; white-space: nowrap;
+}
 .cx-prompt::before {
   content: '❯'; position: absolute; left: 0.23em; top: 6px;
   font-family: var(--font-mono); color: var(--accent); font-weight: 700;


### PR DESCRIPTION
> i can't see the last two prompts (api feedback, screenshot bug report) in the reader

Confirmed against the transcript in the report: those two prompts are `queue-operation` records, and `queue-operation` appeared nowhere in this repo, so they were invisible in the reader — permanently, not late.

## Two corrections to the diagnosis, both from the data

Each one changes the fix, so they are worth stating first.

**1. There are three operations, not two.** In the reference transcript: **91 `enqueue`, 86 `dequeue`, 5 `remove`**.

| | carries text | what it means | visible today? |
|---|---|---|---|
| `enqueue` | yes | typed while the agent was working | no |
| `dequeue` | **no** | popped into a request — the prompt then arrives as an ordinary `user` message | yes, via that message |
| `remove` | yes | leaves the queue, and **no message ever carries it** | **no — this is the bug** |

40 of 45 distinct enqueued texts appear later as real user messages; the 5 that never do are exactly the 5 `remove`s. Three of them are verifiably prompts the operator sent — the meta-row bug I was handed two rounds ago is one of them.

So "render every enqueue" double-renders the common path. **My first attempt** matched enqueued text against later messages instead, and it showed one prompt **six times**: the window held six enqueues of a looped self-prompt and only two of its messages. Text matching cannot work across a window boundary; the records can, because an enqueue and its dequeue/remove sit seconds apart.

**2. One of those five removes is an enqueued `<task-notification>`.** Queued harness noise is still harness noise. The same filter ordinary user text gets (`<…>`, `[Request interrupted`) applies, or the fix trades one bug for another.

## The rule

Emit the queued prompt where it was typed; drop it again unless a `remove` proves it is the only copy. A prompt still in the queue when the window ends is left to its message, for the same reason.

- **No double-render.** The dequeued path is untouched — the real message is still the copy you see.
- **`remove` is ambiguous** between "consumed" and "cancelled", and the records cannot tell them apart: no id, no status, and `last-prompt` records do not carry these texts either (checked). All 5 removes here were real prompts and no cancellation appears in 5,287 lines — but I did not want to bet the reader on that, so **the band says `queued`**. A cancelled prompt would then read as "typed and queued", not as one the agent answered. If Claude Code ever distinguishes the two, that label is where it goes.

## Ordering

It renders **where it was typed** — inside the turn it interrupted — so it opens a new exchange there and the interrupted turn keeps only the work it had done so far. That is the order it happened in, and the answer that follows usually addresses it. Holding it until the turn ended would place it *after* work it predates, which is the bug #85 existed to fix. `splitExchanges` needs nothing new: a queued prompt is an ordinary operator prompt as far as it is concerned, which is what makes the band, the turn number and the timestamp all come out right.

Rendered, it reads:

```
❯ deploy the status change to dev
  ▸ 1 step · 1 tool · 20s · 3.2k tok                      turn 1/2  08:30 AM
❯ ok, now API feedback. i think by default the user should be excluded  [queued]
  40s · 3.6k tok                                          turn 2/2  08:31 AM
  Deployed, and on the API feedback: the user is excluded by default now.
```

## Other harnesses

Claude-specific. Codex rollouts are `response_item`/`event_msg` payloads with no queue concept — the one grep hit in a codex file was the string `queue-operation` quoted inside a tool's output, not a record. OpenCode has no equivalent either.

## Verified

- **The reported case**: parsing a slice of the operator's own transcript around those lines yields all three queued prompts, no duplicates, and the enqueued `<task-notification>` correctly not shown as a prompt.
- **Live, not only on load**: appending an enqueue+remove pair to a transcript with the reader open has the prompt appear on the next poll (prompt bands 2 → 3, queued markers 1 → 2), no reload.
- **`server/test/queued-prompts.test.mjs`** (new, wired into `npm test`) pins six cases with a fixture: the removed path is shown and labelled; the dequeued path is shown once, by its real message; both paths inside one turn keep their order; the same words queued twice keep one copy each; an enqueued `<task-notification>` is not a prompt; a still-queued prompt waits for its message. Mutation-checked — ignoring the records fails 5 checks, showing every enqueue fails 3, dropping the noise filter fails 1.
- Web suite and typecheck green. `server/resize.test.mjs` failed in the full run and passes twice in isolation on this branch (and on pristine main) — the known load-dependent flake, unrelated to trace parsing.

## Left alone deliberately

The digest (`scanClaude`, the same file) still counts only real `user` messages, so the Overview **card's** "last prompt" can lag a queued one — the same records, a different surface, and its own small change rather than scope creep here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
