### PR TITLE
Filter Overview by recent trace activity

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,7 +21,7 @@ import { hiddenSessionIds } from './lib/overviewHidden';
 import { useReaderBatch } from './lib/readerBatch';
 import { paneOwnsBack } from './lib/mobileBack';
 import { isPassive, isRemote, isShareable } from './types';
-import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './components/icons';
+import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SearchGlyph, SortGlyph } from './components/icons';
 
 // `?vvdebug=1` — a phone has no devtools, and the keyboard layout is a guess
 // when the app is embedded cross-origin. Read once: it never changes mid-run,
@@ -174,6 +174,9 @@ export default function App() {
   // unlike the sort beside it: "show me only the stopped ones" is a thing you do
   // for a moment, not a standing preference.
   const [ovChip, setOvChip] = useState<OverviewChip>('all');
+  // A glance, like the state chip: keep it while switching Overview layouts,
+  // but start clean on reload. Filtering reads only the digests already polled.
+  const [ovQuery, setOvQuery] = useState('');
   const toggleTheme = () => setTheme((t) => (t === 'dark' ? 'light' : 'dark'));
   const rememberPath = (p?: string | null) => {
     const next = normalizePath(p);
@@ -1149,6 +1152,7 @@ export default function App() {
               tree={tree}
               chip={ovChip}
               sort={ovSort}
+              query={ovQuery}
               view={ovView}
               archived={archivedIds}
               showArchived={showArchived}
@@ -1185,6 +1189,19 @@ export default function App() {
         </div>
         {activeRef === 'overview' && (
           <div className="zoombar ov-bar">
+            <div className={`ov-search${ovQuery ? ' has-query' : ''}`} title="Filter agent names and recent trace activity">
+              <SearchGlyph />
+              <input
+                value={ovQuery}
+                onChange={(e) => setOvQuery(e.target.value)}
+                onKeyDown={(e) => { if (e.key === 'Escape') { setOvQuery(''); e.currentTarget.blur(); } }}
+                placeholder="Filter recent activity…"
+                aria-label="Filter agents by recent trace activity"
+                autoComplete="off"
+                spellCheck={false}
+              />
+              {ovQuery && <button type="button" aria-label="Clear search" title="Clear search" onClick={() => setOvQuery('')}>×</button>}
+            </div>
             <div className="seg ov-seg">
               {OV_CHIPS.map(({ chip, title }) => (
                 <button key={chip} className={ovChip === chip ? 'on' : ''} title={title}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import StateLogo from './components/StateLogo';
 import Overview from './components/Overview';
 import Locked from './components/Locked';
 import BackupBanner from './components/BackupBanner';
+import OverviewSearchBox from './components/OverviewSearchBox';
 import Welcome from './components/Welcome';
 import * as api from './api';
 import type { Cli, GridSpec, MoveTarget, OverviewChip, OverviewSort, Session, Tree } from './types';
@@ -21,7 +22,7 @@ import { hiddenSessionIds } from './lib/overviewHidden';
 import { useReaderBatch } from './lib/readerBatch';
 import { paneOwnsBack } from './lib/mobileBack';
 import { isPassive, isRemote, isShareable } from './types';
-import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SearchGlyph, SortGlyph } from './components/icons';
+import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './components/icons';
 
 // `?vvdebug=1` — a phone has no devtools, and the keyboard layout is a guess
 // when the app is embedded cross-origin. Read once: it never changes mid-run,
@@ -1189,19 +1190,7 @@ export default function App() {
         </div>
         {activeRef === 'overview' && (
           <div className="zoombar ov-bar">
-            <div className={`ov-search${ovQuery ? ' has-query' : ''}`} title="Filter agent names and recent trace activity">
-              <SearchGlyph />
-              <input
-                value={ovQuery}
-                onChange={(e) => setOvQuery(e.target.value)}
-                onKeyDown={(e) => { if (e.key === 'Escape') { setOvQuery(''); e.currentTarget.blur(); } }}
-                placeholder="Filter recent activity…"
-                aria-label="Filter agents by recent trace activity"
-                autoComplete="off"
-                spellCheck={false}
-              />
-              {ovQuery && <button type="button" aria-label="Clear search" title="Clear search" onClick={() => setOvQuery('')}>×</button>}
-            </div>
+            <OverviewSearchBox value={ovQuery} onChange={setOvQuery} />
             <div className="seg ov-seg">
               {OV_CHIPS.map(({ chip, title }) => (
                 <button key={chip} className={ovChip === chip ? 'on' : ''} title={title}

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -6,6 +6,7 @@ import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionS
 import { chipBuckets, isPassive, isRemote, STATE_LABEL, REMOTE_STATE_LABEL } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
+import { matchesOverviewSearch } from '../lib/overviewSearch';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
 import {
@@ -537,11 +538,12 @@ export function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession
 /** Mission control: one reading column — group capsules with their agents as
  *  slabs, loose agents as standalone panels. Unless a sort is on, in which case
  *  it is one flat ranked column instead (see §"sorted feed" below). */
-export default function Overview({ clis, tree, chip, sort, view, archived, showArchived, showHidden, meta, metaReady, isMobile, onOpen }: {
+export default function Overview({ clis, tree, chip, sort, query, view, archived, showArchived, showHidden, meta, metaReady, isMobile, onOpen }: {
   clis: Cli[];
   tree: Tree;
   chip: OverviewChip;     // controlled by the bottom bar in App
   sort: OverviewSort;     // ditto, and independent of the filter
+  query: string;          // transient recent-activity filter in the bottom bar
   view: 'tiles' | 'list'; // controlled by the bottom bar in App
   archived: Set<string>;
   showArchived: boolean;
@@ -579,14 +581,6 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
   // hide a group and its working agent must not float back to the top.
   const hiddenIds = useMemo(() => hiddenSessionIds(tree), [tree]);
 
-  // One chip can stand for several buckets ('started' is waiting AND working), so
-  // this is set membership, not equality.
-  const buckets = chipBuckets(chip);
-  const visible = (s: MetaSession) =>
-    buckets.includes(bucket(s.state))
-    && (showArchived || !archived.has(s.id))
-    && (showHidden || !hiddenIds.has(s.id));
-
   // Which group each agent is in, by name. Only the sorted feed needs it: the
   // manual feed draws the group as a frame around its members and would be
   // saying it twice (the same rule the sidebar and pane headers follow —
@@ -596,6 +590,16 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
     for (const g of tree.groups) for (const id of g.sessionIds) m[id] = g.name;
     return m;
   }, [tree.groups]);
+
+  // One chip can stand for several buckets ('started' is waiting AND working), so
+  // this is set membership, not equality. Search is the final AND: it filters
+  // the same cards without changing their grouping or order.
+  const buckets = chipBuckets(chip);
+  const visible = (s: MetaSession) =>
+    buckets.includes(bucket(s.state))
+    && (showArchived || !archived.has(s.id))
+    && (showHidden || !hiddenIds.has(s.id))
+    && matchesOverviewSearch(s, groupNameOf[s.id] ?? '', query);
 
   // ---- sorted feed: flat, ranked, groups become a prefix ----
   //
@@ -641,7 +645,7 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
     if (!metaReady) return { running: [], dated: items, undated: [] };
     return rankSessions(items, sort);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived, hiddenIds, showHidden]);
+  }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived, hiddenIds, showHidden, groupNameOf, query]);
 
   // Collapse at constant velocity: duration follows the group's height.
   const toggleGroup = (gid: string, el: HTMLElement) => {
@@ -769,7 +773,9 @@ export default function Overview({ clis, tree, chip, sort, view, archived, showA
   const hiddenCount = hiddenIds.size;
   const empty = (
     <div className="usage-msg mono">
-      {!showHidden && hiddenCount > 0
+      {query.trim()
+        ? `no recent activity matches “${query.trim()}” with the current filters.`
+        : !showHidden && hiddenCount > 0
         ? `nothing to show — ${hiddenCount} hidden. reveal them from the bar below.`
         : chip === 'all' ? 'no agents yet — shells and file panes don’t appear here.'
         : chip === 'started' ? 'nothing started — no agent is running or waiting on you.'

--- a/web/src/components/OverviewSearchBox.tsx
+++ b/web/src/components/OverviewSearchBox.tsx
@@ -1,0 +1,22 @@
+import { SearchGlyph } from './icons';
+
+export default function OverviewSearchBox({ value, onChange }: {
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className={`ov-search${value ? ' has-query' : ''}`} title="Filter agent names and recent trace activity">
+      <SearchGlyph />
+      <input
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={(e) => { if (e.key === 'Escape') { onChange(''); e.currentTarget.blur(); } }}
+        placeholder="Filter recent activity…"
+        aria-label="Filter agents by recent trace activity"
+        autoComplete="off"
+        spellCheck={false}
+      />
+      {value && <button type="button" aria-label="Clear search" title="Clear search" onClick={() => onChange('')}>×</button>}
+    </div>
+  );
+}

--- a/web/src/lib/overviewSearch.ts
+++ b/web/src/lib/overviewSearch.ts
@@ -1,0 +1,32 @@
+import type { MetaSession } from '../api';
+
+/**
+ * The text the Overview already has in memory for one agent.
+ *
+ * This deliberately stays on the digest: filtering the fleet must not turn one
+ * keystroke into a transcript read for every session. It covers identity plus
+ * the current request's prompt, replies, tools and files. Older history belongs
+ * to a future indexed search, not a synchronous scan from the Overview.
+ */
+export function overviewSearchText(s: MetaSession, group = ''): string {
+  const d = s.digest;
+  return [
+    s.name,
+    group,
+    d?.lastPromptRaw,
+    d?.lastPromptText,
+    d?.lastAssistantMd,
+    d?.lastAssistantText,
+    ...Object.keys(d?.sinceTools ?? {}),
+    ...(d?.sinceFiles ?? []),
+    ...(d?.turnsLog ?? []).flatMap((turn) => [turn.answerMd, turn.answer]),
+  ].filter(Boolean).join('\n').normalize('NFKC').toLowerCase();
+}
+
+/** Case-insensitive substring matching; every whitespace-separated term must land. */
+export function matchesOverviewSearch(s: MetaSession, group: string, query: string): boolean {
+  const terms = query.normalize('NFKC').toLowerCase().trim().split(/\s+/).filter(Boolean);
+  if (!terms.length) return true;
+  const text = overviewSearchText(s, group);
+  return terms.every((term) => text.includes(term));
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -84,6 +84,14 @@ body {
 /* overview bottom bar: filter · sort · view segments, centered — three of them
    don't fit a phone on one line, so it wraps rather than overflowing */
 .zoombar.ov-bar { justify-content: center; gap: 8px; flex-wrap: wrap; row-gap: 5px; }
+.ov-search { box-sizing: border-box; flex: 0 1 220px; min-width: 150px; height: 24px; display: flex; align-items: center; gap: 5px; padding: 0 6px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel-2); color: var(--muted); }
+.ov-search.has-query { border-color: var(--border-strong); }
+.ov-search:focus-within { border-color: var(--accent); color: var(--text); }
+.ov-search > svg { width: 13px; height: 13px; flex: none; }
+.ov-search > input { min-width: 0; flex: 1; border: 0; outline: 0; padding: 0; background: transparent; color: var(--text); font: inherit; font-size: 11.5px; }
+.ov-search > input::placeholder { color: var(--muted); }
+.ov-search > button { width: 16px; height: 16px; flex: none; border: 0; padding: 0; border-radius: 50%; background: transparent; color: var(--muted); font: 15px/15px system-ui, sans-serif; cursor: pointer; }
+.ov-search > button:hover { background: var(--hover); color: var(--text); }
 /* the sort segment needs to say what it is — "prompt"/"answer" next to a row of
    filter words would otherwise read as two more filters — so a glyph sits beside
    it, outside the segment (inside, it read as a fourth disabled button) */

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -90,7 +90,8 @@ body {
 .ov-search > svg { width: 13px; height: 13px; flex: none; }
 .ov-search > input { min-width: 0; flex: 1; border: 0; outline: 0; padding: 0; background: transparent; color: var(--text); font: inherit; font-size: 11.5px; }
 .ov-search > input::placeholder { color: var(--muted); }
-.ov-search > button { width: 16px; height: 16px; flex: none; border: 0; padding: 0; border-radius: 50%; background: transparent; color: var(--muted); font: 15px/15px system-ui, sans-serif; cursor: pointer; }
+/* The mark stays small; its box is a real touch target. */
+.ov-search > button { width: 24px; height: 24px; flex: none; margin-right: -6px; border: 0; padding: 0; border-radius: 50%; background: transparent; color: var(--muted); font: 15px/15px system-ui, sans-serif; cursor: pointer; }
 .ov-search > button:hover { background: var(--hover); color: var(--text); }
 /* the sort segment needs to say what it is — "prompt"/"answer" next to a row of
    filter words would otherwise read as two more filters — so a glyph sits beside
@@ -1787,7 +1788,7 @@ a.btn-ghost { text-decoration: none; }
   /* 16px inputs stop iOS zoom-on-focus — touch devices only, so a narrow
      DESKTOP window keeps the reply line at card size */
   @media (pointer: coarse) {
-    .widget input, .widget select, .row .rename, .secret-desc, .fp-input, .pane-head .ph-title-input, .ov-live textarea { font-size: 16px; }
+    .widget input, .widget select, .row .rename, .secret-desc, .fp-input, .pane-head .ph-title-input, .ov-live textarea, .ov-search > input { font-size: 16px; }
     .ov-composer { --ov-first-line: calc(1.45 * 16px + 4px); }
   }
   .ov-headrow { flex-wrap: wrap; }

--- a/web/test/overviewSearch.test.mjs
+++ b/web/test/overviewSearch.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ovsearch-')), 'overviewSearch.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/overviewSearch.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { matchesOverviewSearch, overviewSearchText } = await import(pathToFileURL(out).href);
+
+const session = {
+  id: 'one', name: 'Research Agent', cli: 'codex', state: 'waiting', createdAt: '',
+  digest: {
+    lastPromptText: 'Investigate auth', lastPromptRaw: 'Investigate the OAuth callback', lastPromptTs: 1,
+    lastAssistantText: 'Fixed it', lastAssistantMd: 'Fixed the **redirect**.', lastAssistantTs: 2,
+    sinceTurns: 2, sinceToolCalls: 2, sinceTools: { Read: 1, apply_patch: 1 },
+    sinceFiles: ['/src/login.ts'], sinceTokens: 10,
+    turnsLog: [{ answer: 'Found a stale cookie', answerMd: 'Found a `stale cookie`.', ts: 1 }],
+  },
+};
+
+assert.equal(matchesOverviewSearch(session, 'Web App', ''), true);
+assert.equal(matchesOverviewSearch(session, 'Web App', 'research'), true, 'agent name');
+assert.equal(matchesOverviewSearch(session, 'Web App', 'web app'), true, 'group name and AND terms');
+assert.equal(matchesOverviewSearch(session, 'Web App', 'OAUTH redirect'), true, 'prompt + answer, case-insensitive');
+assert.equal(matchesOverviewSearch(session, 'Web App', 'apply_patch login.ts'), true, 'tool + file');
+assert.equal(matchesOverviewSearch(session, 'Web App', 'stale cookie'), true, 'recent intermediate answer');
+assert.equal(matchesOverviewSearch(session, 'Web App', 'oauth missing'), false, 'every term is required');
+assert.match(overviewSearchText(session, 'Web App'), /oauth callback/);
+
+console.log('overview search: all passed');

--- a/web/test/overviewSearch.test.mjs
+++ b/web/test/overviewSearch.test.mjs
@@ -4,9 +4,13 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
-const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'ovsearch-')), 'overviewSearch.mjs');
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ovsearch-'));
+const out = path.join(tmp, 'overviewSearch.mjs');
 await build({
   entryPoints: [path.join(HERE, '../src/lib/overviewSearch.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
@@ -33,4 +37,88 @@ assert.equal(matchesOverviewSearch(session, 'Web App', 'stale cookie'), true, 'r
 assert.equal(matchesOverviewSearch(session, 'Web App', 'oauth missing'), false, 'every term is required');
 assert.match(overviewSearchText(session, 'Web App'), /oauth callback/);
 
-console.log('overview search: all passed');
+// Browser integration: the real search box drives the real Overview, and the
+// phone CSS keeps both focus and the clear action touch-safe.
+const bundle = path.join(tmp, 'browser.js');
+const stub = path.join(tmp, 'api-stub.ts');
+fs.writeFileSync(stub, `
+  export const getTracePage = () => Promise.reject(new Error('not used'));
+  export const sendInput = () => Promise.resolve({ ok: true });
+`);
+const sessions = [
+  { ...session, id: 'one', name: 'Research Agent' },
+  { ...session, id: 'two', name: 'Docs Agent', digest: { ...session.digest,
+      lastPromptText: 'Rewrite deployment docs', lastPromptRaw: 'Rewrite deployment docs',
+      lastAssistantText: 'README published', lastAssistantMd: 'README published',
+      sinceTools: {}, sinceFiles: [], turnsLog: [] } },
+  { ...session, id: 'three', name: 'Loose Agent', digest: { ...session.digest,
+      lastPromptText: 'Run browser checks', lastPromptRaw: 'Run browser checks',
+      lastAssistantText: 'Still working', lastAssistantMd: 'Still working',
+      sinceTools: { Playwright: 1 }, sinceFiles: [], turnsLog: [] } },
+];
+await build({
+  stdin: {
+    resolveDir: WEB, loader: 'tsx',
+    contents: `
+      import React, { useState } from 'react';
+      import { createRoot } from 'react-dom/client';
+      import Overview from './src/components/Overview.tsx';
+      import OverviewSearchBox from './src/components/OverviewSearchBox.tsx';
+      const sessions = ${JSON.stringify(sessions)};
+      const tree = { order: ['g:web', 's:three'], groups: [{ id: 'web', name: 'Web App', sessionIds: ['one', 'two'] }], sessions, hidden: [] };
+      const meta = Object.fromEntries(sessions.map((s) => [s.id, s]));
+      function Harness() {
+        const [query, setQuery] = useState('');
+        return <><div className="zoombar ov-bar"><OverviewSearchBox value={query} onChange={setQuery} /></div>
+          <div style={{ height: 500 }}><Overview clis={[{ id: 'codex', color: '#5eb6a6' }]} tree={tree}
+            chip="all" sort="manual" query={query} view="tiles" archived={new Set()}
+            showArchived={false} showHidden={false} meta={meta} metaReady={true} isMobile={true} onOpen={() => {}} /></div></>;
+      }
+      createRoot(document.getElementById('root')).render(<Harness />);
+    `,
+  },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+  plugins: [{ name: 'stub-api', setup(b) {
+    b.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub }));
+  } }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+assert.match(css, /@media \(pointer: coarse\) \{[\s\S]*?\.ov-search > input \{ font-size: 16px; \}/,
+  'the phone anti-zoom rule includes the Overview search');
+// Headless Chromium otherwise reports no primary pointer even with hasTouch;
+// enable touch events so the coarse-pointer rule is tested through the cascade.
+const browser = await chromium.launch(chromiumLaunchOptions({ args: ['--touch-events=enabled'] }));
+try {
+  const context = await browser.newContext({ viewport: { width: 390, height: 760 }, isMobile: true, hasTouch: true });
+  const page = await context.newPage();
+  await page.setContent(`<meta name="viewport" content="width=device-width, initial-scale=1.0"><style>${css}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  const search = page.getByLabel('Filter agents by recent trace activity');
+  await search.waitFor();
+  await page.waitForFunction(() => document.querySelectorAll('.ovt-tile').length === 3);
+
+  assert.equal(await page.evaluate(() => matchMedia('(pointer: coarse)').matches), true, 'browser is exercising touch CSS');
+  assert.equal(await search.evaluate((el) => getComputedStyle(el).fontSize), '16px', 'phone input prevents iOS focus zoom');
+  await search.fill('oauth redirect');
+  assert.equal(await page.locator('.ovt-tile').count(), 1, 'prompt + answer terms filter cards');
+  assert.equal(await page.locator('.ovt-name').textContent(), 'Research Agent');
+  await search.fill('web app');
+  assert.equal(await page.locator('.ovt-tile').count(), 2, 'group name keeps its members');
+  const clear = page.getByLabel('Clear search');
+  const clearBox = await clear.boundingBox();
+  assert.ok(clearBox && Math.round(clearBox.width) >= 24 && Math.round(clearBox.height) >= 24,
+    `clear has a 24px touch target (measured ${clearBox?.width}×${clearBox?.height})`);
+  await clear.click();
+  assert.equal(await page.locator('.ovt-tile').count(), 3, 'clear restores the fleet');
+  await search.fill('nothing matches this');
+  assert.match(await page.locator('.usage-msg').textContent(), /no recent activity matches/, 'query-specific empty state');
+  await search.press('Escape');
+  assert.equal(await search.inputValue(), '', 'Escape clears the search');
+  await context.close();
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('overview search: helper, integration, and mobile checks passed');


### PR DESCRIPTION
## Summary

- add an instant search field to the Overview toolbar
- filter cards by agent/group name and the already-polled recent prompt, answer, tool, and file digest
- combine whitespace-separated terms with AND semantics without reading transcripts per keystroke
- add a query-specific empty state and responsive desktop/mobile styling

## Verification

- `npm run build`
- `npm test` (20 frontend suites)
- Playwright browser pass at 1200×800 and 390×760 covering prompt/tool/file matching, AND terms, clear, Escape, empty state, and viewport fit