### PR TITLE
Sidebar: the create panel gets every session type, and says what each one is

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -2190,6 +2190,20 @@ function nextName(cli) {
   return `${base}-${max + 1}`;
 }
 
+// The name a session WOULD get if it were created now, so the create panel can
+// prefill the field instead of showing an empty box. Deliberately a read from
+// the same nextName() the creation path uses: a second copy of the scheme in
+// the client drifts the first time either side changes.
+//
+// The panel treats this as a display value, not an answer — it only sends a
+// name when the operator edits it, so two creations racing on the same prefill
+// still get distinct names from the server (see Sidebar.tsx).
+app.get('/api/next-name', (req, res) => {
+  const cli = String(req.query.cli || '').trim();
+  if (!cliById(cli)) return res.status(400).json({ error: `unknown cli '${cli}'` });
+  res.json({ cli, name: nextName(cli) });
+});
+
 // Create a session and (optionally) start it on an initial prompt. Shared by
 // the UI's POST /api/sessions and the agent API's spawn — one creation path, so
 // quickstart behaves identically whoever asked. Returns null for a bad path.

--- a/server/test/next-name.test.mjs
+++ b/server/test/next-name.test.mjs
@@ -1,0 +1,93 @@
+// The name the create panel shows before you have typed anything.
+//
+// The panel prefills its name field from this endpoint so the operator sees the
+// name the agent will actually get. That makes it a display value, not a
+// reservation: the field stays empty until it is edited, and an untouched field
+// sends no name at all, so the server keeps naming the session the way it always
+// did. This suite pins both halves — the endpoint agrees with the creation path,
+// and two creations racing on the same prefill still land on distinct names.
+//
+// Run with:  node test/next-name.test.mjs
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const PORT = 7893;
+const API = `http://localhost:${PORT}`;
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'next-name-'));
+
+let pass = 0; let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+const srv = spawn('node', ['src/index.js'], {
+  env: { ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent', AM_ALLOW_MISSING_ORIGIN: '1' },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let log = '';
+srv.stdout.on('data', (d) => { log += d; });
+srv.stderr.on('data', (d) => { log += d; });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const api = async (route, init = {}) => {
+  const sep = route.includes('?') ? '&' : '?';
+  const r = await fetch(`${API}${route}${sep}from=operator`, {
+    headers: { 'content-type': 'application/json' }, ...init,
+  });
+  let body = null;
+  try { body = await r.json(); } catch { /* empty */ }
+  return { status: r.status, body };
+};
+// `name` omitted entirely — this is what an untouched prefill sends.
+const mkNameless = (cli = 'shell') =>
+  api('/api/sessions', { method: 'POST', body: JSON.stringify({ cli, path: 'w' }) });
+const hint = (cli) => api(`/api/next-name?cli=${encodeURIComponent(cli)}`);
+
+try {
+  for (let i = 0; i < 120; i++) {
+    if (await fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false)) break;
+    await sleep(250);
+  }
+
+  // ---- the hint is the name the creation path would pick ----
+  const first = await hint('shell');
+  check('a hint comes back for a known cli', first.status === 200, JSON.stringify(first.body));
+  check('and it is the first free name', first.body?.name === 'shell-1', JSON.stringify(first.body));
+  check('the cli is echoed so a late reply cannot fill the wrong field',
+    first.body?.cli === 'shell', JSON.stringify(first.body));
+
+  const made = await mkNameless();
+  check('a nameless create takes exactly that name', made.body?.name === 'shell-1', JSON.stringify(made.body?.name));
+  const second = await hint('shell');
+  check('and the hint moves on', second.body?.name === 'shell-2', JSON.stringify(second.body));
+
+  // ---- the hint reserves nothing: the server still names, so no collision ----
+  const [a, b] = await Promise.all([mkNameless(), mkNameless()]);
+  check('two nameless creates racing on one hint get distinct names',
+    a.body?.name !== b.body?.name, `${a.body?.name} vs ${b.body?.name}`);
+  check('and both are real names, not blanks', !!a.body?.name && !!b.body?.name);
+
+  // ---- an edited field wins ----
+  const named = await api('/api/sessions', {
+    method: 'POST', body: JSON.stringify({ cli: 'shell', path: 'w', name: 'chosen-by-hand' }),
+  });
+  check('a name the operator typed is honoured', named.body?.name === 'chosen-by-hand', JSON.stringify(named.body?.name));
+
+  // ---- bad input ----
+  const unknown = await hint('not-a-cli');
+  check('an unknown cli is a 400, not a guessed name', unknown.status === 400, `status ${unknown.status}`);
+  const blank = await api('/api/next-name');
+  check('a missing cli is a 400 too', blank.status === 400, `status ${blank.status}`);
+} catch (e) {
+  check(`suite threw: ${e && e.message}`, false, log.slice(-600));
+} finally {
+  srv.kill();
+  try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* tmp */ }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -38,6 +38,12 @@ const normalizePath = (path?: string) => (path && path.trim() ? path : '.');
 export const quickStart = (cli: string, prompt: string, name = '', path = '.'): Promise<Session> =>
   fetch('/api/sessions', { method: 'POST', headers: HEADERS, body: JSON.stringify({ cli, name: name || undefined, path: path || '.', prompt: prompt || undefined }) }).then(json);
 
+// The name this cli would get if created now. Used to prefill the create
+// panel; the panel only SENDS a name when the operator edits it, so the server
+// still decides for an untouched field.
+export const nextName = (cli: string): Promise<{ cli: string; name: string }> =>
+  fetch(`/api/next-name?cli=${encodeURIComponent(cli)}`).then(json);
+
 export const createSession = (name: string, cli: string, groupId?: string, path?: string): Promise<Session> =>
   fetch('/api/sessions', { method: 'POST', headers: HEADERS, body: JSON.stringify({ name, cli, groupId, path: normalizePath(path) }) }).then(json);
 

--- a/web/src/components/FolderPicker.tsx
+++ b/web/src/components/FolderPicker.tsx
@@ -83,19 +83,23 @@ function Level({ path, depth, value, onPick }: {
  * workspace root. Picking a not-yet-existing folder is fine: the server
  * creates it when the agent is created.
  */
-export default function FolderPicker({ value, onChange, disabled = false }: {
+export default function FolderPicker({ value, onChange, disabled = false, placeholder }: {
   value: string;
   onChange: (p: string) => void;
   disabled?: boolean;
+  /** Shown instead of the path when the picker is off, so a disabled folder
+   *  says why it is disabled rather than just going grey. */
+  placeholder?: string;
 }) {
   const [open, setOpen] = useState(false);
   const root = isRoot(value);
   return (
     <div className="fp">
-      <button className="fp-current" disabled={disabled} onClick={() => setOpen((o) => !o)} title="Choose where this agent runs">
+      <button className="fp-current" disabled={disabled} onClick={() => setOpen((o) => !o)}
+        title={placeholder || 'Choose where this agent runs'}>
         <FolderGlyph className="fp-ico" open={open || root} />
-        <span className="fp-path">{root ? 'workspaces' : value}</span>
-        <span className="fp-toggle">{open ? '▾' : '▸'}</span>
+        <span className={`fp-path${placeholder ? ' fp-why' : ''}`}>{placeholder || (root ? 'workspaces' : value)}</span>
+        {!placeholder && <span className="fp-toggle">{open ? '▾' : '▸'}</span>}
       </button>
       {open && !disabled && (
         <div className="fp-tree">

--- a/web/src/components/Locked.tsx
+++ b/web/src/components/Locked.tsx
@@ -1,7 +1,6 @@
 import { useState } from 'react';
 import type { SessionState } from '../types';
 import { SlidersGlyph, SunGlyph, GridGlyph, PlusGlyph, AmMark } from './icons';
-import Logo from './Logo';
 import StateLogo from './StateLogo';
 
 // A frozen, slightly dimmed replica of the real sidebar so the install page
@@ -57,10 +56,6 @@ function MockSidebar() {
         ) : (
           <MockRow key={item.name} s={item} />
         ))}
-      </div>
-      <div className="quick-add">
-        <span className="btn-ghost"><Logo cli="shell" size={14} /> Shell</span>
-        <span className="btn-ghost"><Logo cli="files" size={14} /> Files</span>
       </div>
       <div className="legend">
         <span><StateLogo frameOnly state="working" size={12} /> working</span>

--- a/web/src/components/NewSession.tsx
+++ b/web/src/components/NewSession.tsx
@@ -18,8 +18,9 @@ function defaultName(c: Cli, sessions: Session[]) {
   return `${base}-${max + 1}`;
 }
 
-// Creation widget for AI agents. Shell and Files are created via the quick-add
-// buttons at the bottom of the sidebar instead (rename after creation).
+// Creation widget used where the sidebar's own panel is not on screen: adding an
+// agent to a group, and the empty-workspace prompt. The sidebar panel offers
+// Shell and Files in its second picker row; this one is agents only.
 export default function NewSession({
   clis, sessions, defaultPath = '.', onCreate, onCancel,
 }: {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Cli, MoveTarget, Group, Session, Tree } from '../types';
 import { STATE_LABEL, REMOTE_STATE_LABEL, isPassive, isRemote } from '../types';
+import * as api from '../api';
 import Logo from './Logo';
 import StateLogo from './StateLogo';
 import NewSession from './NewSession';
@@ -96,7 +97,6 @@ export default function Sidebar({
   const [quickMode, setQuickMode] = useState<'agent' | 'group'>('agent');
   const [quickCli, setQuickCli] = useState<string | null>(null);
   const [quickPrompt, setQuickPrompt] = useState('');
-  const [quickMore, setQuickMore] = useState(false); // reveals name + folder
   const [quickName, setQuickName] = useState('');
   const [quickLoc, setQuickLoc] = useState('.');
   const [quickError, setQuickError] = useState<string | null>(null);
@@ -175,7 +175,7 @@ export default function Sidebar({
     if (!quickCli || isRemote(quickCli)) throw new Error('Choose a local agent before attaching files.');
     if (!quickPrepareRef.current) {
       quickPrepareRef.current = onPrepareQuickStart(
-        quickCli, quickMore ? quickName.trim() : '', quickMore ? quickLoc : '.',
+        quickCli, quickName.trim(), quickLoc,
       );
     }
     const preparing = quickPrepareRef.current;
@@ -294,8 +294,52 @@ export default function Sidebar({
   // Quickstart: one harness pick + one prompt, agent launches in workspace/.
   // Every agent harness is shown; ones not installed here are greyed out.
   // "More options" adds a name + folder; the group tile flips to group creation.
+  // Row one is the agents you reach for; row two is everything else you can
+  // make from here. Shell and Files used to be buttons of their own below the
+  // tree — they are session types like any other, so they belong in the picker
+  // rather than in a second place that does the same job.
   const quickable = clis.filter((c) => c.id !== 'shell' && !isPassive(c.id) && !isRemote(c.id));
   const remoteCli = clis.find((c) => isRemote(c.id)) || null;
+  const shellCli = clis.find((c) => c.id === 'shell') || null;
+  const filesCli = clis.find((c) => c.id === 'files') || null;
+
+  // What each type can actually use. A field that makes no sense for the type
+  // is disabled with the reason in its own placeholder rather than hidden, so
+  // the panel keeps its shape as you click along the row.
+  const rules = (cli: string | null, mode: 'agent' | 'group') => {
+    if (mode === 'group') return { prompt: null, folder: 'ok', attach: null, promptLabel: '' };
+    if (cli === 'files') {
+      return {
+        prompt: 'a file browser takes no prompt',
+        folder: 'browses the whole workspace',
+        attach: 'attachments go to agents',
+        promptLabel: '',
+      };
+    }
+    if (cli === 'shell') {
+      return { prompt: null, folder: 'ok', attach: 'attachments go to agents', promptLabel: 'first command…' };
+    }
+    if (cli && isRemote(cli)) {
+      return { prompt: null, folder: 'the remote agent brings its own', attach: 'attachments go to local agents', promptLabel: 'first message…' };
+    }
+    return { prompt: null, folder: 'ok', attach: null, promptLabel: '' };
+  };
+  const rule = rules(quickCli, quickMode);
+
+  // The name the server WOULD choose, shown in the field so the panel says what
+  // is about to happen instead of showing an empty box. It is a display value:
+  // `quickName` stays empty until the operator types, and an untouched (or
+  // cleared) field still sends nothing, so the server names the session at
+  // creation time and two quick creations cannot collide on one prefill.
+  const [nameHint, setNameHint] = useState('');
+  useEffect(() => {
+    const target = quickMode === 'group' ? null : quickCli;
+    if (!target) { setNameHint(''); return undefined; }
+    let alive = true;
+    api.nextName(target).then((r) => { if (alive) setNameHint(r.name); }).catch(() => { if (alive) setNameHint(''); });
+    return () => { alive = false; };
+    // tree.sessions: after a create the next name moves on, so re-ask.
+  }, [quickCli, quickMode, tree.sessions.length]);
   const openQuick = () => {
     quickGenerationRef.current += 1;
     setQuickError(null);
@@ -316,7 +360,6 @@ export default function Sidebar({
         || quickable.find((c) => c.available);
       setQuickCli(selected?.id || null);
       setQuickMode('agent');
-      setQuickMore(false);
       setQuickName('');
       setQuickLoc(defaultPath || '.');
       setQuickPrompt(`In this session we will continue from the session traces at ${loc.path}${loc.sessionId ? ` (session ${loc.sessionId})` : ''}`);
@@ -344,12 +387,11 @@ export default function Sidebar({
       } finally { setQuickSending(false); }
       return;
     }
-    if (!p && !quickImages.length && !quickMore) return; // the bare quick path needs a prompt or file
     setQuickSending(true);
     setQuickError(null);
     try {
       await onQuickStart(
-        quickCli, p, quickMore ? quickName.trim() : '', quickMore ? quickLoc : '.',
+        quickCli, p, quickName.trim(), quickLoc,
         quickSessionId || quickImages.length ? {
           sessionId: quickSessionId,
           attachments: quickImages,
@@ -601,17 +643,12 @@ export default function Sidebar({
           <h1>Agent Manager</h1>
         </div>
         <div className="brand-actions">
-          <button
-            className={`icon-btn add-btn bolt-btn${panel === 'quick' ? ' on' : ''}`}
-            onClick={() => (panel === 'quick' ? closePanel() : openQuick())}
-            title="New agent or group"
-          ><PlusGlyph /></button>
           <button className="icon-btn" onClick={onOpenSettings} title="Settings"><SlidersGlyph /></button>
           <button className="icon-btn" onClick={onToggleTheme} title="Toggle light / dark">{theme === 'dark' ? <MoonGlyph /> : <SunGlyph />}</button>
         </div>
       </div>
 
-      {panel === 'quick' && (
+      {panel !== 'create' && (
         <div className="controls">
           <div
             className={`widget quick${quickDrop ? ' image-drop' : ''}`}
@@ -643,7 +680,8 @@ export default function Sidebar({
                   onClick={() => { setQuickMode('agent'); if (quickCli !== c.id) resetQuickTarget(); setQuickCli(c.id); }}
                 ><Logo cli={c.id} size={14} /></button>
               ))}
-              <span className="quick-sep" />
+            </div>
+            <div className="quick-clis quick-clis-2">
               <button
                 className={`quick-cli quick-grp${quickMode === 'group' ? ' on' : ''}`}
                 title="New group"
@@ -668,6 +706,16 @@ export default function Sidebar({
                   }}
                 ><Logo cli="remote" size={14} /></button>
               )}
+              {[shellCli, filesCli].filter(Boolean).map((c) => (
+                <button
+                  key={c!.id}
+                  className={`quick-cli${quickMode === 'agent' && quickCli === c!.id ? ' on' : ''}${c!.available ? '' : ' off'}`}
+                  title={c!.label}
+                  disabled={!c!.available || quickSending || quickImages.length > 0}
+                  style={quickMode === 'agent' && quickCli === c!.id ? { borderColor: c!.color } : undefined}
+                  onClick={() => { setQuickMode('agent'); if (quickCli !== c!.id) resetQuickTarget(); setQuickCli(c!.id); }}
+                ><Logo cli={c!.id} size={14} /></button>
+              ))}
             </div>
 
             {quickMode === 'agent' ? (
@@ -687,15 +735,33 @@ export default function Sidebar({
                         : 'Files are uploading to this stopped agent now; launch waits until they are ready.'}
                   </div>
                 )}
+                <input
+                  className="quick-name"
+                  placeholder={nameHint || 'Name'}
+                  title={nameHint ? `Leave it as it is and the agent is named ${nameHint}` : undefined}
+                  value={quickName}
+                  disabled={quickSending || quickImages.length > 0}
+                  onChange={(e) => { resetQuickTarget(); setQuickName(e.target.value); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter') submitQuick(); }}
+                />
+                <FolderPicker
+                  disabled={quickSending || quickImages.length > 0 || rule.folder !== 'ok'}
+                  placeholder={rule.folder !== 'ok' ? rule.folder : undefined}
+                  value={quickLoc}
+                  onChange={(value) => { resetQuickTarget(); setQuickLoc(value); }}
+                />
                 <textarea
                   autoFocus
                   rows={1}
                   className="quick-prompt"
-                  placeholder={quickCli ? `prompt for ${clis.find((c) => c.id === quickCli)?.label ?? quickCli}…` : 'prompt…'}
-                  value={quickPrompt}
-                  disabled={quickSending}
+                  placeholder={rule.prompt
+                    || rule.promptLabel
+                    || (quickCli ? `prompt for ${clis.find((c) => c.id === quickCli)?.label ?? quickCli}…` : 'prompt…')}
+                  title={rule.prompt || undefined}
+                  value={rule.prompt ? '' : quickPrompt}
+                  disabled={quickSending || !!rule.prompt}
                   onPaste={(event) => {
-                    if (quickSending || !quickCli || isRemote(quickCli)) return;
+                    if (quickSending || !quickCli || rule.attach) return;
                     const files = filesFromTransfer(event.clipboardData);
                     if (!files.length) return;
                     event.preventDefault(); addQuickImages(files);
@@ -703,41 +769,23 @@ export default function Sidebar({
                   onChange={(e) => { setQuickPrompt(e.target.value); e.currentTarget.style.height = 'auto'; e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`; }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitQuick(); }
-                    if (e.key === 'Escape') closePanel();
                   }}
                 />
                 <Attachments
                   attachments={quickImages}
-                  disabled={quickSending || !quickCli || isRemote(quickCli)}
+                  disabled={quickSending || !quickCli || !!rule.attach}
                   showPicker={false}
                   onFiles={addQuickImages}
                   onRemove={removeQuickImage}
                   onRetry={retryQuickImage}
                 />
-                {quickMore && (
-                  <>
-                    <input
-                      placeholder="Name (optional)"
-                      value={quickName}
-                      disabled={quickSending || quickImages.length > 0}
-                      onChange={(e) => { resetQuickTarget(); setQuickName(e.target.value); }}
-                      onKeyDown={(e) => { if (e.key === 'Enter') submitQuick(); if (e.key === 'Escape') closePanel(); }}
-                    />
-                    <FolderPicker disabled={quickSending || quickImages.length > 0} value={quickLoc} onChange={(value) => { resetQuickTarget(); setQuickLoc(value); }} />
-                    <div className="widget-actions">
-                      <button className="btn-primary" onClick={submitQuick} disabled={quickSending || quickFilesBlocked}>{quickSending ? 'Starting…' : `Create${quickPrompt.trim() || quickImages.length ? ' & send' : ''}`}</button>
-                      <button className="btn-ghost" onClick={closePanel} disabled={quickSending}>Cancel</button>
-                    </div>
-                  </>
-                )}
-                <div className="quick-foot">
-                  <button className="quick-more" onClick={() => setQuickMore((v) => !v)} disabled={quickSending || quickImages.length > 0}>{quickMore ? '▴ less' : '▾ more options'}</button>
-                  <span className="quick-hint mono">↵ launch · ⇧↵ newline</span>
+                <div className="widget-actions">
+                  <button className="btn-primary" onClick={submitQuick} disabled={quickSending || quickFilesBlocked}>{quickSending ? 'Starting…' : `Create${quickPrompt.trim() || quickImages.length ? ' & send' : ''}`}</button>
                 </div>
               </>
             ) : (
               <>
-                <input autoFocus placeholder="Group name" value={groupName}
+                <input autoFocus className="quick-name" placeholder="Group name" value={groupName}
                   onChange={(e) => setGroupName(e.target.value)}
                   onKeyDown={(e) => { if (e.key === 'Enter') submitGroup(); if (e.key === 'Escape') closePanel(); }} />
                 <FolderPicker value={groupLoc} onChange={setGroupLoc} />
@@ -822,35 +870,24 @@ export default function Sidebar({
           const anyVisible = agents.length === 0 || agents.some((s) => !isHidden(s.id));
           return anyVisible ? GroupBlock(g) : null;
         })}
-        {!showArchived && archived.size > 0 && (
-          <div className="arch-note">not showing {archived.size} archived session{archived.size === 1 ? '' : 's'}</div>
+        {archived.size > 0 && (
+          // Renders in BOTH states on purpose: this line is the switch now, so
+          // one that only appeared while archived were hidden would be a door
+          // that locks behind you.
+          <button className="arch-note arch-toggle" onClick={onToggleArchived}>
+            {showArchived ? 'hide' : 'show'} {archived.size} archived session{archived.size === 1 ? '' : 's'}
+          </button>
         )}
       </div>
 
       {/* Quick-add utilities: created instantly with a default name (double-
           click to rename afterwards). Both open at the workspaces root. */}
-      <div className="quick-add">
-        <button className="btn-ghost" title="New shell at the workspaces root" onClick={() => onNewSession('', 'shell', '.')}>
-          <Logo cli="shell" size={14} /> Shell
-        </button>
-        <button className="btn-ghost" title="New file browser (whole workspace)" onClick={() => onNewSession('', 'files', '.')}>
-          <Logo cli="files" size={14} /> Files
-        </button>
-      </div>
-
       <div className="legend">
         <span><StateLogo frameOnly state="working" size={12} /> working</span>
         <span><StateLogo frameOnly state="waiting" size={12} /> your turn</span>
         <span><StateLogo frameOnly state="idle" size={12} /> idle</span>
         <span><StateLogo frameOnly state="stopped" size={12} /> stopped</span>
-        {archived.size > 0 && (
-          <label className="legend-arch" title="Sessions with no activity beyond the archive window (Settings)">
-            <input type="checkbox" checked={showArchived} onChange={onToggleArchived} />
-            <span className="lbox" />
-            archived
-          </label>
-        )}
-      </div>
+              </div>
     </aside>
   );
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -293,7 +293,6 @@ export default function Sidebar({
   };
   // Quickstart: one harness pick + one prompt, agent launches in workspace/.
   // Every agent harness is shown; ones not installed here are greyed out.
-  // "More options" adds a name + folder; the group tile flips to group creation.
   // Row one is the agents you reach for; row two is everything else you can
   // make from here. Shell and Files used to be buttons of their own below the
   // tree — they are session types like any other, so they belong in the picker
@@ -302,6 +301,29 @@ export default function Sidebar({
   const remoteCli = clis.find((c) => isRemote(c.id)) || null;
   const shellCli = clis.find((c) => c.id === 'shell') || null;
   const filesCli = clis.find((c) => c.id === 'files') || null;
+
+  // The picker is a row of logos, and a logo does not say what it is. Each button
+  // carries a sentence on hover: who makes it, or what the type does. Keyed by id
+  // with a fallback, so a harness added to the server without a line here still
+  // gets a usable tooltip rather than an empty one.
+  const blurbs: Record<string, string> = {
+    claude: "Anthropic's coding agent",
+    codex: "OpenAI's coding agent",
+    gemini: "Google's coding agent",
+    opencode: 'open-source agent, your choice of model',
+    hermes: "Nous Research's agent",
+    openclaw: 'open-source Claude Code fork',
+    qwen: "Alibaba's coding agent",
+    remote: 'an agent running on another machine',
+    // no em-dash in a blurb: the tooltip already joins label and blurb with one
+    shell: 'a plain terminal, no agent',
+    files: 'browse the workspace files',
+  };
+  const cliTitle = (c: { id: string; label: string; available?: boolean; version?: string | null }) => {
+    const what = blurbs[c.id] ? ` — ${blurbs[c.id]}` : '';
+    if (c.available === false) return `${c.label}${what} (not installed)`;
+    return `${c.label}${what}`;
+  };
 
   // What each type can actually use. A field that makes no sense for the type
   // is disabled with the reason in its own placeholder rather than hidden, so
@@ -643,12 +665,17 @@ export default function Sidebar({
           <h1>Agent Manager</h1>
         </div>
         <div className="brand-actions">
+          <button
+            className={`icon-btn add-btn bolt-btn${panel === 'quick' ? ' on' : ''}`}
+            onClick={() => (panel === 'quick' ? closePanel() : openQuick())}
+            title="New agent or group"
+          ><PlusGlyph /></button>
           <button className="icon-btn" onClick={onOpenSettings} title="Settings"><SlidersGlyph /></button>
           <button className="icon-btn" onClick={onToggleTheme} title="Toggle light / dark">{theme === 'dark' ? <MoonGlyph /> : <SunGlyph />}</button>
         </div>
       </div>
 
-      {panel !== 'create' && (
+      {panel === 'quick' && (
         <div className="controls">
           <div
             className={`widget quick${quickDrop ? ' image-drop' : ''}`}
@@ -674,7 +701,7 @@ export default function Sidebar({
                 <button
                   key={c.id}
                   className={`quick-cli${quickMode === 'agent' && quickCli === c.id ? ' on' : ''}${c.available ? '' : ' off'}`}
-                  title={c.available ? c.label : `${c.label} (not installed)`}
+                  title={cliTitle(c)}
                   disabled={!c.available || quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === c.id ? { borderColor: c.color } : undefined}
                   onClick={() => { setQuickMode('agent'); if (quickCli !== c.id) resetQuickTarget(); setQuickCli(c.id); }}
@@ -684,7 +711,7 @@ export default function Sidebar({
             <div className="quick-clis quick-clis-2">
               <button
                 className={`quick-cli quick-grp${quickMode === 'group' ? ' on' : ''}`}
-                title="New group"
+                title="Group — several agents created together, sharing a folder"
                 disabled={quickSending || quickImages.length > 0}
                 onClick={() => { resetQuickTarget(); setQuickMode('group'); }}
               >
@@ -698,7 +725,7 @@ export default function Sidebar({
               {remoteCli && (
                 <button
                   className={`quick-cli${quickMode === 'agent' && quickCli === 'remote' ? ' on' : ''}`}
-                  title="Remote agent — an agent on another machine"
+                  title={cliTitle(remoteCli)}
                   disabled={quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === 'remote' ? { borderColor: remoteCli.color } : undefined}
                   onClick={() => {
@@ -710,7 +737,7 @@ export default function Sidebar({
                 <button
                   key={c!.id}
                   className={`quick-cli${quickMode === 'agent' && quickCli === c!.id ? ' on' : ''}${c!.available ? '' : ' off'}`}
-                  title={c!.label}
+                  title={cliTitle(c!)}
                   disabled={!c!.available || quickSending || quickImages.length > 0}
                   style={quickMode === 'agent' && quickCli === c!.id ? { borderColor: c!.color } : undefined}
                   onClick={() => { setQuickMode('agent'); if (quickCli !== c!.id) resetQuickTarget(); setQuickCli(c!.id); }}
@@ -742,7 +769,7 @@ export default function Sidebar({
                   value={quickName}
                   disabled={quickSending || quickImages.length > 0}
                   onChange={(e) => { resetQuickTarget(); setQuickName(e.target.value); }}
-                  onKeyDown={(e) => { if (e.key === 'Enter') submitQuick(); }}
+                  onKeyDown={(e) => { if (e.key === 'Enter') submitQuick(); if (e.key === 'Escape') closePanel(); }}
                 />
                 <FolderPicker
                   disabled={quickSending || quickImages.length > 0 || rule.folder !== 'ok'}
@@ -769,6 +796,7 @@ export default function Sidebar({
                   onChange={(e) => { setQuickPrompt(e.target.value); e.currentTarget.style.height = 'auto'; e.currentTarget.style.height = `${e.currentTarget.scrollHeight}px`; }}
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); submitQuick(); }
+                    if (e.key === 'Escape') closePanel();
                   }}
                 />
                 <Attachments
@@ -781,6 +809,7 @@ export default function Sidebar({
                 />
                 <div className="widget-actions">
                   <button className="btn-primary" onClick={submitQuick} disabled={quickSending || quickFilesBlocked}>{quickSending ? 'Starting…' : `Create${quickPrompt.trim() || quickImages.length ? ' & send' : ''}`}</button>
+                  <button className="btn-ghost" onClick={closePanel} disabled={quickSending}>Cancel</button>
                 </div>
               </>
             ) : (

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -201,15 +201,29 @@ body {
 .grp-mini .cli-logo { width: 8px; height: 8px; }
 .quick-prompt { width: 100%; resize: none; overflow: hidden; min-height: 34px; max-height: 160px; padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); color: var(--text); font: inherit; font-size: 13px; line-height: 1.45; }
 .quick-prompt:focus { outline: 2px solid color-mix(in srgb, var(--accent) 45%, transparent); border-color: var(--accent); }
-.quick-hint { font-size: 10.5px; color: var(--muted); }
-/* the group tile sits apart from the harnesses behind a hairline */
-.quick-sep { width: 1px; align-self: stretch; background: var(--border); margin: 3px 2px; }
+/* Name, folder and prompt are one column of equal rows. The folder button was
+   the shortest of the three, so the other two come down to it rather than it
+   stretching up — one number, so they cannot drift apart again. */
+.controls .widget { --field-h: 28px; }
+.controls .widget .quick-name,
+.controls .widget .fp .fp-current {
+  height: var(--field-h); min-height: var(--field-h);
+  padding-top: 0; padding-bottom: 0;
+}
+.controls .widget .quick-prompt {
+  min-height: var(--field-h); height: var(--field-h);
+  padding-top: 5px; padding-bottom: 5px; line-height: 1.35;
+}
+/* Second picker row: everything you can make that is not one of the agents. */
+.quick-clis-2 { margin-top: 4px; }
+/* A field switched off because it means nothing for this type says so in its
+   own box, rather than going grey and leaving you to guess. */
+.fp-current .fp-why { color: var(--muted); font-style: italic; }
+.controls .quick-prompt:disabled, .controls .quick-name:disabled { background: var(--panel-2); }
+.controls .quick-prompt:disabled::placeholder { font-style: italic; }
+/* the group tile leads the second picker row — the things that are not agents */
 .quick-grp { color: var(--muted); }
 .quick-grp.on { color: var(--accent); border-color: var(--accent) !important; }
-.quick-foot { display: flex; align-items: center; gap: 8px; }
-.quick-foot .quick-hint { margin-left: auto; white-space: nowrap; }
-.quick-more { background: none; border: none; padding: 0; font: inherit; font-size: 10.5px; font-weight: 600; color: var(--accent); cursor: pointer; white-space: nowrap; }
-.quick-more:hover { text-decoration: underline; }
 .quick-recovery { margin-top: -3px; color: var(--muted); font-size: 9.5px; line-height: 1.35; }
 .cart-row.off { opacity: 0.45; }
 
@@ -287,7 +301,11 @@ body {
 .fp-msg { color: var(--muted); cursor: default; }
 .fp-input { flex: 1; padding: 3px 8px !important; font-size: 12px !important; }
 
-.cart { display: flex; flex-direction: column; gap: 4px; }
+/* The panel no longer opens on demand — it is always there — so its height is
+   now permanent furniture above the fleet list. The cart is the one part that
+   grows without limit (one row per installed harness), so it scrolls inside a
+   cap instead of pushing the list off the bottom of a short window. */
+.cart { display: flex; flex-direction: column; gap: 4px; max-height: 168px; overflow-y: auto; }
 .cart-row { display: flex; align-items: center; gap: 8px; padding: 3px 4px; border-radius: var(--r-md); font-size: 13px; }
 .cart-row.has { background: color-mix(in srgb, var(--accent) 8%, transparent); }
 .cart-name { color: var(--text); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
@@ -530,7 +548,10 @@ body {
 .ov-note { font-size: 11px; color: var(--danger); }
 
 /* tree */
-.tree { flex: 1; overflow-y: auto; padding: 6px 8px 10px; display: flex; flex-direction: column; }
+/* min-height beats flex's default min-content floor AND guarantees the list
+   keeps room for a few rows: with an always-open create panel, a short window
+   would otherwise hand every pixel to the panel and leave the fleet invisible. */
+.tree { flex: 1; min-height: 108px; overflow-y: auto; padding: 6px 8px 10px; display: flex; flex-direction: column; }
 .tree > * { flex: none; } /* rows keep their natural height; the arch-note's margin-top:auto sinks it */
 .empty-hint { color: var(--muted); font-size: 12px; padding: 12px 10px; line-height: 1.5; }
 .empty-hint.nested { padding: 6px 10px 8px 38px; font-size: 11.5px; }
@@ -641,9 +662,6 @@ body {
 .status.idle, .status.stopped { color: var(--muted); }
 .status.stopped { opacity: 0.5; }
 
-/* quick-add utilities (shell / files) pinned above the legend */
-.quick-add { display: flex; gap: 6px; padding: 10px 10px; border-top: 1px solid var(--border); }
-.quick-add .btn-ghost { flex: 1; display: inline-flex; align-items: center; justify-content: center; gap: 7px; padding: 5.5px 8px; font-family: var(--font-mono); font-size: 12px; font-weight: 500; border-radius: var(--r-sm); }
 /* the create panel speaks the same dense mono voice as the rows */
 .controls .widget { gap: 6px; padding: 8px; border-radius: var(--r-md); }
 .controls .w-field { gap: 3px; }
@@ -662,16 +680,13 @@ body {
 .legend { display: flex; flex-wrap: wrap; align-items: center; gap: 6px 12px; padding: 10px 16px; border-top: 1px solid var(--border); font-size: 10.5px; color: var(--muted); }
 .legend > span { display: inline-flex; align-items: center; gap: 5px; }
 /* archived toggle: a quiet custom checkbox speaking the app's language */
-.legend-arch { position: relative; display: inline-flex; align-items: center; gap: 5px; cursor: pointer; }
-.legend-arch input { position: absolute; inset: 0; opacity: 0; margin: 0; cursor: pointer; }
-.legend-arch .lbox { width: 11px; height: 11px; flex: none; border: 1px solid var(--border-strong); border-radius: 3.5px; background: var(--panel-2); display: inline-flex; align-items: center; justify-content: center; transition: background 0.12s, border-color 0.12s; }
-.legend-arch:hover .lbox { border-color: var(--muted); }
-.legend-arch input:checked ~ .lbox { background: var(--accent); border-color: var(--accent); }
-.legend-arch input:checked ~ .lbox::after { content: ''; width: 5px; height: 2.5px; border-left: 1.5px solid var(--accent-fg); border-bottom: 1.5px solid var(--accent-fg); transform: rotate(-45deg) translateY(-1px); }
 /* archived rows/tiles: present but visibly parked */
 .row.archived .name, .row.archived .state-logo, .row.archived > .cli-logo { opacity: 0.45; }
 .ovt-tile.archived .ovt-head { opacity: 0.55; }
 .arch-note { font-size: 10.5px; color: var(--muted); font-style: italic; text-align: center; padding: 14px 12px 4px; margin-top: auto; }
+/* It reads as a sentence until you point at it, then as the link it is. */
+.arch-toggle { display: block; width: 100%; background: none; border: none; font: inherit; font-size: 10.5px; font-style: italic; color: var(--muted); cursor: pointer; }
+.arch-toggle:hover { color: var(--accent); text-decoration: underline; text-underline-offset: 2px; }
 
 /* main: tiles */
 .tiles { height: 100%; display: grid; gap: 12px; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -191,8 +191,12 @@ body {
 /* quickstart: one row of harnesses (+ the group tile), one prompt, go */
 /* Sized so every tile fits on ONE row at the sidebar's width; wrap stays as a
    fallback for a narrower viewport rather than overflowing. */
-.quick-clis { display: flex; gap: 4px; align-items: center; flex-wrap: wrap; }
-.quick-cli { width: 25px; height: 25px; flex: none; display: inline-flex; align-items: center; justify-content: center; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md); cursor: pointer; padding: 0; opacity: 0.65; }
+/* Six to a row, both rows on the same track size, so the picker fills the panel
+   instead of trailing off mid-width. A grid rather than flex: row two has fewer
+   buttons, and they must land on the same widths as row one rather than sizing
+   themselves. A seventh harness wraps onto a new line of the same grid. */
+.quick-clis { display: grid; grid-template-columns: repeat(6, 1fr); gap: 4px; align-items: center; }
+.quick-cli { width: 100%; height: 30px; flex: none; display: inline-flex; align-items: center; justify-content: center; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-md); cursor: pointer; padding: 0; opacity: 0.65; }
 .quick-cli:hover:not(:disabled) { opacity: 1; border-color: var(--border-strong); }
 .quick-cli.on { opacity: 1; border-width: 1.5px; box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent); }
 .quick-cli.off { opacity: 0.25; cursor: default; }


### PR DESCRIPTION
The create panel still opens from **+**. What changed is what is inside it: every session type is reachable from it, each button says what it is, and the fields it shows are the ones the type can actually use.

**Screens and measurements:** https://lvwerra-agent-artifacts.static.hf.space/create-panel/index.html

## What changed

| | |
|---|---|
| Two picker rows | agents on the first; group, remote, shell, files on the second |
| Shell and Files | were a separate strip pinned above the legend — ordinary choices now |
| Picker fills the width | six-column grid, so row one fills the panel and row two lands on the same track widths |
| Every button explains itself | a sentence on hover: who makes the agent, or what the type does |
| Name field first | prefilled with the name the agent will actually get |
| Inapplicable fields | disabled and *saying why*, instead of vanishing |
| One field height | name, folder and prompt share a single `--field-h` |
| Expander + `↵ launch · ⇧↵ newline` | gone — the prompt is in reach the moment the panel opens |

Plus the one thing outside the panel: **the archived line at the foot of the list is the switch now**, so the legend's checkbox is gone.

## Notes on three of those

**The prefilled name cannot collide.** It is a *display value, not a reservation*. `GET /api/next-name?cli=` calls the same `nextName()` the creation path calls — no second copy of the scheme in the client to drift. The field then stays empty until the operator edits it, so an untouched (or cleared) field sends no name at all and the server names the session exactly as it always did. Two creates racing on one prefill get distinct names. `server/test/next-name.test.mjs` pins both halves; it fails under three mutations (name drifting from the creation path, unknown cli accepted, wrong cli echoed).

**The picker.** A six-column grid rather than a flex row of fixed 25px squares, so row two cannot size itself to its own four buttons. One line, filling the width, at every sidebar width: 37×30 on desktop, 55×30 at 390, 44×30 at 320. A seventh harness wraps onto a new line of the same grid.

**Tooltips** are keyed by cli id with a fallback to the plain label, so a harness the server adds without a line here still gets a usable tooltip, and `(not installed)` still follows an unavailable one.

**The archived line renders in both states** — `show 2 archived sessions` ⇄ `hide 2 archived sessions`. One that only appeared while archived sessions were hidden would be a door that locks behind you.

## Two guards on panel height

An earlier revision of this branch left the panel permanently open; that is reverted, but two things it exposed are worth keeping. The group cart grows one row per installed harness — at 1280×560 it left **zero session rows visible** — so it now scrolls inside a 168px cap, and the tree keeps a 108px floor. Both only matter while the panel is open, which is now again a deliberate act.

## Two things I touched that were not on the list

- `Locked.tsx` painted a mock sidebar including the Shell/Files strip. With the strip gone from the real sidebar the mock was depicting a control that no longer exists, so it goes from the mock too.
- Dead CSS left by the deletions (`.quick-sep`, `.quick-foot`, `.quick-hint`, `.quick-more`, `.legend-arch`, `.quick-add`) removed, and two comments that described the old sidebar rewritten.

## Noted, not fixed

- `NewSession.tsx` keeps its own local copy of the naming scheme. It is still used for "add an agent to this group" and the empty-workspace prompt. Pointing it at the new endpoint is the obvious follow-up, but it is a different component and I left it alone.
- **Two suites already fail on the base commit** (`4faae2f`), unrelated to this branch — I checked both against a clean tree: `server/test/crons.test.mjs` (`run on restart fires once…` — the run list carries an extra `trigger: 'schedule'` entry) and `server/mobile.test.mjs` (`getByTitle('Back to list')` matches two elements).

Green otherwise: web 20/20, `test:render`, `test:screenshots` (which drives this panel directly), and every server suite bar those two.

Do not merge on my account — this wants the operator's eye on the panel first.