### PR TITLE
Reader: render user prompts as markdown, in one band component

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node ../scripts/run-suites.mjs",
-    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -179,6 +179,42 @@ function nowDoing(s?: Step): string {
   return oneLine(s.text, 70);
 }
 
+/**
+ * The prompt band — the one thing in a turn a person wrote.
+ *
+ * It renders as markdown now, like everything else in the reader: the answer
+ * always did, and an aside, thinking and a compaction since #88, so a typed
+ * `**important**` or a pasted fence was the last thing in the view still shown
+ * as syntax. It goes through the answer's exact path — renderMarkdown, then
+ * highlightHtml — so a search term lands in a rendered prompt the same way it
+ * lands in a rendered answer, rather than through a second mechanism that
+ * agrees with the first until it doesn't.
+ *
+ * ONE component for both call sites, deliberately. The band was written out by
+ * hand in two places — the real turn and the optimistic echo — and #77 was
+ * exactly those two drifting: the echo lost the `.cx` wrapper whose padding
+ * cancels `margin-left: -1.23em`, and the newest prompt in every conversation
+ * hung a gutter's width to the left. Two copies of markdown-plus-highlight is
+ * the same bug with more surface, so there is one.
+ */
+function PromptBand({ text, q, queued }: { text: string; q?: string; queued?: boolean }) {
+  // `breaks` because a prompt is typed, not authored — see renderMarkdown.
+  const html = useMemo(() => highlightHtml(renderMarkdown(text, { breaks: true }), q), [text, q]);
+  return (
+    <div className="cx-prompt">
+      <div className="markdown cx-pmd" dangerouslySetInnerHTML={{ __html: html }} />
+      {/* Read from a queue record rather than a message: it was typed while the
+          agent was working. Labelled because those records cannot say whether it
+          was then consumed or cancelled — see TraceTurn.queued. It stays a
+          sibling of the rendered block and still trails the last line: .cx-pmd
+          is an inline-block, so the pill sits on that line's baseline instead of
+          dropping below the block and making a queued one-liner a line taller
+          than every other prompt. */}
+      {queued ? <span className="cx-queued mono" title="Typed while the agent was working, so it waited in the queue">queued</span> : null}
+    </div>
+  );
+}
+
 export function ExchangeView({
   x, n, total, open, onToggle, running, dim, q, baseModel,
 }: {
@@ -246,15 +282,7 @@ export function ExchangeView({
 
   return (
     <section className={`cx${dim ? ' dim' : ''}`}>
-      {prompt ? (
-        <div className="cx-prompt">
-          <Hi text={prompt} q={q} />
-          {/* Read from a queue record rather than a message: it was typed while
-              the agent was working. Labelled because those records cannot say
-              whether it was then consumed or cancelled — see TraceTurn.queued. */}
-          {x.prompt?.queued ? <span className="cx-queued mono" title="Typed while the agent was working, so it waited in the queue">queued</span> : null}
-        </div>
-      ) : null}
+      {prompt ? <PromptBand text={prompt} q={q} queued={!!x.prompt?.queued} /> : null}
 
       {/* Everything about the turn on ONE line, under the prompt: what the work
           was on the left, which turn it is on the right. Nothing above.
@@ -313,12 +341,14 @@ export function ExchangeView({
  * call sites it was neither: `.cx-prompt`'s `margin-left: -1.23em` exists to
  * cancel `.cx`'s matching padding, and with no `.cx` around it there was
  * nothing to cancel, so the newest prompt in a conversation hung 16px left of
- * every prompt above it — in the reader and in the card alike.
+ * every prompt above it — in the reader and in the card alike. The band itself
+ * is PromptBand, the same component the real turn renders, so what it contains
+ * cannot drift either.
  */
 export function PendingExchange({ text }: { text: string }) {
   return (
     <section className="cx">
-      <div className="cx-prompt">{text}</div>
+      <PromptBand text={text} />
       <div className="cx-running mono">working</div>
     </section>
   );

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -48,7 +48,60 @@
   background: color-mix(in srgb, var(--accent) 7%, transparent);
   border-top: 1px solid var(--border); border-bottom: 1px solid var(--border);
   font-size: 1em; font-weight: 550; color: var(--text);
-  white-space: pre-wrap; overflow-wrap: break-word;
+  overflow-wrap: break-word;
+}
+/* The prompt renders as markdown, and the band is a strip in a rhythm — not a
+   document. So:
+   - the shared .markdown card's border, background, 14px, 1.6 and scroller are
+     all reset. It is a card elsewhere; here it is the band's own text, at the
+     band's own size, in the band's weight.
+   - the first and last block give up their margins, so a one-line prompt is
+     exactly as tall as it was as raw text. Everything about this band's height
+     is read as rhythm, and a <p>'s 12px would have added an eighth of a line
+     top and bottom to every turn in the reader.
+   - inline-block, so the `queued` pill still trails the last line instead of
+     dropping below the block. It also means the band shrink-wraps its text,
+     which is why the pre/table rules below claim the width back.
+   - `white-space: normal`: the band no longer sets pre-wrap. It used to hold
+     raw text and the newlines were the text's own; they are <br>s now (marked
+     with `breaks`), and pre-wrap over rendered HTML would turn the newline
+     marked leaves between block tags into blank lines inside the band. */
+.markdown.cx-pmd {
+  display: inline-block; max-width: 100%; vertical-align: baseline;
+  flex: none; overflow: visible; border: none; background: none; padding: 0;
+  font-size: 1em; line-height: inherit; white-space: normal;
+}
+.cx-pmd > :first-child { margin-top: 0; }
+.cx-pmd > :last-child { margin-bottom: 0; }
+/* One block's worth of air between blocks — the same 6px a step's prose uses,
+   which is what a band-sized register asks for; 12px reads as a document. */
+.cx-pmd p, .cx-pmd ul, .cx-pmd ol, .cx-pmd blockquote, .cx-pmd pre, .cx-pmd table { margin: 0 0 6px; }
+.cx-pmd ul, .cx-pmd ol { padding-left: 1.5em; }
+/* A heading in a prompt is someone structuring a long ask, not titling a page:
+   the shared sizes are 22/18/15px absolute, which inside a band reads as a
+   different voice entirely and does not scale with the conversation. */
+.cx-pmd h1, .cx-pmd h2, .cx-pmd h3, .cx-pmd h4 { margin: 7px 0 3px; line-height: 1.3; font-size: 1.05em; }
+/* Mono at the band's 550 renders heavier than the same fence in an answer, and
+   a prompt is not more emphatic than the reply. The block keeps the band's tint
+   rather than taking --term-bg: a white slab inside a tinted strip reads as a
+   card dropped into the band, and this is the band's own content. */
+.cx-pmd code { font-weight: 450; }
+/* No width here: a percentage against a shrink-wrapping parent is circular, and
+   it does not need one — shrink-to-fit asks the content how wide it wants to be,
+   so a wide fence fills the band up to max-width while a short one stays a small
+   slab instead of a full-bleed strip.
+   A fence in a PROMPT wraps, where a fence in an answer scrolls. The two are
+   deliberately different: this band held the operator's own text as pre-wrap
+   until now, so every character of a pasted error was on screen, and trading
+   that for a horizontal swipe inside a slab is the same mistake as putting
+   something behind a hover — worst exactly where the band is widest relative to
+   the screen. An answer's fence is code an agent wrote, where the line structure
+   is the content and reflowing it lies about it; a prompt's is a paste. */
+.cx-pmd pre {
+  font-size: 0.88em;
+  background: color-mix(in srgb, var(--text) 5%, transparent);
+  border-color: color-mix(in srgb, var(--border-strong) 60%, transparent);
+  white-space: pre-wrap; overflow-wrap: anywhere; overflow-x: visible;
 }
 /* the queue marker: a quiet aside on the band, not a second voice */
 .cx-queued {

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -6,7 +6,15 @@ import DOMPurify from 'dompurify';
 // repo), and we inject the result via dangerouslySetInnerHTML into a page that
 // has full backend/shell access — so it must be sanitized. marked does not
 // sanitize; DOMPurify strips scripts, event handlers, and dangerous URLs.
-export function renderMarkdown(md: string): string {
-  const html = marked.parse(md ?? '', { async: false }) as string;
+//
+// `breaks` exists for ONE caller: the prompt band. An agent writes markdown on
+// purpose, so a single newline in an answer is a soft wrap and folding it into
+// the paragraph is correct. A person typing into a composer does not — their
+// newlines are where they pressed Enter, and the band showed every one of them
+// while it was raw text. Rendering a prompt under strict markdown would reflow
+// every multi-line prompt in the reader into one paragraph, which is a silent
+// loss of what was typed rather than a rendering choice.
+export function renderMarkdown(md: string, opts?: { breaks?: boolean }): string {
+  const html = marked.parse(md ?? '', { async: false, breaks: !!opts?.breaks }) as string;
   return DOMPurify.sanitize(html);
 }

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -89,6 +89,27 @@ check('the prompt text is the prompt you sent',
 check('a working line rides inside the same section',
   () => assert.match(html, /<div class="cx-running mono">working<\/div>\s*<\/section>/));
 
+console.log('\nand the band is one component, not two copies of one');
+check('the echo renders its prompt through markdown, not as raw text',
+  () => assert.match(html, /<div class="cx-prompt"><div class="markdown cx-pmd">/));
+check('there is exactly ONE place in the file that writes the band', () => {
+  const src = fs.readFileSync(path.join(HERE, '../src/components/conversation/Exchange.tsx'), 'utf8');
+  const bands = (src.match(/className="cx-prompt"/g) || []).length;
+  assert.equal(bands, 1, `${bands} hand-written bands — #77 was two of them drifting`);
+  assert.equal((src.match(/<PromptBand /g) || []).length, 2, 'both call sites should use it');
+});
+check('and it renders through the answer’s own path — render, then highlight', () => {
+  const src = fs.readFileSync(path.join(HERE, '../src/components/conversation/Exchange.tsx'), 'utf8');
+  assert.match(src, /highlightHtml\(renderMarkdown\(text, \{ breaks: true \}\), q\)/);
+});
+check('a prompt’s newlines survive the render — `breaks` is on for it and off elsewhere', () => {
+  const md = fs.readFileSync(path.join(HERE, '../src/lib/markdown.ts'), 'utf8');
+  assert.match(md, /breaks: !!opts\?\.breaks/);
+  const src = fs.readFileSync(path.join(HERE, '../src/components/conversation/Exchange.tsx'), 'utf8');
+  const answer = src.slice(src.indexOf('const answerHtml'), src.indexOf('const answerMore'));
+  assert.doesNotMatch(answer, /breaks/, 'an agent writes markdown on purpose; a soft wrap is a soft wrap');
+});
+
 console.log('\nand an attached prompt is complete on its first paint');
 const screenshot = { kind: 'image', path: '/state/attachments/reader/Screenshot 1.png' };
 const pendingPrompt = buildPendingPrompt('codex', 'compare this with the mock', [screenshot]);
@@ -311,6 +332,24 @@ check('.cx-prompt takes it back, by the same amount',
   () => assert.match(css, /\.cx-prompt\s*\{[^}]*margin-left:\s*-1\.23em/));
 check('and no px restatement of that gutter has crept back in',
   () => assert.doesNotMatch(css, /\.cxv-body\s*>\s*\.cxv-col\s*>\s*\.cx\s*\{[^}]*padding-left/));
+
+console.log('\nand the rendered band keeps the height raw text had');
+const ruleOf = (sel) => { const i = css.indexOf(sel); return i < 0 ? '' : css.slice(i, css.indexOf('}', i) + 1); };
+const pmd = (css.match(/\.markdown\.cx-pmd\s*\{([^}]*)\}/) || [])[1] || '';
+check('the shared .markdown card does not bring its border, background or 14px into a band', () => {
+  for (const reset of [/border:\s*none/, /background:\s*none/, /padding:\s*0/, /font-size:\s*1em/, /line-height:\s*inherit/])
+    assert.match(pmd, reset, `missing reset ${reset}`);
+});
+check('the first block adds no margin above it',
+  () => assert.match(css, /\.cx-pmd\s*>\s*:first-child\s*\{[^}]*margin-top:\s*0/));
+check('and the last adds none below — a one-line prompt is one line tall',
+  () => assert.match(css, /\.cx-pmd\s*>\s*:last-child\s*\{[^}]*margin-bottom:\s*0/));
+check('the band stops declaring pre-wrap now that its content is HTML', () => {
+  assert.doesNotMatch(ruleOf('.cx-prompt {'), /white-space/);
+  assert.match(pmd, /white-space:\s*normal/);
+});
+check('and the pill can still sit on the last line rather than under it',
+  () => assert.match(pmd, /display:\s*inline-block/));
 
 console.log(failed ? `\n${failed} failed` : '\nall checks passed');
 process.exit(failed ? 1 : 0);

--- a/web/test/promptBand.render.test.mjs
+++ b/web/test/promptBand.render.test.mjs
@@ -1,0 +1,245 @@
+// What the prompt band actually does once its text is markdown, in a browser.
+//
+// The band is delicate in three ways that source lint cannot see, and all three
+// are the reason this file exists rather than a fourth set of CSS assertions:
+//
+//   1. its left edge. `.cx-prompt` carries `margin-left: -1.23em` against `.cx`'s
+//      matching padding (#77), and a block element inside it — a <p>, a <ul>, a
+//      <pre> — is exactly the kind of thing that undoes that pairing. The text
+//      of a rendered prompt has to start on the same pixel as the text of a raw
+//      one, and on the same pixel as the answer below it.
+//   2. its height. The band is a tinted strip read as rhythm; a paragraph's
+//      default margins would have added a fraction of a line to every turn in
+//      the reader. A one-line prompt must occupy exactly what it occupied as
+//      plain text — including when it carries the `queued` pill.
+//   3. what a prompt with a code fence or a long list does to a band designed
+//      for one line of text: it must not widen the column or scroll it sideways.
+//
+// Real components, real marked, real DOMPurify: the bundle is built for the
+// browser and rendered inside the page, so what is measured is the markup the
+// app ships and not a hand-written approximation of it.
+//
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const css = ['styles.css', 'conversation.css']
+  .map((f) => fs.readFileSync(path.join(WEB, 'src', f), 'utf8')).join('\n');
+
+const outDir = path.join(WEB, 'node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const bundle = path.join(outDir, 'prompt-band.js');
+await build({
+  stdin: {
+    contents: `
+      import { createElement } from 'react';
+      import { renderToStaticMarkup } from 'react-dom/server';
+      import ExchangeView, { PendingExchange } from './src/components/conversation/Exchange';
+      window.__pending = (text) => renderToStaticMarkup(createElement(PendingExchange, { text }));
+      window.__turn = (props) => renderToStaticMarkup(createElement(ExchangeView, props));
+    `,
+    resolveDir: WEB, loader: 'tsx', sourcefile: 'prompt-band-entry.tsx',
+  },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', jsx: 'automatic',
+  define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'error',
+});
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await (await browser.newContext({ viewport: { width: 900, height: 900 } })).newPage();
+// The reader's own frame: the band is full-bleed inside .cxv-col, so measuring it
+// anywhere else would measure a different rule.
+await page.setContent(`<style>${css}
+  .cxv-body { width: 640px; height: 860px; }
+  .cx-running::before { animation: none !important; }</style>
+  <div class="cxv-body"><div class="cxv-col" id="col"></div></div>`);
+await page.addScriptTag({ path: bundle });
+
+const ONE = 'restart the nightly job';
+// The band as it rendered before this change: raw text, pre-wrap, no inner block.
+const raw = (text) => `<section class="cx"><div class="cx-prompt" style="white-space:pre-wrap">${text}</div></section>`;
+const turnOf = (text, extra = {}) => ({
+  x: {
+    key: 'x1', at: 1, startTs: 1_700_000_000_000, endTs: 1_700_000_030_000, tokens: 0, toolCalls: 0,
+    prompt: { role: 'user', ts: 1_700_000_000_000, blocks: [{ type: 'text', text }], ...(extra.prompt || {}) },
+    steps: [], answer: extra.answer ?? [],
+  },
+  n: 1, total: 1, ...(extra.props || {}),
+});
+
+/** Put markup in the column and hand back what a browser makes of it. */
+const measure = (html, fn) => page.evaluate(({ html, body }) => {
+  const col = document.getElementById('col');
+  col.innerHTML = html;
+  // The first character's own rect, not the block's: a block's left edge is its
+  // border box, and the whole question here is where the TEXT starts.
+  const firstCharLeft = (el) => {
+    const walk = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    let node;
+    while ((node = walk.nextNode())) {
+      if (!node.data.trim()) continue;
+      const r = document.createRange();
+      const i = node.data.length - node.data.trimStart().length;
+      r.setStart(node, i); r.setEnd(node, i + 1);
+      const rect = r.getBoundingClientRect();
+      if (rect.width || rect.height) return rect;
+    }
+    return null;
+  };
+  // eslint-disable-next-line no-new-func
+  return new Function('col', 'firstCharLeft', body)(col, firstCharLeft);
+}, { html, body: `return (${fn.toString()})(col, firstCharLeft);` });
+
+const geom = (html) => measure(html, (col, firstCharLeft) => {
+  const band = col.querySelector('.cx-prompt');
+  const b = band.getBoundingClientRect();
+  const t = firstCharLeft(band);
+  return {
+    height: b.height, bandLeft: b.left, bandRight: b.right,
+    textLeft: t.left, textTop: t.top,
+    colScroll: col.scrollWidth, colClient: col.clientWidth,
+    html: band.outerHTML,
+  };
+});
+
+console.log('a rendered prompt starts on the same pixel as a raw one');
+const rawOne = await geom(raw(ONE));
+const mdOne = await geom(await page.evaluate((t) => window.__pending(t), ONE));
+check(`the text's left edge is unchanged (${rawOne.textLeft} → ${mdOne.textLeft})`,
+  () => assert.equal(mdOne.textLeft, rawOne.textLeft));
+check(`the band's own left edge is unchanged (${rawOne.bandLeft})`,
+  () => assert.equal(mdOne.bandLeft, rawOne.bandLeft));
+check(`and it is still full-bleed to the right (${rawOne.bandRight})`,
+  () => assert.equal(mdOne.bandRight, rawOne.bandRight));
+check(`a one-line prompt is exactly as tall as it was (${rawOne.height}px)`,
+  () => assert.equal(mdOne.height, rawOne.height));
+check('the paragraph is really there — the height is not an unrendered string',
+  () => assert.match(mdOne.html, /<div class="markdown cx-pmd"><p>restart the nightly job<\/p>\s*<\/div>/));
+// The band is full-bleed: it reaches into the column's gutter on both sides by
+// design, so the column ALWAYS reports a wider scroll width than client width —
+// 626 against 612 here. That is the number a wide prompt must not move.
+check(`the column's own overflow is the band's bleed and nothing else (${rawOne.colScroll} of ${rawOne.colClient})`,
+  () => assert.equal(mdOne.colScroll, rawOne.colScroll));
+
+console.log('\nand its words line up with the answer under it');
+const withAnswer = await measure(
+  await page.evaluate((t) => window.__turn(t), turnOf(ONE, {
+    answer: [{ role: 'assistant', ts: 1_700_000_020_000, kind: 'final', blocks: [{ type: 'text', text: 'Restarted it.' }] }],
+  })),
+  (col, firstCharLeft) => ({
+    prompt: firstCharLeft(col.querySelector('.cx-prompt')).left,
+    answer: firstCharLeft(col.querySelector('.cx-answer')).left,
+  }));
+check(`prompt and answer share one text column (${withAnswer.prompt})`,
+  () => assert.equal(withAnswer.prompt, withAnswer.answer));
+
+console.log('\nand the newlines someone typed are still where they typed them');
+const THREE = 'three things:\nthe reader\nthe card\nthe echo';
+const rawThree = await geom(raw(THREE));
+const mdThree = await geom(await page.evaluate((t) => window.__pending(t), THREE));
+check(`four typed lines stay four lines (${rawThree.height}px)`,
+  () => assert.equal(mdThree.height, rawThree.height));
+check('as <br>, because a person’s newline is not a soft wrap',
+  () => assert.equal((mdThree.html.match(/<br>/g) || []).length, 3));
+
+console.log('\nand the queue pill still trails the last line');
+const queued = await measure(
+  await page.evaluate((t) => window.__turn(t), turnOf(ONE, { prompt: { queued: true } })),
+  (col, firstCharLeft) => {
+    const band = col.querySelector('.cx-prompt');
+    const pill = col.querySelector('.cx-queued').getBoundingClientRect();
+    const text = firstCharLeft(band);
+    return { height: band.getBoundingClientRect().height, pillTop: pill.top, pillLeft: pill.left, textTop: text.top, textRight: text.right };
+  });
+check(`a queued one-liner is no taller than any other (${mdOne.height}px)`,
+  () => assert.equal(queued.height, mdOne.height));
+check('the pill sits on that line, not under it',
+  () => assert.ok(Math.abs(queued.pillTop - queued.textTop) < 6,
+    `pill top ${queued.pillTop} vs text top ${queued.textTop}`));
+check('and to the right of the words, where it always was',
+  () => assert.ok(queued.pillLeft > queued.textRight, `${queued.pillLeft} should be right of ${queued.textRight}`));
+
+console.log('\nand a prompt that is not one line of text stays inside the band');
+// One line far wider than any pane: the point of the fence check is what a band
+// does with content it cannot fit, so the content has to be unfittable.
+const FENCE = 'this keeps failing:\n\n```\nnpm run build --workspace web\nError: EACCES: permission denied, mkdir \'/usr/local/lib/node_modules/.vite-temp/agent-manager/web/dist/assets/index-8f2c1a44.js\' — retried three times with the same result\n```\n\nwhat do you make of it?';
+const fence = await measure(await page.evaluate((t) => window.__pending(t), FENCE), (col) => {
+  const band = col.querySelector('.cx-prompt');
+  const pre = col.querySelector('.cx-prompt pre');
+  const cs = getComputedStyle(band);
+  return {
+    inside: pre.getBoundingClientRect().right <= band.getBoundingClientRect().right - parseFloat(cs.paddingRight) + 0.5,
+    preScrolls: pre.scrollWidth > pre.clientWidth,
+    // Line boxes, counted: `line-height: normal` computes to a keyword, so
+    // dividing the height by it gives NaN.
+    preLines: (() => { const r = document.createRange(); r.selectNodeContents(pre); return r.getClientRects().length; })(),
+    colScroll: col.scrollWidth,
+    tag: pre.firstElementChild?.tagName,
+  };
+});
+check('the fence is a <pre><code> block, rendered rather than shown as backticks',
+  () => assert.equal(fence.tag, 'CODE'));
+check('it stops at the band’s padding rather than bleeding past it',
+  () => assert.ok(fence.inside, 'the fence overflows the band'));
+// The band held raw text until now, so a pasted error was fully on screen. A
+// fence that scrolled instead would hide the end of it behind a horizontal drag
+// — on a phone, inside a slab a third of the screen wide. It wraps instead.
+check(`a line too long for the pane wraps rather than hiding (${fence.preLines} lines)`,
+  () => assert.ok(!fence.preScrolls && fence.preLines >= 3,
+    `scrolls=${fence.preScrolls}, lines=${fence.preLines}`));
+check('and never scrolls the reader column sideways',
+  () => assert.equal(fence.colScroll, rawOne.colScroll));
+
+const LIST = 'please do all of these:\n\n- restart the nightly job\n- then check the trace for the EACCES line\n- and tell me whether the deploy config changed\n\nin that order.';
+const list = await measure(await page.evaluate((t) => window.__pending(t), LIST), (col, firstCharLeft) => {
+  const band = col.querySelector('.cx-prompt');
+  const items = [...col.querySelectorAll('.cx-prompt li')];
+  return {
+    count: items.length,
+    intro: firstCharLeft(band).left,
+    item: firstCharLeft(items[0]).left,
+    colScroll: col.scrollWidth,
+  };
+});
+check('a list is a list', () => assert.equal(list.count, 3));
+check(`its items are indented from the prompt's own column (${list.intro} → ${list.item})`,
+  () => assert.ok(list.item > list.intro && list.item - list.intro < 40,
+    `items at ${list.item} against text at ${list.intro}`));
+check('and it does not scroll the column either',
+  () => assert.equal(list.colScroll, rawOne.colScroll));
+
+console.log('\nand a search term still lands in it');
+const hit = await measure(
+  await page.evaluate((t) => window.__turn(t), turnOf('restart the **nightly** job', { props: { q: 'nightly' } })),
+  (col) => {
+    const marks = [...col.querySelectorAll('.cx-prompt mark.cx-hit')];
+    return {
+      marks: marks.map((m) => m.textContent),
+      insideStrong: marks.every((m) => !!m.closest('strong')),
+      html: col.querySelector('.cx-pmd').innerHTML,
+    };
+  });
+check('the term is marked inside the rendered prompt',
+  () => assert.deepEqual(hit.marks, ['nightly']));
+check('…through the markdown, not over it — the emphasis survives the highlight',
+  () => assert.ok(hit.insideStrong, hit.html));
+check('and the syntax itself is gone from the band',
+  () => assert.doesNotMatch(hit.html, /\*\*/));
+
+await browser.close();
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
The reader rendered everything except the thing a person wrote. The answer has always gone through `renderMarkdown`; an aside, thinking and a compaction have since #88. The prompt band was raw text, so a typed `**important**`, a pasted fence or a list showed its syntax.

Screens (four prompt shapes, dark, phone, the Overview card, search, the optimistic echo): **https://lvwerra-agent-artifacts.static.hf.space/prompt-markdown.html**

### What changed

`PromptBand` — one component, used by both call sites — renders the prompt through the answer's exact path, `highlightHtml(renderMarkdown(text, { breaks: true }), q)`.

**One band, not two.** #77 was precisely the real turn and the optimistic echo drifting: written out by hand in two places, the echo lost the `.cx` wrapper whose padding cancels `.cx-prompt`'s `margin-left: -1.23em`, and the newest prompt in every conversation hung a gutter's width left of the ones above it. Two copies of markdown-plus-highlight is that bug with more surface. `pendingExchange.test.mjs` now fails if a second hand-written band appears in the file, and if either call site stops using the component.

**`breaks: true`, for the prompt only.** A prompt is typed, not authored: its newlines are where someone pressed Enter, and the band showed every one of them as `pre-wrap`. Under strict markdown every multi-line prompt in the reader would have quietly reflowed into one paragraph — a loss of what was typed, not a rendering choice. An agent writes markdown deliberately, so an answer's single newline stays a soft wrap; a test reads the answer's own call to keep it that way.

**The band keeps its geometry**, and it is measured rather than argued. `promptBand.render.test.mjs` builds the real component for the browser — real `marked`, real `DOMPurify` — renders it inside the reader's own frame, and compares against the band as it was:

| | raw text | rendered |
| --- | --- | --- |
| text left edge | `29.984375px` | `29.984375px` |
| band left / right edge | `14 / 640px` | `14 / 640px` |
| one-line band height | `30px` | `30px` |
| four typed lines | `75px` | `75px` |
| queued one-liner | `30px` | `30px` |
| column scroll / client | `626 of 612` | `626 of 612` |

The rendered prompt's text also starts on the same pixel as the answer below it, which is §3.2's one-column rule. The column overflows its client width by the gutter in **both** cases — the band is full-bleed by design, and that is the number a wide prompt must not move; my first version of that check asserted equality with `clientWidth` and was wrong about the baseline, not about the code.

How the heights hold:

- `.cx-pmd > :first-child` / `:last-child` give up their margins, so a `<p>` does not add a fraction of a line to every turn in the reader.
- The shared `.markdown` card's border, background, `14px` and `1.6` are reset — it is a card elsewhere; here it is the band's own text at the band's own size.
- The rendered block is an `inline-block`, so the `queued` pill still sits on the last line's baseline instead of dropping below it and making a queued one-liner a line taller than every other prompt.
- Headings step to `1.05em` and blocks space at `6px`: the shared `22px` h1 and `12px` paragraph gaps read as a document dropped into a strip.

Mutation-checked, each against the assertions it should break: default last-child margin (2 fail), no `inline-block` (2), no `max-width` (3), no `breaks` (2), no font-size/line-height reset (2), no highlight (1), a fence that scrolls (1), a hand-written second band (2).

### Two judgement calls, since the band was designed for one line of text

**A fence in a prompt wraps; a fence in an answer scrolls.** I looked at it before claiming it worked, and the first version scrolled — which on a phone hides the end of a pasted error behind a horizontal drag inside a slab. This band held the operator's own text as `pre-wrap` until now, so all of it was on screen; trading that for a swipe is the same mistake as putting something behind a hover. An answer's fence is code an agent wrote, where the line structure *is* the content and reflowing it lies about it; a prompt's fence is a paste. The divergence is written down where the rule lives.

**Nothing is capped.** A prompt with a 200-line paste makes a tall tinted band — but it already did as raw text, and the answer's own fences are uncapped too, so a cap here would be new behaviour rather than preserved behaviour. If it bites, it belongs on both.

One more thing worth stating: raw HTML in a prompt now renders as HTML. It goes through the same `DOMPurify` sanitiser as agent output, so a `<script>` or an `onerror` does not survive, but `<div>hi</div>` will draw a div where it used to show angle brackets.

### State

Typecheck clean. 17 web suites, 3 browser suites (`npm run test:render`, which now includes this one), 24 server suites — all green. Branch off `3ce91a9`.
