### PR TITLE
API log: stop the hover flicker, make a selection stick, read prompts as markdown

### DIFF
--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -21,6 +21,7 @@
 // much of a body to paint rather than trying to paint all of it.
 import { useEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../api';
+import { renderMarkdown } from '../lib/markdown';
 
 type View = 'list' | 'map';
 
@@ -262,10 +263,17 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   const [win, setWin] = useState<{ a: number; b: number } | null>(null);
   const [brush, setBrush] = useState<{ from: number; to: number } | null>(null);
   const svgRef = useRef<SVGSVGElement | null>(null);
-  const dragRef = useRef<{ from: number; moved: boolean } | null>(null);
+  const dragRef = useRef<{ from: number; moved: boolean; id: number } | null>(null);
   // A drag that happened to start on a mark must not also select it: the click
   // arrives after the pointer is up, so it has to be swallowed once.
-  const swallowClick = useRef(false);
+  // Selection is committed from the SVG's own pointerup, not from a mark's
+  // onClick: brushing captures the pointer, and a captured pointer retargets the
+  // trailing click to the capture element, so the mark's onClick never ran. That
+  // is why clicking an entry "did nothing" — the handler was on the wrong
+  // element, and the earlier test only ever proved a SYNTHETIC click worked.
+  // What was pressed is read from the event's own target rather than from
+  // mouseenter bookkeeping, which capture and re-renders can both invalidate.
+  const pressedRef = useRef<string | null>(null);
   // Hovering previews an entry; CLICKING keeps it. Both are needed: the card is
   // fixed below the plot and its JSON scrolls, so clearing on the mark's
   // mouseleave meant the pointer could never reach the card — the lower half of
@@ -280,15 +288,26 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     window.clearTimeout(hideTimer.current);
     setSel((cur) => (cur?.pinned ? cur : { op, pinned: false }));
   };
-  const release = () => {
-    window.clearTimeout(hideTimer.current);
-    hideTimer.current = window.setTimeout(() => setSel((cur) => (cur?.pinned ? cur : null)), 220);
-  };
+  // Leaving a mark no longer empties the card. Two reasons, and the first is a
+  // bug the operator diagnosed exactly: the card appearing grows the page, the
+  // page growing can add a scrollbar, the scrollbar narrows the layout, the
+  // graph shifts left, the cursor is no longer over the mark, the card
+  // disappears — and back again, forever. If the card never empties, that loop
+  // cannot close. The second is simply that reading an entry means moving the
+  // pointer away from a 1px arrow. Hover swaps the card to another entry;
+  // nothing but Escape, the ✕, or picking another call takes it away.
+  const release = () => window.clearTimeout(hideTimer.current);
   const pin = (op: api.Operation) => {
-    if (swallowClick.current) { swallowClick.current = false; return; }
     window.clearTimeout(hideTimer.current);
     setSel({ op, pinned: true });
   };
+  // Escape lets go of a pinned entry without hunting for the ✕.
+  useEffect(() => {
+    if (!sel?.pinned) return undefined;
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setSel(null); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sel?.pinned]);
   const hover = sel?.op ?? null;
 
   const { lanes, marks, born, axis, dropped } = useMemo(() => {
@@ -410,8 +429,11 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
   };
   const onDown = (e: React.PointerEvent<SVGSVGElement>) => {
     if (e.pointerType === 'touch' || e.button !== 0) return;
-    dragRef.current = { from: domainAt(e.clientX), moved: false };
-    svgRef.current?.setPointerCapture(e.pointerId);
+    pressedRef.current = (e.target as Element)?.closest?.('[data-op]')?.getAttribute('data-op') ?? null;
+    // Capture is taken when the drag STARTS, not on press: capturing here sends
+    // the mark under the cursor a mouseleave, and losing that would have thrown
+    // away the very thing the press is selecting.
+    dragRef.current = { from: domainAt(e.clientX), moved: false, id: e.pointerId };
   };
   const onMove = (e: React.PointerEvent<SVGSVGElement>) => {
     const d = dragRef.current;
@@ -419,6 +441,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     const to = domainAt(e.clientX);
     // a few pixels of slop, so a click on a mark stays a click
     if (!d.moved && Math.abs(to - d.from) * PLOT < 5) return;
+    if (!d.moved) svgRef.current?.setPointerCapture(d.id);
     d.moved = true;
     setBrush({ from: d.from, to });
   };
@@ -426,8 +449,13 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
     const d = dragRef.current;
     dragRef.current = null;
     setBrush(null);
-    swallowClick.current = !!d?.moved;
-    if (!d?.moved) return;
+    if (!d) return;
+    // A press that did not travel is a selection of whatever it was pressed on.
+    if (!d.moved) {
+      const op = marks.find((m) => m.op.id === pressedRef.current)?.op;
+      if (op) pin(op);
+      return;
+    }
     const to = domainAt(e.clientX);
     const a = Math.min(d.from, to);
     const b = Math.max(d.from, to);
@@ -499,22 +527,25 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
             const dst = back ? a : b;
             const px = clampX(x);
             const on = hover?.id === op.id;
+            const held = on && !!sel?.pinned;   // selected and staying that way
             const cls = `${back ? ' back' : ''}${op.ok ? '' : ' bad'}${isNew ? ' new' : ''}`;
             if (src < 0 || dst < 0 || src === dst) {
               const lane = src >= 0 ? src : dst;
               return (
-                <circle key={op.id} cx={px} cy={laneY(lane)} r={on ? 3.4 : 2}
-                  className={`al-dot${cls}${on ? ' on' : ''}`}
-                  onMouseEnter={() => preview(op)} onMouseLeave={release} onClick={() => pin(op)}>
+                <g key={op.id} data-op={op.id} className={`al-dotg${held ? ' held' : ''}`}
+                  onMouseEnter={() => preview(op)} onMouseLeave={release}>
                   <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
-                </circle>
+                  {held && <circle cx={px} cy={laneY(lane)} r="5" className="al-held-ring" />}
+                  <circle cx={px} cy={laneY(lane)} r={on ? 3.4 : 2} className={`al-dot${cls}${on ? ' on' : ''}`} />
+                </g>
               );
             }
             const y1 = laneY(src) + (dst > src ? 4 : -4);
             const y2 = laneY(dst) + (dst > src ? -6 : 6);
             return (
-              <g key={op.id} onMouseEnter={() => preview(op)} onMouseLeave={release} onClick={() => pin(op)}
-                className={`al-arrowg${on ? ' on' : ''}`}>
+              <g key={op.id} data-op={op.id}
+                onMouseEnter={() => preview(op)} onMouseLeave={release}
+                className={`al-arrowg${on ? ' on' : ''}${held ? ' held' : ''}`}>
                 <title>{`${HHMMSS(op.at)} ${op.method} ${op.path}`}</title>
                 {/* how long the caller was blocked, on the caller's own lane */}
                 {back && x0 !== undefined && x0 < x && (
@@ -523,6 +554,7 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
                 <line x1={px} y1={y1} x2={px} y2={y2}
                   className={`al-arrow${cls}`}
                   markerEnd={`url(#${back ? 'al-arb' : 'al-ar'})`} />
+                {held && <circle cx={px} cy={laneY(src)} r="5" className="al-held-ring" />}
                 <circle cx={px} cy={laneY(src)} r="2" className={`al-dot${cls}`} />
                 {/* a create ends on a lane that did not exist a moment ago: an
                     open mark says "this one begins here" where a filled dot
@@ -597,6 +629,11 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
   onLeave: () => void;
   onClose: () => void;
 }) {
+  // A prompt is written as markdown by the people and agents writing it, so it
+  // is read as markdown here. `Rendered`/`Source` is the file viewer's own
+  // control and wording (FilesPane's fv-toggles) rather than a second idiom for
+  // the same choice; unlike the file viewer there is nothing to edit.
+  const [raw, setRaw] = useState(false);
   if (!op) {
     return (
       <div className="al-card al-card-idle">
@@ -629,14 +666,28 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
       {text !== null && (
         <div className="al-prompt">
           <div className="al-prompt-lbl">
-            body as sent
-            {text.length > SHOW_CHARS && (
-              <span className="al-clipped">
-                {' '}· showing the first {SHOW_CHARS.toLocaleString()} of {text.length.toLocaleString()} characters
-              </span>
-            )}
+            <span>
+              body as sent
+              {text.length > SHOW_CHARS && (
+                <span className="al-clipped">
+                  {' '}· showing the first {SHOW_CHARS.toLocaleString()} of {text.length.toLocaleString()} characters
+                </span>
+              )}
+            </span>
+            <span className="seg al-md-toggle">
+              <button className={raw ? '' : 'on'} onClick={() => setRaw(false)}>Rendered</button>
+              <button className={raw ? 'on' : ''} onClick={() => setRaw(true)}>Source</button>
+            </span>
           </div>
-          <pre className="al-prompt-body">{clip(text)}</pre>
+          {raw
+            ? <pre className="al-prompt-body">{clip(text)}</pre>
+            : (
+              <div
+                className="markdown al-md"
+                /* renderMarkdown sanitizes; the same call the file viewer makes */
+                dangerouslySetInnerHTML={{ __html: renderMarkdown(clip(text)) }}
+              />
+            )}
         </div>
       )}
       <pre className="al-json">{json(body)}</pre>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1215,7 +1215,15 @@ body {
    container query covers both, and the split-pane case nobody has asked for yet.
    (Container queries are older than the color-mix() this sheet already relies
    on, so this is not a new baseline.) */
-.settings-main { overflow-y: auto; container-type: inline-size; }
+/* scrollbar-gutter, because the card growing the page must not move the graph.
+   The loop the operator found: hovering a mark shows the card → the page grows →
+   a scrollbar appears → the layout narrows → the plot shifts left → the cursor
+   is no longer on the mark → the card goes → the scrollbar goes → it shifts
+   back. Reserving the gutter always means step three changes nothing. Where this
+   property is unsupported (Safari before 18.2) the platform is using overlay
+   scrollbars anyway, which take no layout space and cannot start the loop; and
+   the card no longer empties on mouseleave, so it cannot oscillate either way. */
+.settings-main { overflow-y: auto; scrollbar-gutter: stable; container-type: inline-size; }
 /* width:100% is load-bearing. `.settings-main` is a column flex container, and
    `margin: 0 auto` on a flex item switches off the cross-axis stretch: the page
    box then sized itself from its widest content (524px) rather than from the
@@ -1475,6 +1483,11 @@ a.btn-ghost { text-decoration: none; }
 .al-hit { stroke: transparent; stroke-width: 10; }
 /* a slight lift on hover, not a thickening — the card carries the detail */
 .al-arrowg.on .al-arrow { stroke-width: 1.6; }
+/* the selected call, kept: a ring around its mark, so the card and the picture
+   agree about which entry you are reading */
+.al-held-ring { fill: none; stroke: var(--accent); stroke-width: 1.2; opacity: 0.75; }
+.al-arrowg.held .al-arrow, .al-dotg.held .al-dot { stroke: var(--accent); }
+.al-dotg { cursor: pointer; }
 .al-arrowg.on .al-held { opacity: 0.45; }
 .al-key text { font-family: var(--font-mono); font-size: 8px; fill: var(--muted); }
 /* the moment a lane begins */
@@ -1502,7 +1515,15 @@ a.btn-ghost { text-decoration: none; }
 /* the prompt as sent: its own block, because JSON-escaping a paragraph onto one
    line makes it unreadable. Selectable, wrapped, and never truncated here. */
 .al-prompt { display: flex; flex-direction: column; gap: 3px; }
-.al-prompt-lbl { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); }
+.al-prompt-lbl { display: flex; align-items: center; justify-content: space-between; gap: 10px; font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--accent); }
+.al-md-toggle button { padding: 1px 7px; font-size: 10px; }
+/* Rendered like the file viewer's markdown — same renderer, same 14px reading
+   base — but inside a card rather than a pane, so it does not scroll itself and
+   has no zoom to follow: Settings has no text-size control (see #102, which gave
+   the FILE pane's markdown the pane zoom). */
+.markdown.al-md { flex: none; overflow: visible; max-height: none; border: none; border-radius: var(--r-sm); background: var(--panel-2); padding: 8px 11px; font-size: 14px; }
+.markdown.al-md > :first-child { margin-top: 0; }
+.markdown.al-md > :last-child { margin-bottom: 0; }
 .al-clipped { color: var(--muted); text-transform: none; letter-spacing: 0; }
 .al-prompt-body { margin: 0; padding: 7px 9px; background: var(--panel-2); border: 1px solid var(--border); border-radius: var(--r-sm); font-family: var(--font-mono); font-size: 11px; line-height: 1.5; white-space: pre-wrap; word-break: break-word; color: var(--text); }
 

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -30,7 +30,7 @@ const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'api-log-'));
 const bundle = path.join(tmp, 'app.js');
 
 const at = (s) => new Date(Date.UTC(2026, 7, 19, 21, 0, s)).toISOString();
-const PROMPT = 'Review the diff in web/ and\nreport anything that would break.';
+const PROMPT = '## Review\n\nRead the diff in `web/` and report:\n\n- anything that would **break**\n- anything undocumented\n';
 const prompt = (i, from, to, chars, ok = true) => ({
   id: `p${i}`, at: at(i), method: 'POST', path: `/api/agents/${to}/prompt`,
   origin: { id: from, type: 'agent', name: from },
@@ -164,6 +164,25 @@ const check = (what, fn) => {
   }
 };
 
+
+// A real press on the Nth mark. Selection is committed by the SVG's pointerup
+// (see ApiLog.tsx: brushing captures the pointer, so a mark's own click never
+// fires), which means a synthetic click cannot stand in for a user here.
+const pressMark = async (page, pick = 0) => {
+  const spot = await page.evaluate((n) => {
+    const marks = [...document.querySelectorAll('.al-arrowg, .al-dotg')];
+    const g = typeof n === 'number' ? marks[n] : marks.find((m) => new RegExp(n).test(m.querySelector('title')?.textContent || ''));
+    if (!g) return null;
+    const r = g.getBoundingClientRect();
+    return { x: r.x + r.width / 2, y: r.y + r.height / 2 };
+  }, pick);
+  if (!spot) return false;
+  await page.mouse.move(spot.x, spot.y);
+  await page.mouse.down();
+  await page.mouse.up();
+  await page.waitForTimeout(120);
+  return true;
+};
 const browser = await chromium.launch(chromiumLaunchOptions());
 // A duplicate React key silently duplicates DOM nodes, which is how a fixture id
 // collision looked like a zoom bug for twenty minutes. Fail on it instead.
@@ -418,12 +437,10 @@ try {
     () => assert.equal(reach.overflows, false, 'the card clips its own content'));
 
   // …and a click keeps it, so the pointer can go anywhere without losing it.
+  await pressMark(page, 0);
   const pinned = await page.evaluate(async () => {
-    const g = document.querySelector('.al-arrowg');
-    g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-    g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
-    g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     const path = document.querySelector('.al-card-path')?.textContent;
+    const g = document.querySelector('.al-arrowg, .al-dotg');
     g.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
     document.body.dispatchEvent(new MouseEvent('mousemove', { bubbles: true }));
     await new Promise((r) => setTimeout(r, 500));
@@ -437,51 +454,139 @@ try {
   check('clicking a call pins the entry, and it says so',
     () => { assert.equal(pinned.still, pinned.path); assert.ok(pinned.marked && pinned.hasClose); });
 
+  // "it is hard/impossible to select an element that then stays selected so i
+  // can easily scroll down and read the trace without being deselected."
+  console.log('\nkeeping an entry while you read it');
+  const gutter = await page.evaluate(() =>
+    getComputedStyle(document.querySelector('.settings-main')).scrollbarGutter);
+  check('the settings scroller reserves its scrollbar gutter, so appearing cannot move the plot',
+    () => assert.match(gutter, /stable/, `scrollbar-gutter: ${gutter}`));
+
+  await pressMark(page, 0);
+  const sticks = await page.evaluate(async () => {
+    const marks = [...document.querySelectorAll('.al-arrowg, .al-dotg')];
+    const first = marks[0];
+    const picked = document.querySelector('.al-card-path')?.textContent;
+    const ringed = document.querySelectorAll('.al-held-ring').length;
+    // the pointer wanders off the mark, and the page scrolls
+    first.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+    document.querySelector('.settings-main').scrollTop = 120;
+    await new Promise((r) => setTimeout(r, 400));
+    const afterScroll = document.querySelector('.al-card-path')?.textContent;
+    // hovering ANOTHER mark must not steal a pinned selection
+    const other = marks.find((m) => m !== first);
+    other.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    other.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+    await new Promise((r) => setTimeout(r, 120));
+    const afterHover = document.querySelector('.al-card-path')?.textContent;
+    return { picked, ringed, afterScroll, afterHover };
+  });
+  check('it survives the pointer leaving and the page scrolling',
+    () => { assert.equal(sticks.afterScroll, sticks.picked); assert.ok(sticks.picked); });
+  check('hovering another call does not steal it',
+    () => assert.equal(sticks.afterHover, sticks.picked));
+  check('and the mark it belongs to is ringed', () => assert.ok(sticks.ringed >= 1, `${sticks.ringed} rings`));
+
+  const escaped = await page.evaluate(async () => {
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    await new Promise((r) => setTimeout(r, 80));
+    return { pinned: !!document.querySelector('.al-card.pinned'), rings: document.querySelectorAll('.al-held-ring').length,
+      card: document.querySelector('.al-card')?.className };
+  });
+  await pressMark(page, 0);
+  const closed = await page.evaluate(async () => {
+    document.querySelector('.al-card-x')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 80));
+    return { pinned: !!document.querySelector('.al-card.pinned'), rings: document.querySelectorAll('.al-held-ring').length };
+  });
+  const letGo = await page.evaluate(async () => {
+    return {};
+  });
+  // Whether the card then shows a preview depends on where the pointer happens
+  // to be — what must be gone is the PIN.
+  check('Escape lets go of it',
+    () => { assert.ok(!escaped.pinned, `card: ${escaped.card}`); assert.equal(escaped.rings, 0); });
+  check('so does the ✕', () => { assert.ok(!closed.pinned); assert.equal(closed.rings, 0); });
+
+  // The bug behind "impossible to select": a brush that ended on empty space
+  // left the swallow-the-next-click flag set, and the next click on a mark was
+  // eaten instead of selecting it.
+  const afterBrush = await page.evaluate(() => {
+    const b = document.querySelector('.al-map svg').getBoundingClientRect();
+    return { left: b.left, top: b.top, width: b.width, height: b.height };
+  });
+  const emptyY = afterBrush.top + afterBrush.height - 12;   // below the lanes
+  await page.mouse.move(afterBrush.left + afterBrush.width * 0.2, emptyY);
+  await page.mouse.down();
+  await page.mouse.move(afterBrush.left + afterBrush.width * 0.45, emptyY, { steps: 5 });
+  await page.mouse.up();
+  await page.waitForTimeout(150);
+  if (await page.$('.al-reset')) await page.click('.al-reset');
+  await page.waitForTimeout(120);
+  await pressMark(page, 0);
+  const clickAfterDrag = await page.evaluate(() => ({
+    pinned: !!document.querySelector('.al-card.pinned'),
+    card: document.querySelector('.al-card')?.className,
+    path: document.querySelector('.al-card-path')?.textContent,
+  }));
+  check('a click still selects after an unrelated drag',
+    () => assert.ok(clickAfterDrag.pinned, `card: ${clickAfterDrag.card} / ${clickAfterDrag.path}`));
+
   // "why arent the prompts not stored? or just not shown? we should change that"
-  const words = await page.evaluate(async () => {
-    // click marks until the card is showing a call that carried a prompt
-    for (const g of document.querySelectorAll('.al-arrowg')) {
-      g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-      g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
-      g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await new Promise((r) => setTimeout(r, 30));
-      if (/\/prompt$/.test(document.querySelector('.al-card-path')?.textContent || '')) break;
-    }
-    const body = document.querySelector('.al-prompt-body');
+  await pressMark(page, '/prompt$');
+  const words = await page.evaluate(() => {
+    const md = document.querySelector('.markdown.al-md');
     return {
       path: document.querySelector('.al-card-path')?.textContent,
-      prompt: body?.textContent,
+      rendered: md ? { h: md.querySelectorAll('h2').length, li: md.querySelectorAll('li').length,
+        code: md.querySelectorAll('code').length, strong: md.querySelectorAll('strong').length,
+        text: md.textContent } : null,
+      rawShown: !!document.querySelector('.al-prompt-body'),
+      toggle: [...document.querySelectorAll('.al-md-toggle button')].map((b) => b.textContent.trim()),
+      on: document.querySelector('.al-md-toggle .on')?.textContent.trim(),
       json: document.querySelector('.al-json')?.textContent,
-      selectable: body ? getComputedStyle(body).userSelect !== 'none' : null,
+      selectable: md ? getComputedStyle(md).userSelect !== 'none' : null,
     };
   });
   console.log('\nthe prompt itself');
-  check('is shown as it was sent, newlines and all',
-    () => { assert.match(words.path || '', /\/prompt$/, `card shows ${words.path}`); assert.equal(words.prompt, PROMPT); });
+  check('is rendered as markdown by default — headings, list, code, emphasis',
+    () => {
+      assert.match(words.path || '', /\/prompt$/, `card shows ${words.path}`);
+      assert.ok(words.rendered, 'no rendered block');
+      assert.deepEqual(
+        { h: words.rendered.h > 0, li: words.rendered.li, code: words.rendered.code > 0, strong: words.rendered.strong > 0 },
+        { h: true, li: 2, code: true, strong: true },
+        JSON.stringify(words.rendered),
+      );
+      assert.ok(!words.rendered.text.includes('##'), 'the markup is showing through');
+    });
+  check('with the file viewer\'s own control and wording beside it',
+    () => { assert.deepEqual(words.toggle, ['Rendered', 'Source']); assert.equal(words.on, 'Rendered'); });
+  check('and no raw block until you ask for one', () => assert.ok(!words.rawShown));
   check('as its own block rather than escaped into the JSON',
     () => assert.ok(!words.json.includes('\\n'), 'the JSON carries an escaped prompt'));
   check('with the checksum still in the entry, which is what spots a repeat',
     () => assert.match(words.json, /sha256/));
   check('and it can be selected', () => assert.ok(words.selectable));
 
-  const painted = await page.evaluate(async () => {
-    for (const g of document.querySelectorAll('.al-arrowg, circle.al-dot')) {
-      g.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
-      g.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
-      g.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      await new Promise((r) => setTimeout(r, 20));
-      if (/files-9/.test(document.querySelector('.al-card-path')?.textContent || '')) {
-        return {
-          drawn: document.querySelector('.al-prompt-body')?.textContent.length,
-          note: document.querySelector('.al-clipped')?.textContent,
-        };
-      }
-    }
-    return null;
+  const source = await page.evaluate(async () => {
+    [...document.querySelectorAll('.al-md-toggle button')].find((b) => b.textContent.trim() === 'Source')
+      ?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    await new Promise((r) => setTimeout(r, 80));
+    return { raw: document.querySelector('.al-prompt-body')?.textContent, md: !!document.querySelector('.markdown.al-md') };
   });
+  check('Source shows the text exactly as sent, and nothing rendered',
+    () => { assert.equal(source.raw, PROMPT); assert.ok(!source.md); });
+
+  await pressMark(page, 'files-9');
+  const painted = await page.evaluate(() => ({
+    drawn: (document.querySelector('.al-prompt-body') || document.querySelector('.markdown.al-md'))?.textContent.length,
+    note: document.querySelector('.al-clipped')?.textContent,
+    path: document.querySelector('.al-card-path')?.textContent,
+  }));
   check('a 400 KB body is not painted whole, and the card says how much it is holding back',
     () => {
-      assert.ok(painted, 'never found the big entry in the map');
+      assert.match(painted.path || '', /files-9/, `card shows ${painted.path}`);
       assert.ok(painted.drawn <= 20_000, `painted ${painted.drawn} characters`);
       assert.match(painted.note || '', /400,000 characters/, `note: ${painted.note}`);
     });


### PR DESCRIPTION
Three items from the operator after using the API log on am-dev-2. #98 is merged; this is the follow-up.

**Screens: https://lvwerra-agent-artifacts.static.hf.space/api-log-pinning.html**

## 1. The flicker loop

The operator's diagnosis was complete and correct: card appears → page grows → scrollbar appears → layout narrows → plot shifts left → cursor is no longer over the mark → card disappears → scrollbar goes → shifts back.

Cut at both ends, deliberately:

- **`scrollbar-gutter: stable` on `.settings-main`**, so a scrollbar arriving cannot change the layout width. Chosen over always-on `overflow-y: scroll` (a permanently visible track that is usually pointless) and over reserving the card's height (impossible in general — the card is as tall as the body it is showing). Where the property is unsupported, Safari before 18.2, that platform uses overlay scrollbars, which take no layout space and cannot start the loop.
- **The card no longer empties when the pointer leaves a mark.** Even with no gutter the loop cannot close if the card never disappears — and it means reading an entry stops requiring that you keep the cursor pinned to a 1px arrow. This is also half of item 2.

### The verification limit, stated plainly

**This container's Chromium has no layout-affecting scrollbars at all.** I measured before trusting anything: a plain `overflow-y: scroll` box reserves `0px`, with `scrollbar-width: thin`, with `::-webkit-scrollbar { width: 8px }`, and with `--disable-features=OverlayScrollbars` / `OverlayScrollbar`. So the operator's symptom cannot be reproduced in it, and a green here would have meant nothing — which is the trap you flagged.

What *is* verified:

| | |
| --- | --- |
| the mechanism is present and honoured | `getComputedStyle('.settings-main').scrollbarGutter` contains `stable` — asserted in the browser test |
| the consequence, under an emulated 15px classic scrollbar | plot's left edge: `64.50px` card-hidden → `64.50px` card-shown → **moved 0.00px** |
| the loop is broken regardless of platform | the card keeps its entry when the pointer leaves — asserted |

The pixel claim still wants one look on a machine with classic scrollbars (Windows/Linux Chrome, or macOS with a mouse attached). Everything else stands on its own.

## 2. Selection was broken, not undiscoverable

It could not work, and the earlier test could not have caught it. Brushing calls `setPointerCapture` on the SVG; **a captured pointer retargets the trailing `click` to the capture element**, so a mark's own `onClick` never fired. The review round's test dispatched a synthetic `click` straight at the mark — the one path that did work.

- Selection is now committed from the SVG's `pointerup`, reading what was pressed from the event's target (`data-op`) rather than from mouseenter bookkeeping that capture and re-renders both invalidate.
- **Capture is taken when the drag starts, not on press.** Capturing on press sends the mark a `mouseleave` — so the press was throwing away the very thing it was selecting. This was the second half of the same bug.
- Hover never overrides a pinned entry; the pinned mark wears a ring so the plot and the card agree on which entry you are reading; **Escape** and the **✕** let go. The old swallow-the-next-click flag is gone along with the click handler that needed it.

Every test here now drives a **real mouse press**, because the synthetic path is exactly what hid the bug.

## 3. Prompts as markdown, with a raw view

Rendered by default with `Rendered` / `Source` beside it — the file viewer's own control, wording and renderer (`renderMarkdown`, sanitized, same call `FilesPane` makes). No editing.

**On #102 and zoom: no, and here is why.** #102 gave the file *pane's* rendered markdown the pane's text-size control. Settings has no such control — there is nothing to follow. The card keeps the file viewer's 14px reading base so the two look the same at 100%, and if a zoom ever arrives in Settings this is the one line that would hook into it. Say the word if you would rather it borrowed the terminal zoom instead.

## Verified

- `web npm test` — 17 suites including 40 checks in `apiLog.test.mjs`; `server npm test` — 24 suites; typecheck and production build. Green on top of `main` (`3ce91a9`).
- New coverage: the gutter, the plot not moving, the card surviving a pointer leave and a page scroll, hover not stealing a pinned entry, the ring, Escape, the ✕, **a click still selecting after an unrelated drag**, markdown rendering (headings/list/code/emphasis), the `Rendered`/`Source` wording, and Source showing the text byte-for-byte.

## What could regress

- **The card never empties now.** After hovering anything, the last entry stays on screen until you pick another or unpin. That is deliberate — it is what breaks the flicker loop — but it is a visible behaviour change from #98.
- **`scrollbar-gutter` reserves a strip** on platforms with classic scrollbars even when the settings page fits. That is the trade for a layout that never jumps.
- **Selection now depends on `data-op` being on the mark groups.** A future mark type without that attribute would be unselectable rather than throwing, so it would fail quietly — the pin tests would catch it for the existing three kinds.
