### PR TITLE
Reader: the scrollbar is gone until you scroll

### DIFF
--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -373,6 +373,22 @@ export default function ConversationView({
     });
   }, [session.id]);
 
+  // The scrollbar shows only while the reader is moving (see .cxv-scrolling in
+  // conversation.css). Driven straight on the node rather than through state:
+  // this runs on every scroll frame, and re-rendering the whole conversation to
+  // change one class name would tax the one interaction that has to stay
+  // smooth. Any scroll counts — wheel, trackpad, touch, Page Down, and the
+  // reader's own jumps all raise the same event.
+  const barIdle = useRef<number>(0);
+  const showScrollbar = () => {
+    const el = scroller.current;
+    if (!el) return;
+    el.classList.add('cxv-scrolling');
+    window.clearTimeout(barIdle.current);
+    barIdle.current = window.setTimeout(() => el.classList.remove('cxv-scrolling'), 700);
+  };
+  useEffect(() => () => window.clearTimeout(barIdle.current), []);
+
   // Scroll fires in bursts; one write per quiet moment is plenty.
   const settle = useRef<number>(0);
   const onScrolled = () => {
@@ -516,6 +532,7 @@ export default function ConversationView({
           // Reading back into the conversation: fetch the stretch in front of
           // what we hold before the reader arrives at it.
           if (el.scrollTop < NEAR_TOP_PX) loadOlder();
+          showScrollbar();
           onScrolled();
         }}>
         <div className="cxv-col">

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -280,6 +280,47 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    12px apart, which reads as one blank line too many at the end of every
    conversation. 12px makes the end of the flow spaced like the flow. */
 .cxv-body { --cx-gutter: 14px; --cx-tail: 12px; flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; background: var(--panel); padding: 4px var(--cx-gutter) var(--cx-tail); }
+
+/* The scrollbar is invisible until something scrolls, then fades back out.
+   `.cxv-scrolling` is put on the node by the reader itself, on every scroll
+   event, so this answers to a wheel, a trackpad, a touch drag, Page Down, and
+   the reader's own jump to the newest exchange alike — they all scroll, and
+   scrolling is what the class listens to.
+
+   Only the THUMB'S COLOUR changes. No width is set here on purpose: the track
+   keeps whatever room the platform already gives it, so the reading column is
+   the same width whether the bar is showing or not and the text never steps
+   sideways as you scroll. On a platform with overlay scrollbars (macOS, iOS)
+   nothing is reserved before or after, and the thumb is transparent at rest —
+   which is what those platforms already do, so this does not fight them.
+
+   Appearing is immediate (`transition: none` on the way in); leaving is a fade
+   after a short hold, so a pause between two flicks does not blink at you.
+
+   The colour and the 8px width both come from the app-wide scrollbar in
+   styles.css, so the reader's bar is the same bar every other pane has — the
+   only difference is that this one is not there when you are not scrolling. */
+.cxv-body {
+  scrollbar-color: transparent transparent;
+  transition: scrollbar-color 420ms ease 260ms;
+}
+.cxv-body.cxv-scrolling {
+  scrollbar-color: var(--border-strong) transparent;
+  transition: none;
+}
+.cxv-body::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  transition: background-color 420ms ease 260ms;
+}
+.cxv-body.cxv-scrolling::-webkit-scrollbar-thumb {
+  background-color: var(--border-strong);
+  transition: none;
+}
+@media (prefers-reduced-motion: reduce) {
+  /* The global kill switch already removes animations; this drops the fade's
+     delay too, so the bar simply goes rather than lingering. */
+  .cxv-body, .cxv-body::-webkit-scrollbar-thumb { transition: none; }
+}
 .cxv-col { display: flex; flex-direction: column; min-width: 0; }
 .cxv-msg { font-size: 0.85em; color: var(--muted); padding: 6px 0; }
 /* The line above the oldest loaded exchange. Fixed height on purpose: it sits


### PR DESCRIPTION
> in the reader can we hide the scrollbar when we are not scrolling? … just fade it entirely until scrolling again

**[Scroll it yourself →](https://lvwerra-agent-artifacts.static.hf.space/scrollbar-fade.html)** — the demo panel on that page carries the same CSS, so you can see the behaviour in a real browser.

`.cxv-body` is transparent at rest, opaque the instant anything scrolls it, and fades back out ~700ms after you stop (420ms fade, 260ms hold). Appearing is immediate; only leaving is animated.

## Every way of scrolling brings it back

The class is added by the reader's existing `onScroll`, so there is no list of input types to keep up to date — wheel, trackpad, touch drag, Page Down and the reader's own jump to the newest exchange all raise the same event. Verified each one in a real reader with a 40-turn transcript:

| moment | bar | reading column | scroller | overscroll |
|---|---|---|---|---|
| at rest | hidden | 864 | 892 | contain |
| wheel | **shown** | 864 | 892 | contain |
| programmatic jump | **shown** | 864 | 892 | contain |
| Page Down | **shown** | 864 | 892 | contain |
| touch drag (phone) | **shown** | 356 | 372 | contain |
| ~1s idle | hidden | 864 / 356 | 892 / 372 | contain |

It is set straight on the DOM node rather than through React state — this fires on every scroll frame, and re-rendering the conversation to change one class name would tax the one interaction that has to stay smooth.

## No geometry changes, which is the way this goes wrong

The rules set **no width and no `scrollbar-width`** — only the thumb's colour (WebKit) and `scrollbar-color` (Firefox). The track keeps exactly the room the app-wide scrollbar in `styles.css:47-50` already gives it, so the column is the same width bar or no bar. The widths above are identical in every row, and the computed `scrollbar-width` is the same as on main (`thin`).

`overscroll-behavior: contain` is untouched and still reads `contain` in every state.

## One thing I changed my mind about

My first cut gave the thumb its own colour and a 3px inset border. Then I found `styles.css:47-50`: the app already styles every scrollbar, 8px, `var(--border-strong)`. The reader would have had a bar unlike every other pane's for no reason. It now borrows both, so this is the same bar the whole app uses — the only difference is that it is not there when you are not scrolling.

## What I could not check here

- **The classic reserved-gutter case.** Headless Chromium always draws overlay scrollbars, and `--disable-features=OverlayScrollbar(s)` had no effect on either the shell or the full binary, so `reservedGutter` measured 0 in every run — the one mode where a shift is impossible anyway. The argument that it cannot shift is structural rather than measured: no width and no `scrollbar-width` are declared, and the computed value matches main. If you want it seen, the demo page above shows a reserved 8px bar on a normal desktop Chrome.
- **Firefox.** Implemented with `scrollbar-color`, which is the right property, but there is no Firefox binary on this box, so whether Firefox animates the fade or snaps is unverified. Worst case there is a snap rather than a fade — the hiding still works.
- **Screenshots.** Headless Chromium does not paint overlay scrollbars into a screenshot at all: the idle and scrolling captures came out byte-identical. That is why the link above is an interactive demo rather than a pair of images.

Phone was checked as an emulated 390×780 touch context, not a real handset. Nothing is forced on iOS — the rules only make the thumb transparent at rest, which is what overlay platforms already do, so this does not fight the platform or leave a bar showing.

## Scope

Reader only, as asked. The sidebar and the Overview are also long scrollers with a permanently visible bar and would suit the same treatment, but that is the operator's call rather than mine.

Web suite: 17 suites. `npm run test:render`: all checks. `reader-info.test.mjs` and `screenshot-input.test.mjs` (31/31) green — `screenshot-input` timed out once on the attachment-retry chip, a flake I have hit on this box before and unrelated to this change; it passed on re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)