### PR TITLE
Reader: sub-agents in the summary line, the list, and one level down (PoC)

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -29,7 +29,7 @@ import {
 // frontend's framing is unchanged.
 const TERM_CTRL = '\x00\x00AM:';
 import { buildUsage } from './usage.js';
-import { buildTraces, traceDigests, digestFor, traceLocation, readTrace, readTraceBundle, readTraceByPath, traceHarnessOf } from './traces.js';
+import { buildTraces, traceDigests, digestFor, traceLocation, readTrace, readTraceBundle, readTraceByPath, traceHarnessOf, subagentRoster, readSubagentTrace } from './traces.js';
 import { initPush, publicKey, deviceCount, addSubscription, removeSubscription, sendToAll } from './push.js';
 import { startVisibilityWatch, isPublic, visibility } from './visibility.js';
 import { kindOfName, kindOfFile, mimeOf, readTextHead, TEXT_MAX } from './preview.js';
@@ -646,6 +646,40 @@ app.get('/api/agents/:id/tail', (req, res) => {
   const text = capturePane(s.id, lines);
   if (text === null) return res.json({ id: s.id, state: 'stopped', text: '', note: 'not running' });
   res.json({ id: s.id, state: deriveState(s, agentInfo().get(s.id)), text });
+});
+
+// The sub-agents this session spawned, and one sub-agent's own transcript.
+//
+// Both read the `subagents/` directory next to the session's transcript and
+// never the transcript itself: the parent is up to 292 MB on this machine and
+// the roster is a directory listing. Whether a sub-agent has FINISHED is not
+// answered here — that fact lives in the parent's own records, which the reader
+// already has for the window it is showing, and inventing an answer from file
+// mtime would be wrong several times an hour (measured: p99 silence 112s inside
+// a live sub-agent, max 601s).
+app.get('/api/agents/:id/subagents', async (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  try {
+    res.json({ id: s.id, ...(await subagentRoster(s)) });
+  } catch (e) {
+    console.error('[subagents]', e && e.message);
+    res.status(500).json({ error: (e && e.message) || 'roster failed' });
+  }
+});
+
+app.get('/api/agents/:id/subagents/:agentId', async (req, res) => {
+  const s = store.get(req.params.id);
+  if (!s) return res.status(404).json({ error: 'not found' });
+  try {
+    res.json(await readSubagentTrace(s, req.params.agentId, traceOpts(req.query)));
+  } catch (e) {
+    if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
+      return res.status(404).json({ error: e.message, code: e.code });
+    }
+    console.error('[subagent-trace]', e && e.message);
+    res.status(500).json({ error: (e && e.message) || 'sub-agent trace read failed' });
+  }
 });
 
 // Block until the target reaches one of `state` — so a coordinating agent makes

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1045,7 +1045,14 @@ async function normalizeClaude(file, out, range) {
   for await (const j of jsonLines(file, range)) {
     // These embed whole file contents; share.js drops them and so do we.
     if (j.type === 'file-history-snapshot' || j.type === 'file-history-delta') continue;
-    if (j.isMeta || j.sourceToolUseID) continue;
+    // `isMeta` is the harness talking to itself, and dropped — with one
+    // exception, added for the reader's sub-agent strip: a `task-notification`
+    // is the ONLY record that says a sub-agent finished, and what it handed
+    // back. In a sub-agent's own transcript (CLI 2.1.209) those records carry
+    // isMeta, while in a parent's they do not, so dropping them meant a
+    // sub-agent that spawned sub-agents could never show any of them as done.
+    // It still renders as a `system` turn, which the reader does not draw.
+    if ((j.isMeta || j.sourceToolUseID) && j.origin?.kind !== 'task-notification') continue;
     if (j.type === 'queue-operation') {
       const text = queueKey(j.content);
       if (j.operation === 'enqueue') {
@@ -1107,7 +1114,12 @@ async function normalizeClaude(file, out, range) {
         // Injected environment/reminder blobs are not prompts — show them, but
         // as system so the conversation reads correctly (same rule the digest
         // uses to avoid counting them).
-        if (j.type === 'user' && (t.startsWith('<') || t.startsWith('[Request interrupted'))) {
+        // `[SYSTEM NOTIFICATION - NOT USER INPUT]` is how CLI 2.1.209 opens a
+        // task-notification inside a SUB-AGENT's transcript, where the parent's
+        // copy opens with the tag itself. It says so on the tin; without it in
+        // this list the record reads as something the operator typed, and the
+        // reader would open a new exchange with harness noise in the prompt band.
+        if (j.type === 'user' && (t.startsWith('<') || t.startsWith('[Request interrupted') || t.startsWith('[SYSTEM NOTIFICATION'))) {
           out.push({ role: 'system', ts, blocks: [textBlock('text', t)] });
           continue;
         }
@@ -1949,6 +1961,89 @@ export async function readTrace(session, opts = {}) {
     sessionId: hit.sessionId || session.sessionUuid || null,
     size: st.size,
   }, opts);
+}
+
+/**
+ * The sub-agents a Claude session spawned, from the directory beside its own
+ * transcript. (PoC — see docs/… nothing; this is the reader's sub-agent strip.)
+ *
+ *   <project>/<session-uuid>.jsonl          the parent, up to 292 MB here
+ *   <project>/<session-uuid>/subagents/
+ *       agent-<agentId>.jsonl               the child's transcript
+ *       agent-<agentId>.meta.json           187 bytes, and the whole point
+ *
+ * The roster is a directory listing plus a few kilobytes: the sidecar names the
+ * task (`description`), the exact spawning call (`toolUseId`), the parent agent
+ * and the depth. Nothing here opens the parent transcript, which is the only
+ * reason this can be asked for on a poll — reading the parent per poll is not
+ * survivable at 292 MB.
+ *
+ * Two timestamps come free from stat(), and they are not the same thing:
+ *   spawnedAt   — the sidecar's mtime. Written once, when the agent is created.
+ *   lastWroteAt — the transcript's mtime. Moves while it works, and then stops
+ *                 whether it finished or died. It is reported, never judged:
+ *                 measured gaps between consecutive records inside a LIVE
+ *                 sub-agent run to 601s (p99 112s), so "silent means dead" is
+ *                 wrong several times an hour. Whether one is finished is
+ *                 decided in the client from the parent's own records.
+ */
+export async function subagentRoster(session) {
+  const loc = await traceLocation(session);
+  if (!loc || session.cli !== 'claude' || loc.format !== 'jsonl') {
+    return { supported: false, reason: session.cli === 'claude' ? 'no transcript yet' : `${session.cli} keeps sub-agents elsewhere`, dir: null, agents: [] };
+  }
+  const dir = path.join(loc.path.replace(/\.jsonl$/, ''), 'subagents');
+  let names = [];
+  try { names = await fsp.readdir(dir); } catch { return { supported: true, dir, agents: [] }; }
+
+  const agents = [];
+  for (const name of names) {
+    const m = /^agent-([A-Za-z0-9_-]+)\.meta\.json$/.exec(name);
+    if (!m) continue;
+    const agentId = m[1];
+    const metaPath = path.join(dir, name);
+    const filePath = path.join(dir, `agent-${agentId}.jsonl`);
+    let meta = {};
+    try { meta = JSON.parse(await fsp.readFile(metaPath, 'utf8')) || {}; } catch { /* a half-written sidecar is still an agent */ }
+    const [metaSt, fileSt] = await Promise.all([statRetry(metaPath), statRetry(filePath)]);
+    agents.push({
+      agentId,
+      agentType: meta.agentType || null,
+      description: meta.description || null,
+      toolUseId: meta.toolUseId || null,
+      parentAgentId: meta.parentAgentId || null,
+      depth: Number.isFinite(meta.spawnDepth) ? meta.spawnDepth : null,
+      spawnedAt: metaSt ? Math.round(metaSt.mtimeMs) : null,
+      lastWroteAt: fileSt ? Math.round(fileSt.mtimeMs) : null,
+      bytes: fileSt ? fileSt.size : 0,
+      hasTranscript: !!fileSt,
+    });
+  }
+  agents.sort((a, b) => (a.spawnedAt || 0) - (b.spawnedAt || 0));
+  return { supported: true, dir, agents };
+}
+
+/**
+ * One sub-agent's transcript, read as an ordinary trace.
+ *
+ * It IS an ordinary trace — same records, same normalizer, so the reader can
+ * render a sub-agent with the component it already uses for a session. The file
+ * is small (11 MB across all 38 of the largest session here) where the parent
+ * is not, which is the other half of why this feature is affordable.
+ *
+ * `agentId` arrives from the browser and lands in a path, so it is matched
+ * against the id shape rather than trusted.
+ */
+export async function readSubagentTrace(session, agentId, opts = {}) {
+  if (!/^[A-Za-z0-9_-]{1,64}$/.test(String(agentId || ''))) {
+    const e = new Error('not a sub-agent id'); e.code = 'no-trace'; throw e;
+  }
+  const loc = await traceLocation(session);
+  if (!loc || session.cli !== 'claude' || loc.format !== 'jsonl') {
+    const e = new Error('this session keeps no sub-agent transcripts'); e.code = 'unsupported-harness'; throw e;
+  }
+  const file = path.join(loc.path.replace(/\.jsonl$/, ''), 'subagents', `agent-${agentId}.jsonl`);
+  return readTraceByPath(file, opts);
 }
 
 /**

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1183,7 +1183,7 @@ async function normalizeClaude(file, out, range) {
 // attach to it — so one row reads "text + 16 tool calls (exec_command,
 // apply_patch, write_stdin)" the way the Hub's own viewer shows it, instead of
 // 17 separate rows.
-async function normalizeCodex(file, out, range) {
+async function normalizeCodex(file, out, range, allowSubagent = false) {
   const stitch = makeStitcher();
   const seenThinking = new Set();
   let cur = null;      // the assistant turn being built
@@ -1201,7 +1201,11 @@ async function normalizeCodex(file, out, range) {
     const ts = j.timestamp ? Date.parse(j.timestamp) || undefined : undefined;
 
     if (j.type === 'session_meta') {
-      if (p.thread_source === 'subagent' || p.source?.subagent) {
+      // A sub-agent's rollout is refused as a SESSION view — it is an internal
+      // thread, not the operator's conversation — but the sub-agent strip asks
+      // for it deliberately, by an id it resolved from this pane's own roster.
+      // Same file, two callers, one of which has the right to see it.
+      if (!allowSubagent && (p.thread_source === 'subagent' || p.source?.subagent)) {
         const err = new Error('this rollout is an internal guardian/subagent thread, not the session');
         err.code = 'trace-not-user-conversation';
         throw err;
@@ -1247,6 +1251,27 @@ async function normalizeCodex(file, out, range) {
           seenThinking.add(text.trim());
           assistant(ts).blocks.push(textBlock('thinking', text));
         }
+      } else if (p.type === 'agent_message') {
+        // Codex's sub-agent post. The parent's rollout carries one per child:
+        //
+        //   author: "/root/pty_summary"   recipient: "/root"
+        //   "Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/pty_summary\nPayload: …"
+        //
+        // and that is the authoritative "this sub-agent finished, and here is
+        // what it handed back" — the same job Claude's `<task-notification>`
+        // does. The study reported no terminal event for codex because it was
+        // looking for `sub_agent_activity`, which CLI 0.149.1 does not emit at
+        // all; this is what it emits instead. Kept as `system` so the reader
+        // does not draw it and the strip can read it, exactly like Claude's.
+        // Encrypted parts are dropped: the NEW_TASK a parent sends a child
+        // carries its payload encrypted, so there is nothing to show.
+        const parts = (Array.isArray(p.content) ? p.content : [])
+          .map((c) => String((c && c.text) || ''))
+          .filter((t) => t.trim());
+        if (!parts.length) continue;
+        const from = p.author ? `Sender: ${p.author}` : '';
+        const text = parts.join('\n');
+        out.push({ role: 'system', ts, blocks: [textBlock('text', text.includes('Sender:') ? text : `${from}\n${text}`)] });
       } else if (['function_call', 'custom_tool_call', 'local_shell_call', 'web_search_call'].includes(p.type)) {
         const use = { type: 'tool_use', id: p.call_id || p.id, name: p.name || p.type, ...capText(p.arguments ?? p.input) };
         const msg = assistant(ts);
@@ -1579,12 +1604,12 @@ function markFinalTurns(out) {
   }
 }
 
-async function parseTraceFile(harness, file, sessionId, range = null) {
+async function parseTraceFile(harness, file, sessionId, range = null, allowSubagent = false) {
   const out = newTrace(harness);
   out.sessionId = sessionId || null;
   switch (harness) {
     case 'claude': await normalizeClaude(file, out, range); break;
-    case 'codex': await normalizeCodex(file, out, range); break;
+    case 'codex': await normalizeCodex(file, out, range, allowSubagent); break;
     case 'openclaw': await normalizeOpenClaw(file, out, range); break;
     case 'sts': await normalizeSts(file, out, range); break;
     case 'opencode': normalizeOpencodeDb(file, sessionId, out); break;
@@ -1751,7 +1776,7 @@ function firstWholeLine(buf, aligned) {
   return nl < 0 ? buf.length : nl + 1;
 }
 
-async function oneWindow(harness, file, sessionId, range, size, prebuilt) {
+async function oneWindow(harness, file, sessionId, range, size, prebuilt, allowSubagent = false) {
   let taskAligned = false;
   if (prebuilt) range.buf = prebuilt;
   if (harness === 'codex' && range.from > 0) {
@@ -1773,7 +1798,7 @@ async function oneWindow(harness, file, sessionId, range, size, prebuilt) {
       range.danglingTaskComplete = 'ignore';
     }
   }
-  const parsed = await parseTraceFile(harness, file, sessionId, range);
+  const parsed = await parseTraceFile(harness, file, sessionId, range, allowSubagent);
   const start = range.start ?? range.from;
   const end = range.end ?? range.to;
   // Having READ to the end of the file is what makes this the end of the
@@ -1794,7 +1819,7 @@ async function oneWindow(harness, file, sessionId, range, size, prebuilt) {
   return { parsed, cur: { mode: 'bytes', start, end, atStart: start <= 0, atEnd } };
 }
 
-async function readWindow(harness, file, sessionId, size, req) {
+async function readWindow(harness, file, sessionId, size, req, allowSubagent = false) {
   const bytes = clampN(Math.trunc(req.bytes) || WINDOW_BYTES, WINDOW_MIN_BYTES, WINDOW_MAX_BYTES);
   const min = clampN(Math.trunc(req.min) || WINDOW_MIN_TURNS, 1, 500);
   const cursor = clampN(Math.trunc(req.cursor) || 0, 0, size);
@@ -1804,10 +1829,10 @@ async function readWindow(harness, file, sessionId, size, req) {
     // one window. Hand back the tail and flag the gap, so the reader replaces
     // what it holds instead of splicing a hole into the middle of it.
     if (size - cursor > WINDOW_MAX_BYTES) {
-      const w = await readWindow(harness, file, sessionId, size, { at: 'tail', bytes, min });
+      const w = await readWindow(harness, file, sessionId, size, { at: 'tail', bytes, min }, allowSubagent);
       return { ...w, cur: { ...w.cur, gap: true } };
     }
-    return oneWindow(harness, file, sessionId, { from: cursor, to: size, aligned: true, eof: true }, size);
+    return oneWindow(harness, file, sessionId, { from: cursor, to: size, aligned: true, eof: true }, size, undefined, allowSubagent);
   }
 
   const to = req.at === 'before' ? cursor : size;
@@ -1831,7 +1856,7 @@ async function readWindow(harness, file, sessionId, size, req) {
       buf = buf && buf.length ? Buffer.concat([head, buf]) : head;
       bufFrom = from;
     }
-    const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size, buf);
+    const w = await oneWindow(harness, file, sessionId, { from, to, aligned: from === 0, eof }, size, buf, allowSubagent);
     if (w.parsed.messages.length >= min || from === 0 || span >= WINDOW_MAX_BYTES) {
       // A window that consumed nothing at all has hit a single line longer than
       // the ceiling (a file-history blob), and no amount of asking again will
@@ -1913,10 +1938,10 @@ async function refuseCodexSubagent(file) {
  *   { offset, limit }                      — index paging (Overview, RENDER mode)
  * `decorate` is the bundle manifest pass, applied to every fresh parse.
  */
-async function serveTrace({ key, harness, file, sessionId, size, decorate }, opts) {
+async function serveTrace({ key, harness, file, sessionId, size, decorate, allowSubagent }, opts) {
   const full = async () => {
     if (viewMemo.key !== key) {
-      const parsed = await tracked(PHASE.readTrace, () => parseTraceFile(harness, file, sessionId));
+      const parsed = await tracked(PHASE.readTrace, () => parseTraceFile(harness, file, sessionId, null, allowSubagent));
       if (decorate) await decorate(parsed);
       viewMemo = { key, val: parsed };
     }
@@ -1927,7 +1952,7 @@ async function serveTrace({ key, harness, file, sessionId, size, decorate }, opt
   if (!opts.window) return pageOf(await full(), opts.offset ?? 0, opts.limit ?? 200);
   if (!WINDOWABLE.has(harness)) return windowIndex(await full(), opts.window);
 
-  if (harness === 'codex') {
+  if (harness === 'codex' && !allowSubagent) {
     try {
       await refuseCodexSubagent(file);
     } catch (e) {
@@ -1936,7 +1961,7 @@ async function serveTrace({ key, harness, file, sessionId, size, decorate }, opt
     }
   }
   const { parsed, cur } = await tracked(PHASE.readTrace, () =>
-    readWindow(harness, file, sessionId, size, opts.window));
+    readWindow(harness, file, sessionId, size, opts.window, allowSubagent));
   if (decorate) await decorate(parsed);
   return windowOf(parsed, cur);
 }
@@ -1964,6 +1989,87 @@ export async function readTrace(session, opts = {}) {
 }
 
 /**
+ * Codex keeps a sub-agent's transcript as an ordinary rollout, in the same tree
+ * as every other session, and says whose child it is in its own header:
+ *
+ *   "thread_source": "subagent",
+ *   "source": { "subagent": { "thread_spawn": {
+ *       "parent_thread_id": "01a0581a-5757-…", "depth": 1,
+ *       "agent_path": "/root/pty_summary", "agent_nickname": "Curie" } } }
+ *
+ * So the roster is: every rollout whose header names this session as its parent.
+ * That means reading first lines rather than a directory listing, which is why
+ * the header is memoized per file+mtime — a rollout's header never changes once
+ * written, and there are tens of files, not thousands.
+ *
+ * `agent_path` is the join key back to the parent's own records: the parent's
+ * `spawn_agent` call carries `{"task_name":"pty_summary"}` and its output
+ * `{"task_name":"/root/pty_summary"}`, and the completion post names the same
+ * path as `Sender:`. There is no shared id anywhere in the pair, so the name is
+ * the link — and it is exact, not a heuristic.
+ */
+const codexHeadMemo = new Map();   // file -> { key, head }
+
+async function codexSubagentHeader(file) {
+  const st = await statRetry(file);
+  if (!st) return null;
+  const key = `${st.mtimeMs}:${st.size}`;
+  const hit = codexHeadMemo.get(file);
+  if (hit && hit.key === key) return hit.head;
+  let head = null;
+  try {
+    for await (const j of jsonLines(file)) {
+      const p = j.payload || j;
+      if (j.type !== 'session_meta' && p?.type !== 'session_meta' && !p?.id) break;
+      const spawn = p?.source?.subagent?.thread_spawn;
+      head = {
+        threadId: p?.id || null,
+        parentThreadId: spawn?.parent_thread_id || null,
+        depth: Number.isFinite(spawn?.depth) ? spawn.depth : null,
+        agentPath: spawn?.agent_path || null,
+        nickname: spawn?.agent_nickname || null,
+        firstTs: j.timestamp ? Date.parse(j.timestamp) || null : null,
+        bytes: st.size,
+        mtimeMs: Math.round(st.mtimeMs),
+      };
+      break;                       // the first line is the header
+    }
+  } catch { /* unreadable file: not a sub-agent as far as we know */ }
+  if (codexHeadMemo.size > 400) codexHeadMemo.clear();
+  codexHeadMemo.set(file, { key, head });
+  return head;
+}
+
+async function codexSubagentRoster(session) {
+  const parentId = session.codexSessionId
+    || (session.codexRollout && (path.basename(session.codexRollout).match(UUID_RE) || [])[1])
+    || null;
+  if (!parentId) return { supported: true, reason: 'no rollout for this pane yet', dir: null, agents: [] };
+  const agents = [];
+  for (const file of await codexFiles()) {
+    const head = await codexSubagentHeader(file);
+    if (!head || head.parentThreadId !== parentId) continue;
+    const task = head.agentPath || '';
+    agents.push({
+      agentId: head.threadId,
+      agentType: head.nickname || 'sub-agent',
+      description: task.split('/').filter(Boolean).pop() || head.nickname || 'sub-agent',
+      /** codex has no per-call id; the task path is what the parent's records name */
+      toolUseId: null,
+      taskName: task || null,
+      parentAgentId: head.parentThreadId,
+      depth: head.depth,
+      spawnedAt: head.firstTs,
+      lastWroteAt: head.mtimeMs,
+      bytes: head.bytes,
+      hasTranscript: true,
+    });
+  }
+  agents.sort((a, b) => (a.spawnedAt || 0) - (b.spawnedAt || 0));
+  return { supported: true, dir: null, agents };
+}
+
+/**
  * The sub-agents a Claude session spawned, from the directory beside its own
  * transcript. (PoC — see docs/… nothing; this is the reader's sub-agent strip.)
  *
@@ -1988,6 +2094,7 @@ export async function readTrace(session, opts = {}) {
  *                 decided in the client from the parent's own records.
  */
 export async function subagentRoster(session) {
+  if (session.cli === 'codex') return codexSubagentRoster(session);
   const loc = await traceLocation(session);
   if (!loc || session.cli !== 'claude' || loc.format !== 'jsonl') {
     return { supported: false, reason: session.cli === 'claude' ? 'no transcript yet' : `${session.cli} keeps sub-agents elsewhere`, dir: null, agents: [] };
@@ -2038,6 +2145,18 @@ export async function readSubagentTrace(session, agentId, opts = {}) {
   if (!/^[A-Za-z0-9_-]{1,64}$/.test(String(agentId || ''))) {
     const e = new Error('not a sub-agent id'); e.code = 'no-trace'; throw e;
   }
+  if (session.cli === 'codex') {
+    // The id IS a thread id, and a rollout's name carries it. Matched against
+    // the roster rather than pasted into a path, so a browser cannot ask for a
+    // file this session is not the parent of.
+    const { agents } = await codexSubagentRoster(session);
+    const mine = agents.find((a) => a.agentId === agentId);
+    if (!mine) { const e = new Error('not a sub-agent of this pane'); e.code = 'no-trace'; throw e; }
+    for (const file of await codexFiles()) {
+      if (path.basename(file).includes(agentId)) return readTraceByPath(file, opts, true);
+    }
+    const e = new Error('sub-agent rollout not found'); e.code = 'no-trace'; throw e;
+  }
   const loc = await traceLocation(session);
   if (!loc || session.cli !== 'claude' || loc.format !== 'jsonl') {
     const e = new Error('this session keeps no sub-agent transcripts'); e.code = 'unsupported-harness'; throw e;
@@ -2060,7 +2179,7 @@ export async function traceHarnessOf(file) {
  * reader above locates a file for a session; this one is handed the file and
  * sniffs the format the same way an imported bundle does.
  */
-export async function readTraceByPath(file, opts = {}) {
+export async function readTraceByPath(file, opts = {}, allowSubagent = false) {
   const st = await statRetry(file);
   if (!st) { const e = new Error('trace file unreadable'); e.code = 'no-trace'; throw e; }
 
@@ -2068,11 +2187,12 @@ export async function readTraceByPath(file, opts = {}) {
   if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
 
   return serveTrace({
-    key: `f:${file}:${st.mtimeMs}:${st.size}`,
+    key: `f:${file}:${st.mtimeMs}:${st.size}${allowSubagent ? ':sub' : ''}`,
     harness,
     file,
     sessionId: null,
     size: st.size,
+    allowSubagent,
   }, opts);
 }
 

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1184,6 +1184,23 @@ async function normalizeClaude(file, out, range) {
 // apply_patch, write_stdin)" the way the Hub's own viewer shows it, instead of
 // 17 separate rows.
 async function normalizeCodex(file, out, range, allowSubagent = false) {
+  // Where this sub-agent's OWN conversation starts.
+  //
+  // A codex sub-agent is spawned with `fork_turns: "all"`, so its rollout opens
+  // with the whole parent conversation copied into it — the operator's prompt,
+  // the parent's earlier turns, the lot — and only then the task it was given.
+  // Rendered whole, an expanded sub-agent shows the parent's history and reads
+  // as if the child had done the parent's work. It is the file that says this,
+  // not the renderer, so the fix is here: the boundary is the NEW_TASK post
+  // addressed to this thread, and everything before it is somebody else's.
+  //
+  //   0  session_meta (this child)      ← its own header
+  //   1  session_meta (the parent)      ┐
+  //   …  developer/user messages        │ the forked conversation
+  //  14  inter_agent_communication…     ┘
+  //  15  agent_message  NEW_TASK → /root/pty_summary   ← the child's own start
+  //  16… its reasoning, its tools, its answer
+  let forkEnd = null;
   const stitch = makeStitcher();
   const seenThinking = new Set();
   let cur = null;      // the assistant turn being built
@@ -1252,6 +1269,12 @@ async function normalizeCodex(file, out, range, allowSubagent = false) {
           assistant(ts).blocks.push(textBlock('thinking', text));
         }
       } else if (p.type === 'agent_message') {
+        // The task hand-off to THIS thread ends the forked prelude. Its payload
+        // is encrypted, so there is nothing to render from it either way.
+        if (allowSubagent && forkEnd === null && /Message Type:\s*NEW_TASK/.test(
+          (Array.isArray(p.content) ? p.content : []).map((c) => String((c && c.text) || '')).join('\n'))) {
+          forkEnd = out.messages.length;
+        }
         // Codex's sub-agent post. The parent's rollout carries one per child:
         //
         //   author: "/root/pty_summary"   recipient: "/root"
@@ -1360,6 +1383,13 @@ async function normalizeCodex(file, out, range, allowSubagent = false) {
     }
   }
   if (encrypted) out.note = `${encrypted} reasoning step${encrypted === 1 ? '' : 's'} were encrypted by the model and carry no readable text`;
+  // …and drop it, now that the whole file has been read. Only when a boundary
+  // was found: a sub-agent spawned without a fork, or one whose hand-off is
+  // outside this window, is better shown whole than shown empty.
+  if (allowSubagent && forkEnd !== null && forkEnd > 0) {
+    out.messages = out.messages.slice(forkEnd);
+  }
+
 }
 
 // OpenClaw — already close to STS: {type:'message', message:{role,content,usage}}

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1038,7 +1038,18 @@ const queueKey = (s) => String(s || '').replace(/\s+/g, ' ').trim();
 // that, and showing it as a prompt would be a new bug in place of the old one.
 const isHarnessText = (t) => t.startsWith('<') || t.startsWith('[Request interrupted');
 
-async function normalizeClaude(file, out, range) {
+async function normalizeClaude(file, out, range, allowSubagent = false) {
+  // Where a FORK's own conversation starts.
+  //
+  // `subagent_type: "fork"` inherits the parent's transcript — the harness says
+  // so itself, in the boilerplate that ends the inherited part: "You are a
+  // worker fork. The transcript above is the parent's history — inherited
+  // reference, not your situation." The last inherited record is the `Agent`
+  // call that created this fork, so rendering the file whole makes a fork
+  // appear to have spawned itself, with its own summary line crediting it with
+  // one sub-agent — and expanding that row opens the same transcript again,
+  // without bound. Same shape as codex's `fork_turns: "all"`, one harness over.
+  let forkEnd = null;
   const stitch = makeStitcher();
   const byMsgId = new Map();
   const pending = [];   // queued prompts, oldest first, until dequeued or removed
@@ -1120,6 +1131,7 @@ async function normalizeClaude(file, out, range) {
         // this list the record reads as something the operator typed, and the
         // reader would open a new exchange with harness noise in the prompt band.
         if (j.type === 'user' && (t.startsWith('<') || t.startsWith('[Request interrupted') || t.startsWith('[SYSTEM NOTIFICATION'))) {
+          if (allowSubagent && forkEnd === null && t.startsWith('<fork-boilerplate>')) forkEnd = out.messages.length;
           out.push({ role: 'system', ts, blocks: [textBlock('text', t)] });
           continue;
         }
@@ -1147,6 +1159,13 @@ async function normalizeClaude(file, out, range) {
       out.push(msg);
       if (id) byMsgId.set(id, msg);
     }
+  }
+  // A fork's inherited prelude goes now that the whole window has been read.
+  // Only when the boilerplate was actually seen: a general-purpose sub-agent
+  // inherits nothing and has none, and a fork whose boilerplate is outside this
+  // window is better shown whole than shown empty.
+  if (allowSubagent && forkEnd !== null && forkEnd > 0) {
+    out.messages = out.messages.slice(forkEnd);
   }
   // Dropped at the end rather than never pushed: which path a queued prompt took
   // is not known until its dequeue or remove has been read. Anything still
@@ -1638,7 +1657,7 @@ async function parseTraceFile(harness, file, sessionId, range = null, allowSubag
   const out = newTrace(harness);
   out.sessionId = sessionId || null;
   switch (harness) {
-    case 'claude': await normalizeClaude(file, out, range); break;
+    case 'claude': await normalizeClaude(file, out, range, allowSubagent); break;
     case 'codex': await normalizeCodex(file, out, range, allowSubagent); break;
     case 'openclaw': await normalizeOpenClaw(file, out, range); break;
     case 'sts': await normalizeSts(file, out, range); break;
@@ -2192,7 +2211,7 @@ export async function readSubagentTrace(session, agentId, opts = {}) {
     const e = new Error('this session keeps no sub-agent transcripts'); e.code = 'unsupported-harness'; throw e;
   }
   const file = path.join(loc.path.replace(/\.jsonl$/, ''), 'subagents', `agent-${agentId}.jsonl`);
-  return readTraceByPath(file, opts);
+  return readTraceByPath(file, opts, true);
 }
 
 /**

--- a/server/test/subagent-traces.test.mjs
+++ b/server/test/subagent-traces.test.mjs
@@ -1,0 +1,120 @@
+// Reading a SUB-AGENT's transcript, on both harnesses.
+//
+// The bug this pins: a codex sub-agent is spawned with `fork_turns: "all"`, so
+// its rollout opens with the parent's entire conversation copied into it and
+// only then the task it was given. Rendered whole, an expanded sub-agent showed
+// the parent's history — the operator's report was "the sub agents expanded
+// seem to mirror the main agent trace". It is the file that says that, not the
+// renderer, so the trim is here.
+//
+// Also pinned: a sub-agent rollout stays refused as a SESSION view, and is only
+// readable through the deliberate path.
+// Run with:  node test/subagent-traces.test.mjs
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import assert from 'node:assert/strict';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'subagent-trace-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const { readTraceByPath } = await import('../src/traces.js');
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+const at = (s) => new Date(Date.UTC(2026, 7, 31, 13, 55, s)).toISOString();
+const rec = (type, payload, sec) => JSON.stringify({ timestamp: at(sec), type, payload });
+
+// A codex sub-agent rollout in the real shape: its own header, the parent's
+// header, the forked conversation, the NEW_TASK hand-off, then its own work.
+const child = path.join(TMP, 'rollout-2026-08-31T13-55-34-01a0581a-9c0c-child.jsonl');
+fs.writeFileSync(child, [
+  rec('session_meta', { id: '01a0581a-9c0c', cwd: TMP, thread_source: 'subagent',
+    source: { subagent: { thread_spawn: { parent_thread_id: '01a0581a-5757', depth: 1, agent_path: '/root/pty_summary', agent_nickname: 'Curie' } } } }, 34),
+  rec('session_meta', { id: '01a0581a-5757', cwd: TMP, thread_source: 'user', source: 'cli' }, 34),
+  rec('event_msg', { type: 'task_started', turn_id: 'parent-turn' }, 34),
+  rec('response_item', { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'THE PARENT PROMPT: rebuild the five scenes' }] }, 34),
+  rec('response_item', { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'THE PARENT ANSWER: spawning three' }] }, 34),
+  rec('event_msg', { type: 'task_started', turn_id: 'child-turn' }, 34),
+  rec('response_item', { type: 'agent_message', author: '/root', recipient: '/root/pty_summary',
+    content: [{ type: 'input_text', text: 'Message Type: NEW_TASK\nTask name: /root/pty_summary\nSender: /root\nPayload:\n' },
+              { type: 'encrypted_content', encrypted_content: 'gAAAAAB…' }] }, 35),
+  rec('response_item', { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ITS OWN WORK: reading the file' }] }, 39),
+  rec('response_item', { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ITS OWN ANSWER: a PTY is a pseudo-terminal.' }] }, 44),
+].join('\n') + '\n');
+
+console.log('a codex sub-agent renders its own conversation, not the one it was forked from');
+{
+  const w = await readTraceByPath(child, { offset: 0, limit: 50 }, true);
+  const text = w.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+  check('the forked parent turns are gone', () => {
+    assert.doesNotMatch(text, /THE PARENT PROMPT/);
+    assert.doesNotMatch(text, /THE PARENT ANSWER/);
+  });
+  check('and everything the child itself did is there', () => {
+    assert.match(text, /ITS OWN WORK/);
+    assert.match(text, /ITS OWN ANSWER/);
+  });
+  check('the hand-off marks the boundary and stays as a system turn', () => {
+    assert.match(text, /Message Type: NEW_TASK/);
+    assert.equal(w.turns[0].role, 'system');
+  });
+  check('the encrypted payload is not rendered as content', () => assert.doesNotMatch(text, /gAAAAAB/));
+}
+
+console.log('\nand a codex sub-agent with no hand-off in view is shown whole, not empty');
+{
+  // A rollout whose NEW_TASK is outside the window — or a spawn shape that never
+  // wrote one. Trimming to a guessed offset would leave the row empty, which is
+  // worse than showing more than its own work.
+  const noHandoff = path.join(TMP, 'rollout-2026-08-31T13-55-40-01a0581a-nohandoff.jsonl');
+  fs.writeFileSync(noHandoff, [
+    rec('session_meta', { id: '01a0581a-bbbb', cwd: TMP, thread_source: 'subagent',
+      source: { subagent: { thread_spawn: { parent_thread_id: '01a0581a-5757', depth: 1, agent_path: '/root/late', agent_nickname: 'Kepler' } } } }, 40),
+    rec('response_item', { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'MID-TASK: still measuring' }] }, 41),
+    rec('response_item', { type: 'message', role: 'assistant', content: [{ type: 'output_text', text: 'ITS ANSWER: 41 files' }] }, 42),
+  ].join('\n') + '\n');
+  const w = await readTraceByPath(noHandoff, { offset: 0, limit: 50 }, true);
+  const text = w.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+  check('it still has its turns', () => {
+    assert.ok(w.turns.length >= 2, `expected the whole thing, got ${w.turns.length} turns`);
+    assert.match(text, /MID-TASK/);
+    assert.match(text, /ITS ANSWER/);
+  });
+}
+
+console.log('\nand a sub-agent rollout is still not a session view');
+{
+  let code = null;
+  try { await readTraceByPath(child, { offset: 0, limit: 50 }); } catch (e) { code = e.code; }
+  check('reading it as a session is refused, as it always was',
+    () => assert.equal(code, 'trace-not-user-conversation'));
+}
+
+console.log('\nand a sub-agent with no fork is shown whole');
+{
+  // Claude's children are not forks: their transcript begins with the task.
+  const claudeChild = path.join(TMP, 'agent-a441b23d799f09ede.jsonl');
+  fs.writeFileSync(claudeChild, [
+    JSON.stringify({ type: 'user', isSidechain: true, agentId: 'a441b23d799f09ede', cwd: TMP, timestamp: at(10),
+      message: { role: 'user', content: 'Reshoot scene 3 with a clean sidebar.' } }),
+    JSON.stringify({ type: 'assistant', isSidechain: true, agentId: 'a441b23d799f09ede', cwd: TMP, timestamp: at(20),
+      message: { id: 'm1', role: 'assistant', content: [{ type: 'text', text: 'Done — the plate is clean.' }] } }),
+  ].join('\n') + '\n');
+  const w = await readTraceByPath(claudeChild, { offset: 0, limit: 50 }, true);
+  const text = w.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+  check('the task it was given is the first thing in it', () => {
+    assert.match(text, /Reshoot scene 3/);
+    assert.equal(w.turns[0].role, 'user');
+  });
+  check('…and its answer is the last', () => assert.match(text, /the plate is clean/));
+}
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/server/test/subagent-traces.test.mjs
+++ b/server/test/subagent-traces.test.mjs
@@ -97,6 +97,45 @@ console.log('\nand a sub-agent rollout is still not a session view');
     () => assert.equal(code, 'trace-not-user-conversation'));
 }
 
+console.log('\nand a CLAUDE fork does not render itself as its own child');
+{
+  // `subagent_type: "fork"` inherits the parent's transcript, and the LAST
+  // inherited record is the Agent call that created this fork — so read whole,
+  // the fork appears to have spawned itself, and opening that row opens the
+  // same file again. The harness marks the boundary itself.
+  const fork = path.join(TMP, 'agent-a69e9dcf7fcc38c68.jsonl');
+  const spawnId = 'toolu_01EMfLbhWBZwwwT5dv5psJwS';
+  fs.writeFileSync(fork, [
+    JSON.stringify({ type: 'user', isSidechain: true, cwd: TMP, timestamp: at(5),
+      message: { role: 'user', content: 'THE PARENT PROMPT: research the week' } }),
+    JSON.stringify({ type: 'assistant', isSidechain: true, cwd: TMP, timestamp: at(6),
+      message: { id: 'p1', role: 'assistant', content: [
+        { type: 'tool_use', id: spawnId, name: 'Agent',
+          input: { subagent_type: 'fork', description: 'Research Meta news', prompt: 'Use WebSearch…' } }] } }),
+    JSON.stringify({ type: 'user', isSidechain: true, cwd: TMP, timestamp: at(6),
+      message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: spawnId, content: 'Fork started — processing in background' }] } }),
+    JSON.stringify({ type: 'user', isSidechain: true, cwd: TMP, timestamp: at(7),
+      message: { role: 'user', content: '<fork-boilerplate>\nYou are a worker fork. The transcript above is the parent\u2019s history — inherited reference, not your situation.' } }),
+    JSON.stringify({ type: 'assistant', isSidechain: true, cwd: TMP, timestamp: at(9),
+      message: { id: 'c1', role: 'assistant', content: [{ type: 'text', text: 'ITS OWN ANSWER: Meta shipped three things.' }] } }),
+  ].join('\n') + '\n');
+
+  const w = await readTraceByPath(fork, { offset: 0, limit: 50 }, true);
+  const text = w.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+  const spawnsInside = w.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'tool_use' && b.name === 'Agent'));
+  check('the inherited parent turns are gone', () => assert.doesNotMatch(text, /THE PARENT PROMPT/));
+  check('…including the Agent call that created it, so it is not its own child',
+    () => assert.deepEqual(spawnsInside, [], 'a fork must not carry its own spawning call'));
+  check('and its own answer is there', () => assert.match(text, /ITS OWN ANSWER/));
+  // (a fork's sidechain is not refused the way a codex subagent rollout is, so
+  // the untrimmed read is what any other caller still gets — awaited out here,
+  // because `check` runs its callback synchronously)
+  const whole = await readTraceByPath(fork, { offset: 0, limit: 50 });
+  const wholeText = whole.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+  check('read as a session, the same file is unchanged — the trim is opt-in',
+    () => assert.match(wholeText, /THE PARENT PROMPT/));
+}
+
 console.log('\nand a sub-agent with no fork is shown whole');
 {
   // Claude's children are not forks: their transcript begins with the task.

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -650,6 +650,8 @@ export interface SubAgentEntry {
   agentType: string | null;
   description: string | null;
   toolUseId: string | null;
+  /** codex has no per-call id; its parent's records name the task instead */
+  taskName?: string | null;
   parentAgentId: string | null;
   depth: number | null;
   spawnedAt: number | null;

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -638,6 +638,41 @@ export const getTraceSummary = (id: string, signal?: AbortSignal): Promise<Trace
 export const getFileTraceWindow = (id: string, p: string, req: TraceReq, bytes?: number, min?: number, signal?: AbortSignal): Promise<TraceWindow> =>
   traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&${traceRange(req)}${windowSize(bytes, min)}`, signal);
 
+// ---- sub-agents ----
+// The roster comes from the `subagents/` directory beside the transcript, not
+// from the transcript: a parent here reaches 292 MB while its whole roster is a
+// directory listing plus 187 bytes per agent. `spawnedAt` is the sidecar's
+// mtime and `lastWroteAt` the transcript's — the second one says when it last
+// wrote, and nothing about whether it is alive (measured silence inside a live
+// sub-agent: p99 112s, max 601s).
+export interface SubAgentEntry {
+  agentId: string;
+  agentType: string | null;
+  description: string | null;
+  toolUseId: string | null;
+  parentAgentId: string | null;
+  depth: number | null;
+  spawnedAt: number | null;
+  lastWroteAt: number | null;
+  bytes: number;
+  hasTranscript: boolean;
+}
+
+export interface SubAgentRoster {
+  id: string;
+  supported: boolean;
+  reason?: string;
+  dir: string | null;
+  agents: SubAgentEntry[];
+}
+
+export const getSubAgents = (id: string, signal?: AbortSignal): Promise<SubAgentRoster> =>
+  traceFetch(`/api/agents/${id}/subagents`, signal);
+
+/** A sub-agent's own transcript, in the same shape as any other trace. */
+export const getSubAgentTrace = (id: string, agentId: string, bytes?: number, signal?: AbortSignal): Promise<TraceWindow> =>
+  traceFetch(`/api/agents/${id}/subagents/${encodeURIComponent(agentId)}?tail=1${windowSize(bytes)}`, signal);
+
 export const getFileTraceSummary = (id: string, p: string, signal?: AbortSignal): Promise<TraceSummary> =>
   traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&summary=1`, signal);
 

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { recall, remember, readWrap, writeWrap } from './filesMemory';
 import type { Session } from '../types';
 import * as api from '../api';
+import { Rails, railPad } from './Rails';
 import type { FileEntry, FileKind, FilePreview } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
@@ -92,18 +93,9 @@ const KIND_LABEL: Record<FileKind, string> = {
   trace: 'trace',
 };
 
-// ASCII-tree rails: one cell per ancestor (vertical line if that ancestor has
-// more siblings below) plus the elbow cell for this row (├ normally, └ if last).
-// `prefix[i]` = "draw a continuation line at ancestor column i".
-function Rails({ prefix, isLast }: { prefix: boolean[]; isLast: boolean }) {
-  return (
-    <span className="rails" aria-hidden>
-      {prefix.map((cont, i) => <span key={i} className={`rail${cont ? ' v' : ''}`} />)}
-      <span className={`rail elbow${isLast ? ' last' : ''}`} />
-    </span>
-  );
-}
-const padFor = (prefix: boolean[]) => ({ paddingLeft: `${(prefix.length + 1) * 1.1}em` });
+// The rails live in components/Rails.tsx: the reader's sub-agent strip draws the
+// same tree, and one copy of six lines is better than two that drift.
+const padFor = railPad;
 
 // One directory listing, fetched once. Used by the pane for the current folder
 // and by every expanded FolderNode, so each level is loaded exactly once.

--- a/web/src/components/Rails.tsx
+++ b/web/src/components/Rails.tsx
@@ -1,0 +1,18 @@
+// ASCII-tree rails: one cell per ancestor (a vertical line if that ancestor has
+// more siblings below) plus the elbow cell for this row — `├` normally, `└` for
+// the last child. `prefix[i]` = "draw a continuation line at ancestor column i".
+//
+// Lifted out of FilesPane so the reader's sub-agent strip can draw the same
+// tree the file browser does, from the same six lines of CSS (`.rails`/`.rail`
+// in styles.css). The rows differ completely; the rails do not.
+export function Rails({ prefix, isLast }: { prefix: boolean[]; isLast: boolean }) {
+  return (
+    <span className="rails" aria-hidden>
+      {prefix.map((cont, i) => <span key={i} className={`rail${cont ? ' v' : ''}`} />)}
+      <span className={`rail elbow${isLast ? ' last' : ''}`} />
+    </span>
+  );
+}
+
+/** The room those cells need: the rails are absolute, so the row pays for them. */
+export const railPad = (prefix: boolean[]) => ({ paddingLeft: `${(prefix.length + 1) * 1.1}em` });

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -577,6 +577,15 @@ export default function ConversationView({
                 // as the widget being "sometimes below and above". The card has
                 // had this guard since it grew an echo; the reader had not.
                 running={live && x === exchanges[exchanges.length - 1] && !sent}
+                // The sub-agent strip needs three things this component has and
+                // an exchange does not: the whole window (a background
+                // sub-agent's completion is recorded in a later turn), the
+                // session id (to read the roster and a child's transcript), and
+                // whether the pane is alive — which is what separates "running"
+                // from "never finished".
+                turns={turns}
+                sessionId={session.id}
+                live={live}
               />
             </div>
           ))}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -15,7 +15,7 @@
 // lib/traceWindows.ts, shared with the Trace pane.
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../../api';
-import type { TraceTurn } from '../../api';
+import type { SubAgentEntry, TraceTurn } from '../../api';
 import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib/traceWindows';
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
@@ -27,6 +27,7 @@ import type { PendingAttachment, PendingPrompt } from '../../lib/attachments';
 import { recallReading, rememberReading } from './readingPosition';
 import { useDraft } from './useDraft';
 import { fmtTok, splitExchanges } from './exchanges';
+import { cachedRoster, loadRoster } from '../../lib/subagentRoster';
 import ExchangeView, { PendingExchange } from './Exchange';
 import Attachments from '../Attachments';
 import Composer from './Composer';
@@ -177,6 +178,23 @@ export default function ConversationView({
 
   const { turns: turnsRef, head, error, version, atStart, blocked, loadOlder, loadNewer } =
     useTraceWindows(src, session.id, { onPrepend, onReset, paused, live });
+
+  // The session's sub-agent roster: fetched here rather than by each exchange,
+  // and held in a module-level cache so a remount starts from what is already
+  // known (see lib/subagentRoster.ts — an effect that owned it lost every
+  // answer to its own cleanup). Refreshed while the pane is alive, because
+  // `lastWroteAt` is the one value on it that goes stale by itself.
+  const [roster, setRoster] = useState<SubAgentEntry[] | null>(() => cachedRoster(session.id));
+  useEffect(() => {
+    let alive = true;
+    const tick = () => loadRoster(session.id, true)
+      .then((agents) => { if (alive) setRoster(agents); })
+      .catch(() => { /* unreadable — the rows fall back to what the window knows */ });
+    tick();
+    if (!live) return () => { alive = false; };
+    const t = window.setInterval(tick, 15_000);
+    return () => { alive = false; window.clearInterval(t); };
+  }, [session.id, live]);
 
   const turns: TraceTurn[] = turnsRef.current;
   const exchanges = useMemo(() => splitExchanges(turns), [version, turns]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -586,6 +604,7 @@ export default function ConversationView({
                 turns={turns}
                 sessionId={session.id}
                 live={live}
+                roster={roster}
               />
             </div>
           ))}

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -7,14 +7,14 @@
 // Left edge: the prompt's ❯ is the ONLY thing outside the text column. No rail
 // on the answer, no rail on the work — scrolling, you find turns by that arrow
 // and the tinted prompt bar, and everything else lines up in one column.
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { SubAgentEntry, TraceTurn } from '../../api';
 import { getSubAgents, getSubAgentTrace } from '../../api';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { agentCounts, agentSpawnsOf, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
-import type { AgentSpawn } from './exchanges';
+import { agentSpawnsOf, agentStatus, fmtClock, fmtDur, fmtTok, isLive, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
+import type { AgentSpawn, AgentStatus } from './exchanges';
 import ToolCall from './ToolCall';
 
 const blocksOf = (t: TraceTurn | TraceTurn[] | null) =>
@@ -178,6 +178,9 @@ function nowDoing(s?: Step): string {
   if (s.kind === 'image') return 'image';
   if (s.kind === 'think') return oneLine(s.text, 70);
   if (s.kind === 'compact') return 'context compacted';
+  // "working · sub-agent Rework the Scene 1 intro" — what the pane last did was
+  // start something, and saying so is more use than naming the tool.
+  if (s.kind === 'agent') return oneLine(`sub-agent ${s.description}`, 70);
   return oneLine(s.text, 70);
 }
 
@@ -252,123 +255,186 @@ function SubAgentTrace({ sessionId, agentId, live }: { sessionId: string; agentI
   );
 }
 
-/** One row: what it was asked, what became of it, and how big it got. */
-function SubAgentRow({ spawn, entry, sessionId, live }: {
-  spawn: AgentSpawn; entry?: SubAgentEntry; sessionId?: string; live: boolean;
+/**
+ * One sub-agent, as a row. The same component in both places it appears: in the
+ * step list, where it replaces the `Agent` tool row it used to be, and under the
+ * working line while it runs. Two renderings of the same thing was how the
+ * count and the list drifted apart in the first cut of this feature.
+ */
+function AgentRow({ spawn, entry, status, sessionId, live, leaving, rosterKnown }: {
+  spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus;
+  sessionId?: string; live: boolean; leaving?: boolean;
+  /** the roster has answered, so "no entry" means "no transcript", not "not yet" */
+  rosterKnown?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const agentId = spawn.agentId || entry?.agentId;
-  // Whether it is FINISHED is the parent's word (a notification, or a
-  // synchronous report). Whether it is running is the pane's state. Neither is
-  // ever inferred from the file's mtime — see exchanges.ts.
-  const status = spawn.outcome
-    ? (spawn.outcome === 'reported' ? 'done' : spawn.outcome)
-    : (live ? 'running' : 'no result');
-  // The harness's own duration when it reported one, the span between the two
-  // records otherwise. Both are the parent's word; neither is a guess from mtime.
+  // Not every spawn has a transcript. the-gatherer's parent holds 168 `Agent`
+  // calls and its `subagents/` directory holds 38 sidecars: the older CLI kept
+  // no per-sub-agent file, so those turns can be counted and their outcomes
+  // read from the notifications, but there is nothing to open. A row that
+  // offers a triangle and then 404s is worse than a row that says so.
+  const can = !!agentId && !!sessionId && (entry ? entry.hasTranscript : !rosterKnown);
+  // The harness's own duration when the notification reported one; otherwise
+  // how long it has been going. Never a guess from mtime — see agentStatus.
   const took = spawn.durationMs ? fmtDur(spawn.durationMs)
     : (spawn.outcomeAt && spawn.spawnedAt ? fmtDur(spawn.outcomeAt - spawn.spawnedAt) : '');
-  const since = !spawn.outcome && entry?.lastWroteAt ? fmtDur(Date.now() - entry.lastWroteAt) : '';
-  const can = !!agentId && !!sessionId && (entry ? entry.hasTranscript : true);
+  const going = !spawn.outcome && spawn.spawnedAt ? fmtDur(Date.now() - spawn.spawnedAt) : '';
+  const quiet = !spawn.outcome && entry?.lastWroteAt ? fmtDur(Date.now() - entry.lastWroteAt) : '';
+  const mark = status === 'running' ? <span className="cs-mark spin" aria-label="running" />
+    : status === 'done' ? <span className="cs-mark ok">✓</span>
+      : status === 'failed' || status === 'killed' ? <span className="cs-mark bad">✗</span>
+        : <span className="cs-tri off">–</span>;
   return (
-    <div className={`ca-row${open ? ' open' : ''}`}>
-      <button className="ca-head" disabled={!can} onClick={() => setOpen((o) => !o)}
-              title={can ? 'Show what this sub-agent did' : 'no transcript on disk for this one'}>
-        <span className={`cs-tri${can ? '' : ' off'}`}>{open ? '▾' : '▸'}</span>
-        <span className={`ca-state ${status.replace(' ', '-')}`}>{status}</span>
-        <span className="ca-what">{spawn.description}</span>
-        <span className="spacer" />
-        {entry?.depth && entry.depth > 1 ? <span className="ca-depth mono">↳{entry.depth}</span> : null}
-        <span className="ca-type mono">{entry?.agentType || spawn.agentType}</span>
-        {/* Two different facts, and the second one is not a verdict: `took` is
-            the parent's recorded span, `wrote` is how long since the file last
-            changed. Silence inside a live sub-agent reached 601s here, so the
-            reader shows the number and lets the operator judge it. */}
-        {took ? <span className="ca-num mono">{took}</span>
-              : since ? <span className="ca-num mono" title="since it last wrote — not a verdict on whether it is alive">wrote {since} ago</span> : null}
-        {/* What it spent, from the completion notification — the only place a
-            sub-agent's own token count is written down. Output-side tokens and
-            tool calls, not a bill: nearly all of the tokens these read were
-            cache reads. */}
-        {spawn.toolCalls ? <span className="ca-num mono">{spawn.toolCalls} calls</span> : null}
-        {spawn.tokens ? <span className="ca-num mono">{fmtTok(spawn.tokens)} tok</span> : null}
-        {entry?.bytes ? <span className="ca-num mono">{fmtTok(entry.bytes)}B</span> : null}
+    <div className={`cs agent ${status}${open ? ' open' : ''}${leaving ? ' leaving' : ''}`}>
+      <button className="cs-head" disabled={!can} onClick={() => setOpen((o) => !o)}
+              title={can ? 'Show the task and what it did' : 'no transcript on disk for this one'}>
+        {open ? <span className="cs-tri">▾</span> : mark}
+        <span className="cs-label mono">sub-agent</span>
+        <span className="cs-detail">{spawn.description}</span>
+        {status === 'stalled' || status === 'no-result' ? (
+          <span className={`cs-state ${status}`}>{status === 'stalled' ? 'no write in 15m' : 'no result'}</span>
+        ) : null}
+        {!can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
+        <span className="cs-facts mono">
+          {entry?.depth && entry.depth > 1 ? <span className="depth">↳{entry.depth}</span> : null}
+          {took ? <span>{took}</span> : going ? <span>{going}</span> : null}
+          {/* Two different facts, and the second is not a verdict: `took` is what
+              the parent recorded, `wrote` is when the file last changed. */}
+          {!spawn.outcome && quiet ? <span className="dim" title="since it last wrote — not a verdict on whether it is alive">wrote {quiet} ago</span> : null}
+          {/* What it spent, from the completion notification: the only place a
+              sub-agent's own count is written down. Tokens and calls, not a bill
+              — nearly all of what these read was cache. */}
+          {spawn.toolCalls ? <span>{spawn.toolCalls} calls</span> : null}
+          {spawn.tokens ? <span>{fmtTok(spawn.tokens)} tok</span> : null}
+        </span>
       </button>
       {open && agentId && sessionId && (
-        <div className="ca-body"><SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} /></div>
+        <div className="cs-body">
+          {/* The task it was given, then what it did with it — the two things the
+              operator asked to see behind a row. */}
+          <AgentTask spawn={spawn} />
+          <SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} />
+        </div>
       )}
     </div>
   );
 }
 
-/**
- * The count in the summary line, and the two levels it opens onto.
- *
- * Level one is the number, next to the steps and tools — the operator asked for
- * "how many are done/running" in that line. Level two is this turn's sub-agents,
- * one row each. Level three is a row's own transcript.
- *
- * The roster is fetched only when the list is opened, and it comes from the
- * `subagents/` directory rather than the parent transcript — the parent reaches
- * 292 MB on this machine, the roster is a directory listing. It fills in what
- * the window cannot see: the agentId for a spawn whose launch receipt scrolled
- * out of the window, the depth, and the size of what each one wrote.
- */
-function SubAgentsButton({ spawns, live, open, onToggle }: {
-  spawns: AgentSpawn[]; live: boolean; open: boolean; onToggle: () => void;
-}) {
-  const counts = agentCounts(spawns, live);
+/** The task, clamped. It is the `Agent` call's own prompt — 3.4 kB is normal. */
+function AgentTask({ spawn }: { spawn: AgentSpawn }) {
+  const [all, setAll] = useState(false);
+  if (!spawn.prompt) return null;
+  const long = spawn.prompt.length > 420;
   return (
-    <button className={`cx-agents${open ? ' on' : ''}`} onClick={onToggle}
-            title={open ? 'Hide the sub-agents' : 'Show what each sub-agent was asked to do'}>
-      <span className="cs-tri">{open ? '▾' : '▸'}</span>
-      {counts.label}
-    </button>
+    <>
+      <div className={`cs-task${all || !long ? '' : ' clamp'}`}>{spawn.prompt}</div>
+      {long && !all && (
+        <button className="cs-more-btn mono" onClick={() => setAll(true)}>
+          show the whole task ({Math.round(spawn.prompt.length / 100) / 10} kB)
+        </button>
+      )}
+    </>
   );
 }
 
 /**
- * The list, one row per sub-agent this turn started.
+ * The sub-agents of THIS turn that are still going, listed under the working
+ * line — the thing the feature is for. Collapsed exchange, nothing expanded:
+ * the pane says it is working, and these say what is working underneath it.
  *
- * The roster is fetched when the list opens, and it comes from the `subagents/`
- * directory rather than the parent transcript — the parent reaches 292 MB on
- * this machine, the roster is a directory listing plus 187 bytes per agent. It
- * fills in what the window cannot see: the agentId for a spawn whose launch
- * receipt has scrolled out of view, the depth, and how much each one wrote.
+ * Running only. A finished sub-agent leaves, because a list that keeps them
+ * grows for the length of the turn and stops being a glance; what persists is
+ * the count in the summary line. It leaves on a fade rather than by vanishing:
+ * rows appearing and disappearing under a live spinner is the shape that
+ * produced the API-log flicker, so a row that has just finished holds its place
+ * for a beat with its ✓ and its duration, then goes.
+ *
+ * Capped, because the rail is not the place to discover that a turn spawned
+ * twenty. Measured first: across the three sessions here the busiest single
+ * exchange spawned FOUR (release-video's turn 24; the-gatherer's busiest is
+ * three), so the cap is generous rather than tight — and the overflow line says
+ * how many it is holding back.
  */
-function SubAgentsList({ spawns, sessionId, live }: { spawns: AgentSpawn[]; sessionId?: string; live: boolean }) {
-  const [roster, setRoster] = useState<SubAgentEntry[] | null>(null);
-  const [note, setNote] = useState('');
-  useEffect(() => {
-    if (!sessionId) return;
-    const ac = new AbortController();
-    getSubAgents(sessionId, ac.signal)
-      .then((r) => { setRoster(r.agents); if (!r.supported && r.reason) setNote(r.reason); })
-      .catch(() => setNote('the roster could not be read'));
-    return () => ac.abort();
-  }, [sessionId]);
+const LIVE_CAP = 6;
 
-  const byToolUse = useMemo(() => {
-    const m = new Map<string, SubAgentEntry>();
-    for (const e of roster || []) if (e.toolUseId) m.set(e.toolUseId, e);
-    return m;
-  }, [roster]);
-  const inThisTurn = new Set(spawns.map((s) => s.toolUseId));
-  const elsewhere = (roster || []).filter((e) => !e.toolUseId || !inThisTurn.has(e.toolUseId)).length;
-
+function LiveAgents({ rows, sessionId, live, rosterKnown }: {
+  rows: { spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus; leaving?: boolean }[];
+  sessionId?: string; live: boolean; rosterKnown?: boolean;
+}) {
+  if (!rows.length) return null;
+  const shown = rows.slice(0, LIVE_CAP);
+  const hidden = rows.length - shown.length;
   return (
-    <div className="cx-agents-list">
-      {spawns.map((s) => (
-        <SubAgentRow key={s.toolUseId} spawn={s} entry={byToolUse.get(s.toolUseId)} sessionId={sessionId} live={live} />
+    <div className="cx-live">
+      {shown.map((r) => (
+        <AgentRow key={r.spawn.toolUseId} spawn={r.spawn} entry={r.entry} status={r.status}
+                  sessionId={sessionId} live={live} leaving={r.leaving} rosterKnown={rosterKnown} />
       ))}
-      {/* Said plainly rather than folded into the count: the number above is this
-          TURN's spawns, and a session's directory usually holds more — including
-          sub-agents that other sub-agents started, which the parent's own tool
-          calls never mention. */}
-      {elsewhere ? <div className="ca-msg mono">{elsewhere} more in this session, from other turns</div> : null}
-      {note ? <div className="ca-msg mono">{note}</div> : null}
+      {hidden > 0 && <div className="cx-live-more mono">…and {hidden} more running — open the work to see them all</div>}
     </div>
   );
+}
+
+/**
+ * The roster, for the facts the window cannot carry: the agentId of a spawn
+ * whose launch receipt has scrolled away, the depth, and when each transcript
+ * last changed. It is a directory listing plus 187 bytes per sub-agent — the
+ * parent transcript it sits next to reaches 292 MB, and is never read here.
+ *
+ * Fetched only when this turn has a sub-agent whose end is unrecorded, and
+ * polled only while the pane is alive, because `lastWroteAt` is the one value
+ * that goes stale on its own.
+ */
+function useRoster(sessionId: string | undefined, need: boolean, live: boolean) {
+  const [roster, setRoster] = useState<SubAgentEntry[] | null>(null);
+  useEffect(() => {
+    if (!sessionId || !need) return;
+    let done = false;
+    const load = () => getSubAgents(sessionId)
+      .then((r) => { if (!done) setRoster(r.agents); })
+      .catch(() => { /* the strip degrades to what the window knows */ });
+    load();
+    if (!live) return () => { done = true; };
+    const t = window.setInterval(load, 15_000);
+    return () => { done = true; window.clearInterval(t); };
+  }, [sessionId, need, live]);
+  return roster;
+}
+
+/**
+ * A row that has just finished keeps its place for LINGER_MS, so the strip
+ * shrinks after you have seen why rather than under your eyes.
+ *
+ * Two conditions, and the second one was a bug before it was a rule: the row
+ * must have been LIVE in this client first. Keyed only on "first seen
+ * finished", every sub-agent that completed hours ago flashed into the strip
+ * for six seconds on page load — the exact jitter the linger exists to prevent.
+ */
+const LINGER_MS = 6000;
+
+function useLinger(liveIds: string[], finishedIds: string[]) {
+  const wasLive = useRef(new Set<string>());
+  const leftAt = useRef(new Map<string, number>());
+  const [, tick] = useState(0);
+  const key = `${liveIds.join('|')}::${finishedIds.join('|')}`;
+  useEffect(() => {
+    for (const id of liveIds) { wasLive.current.add(id); leftAt.current.delete(id); }
+    const now = Date.now();
+    let soonest = Infinity;
+    for (const id of finishedIds) {
+      if (!wasLive.current.has(id)) continue;      // it was already done when we arrived
+      if (!leftAt.current.has(id)) leftAt.current.set(id, now);
+      soonest = Math.min(soonest, (leftAt.current.get(id) as number) + LINGER_MS);
+    }
+    if (!Number.isFinite(soonest)) return;
+    const t = window.setTimeout(() => tick((n) => n + 1), Math.max(0, soonest - now) + 40);
+    return () => window.clearTimeout(t);
+  }, [key]); // eslint-disable-line react-hooks/exhaustive-deps
+  return (id: string) => {
+    const at = leftAt.current.get(id);
+    return at != null && Date.now() - at < LINGER_MS;
+  };
 }
 
 export function ExchangeView({
@@ -395,12 +461,6 @@ export function ExchangeView({
 }) {
   const [selfOpen, setSelfOpen] = useState(false);
   const toggle = onToggle ?? (() => setSelfOpen((o) => !o));
-  // Its own disclosure, next to the work's: the sub-agent list is a different
-  // question from "show me the tool calls", and opening one should not open the
-  // other. It lives here rather than inside the button so the list can render
-  // BELOW the meta row — the row is a flex line, and a list inside it lands to
-  // the right of the numbers instead of under them.
-  const [agentsOpen, setAgentsOpen] = useState(false);
 
   // The work, split where the answer belongs. Grouping runs over each side
   // separately on purpose: two Reads either side of the agent's reply are two
@@ -427,11 +487,33 @@ export function ExchangeView({
   // grouping. `stepSummary(x, stepsOf(x.steps))` would count the whole turn
   // instead and disagree with what unfolds; between the two, the number that
   // matches what you are about to see wins.
-  const summary = stepSummary(x, steps);
   // The sub-agents this turn started. Computed over the whole window, not the
   // exchange, because a background one finishes in a later turn than the one
   // that spawned it.
   const spawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
+  const summary = stepSummary(x, steps, spawns.length);
+  // The roster is only worth asking for while something might still be running.
+  const unresolved = spawns.some((s) => !s.outcome);
+  const roster = useRoster(sessionId, spawns.length > 0 && (unresolved || isOpen), !!live && unresolved);
+  const entryOf = useMemo(() => {
+    const m = new Map<string, SubAgentEntry>();
+    for (const e of roster || []) if (e.toolUseId) m.set(e.toolUseId, e);
+    return m;
+  }, [roster]);
+  const agentRows = useMemo(() => spawns.map((s) => {
+    const entry = entryOf.get(s.toolUseId);
+    return { spawn: s, entry, status: agentStatus(s, { live: !!live, lastWroteAt: entry?.lastWroteAt }) };
+  }), [spawns, entryOf, live]);
+  const lingering = useLinger(
+    agentRows.filter((r) => isLive(r.status)).map((r) => r.spawn.toolUseId),
+    agentRows.filter((r) => !isLive(r.status)).map((r) => r.spawn.toolUseId),
+  );
+  // What the collapsed turn shows under its working line: what is still going,
+  // plus whatever finished in the last few seconds, so the strip shrinks after
+  // you have seen why rather than under your eyes.
+  const liveRows = agentRows
+    .filter((r) => isLive(r.status) || lingering(r.spawn.toolUseId))
+    .map((r) => ({ ...r, leaving: !isLive(r.status) }));
   const latest = running ? nowDoing(steps[steps.length - 1]) : '';
   // Naming the model on every turn is noise when it never changes; when it DOES
   // change mid-session that is worth a word, so say it only then.
@@ -454,6 +536,20 @@ export function ExchangeView({
     </>
   );
   const factsOnRunningRow = !summary && !!running && n != null;
+  // A sub-agent step is a row with a life of its own, so it is drawn by the
+  // component that also draws it under the working line — one rendering, two
+  // places. Everything else is the step rail as it was.
+  const rowByToolUse = new Map(agentRows.map((r) => [r.spawn.toolUseId, r]));
+  const renderStep = (s: Step, key: string) => {
+    if (s.kind !== 'agent') return <StepRow key={key} s={s} q={q} />;
+    const r = rowByToolUse.get(s.toolUseId);
+    return (
+      <AgentRow key={key}
+                spawn={r?.spawn ?? { toolUseId: s.toolUseId, description: s.description, agentType: s.agentType, background: false }}
+                entry={r?.entry} status={r?.status ?? (live ? 'running' : 'no-result')}
+                sessionId={sessionId} live={!!live} rosterKnown={!!roster} />
+    );
+  };
 
   return (
     <section className={`cx${dim ? ' dim' : ''}`}>
@@ -481,19 +577,13 @@ export function ExchangeView({
             different things, and burying the count inside the work fold would
             make "how many are running" cost a click that also unfolds forty
             tool rows. */}
-        {spawns.length > 0 && (
-          <SubAgentsButton spawns={spawns} live={!!live} open={agentsOpen} onToggle={() => setAgentsOpen((o) => !o)} />
-        )}
         {/* Which turn, when, and on what — the viewer's business. A card shows one
             turn, dated in its own header, so it says none of this. */}
         {n != null && facts}
       </div>
       )}
-      {agentsOpen && spawns.length > 0 && (
-        <SubAgentsList spawns={spawns} sessionId={sessionId} live={!!live} />
-      )}
       {isOpen && stepsBefore.length > 0 && (
-        <div className="cx-steps">{stepsBefore.map((s, i) => <StepRow key={i} s={s} q={q} />)}</div>
+        <div className="cx-steps">{stepsBefore.map((s, i) => renderStep(s, `b${i}`))}</div>
       )}
 
       {/* The answer sits where it was said. Usually that is after all the work;
@@ -506,7 +596,7 @@ export function ExchangeView({
         </div>
       ) : null}
       {isOpen && stepsAfter.length > 0 && (
-        <div className="cx-steps">{stepsAfter.map((s, i) => <StepRow key={`a${i}`} s={s} q={q} />)}</div>
+        <div className="cx-steps">{stepsAfter.map((s, i) => renderStep(s, `a${i}`))}</div>
       )}
       {/* Mid-task there is no answer — an agent's aside is not a reply — so the
           running line carries the latest thing that happened instead. */}
@@ -515,6 +605,14 @@ export function ExchangeView({
           working{latest && <span className="cx-running-at">· {latest}</span>}
           {factsOnRunningRow && facts}
         </div>
+      )}
+      {/* …and what is working underneath it. This is the point of the feature:
+          the exchange is collapsed, nothing has been expanded, and the pane's
+          own `working` line is followed by one line per sub-agent still going.
+          Each row is the same row the step list shows, so opening one here
+          gives the task and the trace without leaving the glance. */}
+      {liveRows.length > 0 && !isOpen && (
+        <LiveAgents rows={liveRows} sessionId={sessionId} live={!!live} rosterKnown={!!roster} />
       )}
     </section>
   );

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -11,9 +11,10 @@ import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { SubAgentEntry, TraceTurn } from '../../api';
 import { getSubAgentTrace } from '../../api';
+import { Rails } from '../Rails';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { agentSpawnsOf, agentStatus, anyLive, capRows, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
+import { agentSpawnsOf, agentStatus, anyLive, capRows, railIsLast, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
 import type { AgentSpawn, AgentStatus } from './exchanges';
 import ToolCall from './ToolCall';
 
@@ -274,11 +275,17 @@ function SubAgentTrace({ sessionId, agentId, live, roster }: {
  * working line while it runs. Two renderings of the same thing was how the
  * count and the list drifted apart in the first cut of this feature.
  */
-function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster }: {
+function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, rail }: {
   spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus;
   sessionId?: string; live: boolean; roster?: SubAgentEntry[] | null;
   /** the roster has answered, so "no entry" means "no transcript", not "not yet" */
   rosterKnown?: boolean;
+  /**
+   * Set in the live strip, where the rows hang off the pane's own working line
+   * and the tree says so. Unset in the step list, where a sub-agent is one step
+   * among many and a rail would draw a hierarchy that is not there.
+   */
+  rail?: { isLast: boolean };
 }) {
   const [open, setOpen] = useState(false);
   const agentId = spawn.agentId || entry?.agentId;
@@ -300,8 +307,9 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster }
         : <span className="cs-tri off">–</span>;
   return (
     <div className={`cs agent ${status}${open ? ' open' : ''}`}>
-      <button className="cs-head" disabled={!can} onClick={() => setOpen((o) => !o)}
+      <button className={`cs-head${rail ? ' railed' : ''}`} disabled={!can} onClick={() => setOpen((o) => !o)}
               title={can ? 'Show the task and what it did' : 'no transcript on disk for this one'}>
+        {rail ? <Rails prefix={[]} isLast={rail.isLast} /> : null}
         {open ? <span className="cs-tri">▾</span> : mark}
         <span className="cs-label mono">sub-agent</span>
         <span className="cs-detail">{spawn.description}</span>
@@ -368,11 +376,19 @@ function LiveAgents({ rows, sessionId, live, rosterKnown, roster }: {
   if (!rows.length) return null;
   return (
     <div className="cx-live">
-      {shown.map((r) => (
+      {shown.map((r, i) => (
         <AgentRow key={r.spawn.toolUseId} spawn={r.spawn} entry={r.entry} status={r.status}
-                  sessionId={sessionId} live={live} rosterKnown={rosterKnown} roster={roster} />
+                  sessionId={sessionId} live={live} rosterKnown={rosterKnown} roster={roster}
+                  // …and the elbow belongs to whatever is actually last. With the
+                  // cap in play that is the overflow line, not the last row.
+                  rail={{ isLast: railIsLast(i, shown.length, !!note) }} />
       ))}
-      {note ? <div className="cx-live-more mono">{note}</div> : null}
+      {note ? (
+        <div className="cx-live-more mono">
+          <Rails prefix={[]} isLast />
+          {note}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -14,7 +14,7 @@ import { getSubAgentTrace } from '../../api';
 import { Rails } from '../Rails';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { agentSpawnsOf, agentStatus, anyLive, capRows, railIsLast, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
+import { agentSpawnsOf, agentStatus, anyLive, canOpenAgent, capRows, railIsLast, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
 import type { AgentSpawn, AgentStatus } from './exchanges';
 import ToolCall from './ToolCall';
 
@@ -243,8 +243,10 @@ function PromptBand({ text, q, queued }: { text: string; q?: string; queued?: bo
  * task at the top. On the few that overflow it, the tail keeps the report and
  * the row above still names the task.
  */
-function SubAgentTrace({ sessionId, agentId, live, roster }: {
+function SubAgentTrace({ sessionId, agentId, live, roster, ancestors }: {
   sessionId: string; agentId: string; live: boolean; roster?: SubAgentEntry[] | null;
+  /** the agentIds already open above this one, outermost first */
+  ancestors: string[];
 }) {
   const [state, setState] = useState<{ turns?: TraceTurn[]; error?: string }>({});
   useEffect(() => {
@@ -263,7 +265,8 @@ function SubAgentTrace({ sessionId, agentId, live, roster }: {
   return (
     <>
       {exchanges.map((ex) => (
-        <ExchangeView key={ex.key} x={ex} turns={state.turns} sessionId={sessionId} live={live} roster={roster} dim />
+        <ExchangeView key={ex.key} x={ex} turns={state.turns} sessionId={sessionId} live={live} roster={roster}
+                      ancestors={[...ancestors, agentId]} dim />
       ))}
     </>
   );
@@ -275,7 +278,7 @@ function SubAgentTrace({ sessionId, agentId, live, roster }: {
  * working line while it runs. Two renderings of the same thing was how the
  * count and the list drifted apart in the first cut of this feature.
  */
-function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, rail }: {
+function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, rail, ancestors }: {
   spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus;
   sessionId?: string; live: boolean; roster?: SubAgentEntry[] | null;
   /** the roster has answered, so "no entry" means "no transcript", not "not yet" */
@@ -286,15 +289,24 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, 
    * among many and a rail would draw a hierarchy that is not there.
    */
   rail?: { isLast: boolean };
+  /** the agentIds open above this row, outermost first */
+  ancestors?: string[];
 }) {
   const [open, setOpen] = useState(false);
   const agentId = spawn.agentId || entry?.agentId;
+  const chain = ancestors || [];
+  // A row that names an agent already open above it is a cycle: it renders, and
+  // it does not open. So does one at the nesting cap. Both are backstops — the
+  // parser no longer hands a fork its own spawning call — and both are cheap.
+  const cyclic = !!agentId && chain.includes(agentId);
+  const deep = !cyclic && !!agentId && !canOpenAgent(agentId, chain);
   // Not every spawn has a transcript. the-gatherer's parent holds 168 `Agent`
   // calls and its `subagents/` directory holds 38 sidecars: the older CLI kept
   // no per-sub-agent file, so those turns can be counted and their outcomes
   // read from the notifications, but there is nothing to open. A row that
   // offers a triangle and then 404s is worse than a row that says so.
-  const can = !!agentId && !!sessionId && (entry ? entry.hasTranscript : !rosterKnown);
+  const can = !!agentId && !!sessionId && (entry ? entry.hasTranscript : !rosterKnown)
+    && canOpenAgent(agentId, chain);
   // The harness's own duration when the notification reported one; otherwise
   // how long it has been going. Never a guess from mtime — see agentStatus.
   const took = spawn.durationMs ? fmtDur(spawn.durationMs)
@@ -316,7 +328,9 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, 
         {status === 'stalled' || status === 'no-result' ? (
           <span className={`cs-state ${status}`}>{status === 'stalled' ? 'no write in 15m' : 'no result'}</span>
         ) : null}
-        {!can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
+        {cyclic ? <span className="cs-state">already open above</span>
+          : deep ? <span className="cs-state">nested too deep to open here</span>
+            : !can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
         <span className="cs-facts mono">
           {entry?.depth && entry.depth > 1 ? <span className="depth">↳{entry.depth}</span> : null}
           {/* codex names its sub-agents — Curie, Herschel, Boole — and that name
@@ -339,7 +353,7 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, 
         <div className="cs-body">
           {/* Its trace, drawn by the reader. The task arrives as that trace's own
               first prompt, so nothing here has to render it separately. */}
-          <SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} roster={roster} />
+          <SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} roster={roster} ancestors={chain} />
         </div>
       )}
     </div>
@@ -368,9 +382,10 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, 
  */
 const LIVE_CAP = 10;
 
-function LiveAgents({ rows, sessionId, live, rosterKnown, roster }: {
+function LiveAgents({ rows, sessionId, live, rosterKnown, roster, ancestors }: {
   rows: { spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus }[];
   sessionId?: string; live: boolean; rosterKnown?: boolean; roster?: SubAgentEntry[] | null;
+  ancestors: string[];
 }) {
   const { shown, note } = capRows(rows, LIVE_CAP);
   if (!rows.length) return null;
@@ -378,7 +393,7 @@ function LiveAgents({ rows, sessionId, live, rosterKnown, roster }: {
     <div className="cx-live">
       {shown.map((r, i) => (
         <AgentRow key={r.spawn.toolUseId} spawn={r.spawn} entry={r.entry} status={r.status}
-                  sessionId={sessionId} live={live} rosterKnown={rosterKnown} roster={roster}
+                  sessionId={sessionId} live={live} rosterKnown={rosterKnown} roster={roster} ancestors={ancestors}
                   // …and the elbow belongs to whatever is actually last. With the
                   // cap in play that is the overflow line, not the last row.
                   rail={{ isLast: railIsLast(i, shown.length, !!note) }} />
@@ -394,7 +409,7 @@ function LiveAgents({ rows, sessionId, live, rosterKnown, roster }: {
 }
 
 export function ExchangeView({
-  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live, roster,
+  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live, roster, ancestors,
 }: {
   x: Exchange;
   n?: number;            // 1-based position — the viewer numbers turns, a card does not
@@ -423,6 +438,13 @@ export function ExchangeView({
    * the result away, so rows never got their `wrote 4m ago`.
    */
   roster?: SubAgentEntry[] | null;
+  /**
+   * The sub-agents already open above this exchange, outermost first. Empty at
+   * the top level; each nested trace adds its own id. It is what stops a cycle
+   * in the data from nesting forever, and what keeps a sub-agent from being
+   * counted as its own child.
+   */
+  ancestors?: string[];
 }) {
   const [selfOpen, setSelfOpen] = useState(false);
   const toggle = onToggle ?? (() => setSelfOpen((o) => !o));
@@ -455,11 +477,14 @@ export function ExchangeView({
   // The sub-agents this turn started. Computed over the whole window, not the
   // exchange, because a background one finishes in a later turn than the one
   // that spawned it.
-  const spawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
-  const summary = stepSummary(x, steps, spawns.length);
+  const chain = ancestors || [];
+  const allSpawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
   // Two join keys, because the two harnesses record different things: Claude's
   // sidecar carries the spawning call's id, codex's rollout header carries the
   // task name and no id at all.
+  // …minus any that resolve to an agent already open above: a transcript that
+  // names its own spawning call must not be credited with itself, in the count
+  // or anywhere else.
   const entryOf = useMemo(() => {
     const m = new Map<string, SubAgentEntry>();
     for (const e of roster || []) {
@@ -469,6 +494,12 @@ export function ExchangeView({
     }
     return m;
   }, [roster]);
+  const spawns = useMemo(() => allSpawns.filter((s) => {
+    const id = s.agentId || entryOf.get(s.toolUseId)?.agentId
+      || (s.taskName ? entryOf.get(`task:${s.taskName}`)?.agentId : undefined);
+    return !(id && chain.includes(id));
+  }), [allSpawns, entryOf, chain.join('|')]); // eslint-disable-line react-hooks/exhaustive-deps
+  const summary = stepSummary(x, steps, spawns.length);
   const agentRows = useMemo(() => spawns.map((s) => {
     const entry = entryOf.get(s.toolUseId) || (s.taskName ? entryOf.get(`task:${s.taskName}`) : undefined);
     return { spawn: s, entry, status: agentStatus(s, { live: !!live, lastWroteAt: entry?.lastWroteAt }) };
@@ -511,7 +542,7 @@ export function ExchangeView({
       <AgentRow key={key}
                 spawn={r?.spawn ?? { toolUseId: s.toolUseId, taskName: s.taskName, description: s.description, agentType: s.agentType, background: false }}
                 entry={r?.entry} status={r?.status ?? (live ? 'running' : 'no-result')}
-                sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} />
+                sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} ancestors={chain} />
     );
   };
 
@@ -576,7 +607,7 @@ export function ExchangeView({
           the ones still going and the ones that have landed. Each row is the row
           the step list shows, so opening one here costs no navigation. */}
       {liveNow && !isOpen && (
-        <LiveAgents rows={agentRows} sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} />
+        <LiveAgents rows={agentRows} sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} ancestors={chain} />
       )}
     </section>
   );

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -7,12 +7,14 @@
 // Left edge: the prompt's ❯ is the ONLY thing outside the text column. No rail
 // on the answer, no rail on the work — scrolling, you find turns by that arrow
 // and the tinted prompt bar, and everything else lines up in one column.
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { TraceTurn } from '../../api';
+import type { SubAgentEntry, TraceTurn } from '../../api';
+import { getSubAgents, getSubAgentTrace } from '../../api';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { fmtClock, fmtDur, fmtTok, oneLine, proseOf, stepSummary, stepText, stepsOf } from './exchanges';
+import { agentCounts, agentSpawnsOf, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
+import type { AgentSpawn } from './exchanges';
 import ToolCall from './ToolCall';
 
 const blocksOf = (t: TraceTurn | TraceTurn[] | null) =>
@@ -215,8 +217,162 @@ function PromptBand({ text, q, queued }: { text: string; q?: string; queued?: bo
   );
 }
 
+/**
+ * What one sub-agent did — the reader, one level down.
+ *
+ * A sub-agent's transcript is an ordinary trace: same records, same normalizer,
+ * so it goes through splitExchanges and comes back out as exchanges that this
+ * very component renders. Its first user message is the task it was given, so
+ * the prompt band is already the right thing to show at the top. It is also why
+ * a sub-agent that spawned sub-agents (rl-llm-wiki did, seven of them at depth
+ * 2) unfolds the same way without a second implementation: the directory is
+ * flat, so the same endpoint answers for a child of a child.
+ */
+function SubAgentTrace({ sessionId, agentId, live }: { sessionId: string; agentId: string; live: boolean }) {
+  const [state, setState] = useState<{ turns?: TraceTurn[]; error?: string }>({});
+  useEffect(() => {
+    const ac = new AbortController();
+    setState({});
+    getSubAgentTrace(sessionId, agentId, 400_000, ac.signal)
+      .then((w) => setState({ turns: w.turns }))
+      .catch((e) => { if (!ac.signal.aborted) setState({ error: e?.message || 'could not read it' }); });
+    return () => ac.abort();
+  }, [sessionId, agentId]);
+
+  if (state.error) return <div className="ca-msg mono">{state.error}</div>;
+  if (!state.turns) return <div className="ca-msg mono">reading…</div>;
+  const exchanges = splitExchanges(state.turns);
+  if (!exchanges.length) return <div className="ca-msg mono">nothing recorded yet</div>;
+  return (
+    <div className="ca-trace">
+      {exchanges.map((ex) => (
+        <ExchangeView key={ex.key} x={ex} turns={state.turns} sessionId={sessionId} live={live} dim />
+      ))}
+    </div>
+  );
+}
+
+/** One row: what it was asked, what became of it, and how big it got. */
+function SubAgentRow({ spawn, entry, sessionId, live }: {
+  spawn: AgentSpawn; entry?: SubAgentEntry; sessionId?: string; live: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const agentId = spawn.agentId || entry?.agentId;
+  // Whether it is FINISHED is the parent's word (a notification, or a
+  // synchronous report). Whether it is running is the pane's state. Neither is
+  // ever inferred from the file's mtime — see exchanges.ts.
+  const status = spawn.outcome
+    ? (spawn.outcome === 'reported' ? 'done' : spawn.outcome)
+    : (live ? 'running' : 'no result');
+  // The harness's own duration when it reported one, the span between the two
+  // records otherwise. Both are the parent's word; neither is a guess from mtime.
+  const took = spawn.durationMs ? fmtDur(spawn.durationMs)
+    : (spawn.outcomeAt && spawn.spawnedAt ? fmtDur(spawn.outcomeAt - spawn.spawnedAt) : '');
+  const since = !spawn.outcome && entry?.lastWroteAt ? fmtDur(Date.now() - entry.lastWroteAt) : '';
+  const can = !!agentId && !!sessionId && (entry ? entry.hasTranscript : true);
+  return (
+    <div className={`ca-row${open ? ' open' : ''}`}>
+      <button className="ca-head" disabled={!can} onClick={() => setOpen((o) => !o)}
+              title={can ? 'Show what this sub-agent did' : 'no transcript on disk for this one'}>
+        <span className={`cs-tri${can ? '' : ' off'}`}>{open ? '▾' : '▸'}</span>
+        <span className={`ca-state ${status.replace(' ', '-')}`}>{status}</span>
+        <span className="ca-what">{spawn.description}</span>
+        <span className="spacer" />
+        {entry?.depth && entry.depth > 1 ? <span className="ca-depth mono">↳{entry.depth}</span> : null}
+        <span className="ca-type mono">{entry?.agentType || spawn.agentType}</span>
+        {/* Two different facts, and the second one is not a verdict: `took` is
+            the parent's recorded span, `wrote` is how long since the file last
+            changed. Silence inside a live sub-agent reached 601s here, so the
+            reader shows the number and lets the operator judge it. */}
+        {took ? <span className="ca-num mono">{took}</span>
+              : since ? <span className="ca-num mono" title="since it last wrote — not a verdict on whether it is alive">wrote {since} ago</span> : null}
+        {/* What it spent, from the completion notification — the only place a
+            sub-agent's own token count is written down. Output-side tokens and
+            tool calls, not a bill: nearly all of the tokens these read were
+            cache reads. */}
+        {spawn.toolCalls ? <span className="ca-num mono">{spawn.toolCalls} calls</span> : null}
+        {spawn.tokens ? <span className="ca-num mono">{fmtTok(spawn.tokens)} tok</span> : null}
+        {entry?.bytes ? <span className="ca-num mono">{fmtTok(entry.bytes)}B</span> : null}
+      </button>
+      {open && agentId && sessionId && (
+        <div className="ca-body"><SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} /></div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The count in the summary line, and the two levels it opens onto.
+ *
+ * Level one is the number, next to the steps and tools — the operator asked for
+ * "how many are done/running" in that line. Level two is this turn's sub-agents,
+ * one row each. Level three is a row's own transcript.
+ *
+ * The roster is fetched only when the list is opened, and it comes from the
+ * `subagents/` directory rather than the parent transcript — the parent reaches
+ * 292 MB on this machine, the roster is a directory listing. It fills in what
+ * the window cannot see: the agentId for a spawn whose launch receipt scrolled
+ * out of the window, the depth, and the size of what each one wrote.
+ */
+function SubAgentsButton({ spawns, live, open, onToggle }: {
+  spawns: AgentSpawn[]; live: boolean; open: boolean; onToggle: () => void;
+}) {
+  const counts = agentCounts(spawns, live);
+  return (
+    <button className={`cx-agents${open ? ' on' : ''}`} onClick={onToggle}
+            title={open ? 'Hide the sub-agents' : 'Show what each sub-agent was asked to do'}>
+      <span className="cs-tri">{open ? '▾' : '▸'}</span>
+      {counts.label}
+    </button>
+  );
+}
+
+/**
+ * The list, one row per sub-agent this turn started.
+ *
+ * The roster is fetched when the list opens, and it comes from the `subagents/`
+ * directory rather than the parent transcript — the parent reaches 292 MB on
+ * this machine, the roster is a directory listing plus 187 bytes per agent. It
+ * fills in what the window cannot see: the agentId for a spawn whose launch
+ * receipt has scrolled out of view, the depth, and how much each one wrote.
+ */
+function SubAgentsList({ spawns, sessionId, live }: { spawns: AgentSpawn[]; sessionId?: string; live: boolean }) {
+  const [roster, setRoster] = useState<SubAgentEntry[] | null>(null);
+  const [note, setNote] = useState('');
+  useEffect(() => {
+    if (!sessionId) return;
+    const ac = new AbortController();
+    getSubAgents(sessionId, ac.signal)
+      .then((r) => { setRoster(r.agents); if (!r.supported && r.reason) setNote(r.reason); })
+      .catch(() => setNote('the roster could not be read'));
+    return () => ac.abort();
+  }, [sessionId]);
+
+  const byToolUse = useMemo(() => {
+    const m = new Map<string, SubAgentEntry>();
+    for (const e of roster || []) if (e.toolUseId) m.set(e.toolUseId, e);
+    return m;
+  }, [roster]);
+  const inThisTurn = new Set(spawns.map((s) => s.toolUseId));
+  const elsewhere = (roster || []).filter((e) => !e.toolUseId || !inThisTurn.has(e.toolUseId)).length;
+
+  return (
+    <div className="cx-agents-list">
+      {spawns.map((s) => (
+        <SubAgentRow key={s.toolUseId} spawn={s} entry={byToolUse.get(s.toolUseId)} sessionId={sessionId} live={live} />
+      ))}
+      {/* Said plainly rather than folded into the count: the number above is this
+          TURN's spawns, and a session's directory usually holds more — including
+          sub-agents that other sub-agents started, which the parent's own tool
+          calls never mention. */}
+      {elsewhere ? <div className="ca-msg mono">{elsewhere} more in this session, from other turns</div> : null}
+      {note ? <div className="ca-msg mono">{note}</div> : null}
+    </div>
+  );
+}
+
 export function ExchangeView({
-  x, n, total, open, onToggle, running, dim, q, baseModel,
+  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live,
 }: {
   x: Exchange;
   n?: number;            // 1-based position — the viewer numbers turns, a card does not
@@ -227,9 +383,24 @@ export function ExchangeView({
   dim?: boolean;         // an earlier exchange, prepended above the current one
   q?: string;            // lowercased search term, highlighted where it lands
   baseModel?: string;    // the session's model; a turn only names its own if it differs
+  /**
+   * The whole loaded window. Only the sub-agent strip needs it: a background
+   * sub-agent's completion is recorded in a LATER turn than the one that
+   * spawned it, so an exchange cannot tell on its own whether its sub-agents
+   * finished.
+   */
+  turns?: TraceTurn[];
+  sessionId?: string;    // to fetch a sub-agent's roster and transcript
+  live?: boolean;        // the pane's own process is alive — gates the word "running"
 }) {
   const [selfOpen, setSelfOpen] = useState(false);
   const toggle = onToggle ?? (() => setSelfOpen((o) => !o));
+  // Its own disclosure, next to the work's: the sub-agent list is a different
+  // question from "show me the tool calls", and opening one should not open the
+  // other. It lives here rather than inside the button so the list can render
+  // BELOW the meta row — the row is a flex line, and a list inside it lands to
+  // the right of the numbers instead of under them.
+  const [agentsOpen, setAgentsOpen] = useState(false);
 
   // The work, split where the answer belongs. Grouping runs over each side
   // separately on purpose: two Reads either side of the agent's reply are two
@@ -257,6 +428,10 @@ export function ExchangeView({
   // instead and disagree with what unfolds; between the two, the number that
   // matches what you are about to see wins.
   const summary = stepSummary(x, steps);
+  // The sub-agents this turn started. Computed over the whole window, not the
+  // exchange, because a background one finishes in a later turn than the one
+  // that spawned it.
+  const spawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
   const latest = running ? nowDoing(steps[steps.length - 1]) : '';
   // Naming the model on every turn is noise when it never changes; when it DOES
   // change mid-session that is worth a word, so say it only then.
@@ -292,7 +467,7 @@ export function ExchangeView({
           "weirdly low". In that state the facts ride on the working line itself,
           so there is one row instead of one and a half. The working line does not
           move: it is the last row either way, at the text column. */}
-      {(summary || (n != null && !factsOnRunningRow)) && (
+      {(summary || spawns.length > 0 || (n != null && !factsOnRunningRow)) && (
       <div className="cx-meta mono">
         {steps.length > 0 ? (
           <button className={`cx-fold${isOpen ? ' on' : ''}`} onClick={toggle} title={isOpen ? 'Hide the work' : 'Show the work'}>
@@ -300,10 +475,22 @@ export function ExchangeView({
             {summary}
           </button>
         ) : <span className="cx-fold flat">{summary}</span>}
+        {/* Sub-agents sit in this line, where the operator asked for them, but as
+            their own control: the fold to their left opens the turn's work, and
+            this one opens the list of sub-agents. One button cannot open two
+            different things, and burying the count inside the work fold would
+            make "how many are running" cost a click that also unfolds forty
+            tool rows. */}
+        {spawns.length > 0 && (
+          <SubAgentsButton spawns={spawns} live={!!live} open={agentsOpen} onToggle={() => setAgentsOpen((o) => !o)} />
+        )}
         {/* Which turn, when, and on what — the viewer's business. A card shows one
             turn, dated in its own header, so it says none of this. */}
         {n != null && facts}
       </div>
+      )}
+      {agentsOpen && spawns.length > 0 && (
+        <SubAgentsList spawns={spawns} sessionId={sessionId} live={!!live} />
       )}
       {isOpen && stepsBefore.length > 0 && (
         <div className="cx-steps">{stepsBefore.map((s, i) => <StepRow key={i} s={s} q={q} />)}</div>

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -311,6 +311,11 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster }
         {!can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
         <span className="cs-facts mono">
           {entry?.depth && entry.depth > 1 ? <span className="depth">↳{entry.depth}</span> : null}
+          {/* codex names its sub-agents — Curie, Herschel, Boole — and that name
+              is a better handle than the task path. Shown only when it IS a
+              name: Claude's `general-purpose` is noise on every row. */}
+          {entry?.agentType && !['general-purpose', 'sub-agent', 'agent'].includes(entry.agentType)
+            ? <span className="who">{entry.agentType}</span> : null}
           {took ? <span>{took}</span> : going ? <span>{going}</span> : null}
           {/* Two different facts, and the second is not a verdict: `took` is what
               the parent recorded, `wrote` is when the file last changed. */}
@@ -436,13 +441,20 @@ export function ExchangeView({
   // that spawned it.
   const spawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
   const summary = stepSummary(x, steps, spawns.length);
+  // Two join keys, because the two harnesses record different things: Claude's
+  // sidecar carries the spawning call's id, codex's rollout header carries the
+  // task name and no id at all.
   const entryOf = useMemo(() => {
     const m = new Map<string, SubAgentEntry>();
-    for (const e of roster || []) if (e.toolUseId) m.set(e.toolUseId, e);
+    for (const e of roster || []) {
+      if (e.toolUseId) m.set(e.toolUseId, e);
+      const task = (e.taskName || '').split('/').filter(Boolean).pop();
+      if (task) m.set(`task:${task}`, e);
+    }
     return m;
   }, [roster]);
   const agentRows = useMemo(() => spawns.map((s) => {
-    const entry = entryOf.get(s.toolUseId);
+    const entry = entryOf.get(s.toolUseId) || (s.taskName ? entryOf.get(`task:${s.taskName}`) : undefined);
     return { spawn: s, entry, status: agentStatus(s, { live: !!live, lastWroteAt: entry?.lastWroteAt }) };
   }), [spawns, entryOf, live]);
   // The strip is all-or-nothing: while ANY sub-agent of this turn is still
@@ -481,7 +493,7 @@ export function ExchangeView({
     const r = rowByToolUse.get(s.toolUseId);
     return (
       <AgentRow key={key}
-                spawn={r?.spawn ?? { toolUseId: s.toolUseId, description: s.description, agentType: s.agentType, background: false }}
+                spawn={r?.spawn ?? { toolUseId: s.toolUseId, taskName: s.taskName, description: s.description, agentType: s.agentType, background: false }}
                 entry={r?.entry} status={r?.status ?? (live ? 'running' : 'no-result')}
                 sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} />
     );

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -325,12 +325,14 @@ function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster, 
         {open ? <span className="cs-tri">▾</span> : mark}
         <span className="cs-label mono">sub-agent</span>
         <span className="cs-detail">{spawn.description}</span>
-        {status === 'stalled' || status === 'no-result' ? (
-          <span className={`cs-state ${status}`}>{status === 'stalled' ? 'no write in 15m' : 'no result'}</span>
-        ) : null}
+        {/* One state word. A row that cannot be opened says why it cannot be
+            opened — that is the fact the reader needs — and "no result" beside
+            "already open above" reads as two verdicts about the same row. */}
         {cyclic ? <span className="cs-state">already open above</span>
           : deep ? <span className="cs-state">nested too deep to open here</span>
-            : !can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
+            : status === 'stalled' || status === 'no-result' ? (
+              <span className={`cs-state ${status}`}>{status === 'stalled' ? 'no write in 15m' : 'no result'}</span>
+            ) : !can && rosterKnown ? <span className="cs-state">no transcript kept</span> : null}
         <span className="cs-facts mono">
           {entry?.depth && entry.depth > 1 ? <span className="depth">↳{entry.depth}</span> : null}
           {/* codex names its sub-agents — Curie, Herschel, Boole — and that name
@@ -482,9 +484,6 @@ export function ExchangeView({
   // Two join keys, because the two harnesses record different things: Claude's
   // sidecar carries the spawning call's id, codex's rollout header carries the
   // task name and no id at all.
-  // …minus any that resolve to an agent already open above: a transcript that
-  // names its own spawning call must not be credited with itself, in the count
-  // or anywhere else.
   const entryOf = useMemo(() => {
     const m = new Map<string, SubAgentEntry>();
     for (const e of roster || []) {
@@ -494,11 +493,12 @@ export function ExchangeView({
     }
     return m;
   }, [roster]);
-  const spawns = useMemo(() => allSpawns.filter((s) => {
-    const id = s.agentId || entryOf.get(s.toolUseId)?.agentId
-      || (s.taskName ? entryOf.get(`task:${s.taskName}`)?.agentId : undefined);
-    return !(id && chain.includes(id));
-  }), [allSpawns, entryOf, chain.join('|')]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Every spawn is a row, cycles included. A record that names an agent already
+  // open above it is malformed — no harness writes one now that a fork's
+  // inherited prelude is trimmed at the source — and the honest rendering of it
+  // is one row saying so, counted like any other, not a row quietly dropped
+  // from the list while its tool call is counted as something else.
+  const spawns = allSpawns;
   const summary = stepSummary(x, steps, spawns.length);
   const agentRows = useMemo(() => spawns.map((s) => {
     const entry = entryOf.get(s.toolUseId) || (s.taskName ? entryOf.get(`task:${s.taskName}`) : undefined);

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -7,13 +7,13 @@
 // Left edge: the prompt's ❯ is the ONLY thing outside the text column. No rail
 // on the answer, no rail on the work — scrolling, you find turns by that arrow
 // and the tinted prompt bar, and everything else lines up in one column.
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import type { SubAgentEntry, TraceTurn } from '../../api';
-import { getSubAgents, getSubAgentTrace } from '../../api';
+import { getSubAgentTrace } from '../../api';
 import { renderMarkdown } from '../../lib/markdown';
 import type { Exchange, Step } from './exchanges';
-import { agentSpawnsOf, agentStatus, fmtClock, fmtDur, fmtTok, isLive, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
+import { agentSpawnsOf, agentStatus, anyLive, capRows, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
 import type { AgentSpawn, AgentStatus } from './exchanges';
 import ToolCall from './ToolCall';
 
@@ -221,22 +221,35 @@ function PromptBand({ text, q, queued }: { text: string; q?: string; queued?: bo
 }
 
 /**
- * What one sub-agent did — the reader, one level down.
+ * What one sub-agent did: the reader, one level down, and nothing else.
  *
- * A sub-agent's transcript is an ordinary trace: same records, same normalizer,
- * so it goes through splitExchanges and comes back out as exchanges that this
- * very component renders. Its first user message is the task it was given, so
- * the prompt band is already the right thing to show at the top. It is also why
- * a sub-agent that spawned sub-agents (rl-llm-wiki did, seven of them at depth
- * 2) unfolds the same way without a second implementation: the directory is
- * flat, so the same endpoint answers for a child of a child.
+ * A sub-agent's transcript is an ordinary trace — same records, same normalizer
+ * — so it goes through splitExchanges and comes back out as exchanges that this
+ * very component renders. Its first user message IS the task it was given, so
+ * the prompt band the reader already draws for a user prompt is exactly the
+ * right thing at the top of it: the task is highlighted because it is a prompt,
+ * not because sub-agents get special paint.
+ *
+ * There is deliberately no wrapper of its own — no rail, no badge, no bespoke
+ * task block. The step body it sits in already indents it, and that indent is
+ * the whole hierarchy. An earlier cut of this had a rail, a clamped task panel
+ * and a "show the whole task" button; all three were a second visual language
+ * for content the reader can already draw, and they are gone.
+ *
+ * The window is 2 MB rather than the reader's 384 KB default because a
+ * sub-agent's whole transcript is usually smaller than that (0.27–12 MB here,
+ * most under four), and a window that holds the whole file is what puts the
+ * task at the top. On the few that overflow it, the tail keeps the report and
+ * the row above still names the task.
  */
-function SubAgentTrace({ sessionId, agentId, live }: { sessionId: string; agentId: string; live: boolean }) {
+function SubAgentTrace({ sessionId, agentId, live, roster }: {
+  sessionId: string; agentId: string; live: boolean; roster?: SubAgentEntry[] | null;
+}) {
   const [state, setState] = useState<{ turns?: TraceTurn[]; error?: string }>({});
   useEffect(() => {
     const ac = new AbortController();
     setState({});
-    getSubAgentTrace(sessionId, agentId, 400_000, ac.signal)
+    getSubAgentTrace(sessionId, agentId, 2_000_000, ac.signal)
       .then((w) => setState({ turns: w.turns }))
       .catch((e) => { if (!ac.signal.aborted) setState({ error: e?.message || 'could not read it' }); });
     return () => ac.abort();
@@ -247,11 +260,11 @@ function SubAgentTrace({ sessionId, agentId, live }: { sessionId: string; agentI
   const exchanges = splitExchanges(state.turns);
   if (!exchanges.length) return <div className="ca-msg mono">nothing recorded yet</div>;
   return (
-    <div className="ca-trace">
+    <>
       {exchanges.map((ex) => (
-        <ExchangeView key={ex.key} x={ex} turns={state.turns} sessionId={sessionId} live={live} dim />
+        <ExchangeView key={ex.key} x={ex} turns={state.turns} sessionId={sessionId} live={live} roster={roster} dim />
       ))}
-    </div>
+    </>
   );
 }
 
@@ -261,9 +274,9 @@ function SubAgentTrace({ sessionId, agentId, live }: { sessionId: string; agentI
  * working line while it runs. Two renderings of the same thing was how the
  * count and the list drifted apart in the first cut of this feature.
  */
-function AgentRow({ spawn, entry, status, sessionId, live, leaving, rosterKnown }: {
+function AgentRow({ spawn, entry, status, sessionId, live, rosterKnown, roster }: {
   spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus;
-  sessionId?: string; live: boolean; leaving?: boolean;
+  sessionId?: string; live: boolean; roster?: SubAgentEntry[] | null;
   /** the roster has answered, so "no entry" means "no transcript", not "not yet" */
   rosterKnown?: boolean;
 }) {
@@ -286,7 +299,7 @@ function AgentRow({ spawn, entry, status, sessionId, live, leaving, rosterKnown 
       : status === 'failed' || status === 'killed' ? <span className="cs-mark bad">✗</span>
         : <span className="cs-tri off">–</span>;
   return (
-    <div className={`cs agent ${status}${open ? ' open' : ''}${leaving ? ' leaving' : ''}`}>
+    <div className={`cs agent ${status}${open ? ' open' : ''}`}>
       <button className="cs-head" disabled={!can} onClick={() => setOpen((o) => !o)}
               title={can ? 'Show the task and what it did' : 'no transcript on disk for this one'}>
         {open ? <span className="cs-tri">▾</span> : mark}
@@ -311,134 +324,56 @@ function AgentRow({ spawn, entry, status, sessionId, live, leaving, rosterKnown 
       </button>
       {open && agentId && sessionId && (
         <div className="cs-body">
-          {/* The task it was given, then what it did with it — the two things the
-              operator asked to see behind a row. */}
-          <AgentTask spawn={spawn} />
-          <SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} />
+          {/* Its trace, drawn by the reader. The task arrives as that trace's own
+              first prompt, so nothing here has to render it separately. */}
+          <SubAgentTrace sessionId={sessionId} agentId={agentId} live={live} roster={roster} />
         </div>
       )}
     </div>
   );
 }
 
-/** The task, clamped. It is the `Agent` call's own prompt — 3.4 kB is normal. */
-function AgentTask({ spawn }: { spawn: AgentSpawn }) {
-  const [all, setAll] = useState(false);
-  if (!spawn.prompt) return null;
-  const long = spawn.prompt.length > 420;
-  return (
-    <>
-      <div className={`cs-task${all || !long ? '' : ' clamp'}`}>{spawn.prompt}</div>
-      {long && !all && (
-        <button className="cs-more-btn mono" onClick={() => setAll(true)}>
-          show the whole task ({Math.round(spawn.prompt.length / 100) / 10} kB)
-        </button>
-      )}
-    </>
-  );
-}
-
 /**
- * The sub-agents of THIS turn that are still going, listed under the working
- * line — the thing the feature is for. Collapsed exchange, nothing expanded:
- * the pane says it is working, and these say what is working underneath it.
+ * The sub-agents of this turn, listed under the working line — the thing the
+ * feature is for. Collapsed exchange, nothing expanded: the pane says it is
+ * working, and these say what is working underneath it.
  *
- * Running only. A finished sub-agent leaves, because a list that keeps them
- * grows for the length of the turn and stops being a glance; what persists is
- * the count in the summary line. It leaves on a fade rather than by vanishing:
- * rows appearing and disappearing under a live spinner is the shape that
- * produced the API-log flicker, so a row that has just finished holds its place
- * for a beat with its ✓ and its duration, then goes.
+ * ALL OF THEM, and the strip is the unit that comes and goes. A sub-agent that
+ * finishes stays in the strip with its finished mark for as long as any sibling
+ * is still running; when the last one finishes the whole strip goes, and the
+ * sub-agents are where every other step is — in the collapsed work. That is one
+ * appearance and one disappearance per turn instead of one per sub-agent, and it
+ * is why the six-second linger this file used to carry (and the client-side
+ * "first seen finished" bookkeeping behind it) is deleted rather than kept: it
+ * existed to soften rows leaving one at a time, which no longer happens.
  *
- * Capped, because the rail is not the place to discover that a turn spawned
- * twenty. Measured first: across the three sessions here the busiest single
- * exchange spawned FOUR (release-video's turn 24; the-gatherer's busiest is
- * three), so the cap is generous rather than tight — and the overflow line says
- * how many it is holding back.
+ * CAPPED, because rows now accumulate: a release-video turn ends at 22, and
+ * the-gatherer's busiest ends at 40. Over the cap, the rows that give way are
+ * the FINISHED ones, oldest first — the strip is about what is still going, and
+ * the finished ones are one click away in the work. The strip's height therefore
+ * stops growing at the cap instead of resizing every time one completes.
  */
-const LIVE_CAP = 6;
+const LIVE_CAP = 10;
 
-function LiveAgents({ rows, sessionId, live, rosterKnown }: {
-  rows: { spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus; leaving?: boolean }[];
-  sessionId?: string; live: boolean; rosterKnown?: boolean;
+function LiveAgents({ rows, sessionId, live, rosterKnown, roster }: {
+  rows: { spawn: AgentSpawn; entry?: SubAgentEntry; status: AgentStatus }[];
+  sessionId?: string; live: boolean; rosterKnown?: boolean; roster?: SubAgentEntry[] | null;
 }) {
+  const { shown, note } = capRows(rows, LIVE_CAP);
   if (!rows.length) return null;
-  const shown = rows.slice(0, LIVE_CAP);
-  const hidden = rows.length - shown.length;
   return (
     <div className="cx-live">
       {shown.map((r) => (
         <AgentRow key={r.spawn.toolUseId} spawn={r.spawn} entry={r.entry} status={r.status}
-                  sessionId={sessionId} live={live} leaving={r.leaving} rosterKnown={rosterKnown} />
+                  sessionId={sessionId} live={live} rosterKnown={rosterKnown} roster={roster} />
       ))}
-      {hidden > 0 && <div className="cx-live-more mono">…and {hidden} more running — open the work to see them all</div>}
+      {note ? <div className="cx-live-more mono">{note}</div> : null}
     </div>
   );
 }
 
-/**
- * The roster, for the facts the window cannot carry: the agentId of a spawn
- * whose launch receipt has scrolled away, the depth, and when each transcript
- * last changed. It is a directory listing plus 187 bytes per sub-agent — the
- * parent transcript it sits next to reaches 292 MB, and is never read here.
- *
- * Fetched only when this turn has a sub-agent whose end is unrecorded, and
- * polled only while the pane is alive, because `lastWroteAt` is the one value
- * that goes stale on its own.
- */
-function useRoster(sessionId: string | undefined, need: boolean, live: boolean) {
-  const [roster, setRoster] = useState<SubAgentEntry[] | null>(null);
-  useEffect(() => {
-    if (!sessionId || !need) return;
-    let done = false;
-    const load = () => getSubAgents(sessionId)
-      .then((r) => { if (!done) setRoster(r.agents); })
-      .catch(() => { /* the strip degrades to what the window knows */ });
-    load();
-    if (!live) return () => { done = true; };
-    const t = window.setInterval(load, 15_000);
-    return () => { done = true; window.clearInterval(t); };
-  }, [sessionId, need, live]);
-  return roster;
-}
-
-/**
- * A row that has just finished keeps its place for LINGER_MS, so the strip
- * shrinks after you have seen why rather than under your eyes.
- *
- * Two conditions, and the second one was a bug before it was a rule: the row
- * must have been LIVE in this client first. Keyed only on "first seen
- * finished", every sub-agent that completed hours ago flashed into the strip
- * for six seconds on page load — the exact jitter the linger exists to prevent.
- */
-const LINGER_MS = 6000;
-
-function useLinger(liveIds: string[], finishedIds: string[]) {
-  const wasLive = useRef(new Set<string>());
-  const leftAt = useRef(new Map<string, number>());
-  const [, tick] = useState(0);
-  const key = `${liveIds.join('|')}::${finishedIds.join('|')}`;
-  useEffect(() => {
-    for (const id of liveIds) { wasLive.current.add(id); leftAt.current.delete(id); }
-    const now = Date.now();
-    let soonest = Infinity;
-    for (const id of finishedIds) {
-      if (!wasLive.current.has(id)) continue;      // it was already done when we arrived
-      if (!leftAt.current.has(id)) leftAt.current.set(id, now);
-      soonest = Math.min(soonest, (leftAt.current.get(id) as number) + LINGER_MS);
-    }
-    if (!Number.isFinite(soonest)) return;
-    const t = window.setTimeout(() => tick((n) => n + 1), Math.max(0, soonest - now) + 40);
-    return () => window.clearTimeout(t);
-  }, [key]); // eslint-disable-line react-hooks/exhaustive-deps
-  return (id: string) => {
-    const at = leftAt.current.get(id);
-    return at != null && Date.now() - at < LINGER_MS;
-  };
-}
-
 export function ExchangeView({
-  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live,
+  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live, roster,
 }: {
   x: Exchange;
   n?: number;            // 1-based position — the viewer numbers turns, a card does not
@@ -456,8 +391,17 @@ export function ExchangeView({
    * finished.
    */
   turns?: TraceTurn[];
-  sessionId?: string;    // to fetch a sub-agent's roster and transcript
+  sessionId?: string;    // to fetch a sub-agent's transcript
   live?: boolean;        // the pane's own process is alive — gates the word "running"
+  /**
+   * The session's sub-agent roster, fetched ONCE by the reader rather than by
+   * each exchange. It carries what the window cannot: the agentId of a spawn
+   * whose launch receipt has scrolled away, the depth, and when each transcript
+   * last changed. Per-exchange fetching also lost the answer — an effect keyed
+   * on the pane's liveness re-ran the moment the pane started working and threw
+   * the result away, so rows never got their `wrote 4m ago`.
+   */
+  roster?: SubAgentEntry[] | null;
 }) {
   const [selfOpen, setSelfOpen] = useState(false);
   const toggle = onToggle ?? (() => setSelfOpen((o) => !o));
@@ -492,9 +436,6 @@ export function ExchangeView({
   // that spawned it.
   const spawns = useMemo(() => agentSpawnsOf(x, turns || []), [x, turns]);
   const summary = stepSummary(x, steps, spawns.length);
-  // The roster is only worth asking for while something might still be running.
-  const unresolved = spawns.some((s) => !s.outcome);
-  const roster = useRoster(sessionId, spawns.length > 0 && (unresolved || isOpen), !!live && unresolved);
   const entryOf = useMemo(() => {
     const m = new Map<string, SubAgentEntry>();
     for (const e of roster || []) if (e.toolUseId) m.set(e.toolUseId, e);
@@ -504,16 +445,11 @@ export function ExchangeView({
     const entry = entryOf.get(s.toolUseId);
     return { spawn: s, entry, status: agentStatus(s, { live: !!live, lastWroteAt: entry?.lastWroteAt }) };
   }), [spawns, entryOf, live]);
-  const lingering = useLinger(
-    agentRows.filter((r) => isLive(r.status)).map((r) => r.spawn.toolUseId),
-    agentRows.filter((r) => !isLive(r.status)).map((r) => r.spawn.toolUseId),
-  );
-  // What the collapsed turn shows under its working line: what is still going,
-  // plus whatever finished in the last few seconds, so the strip shrinks after
-  // you have seen why rather than under your eyes.
-  const liveRows = agentRows
-    .filter((r) => isLive(r.status) || lingering(r.spawn.toolUseId))
-    .map((r) => ({ ...r, leaving: !isLive(r.status) }));
+  // The strip is all-or-nothing: while ANY sub-agent of this turn is still
+  // going it lists them all, finished ones included, so the list a glance sees
+  // does not rearrange itself every time one lands. When none is live it is not
+  // rendered at all and they are in the work with every other step.
+  const liveNow = anyLive(agentRows.map((r) => r.status));
   const latest = running ? nowDoing(steps[steps.length - 1]) : '';
   // Naming the model on every turn is noise when it never changes; when it DOES
   // change mid-session that is worth a word, so say it only then.
@@ -547,7 +483,7 @@ export function ExchangeView({
       <AgentRow key={key}
                 spawn={r?.spawn ?? { toolUseId: s.toolUseId, description: s.description, agentType: s.agentType, background: false }}
                 entry={r?.entry} status={r?.status ?? (live ? 'running' : 'no-result')}
-                sessionId={sessionId} live={!!live} rosterKnown={!!roster} />
+                sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} />
     );
   };
 
@@ -608,11 +544,11 @@ export function ExchangeView({
       )}
       {/* …and what is working underneath it. This is the point of the feature:
           the exchange is collapsed, nothing has been expanded, and the pane's
-          own `working` line is followed by one line per sub-agent still going.
-          Each row is the same row the step list shows, so opening one here
-          gives the task and the trace without leaving the glance. */}
-      {liveRows.length > 0 && !isOpen && (
-        <LiveAgents rows={liveRows} sessionId={sessionId} live={!!live} rosterKnown={!!roster} />
+          own `working` line is followed by every sub-agent this turn started —
+          the ones still going and the ones that have landed. Each row is the row
+          the step list shows, so opening one here costs no navigation. */}
+      {liveNow && !isOpen && (
+        <LiveAgents rows={agentRows} sessionId={sessionId} live={!!live} rosterKnown={!!roster} roster={roster} />
       )}
     </section>
   );

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -290,7 +290,10 @@ export const fmtClock = (ms?: number) =>
 // subagents in this conversation's subagent tree". Same facility, different
 // plumbing.
 const AGENT_TOOLS = new Set(['Agent', 'Task', 'spawn_agent']);
-const LAUNCH_RECEIPT = /^Async agent launched successfully/;
+// Two launch acknowledgements, both of which arrive at once and neither of
+// which is the sub-agent's work: the background spawn's, and a fork's. Getting
+// the second one wrong marked every fork finished the moment it started.
+const LAUNCH_RECEIPT = /^(Async agent launched successfully|Fork started)/;
 const AGENT_ID_IN_RECEIPT = /agentId:\s*([A-Za-z0-9_-]+)/;
 const NOTIFICATION_ID = /<tool-use-id>([^<]+)<\/tool-use-id>/;
 const NOTIFICATION_STATUS = /<status>([a-z]+)<\/status>/;
@@ -510,6 +513,31 @@ export function agentStatus(
   if (!opts.live) return 'no-result';
   const quiet = opts.lastWroteAt ? (opts.now ?? Date.now()) - opts.lastWroteAt : 0;
   return quiet > STALE_MS ? 'stalled' : 'running';
+}
+
+/**
+ * How deep the reader will nest a sub-agent inside a sub-agent.
+ *
+ * The measured maximum on this machine is depth 2 (rl-llm-wiki: three agents
+ * that spawned seven), and nothing deeper exists in any of the sessions here,
+ * so this is a backstop rather than a limit anyone will meet. It is here
+ * because the reader must not hang on malformed data: a transcript that names
+ * itself as its own child — which a fork's inherited prelude did until the
+ * parser stopped handing it over — would otherwise open forever.
+ */
+export const MAX_NEST = 3;
+
+/**
+ * Whether a row may be opened, given who is already open above it.
+ *
+ * `ancestors` is the chain of agentIds from the outermost open row down to this
+ * one. A row that names an agent already in that chain is a cycle, and it
+ * renders as a row that cannot be opened rather than as infinite nesting.
+ */
+export function canOpenAgent(agentId: string | undefined, ancestors: string[], cap = MAX_NEST) {
+  if (!agentId) return false;
+  if (ancestors.includes(agentId)) return false;
+  return ancestors.length < cap;
 }
 
 /** A sub-agent the parent has not heard back from, on a pane that is alive. */

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -117,7 +117,7 @@ export type Step =
    * duration and nothing to open. And a sub-agent has a life after the call
    * returns, which no other tool row has to represent.
    */
-  | { kind: 'agent'; toolUseId: string; description: string; agentType: string; blocks: TraceBlock[] }
+  | { kind: 'agent'; toolUseId: string; description: string; agentType: string; taskName?: string; blocks: TraceBlock[] }
   | { kind: 'tools'; name: string; count: number; details: string[]; failed: boolean; blocks: TraceBlock[] }
   | { kind: 'note'; text: string; more?: number }
   | { kind: 'shell'; command: string; out: string; failed: boolean }
@@ -212,10 +212,11 @@ export function stepsOf(turns: TraceTurn[]): Step[] {
         i = j - 1;
         if (AGENT_TOOLS.has(b.name) && b.id) {
           const input = agentInput(b.text);
+          const task = (input.task_name || '').split('/').filter(Boolean).pop() || '';
           out.push({
-            kind: 'agent', toolUseId: b.id, blocks: group,
-            description: input.description || argSummary(b.text) || 'sub-agent',
-            agentType: input.subagent_type || 'agent',
+            kind: 'agent', toolUseId: b.id, blocks: group, taskName: task || undefined,
+            description: input.description || task || argSummary(b.text) || 'sub-agent',
+            agentType: input.subagent_type || (task ? 'sub-agent' : 'agent'),
           });
           continue;
         }
@@ -280,7 +281,15 @@ export const fmtClock = (ms?: number) =>
 // So the outcome is the NOTIFICATION for a background spawn, and the result
 // itself only when it is the agent's own report (a synchronous spawn). Observed
 // statuses: completed, failed, killed.
-const AGENT_TOOLS = new Set(['Agent', 'Task']);
+// Claude spawns with `Agent` (older CLIs: `Task`); codex spawns with
+// `spawn_agent` in its `collaboration` namespace. The first cut of this feature
+// treated `collaboration.spawn_agent` as Agent Manager's own peer-spawning tool
+// and excluded codex on that basis. That was wrong: a real run on this machine
+// produced three rollouts whose headers name the pane as `parent_thread_id`
+// with `thread_source: "subagent"`, and codex itself called them "native
+// subagents in this conversation's subagent tree". Same facility, different
+// plumbing.
+const AGENT_TOOLS = new Set(['Agent', 'Task', 'spawn_agent']);
 const LAUNCH_RECEIPT = /^Async agent launched successfully/;
 const AGENT_ID_IN_RECEIPT = /agentId:\s*([A-Za-z0-9_-]+)/;
 const NOTIFICATION_ID = /<tool-use-id>([^<]+)<\/tool-use-id>/;
@@ -296,9 +305,42 @@ const NOTIFICATION_MS = /<duration_ms>(\d+)<\/duration_ms>/;
 
 export type AgentOutcome = 'completed' | 'failed' | 'killed' | 'reported';
 
+/**
+ * Codex's completion post, in the parent's own rollout:
+ *
+ *   Message Type: FINAL_ANSWER
+ *   Sender: /root/pty_summary
+ *   Payload: …the sub-agent's answer…
+ *
+ * This is codex's equivalent of Claude's `<task-notification>` — recorded by
+ * the parent, naming which sub-agent, timestamped, and carrying what it handed
+ * back. The feasibility study reported "no terminal event observed" because it
+ * looked for `sub_agent_activity` events, which CLI 0.149.1 does not emit at
+ * all; this is what it emits instead. `wait_agent` is NOT usable for this: its
+ * output is `{"message":"Wait completed.","timed_out":false}` and names no
+ * agent, so it says something finished without saying what.
+ */
+const FINAL_ANSWER = /Message Type:\s*FINAL_ANSWER/;
+// The type has to BE final, not listed among the options: codex documents this
+// very format in its own developer prompt — "Message Type: MESSAGE |
+// FINAL_ANSWER … Sender: <author>" — in the same thread the real posts arrive
+// in, so a looser match reads the explanation as an event. (A sender-shape
+// guard was tried too and removed: an unmatched name matches no spawn, so it
+// changed nothing and no test could tell the difference.)
+const POST_SENDER = /Sender:\s*(\S+)/;
+/** the parent's own path is `/root`; a child's is `/root/<task name>` */
+const taskOf = (p: string) => (p || '').split('/').filter(Boolean).pop() || '';
+
 export interface AgentSpawn {
   /** the parent's own call id — the join key the sidecar files carry too */
   toolUseId: string;
+  /**
+   * Codex's join key instead of an id: the `spawn_agent` call names a
+   * `task_name`, the child's rollout header repeats it as `agent_path`, and the
+   * completion post names it as `Sender:`. There is no shared id anywhere in
+   * that chain, so the name IS the link — exact, not a heuristic.
+   */
+  taskName?: string;
   description: string;
   agentType: string;
   /** from the launch receipt; the roster supplies it when the receipt is not in view */
@@ -317,13 +359,13 @@ export interface AgentSpawn {
 }
 
 /** The `Agent` call's input, which is JSON unless the block was capped mid-object. */
-export const agentInput = (text: string): { description?: string; subagent_type?: string; prompt?: string } => {
+export const agentInput = (text: string): { description?: string; subagent_type?: string; prompt?: string; task_name?: string } => {
   try { return JSON.parse(text || '{}'); } catch { /* capped */ }
   const pick = (k: string) => {
     const m = new RegExp(`"${k}":\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(text || '');
     return m ? m[1].replace(/\\"/g, '"') : undefined;
   };
-  return { description: pick('description'), subagent_type: pick('subagent_type'), prompt: pick('prompt') };
+  return { description: pick('description'), subagent_type: pick('subagent_type'), prompt: pick('prompt'), task_name: pick('task_name') };
 };
 
 const textOfTurn = (t: TraceTurn) =>
@@ -337,6 +379,7 @@ const textOfTurn = (t: TraceTurn) =>
  */
 function outcomes(turns: TraceTurn[]) {
   const byId = new Map<string, { outcome: AgentOutcome; at?: number; tokens?: number; toolCalls?: number; durationMs?: number }>();
+  const byTask = new Map<string, { outcome: AgentOutcome; at?: number }>();
   const receipts = new Map<string, { text: string; at?: number; failed?: boolean }>();
   for (const t of turns) {
     for (const b of t.blocks) {
@@ -345,6 +388,12 @@ function outcomes(turns: TraceTurn[]) {
     // The harness's own completion messages arrive as user text and the trace
     // reader keeps them as `system` turns, which is why they are readable here.
     const text = textOfTurn(t);
+    // codex: a sub-agent's own answer, posted back into the parent's thread
+    if (FINAL_ANSWER.test(text)) {
+      const who = POST_SENDER.exec(text);
+      const task = taskOf(who ? who[1] : '');
+      if (task) byTask.set(task, { outcome: 'reported', at: t.ts });
+    }
     if (!text.includes('<task-notification>')) continue;
     for (const part of text.split('<task-notification>').slice(1)) {
       const id = NOTIFICATION_ID.exec(part);
@@ -358,33 +407,54 @@ function outcomes(turns: TraceTurn[]) {
       });
     }
   }
-  return { byId, receipts };
+  return { byId, byTask, receipts };
 }
 
 /** The sub-agents THIS exchange spawned, with whatever the parent knows of their end. */
 export function agentSpawnsOf(x: Exchange, turns: TraceTurn[]): AgentSpawn[] {
-  const { byId, receipts } = outcomes(turns);
+  const { byId, byTask, receipts } = outcomes(turns);
   const out: AgentSpawn[] = [];
   for (const t of x.steps) {
     for (const b of t.blocks) {
       if (b.type !== 'tool_use' || !AGENT_TOOLS.has(b.name) || !b.id) continue;
       const input = agentInput(b.text || '');
+      const task = taskOf(input.task_name || '');
       const receipt = receipts.get(b.id);
-      const background = !!receipt && LAUNCH_RECEIPT.test(receipt.text);
+      // codex's `spawn_agent` answers `{"task_name":"/root/pty_summary"}` — an
+      // acknowledgement, exactly like Claude's async launch receipt, and never
+      // the sub-agent's work. Without this, every codex spawn read as finished
+      // the moment it started: the same trap as Claude's background receipt,
+      // one shape further along. Its sub-agents always run concurrently, so
+      // this path has no synchronous case at all.
+      const codex = b.name === 'spawn_agent';
+      const background = codex || (!!receipt && LAUNCH_RECEIPT.test(receipt.text));
       const note = byId.get(b.id);
       const spawn: AgentSpawn = {
         toolUseId: b.id,
-        description: input.description || (b.text || '').slice(0, 80) || 'sub-agent',
-        agentType: input.subagent_type || 'agent',
+        taskName: task || undefined,
+        // codex's spawn carries a task NAME and an encrypted message, so the
+        // name is the description there; Claude's carries a written description.
+        description: input.description || task || (b.text || '').slice(0, 80) || 'sub-agent',
+        agentType: input.subagent_type || (task ? 'sub-agent' : 'agent'),
         spawnedAt: t.ts,
         background,
+        // …and nothing readable to show as a task: codex encrypts the message it
+        // sends its sub-agent, so there is no prompt on this path. The child's
+        // own trace still opens.
         prompt: input.prompt,
       };
       const idInReceipt = receipt && AGENT_ID_IN_RECEIPT.exec(receipt.text);
       if (idInReceipt) spawn.agentId = idInReceipt[1];
+      const post = task ? byTask.get(task) : undefined;
       if (note) {
         spawn.outcome = note.outcome; spawn.outcomeAt = note.at;
         spawn.tokens = note.tokens; spawn.toolCalls = note.toolCalls; spawn.durationMs = note.durationMs;
+      } else if (post) {
+        // codex: the answer came back, which is the whole of what is recorded.
+        // No token count, no tool count — those are not written down on this
+        // path, and the row shows the span it can prove instead of inventing
+        // numbers.
+        spawn.outcome = post.outcome; spawn.outcomeAt = post.at;
       }
       else if (receipt && !background) {
         // A synchronous spawn hands its report back AS the result, so this one

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -109,6 +109,15 @@ export function splitExchanges(turns: TraceTurn[]): Exchange[] {
 
 export type Step =
   | { kind: 'think'; text: string; more?: number }
+  /**
+   * A sub-agent spawn. Its own kind, and NOT a `tools` row, for two reasons:
+   * consecutive calls to one tool collapse into `Read ×4`, and spawns arrive
+   * consecutively — three in a row inside one real turn — so grouping would
+   * render four sub-agents as a single `Agent ×3` row with no state, no
+   * duration and nothing to open. And a sub-agent has a life after the call
+   * returns, which no other tool row has to represent.
+   */
+  | { kind: 'agent'; toolUseId: string; description: string; agentType: string; blocks: TraceBlock[] }
   | { kind: 'tools'; name: string; count: number; details: string[]; failed: boolean; blocks: TraceBlock[] }
   | { kind: 'note'; text: string; more?: number }
   | { kind: 'shell'; command: string; out: string; failed: boolean }
@@ -159,6 +168,9 @@ export function stepText(s: Step): string {
   if (s.kind === 'tools') return [s.name, ...s.details, ...s.blocks.map((b) => ('text' in b ? b.text : ''))].join('\n');
   if (s.kind === 'shell') return `${s.command}\n${s.out}`;
   if (s.kind === 'image') return '';
+  // A sub-agent row is searchable by the task it was given and by the call's
+  // own input; its transcript is a different file and is not in this window.
+  if (s.kind === 'agent') return [s.description, s.agentType, ...s.blocks.map((b) => ('text' in b ? b.text : ''))].join('\n');
   return s.text;
 }
 
@@ -198,6 +210,15 @@ export function stepsOf(turns: TraceTurn[]): Step[] {
           j++;
         }
         i = j - 1;
+        if (AGENT_TOOLS.has(b.name) && b.id) {
+          const input = agentInput(b.text);
+          out.push({
+            kind: 'agent', toolUseId: b.id, blocks: group,
+            description: input.description || argSummary(b.text) || 'sub-agent',
+            agentType: input.subagent_type || 'agent',
+          });
+          continue;
+        }
         pushTool(b.name, argSummary(b.text), group, failed);
       } else if (b.type === 'tool_result') {
         pushTool('result', oneLine(b.text, 60), [b], !!b.failed);
@@ -291,7 +312,19 @@ export interface AgentSpawn {
   durationMs?: number;
   /** a spawn whose receipt says it was launched into the background */
   background: boolean;
+  /** the task, verbatim from the call — what the row shows when it is opened */
+  prompt?: string;
 }
+
+/** The `Agent` call's input, which is JSON unless the block was capped mid-object. */
+export const agentInput = (text: string): { description?: string; subagent_type?: string; prompt?: string } => {
+  try { return JSON.parse(text || '{}'); } catch { /* capped */ }
+  const pick = (k: string) => {
+    const m = new RegExp(`"${k}":\\s*"((?:[^"\\\\]|\\\\.)*)"`).exec(text || '');
+    return m ? m[1].replace(/\\"/g, '"') : undefined;
+  };
+  return { description: pick('description'), subagent_type: pick('subagent_type'), prompt: pick('prompt') };
+};
 
 const textOfTurn = (t: TraceTurn) =>
   t.blocks.filter((b) => b.type === 'text').map((b) => ('text' in b ? b.text : '')).join('\n');
@@ -335,8 +368,7 @@ export function agentSpawnsOf(x: Exchange, turns: TraceTurn[]): AgentSpawn[] {
   for (const t of x.steps) {
     for (const b of t.blocks) {
       if (b.type !== 'tool_use' || !AGENT_TOOLS.has(b.name) || !b.id) continue;
-      let input: { description?: string; subagent_type?: string; prompt?: string } = {};
-      try { input = JSON.parse(b.text || '{}'); } catch { /* the input was capped mid-JSON */ }
+      const input = agentInput(b.text || '');
       const receipt = receipts.get(b.id);
       const background = !!receipt && LAUNCH_RECEIPT.test(receipt.text);
       const note = byId.get(b.id);
@@ -346,6 +378,7 @@ export function agentSpawnsOf(x: Exchange, turns: TraceTurn[]): AgentSpawn[] {
         agentType: input.subagent_type || 'agent',
         spawnedAt: t.ts,
         background,
+        prompt: input.prompt,
       };
       const idInReceipt = receipt && AGENT_ID_IN_RECEIPT.exec(receipt.text);
       if (idInReceipt) spawn.agentId = idInReceipt[1];
@@ -366,6 +399,51 @@ export function agentSpawnsOf(x: Exchange, turns: TraceTurn[]): AgentSpawn[] {
 }
 
 export const isFinished = (s: AgentSpawn) => !!s.outcome;
+
+/**
+ * How long a sub-agent may go without writing before the reader stops calling
+ * it "running".
+ *
+ * mtime is not a verdict on its own: measured across 8,757 gaps between
+ * consecutive records inside sub-agent transcripts, the median is 2.7s, p99 is
+ * 112s and the LONGEST silence inside a run that finished normally is 601s. So
+ * any threshold near ten minutes calls live sub-agents dead — a first draft of
+ * this constant was exactly 600s and the test caught it by one second. This one
+ * is 1.5× the worst silence observed, and still a guess: which is why the row
+ * that crosses it says how long it has been quiet rather than saying "dead",
+ * and keeps its transcript one click away.
+ *
+ * It exists because of the case it catches: 9 of release-video's 22 sub-agents
+ * have no recorded outcome at all, because the pane was restarted or the
+ * notification was lost to a compaction. Without this rule those rows spin
+ * under the working line forever — a phantom worker, which is worse than
+ * showing nothing.
+ */
+export const STALE_MS = 15 * 60 * 1000;
+
+export type AgentStatus = 'done' | 'failed' | 'killed' | 'running' | 'stalled' | 'no-result';
+
+/**
+ * One place decides what a row says, because three inputs decide it: what the
+ * parent recorded, whether the pane's own process is alive, and when the
+ * sub-agent's transcript last changed.
+ */
+export function agentStatus(
+  s: AgentSpawn,
+  opts: { live: boolean; lastWroteAt?: number | null; now?: number },
+): AgentStatus {
+  if (s.outcome === 'completed' || s.outcome === 'reported') return 'done';
+  if (s.outcome === 'failed') return 'failed';
+  if (s.outcome === 'killed') return 'killed';
+  // No outcome recorded. A pane that is not running cannot have anything
+  // running under it, whatever the files say.
+  if (!opts.live) return 'no-result';
+  const quiet = opts.lastWroteAt ? (opts.now ?? Date.now()) - opts.lastWroteAt : 0;
+  return quiet > STALE_MS ? 'stalled' : 'running';
+}
+
+/** The rows the collapsed exchange shows under its working line: the live ones. */
+export const isLive = (st: AgentStatus) => st === 'running' || st === 'stalled';
 
 /**
  * The count for the summary line, and the reason it needs the pane's state.
@@ -394,10 +472,15 @@ export function agentCounts(list: AgentSpawn[], live: boolean) {
  * "14 steps · 9 tools · 42s · 21.0k tok" — the whole turn in one line. There is
  * no header above the prompt any more, so this carries the numbers everywhere.
  */
-export function stepSummary(x: Exchange, steps: Step[]): string {
+export function stepSummary(x: Exchange, steps: Step[], subAgents = 0): string {
   const bits: string[] = [];
   if (steps.length) bits.push(`${steps.length} step${steps.length === 1 ? '' : 's'}`);
-  if (x.toolCalls) bits.push(`${x.toolCalls} tool${x.toolCalls === 1 ? '' : 's'}`);
+  // Sub-agents are counted as sub-agents and not also as tools. They ARE tool
+  // calls, but reporting one turn's four spawns inside "53 tools" and again as
+  // "4 sub-agents" makes the two numbers argue about the same work.
+  const tools = Math.max(0, x.toolCalls - subAgents);
+  if (tools) bits.push(`${tools} tool${tools === 1 ? '' : 's'}`);
+  if (subAgents) bits.push(`${subAgents} sub-agent${subAgents === 1 ? '' : 's'}`);
   const d = fmtDur(x.endTs - x.startTs);
   if (d) bits.push(d);
   if (x.tokens) bits.push(`${fmtTok(x.tokens)} tok`);

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -33,7 +33,8 @@ export const isOperatorPrompt = (t: TraceTurn) => {
   if (t.role !== 'user') return false;
   const text = t.blocks.filter((b) => b.type === 'text').map((b) => ('text' in b ? b.text : '')).join('').trim();
   if (!text) return t.blocks.some((b) => b.type === 'image');
-  return !text.startsWith('<') && !text.startsWith('[Request interrupted');
+  return !text.startsWith('<') && !text.startsWith('[Request interrupted')
+    && !text.startsWith('[SYSTEM NOTIFICATION');
 };
 
 const usageOf = (t: TraceTurn) => (t.usage ? (t.usage.in || 0) + (t.usage.out || 0) : 0);
@@ -235,6 +236,159 @@ export const fmtDur = (ms: number) => {
 
 export const fmtClock = (ms?: number) =>
   ms ? new Date(ms).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+
+// ---------- sub-agents ----------
+//
+// A Claude pane spawns a sub-agent with the `Agent` tool (named `Task` in older
+// CLIs; both are matched). Everything the reader needs about the SPAWN is in the
+// turn it is already showing: the call names the task, and the parent's own
+// later records say how it ended.
+//
+// The one trap, measured on this machine rather than assumed: for a BACKGROUND
+// spawn — which is all 22 of release-video's and all 38 of the-gatherer's — the
+// `tool_result` arrives two seconds after the call and says "Async agent
+// launched successfully". It is a receipt, not an outcome. Treating a result as
+// completion marks every sub-agent finished the moment it starts; on the agent
+// checked end to end that would have been 4m26s early:
+//
+//   08:36:05  Agent tool_use            spawn
+//   08:36:07  tool_result               "Async agent launched successfully… agentId: a000425…"
+//   08:40:31  (child's last record)
+//   08:40:33  <task-notification>       <tool-use-id>…</tool-use-id><status>completed</status>
+//
+// So the outcome is the NOTIFICATION for a background spawn, and the result
+// itself only when it is the agent's own report (a synchronous spawn). Observed
+// statuses: completed, failed, killed.
+const AGENT_TOOLS = new Set(['Agent', 'Task']);
+const LAUNCH_RECEIPT = /^Async agent launched successfully/;
+const AGENT_ID_IN_RECEIPT = /agentId:\s*([A-Za-z0-9_-]+)/;
+const NOTIFICATION_ID = /<tool-use-id>([^<]+)<\/tool-use-id>/;
+const NOTIFICATION_STATUS = /<status>([a-z]+)<\/status>/;
+// The notification also carries what the sub-agent SPENT, which is the only
+// place that number is written down: `<usage><subagent_tokens>41700</…>
+// <tool_uses>13</…><duration_ms>172127</…></usage>`. Reported as tokens and
+// calls rather than a cost — 554M of the 556M tokens read by the sub-agents on
+// this machine were cache reads, which are not billed like fresh input.
+const NOTIFICATION_TOKENS = /<subagent_tokens>(\d+)<\/subagent_tokens>/;
+const NOTIFICATION_CALLS = /<tool_uses>(\d+)<\/tool_uses>/;
+const NOTIFICATION_MS = /<duration_ms>(\d+)<\/duration_ms>/;
+
+export type AgentOutcome = 'completed' | 'failed' | 'killed' | 'reported';
+
+export interface AgentSpawn {
+  /** the parent's own call id — the join key the sidecar files carry too */
+  toolUseId: string;
+  description: string;
+  agentType: string;
+  /** from the launch receipt; the roster supplies it when the receipt is not in view */
+  agentId?: string;
+  spawnedAt?: number;
+  outcome?: AgentOutcome;
+  outcomeAt?: number;
+  /** from the completion notification: what it spent, as the harness counted it */
+  tokens?: number;
+  toolCalls?: number;
+  durationMs?: number;
+  /** a spawn whose receipt says it was launched into the background */
+  background: boolean;
+}
+
+const textOfTurn = (t: TraceTurn) =>
+  t.blocks.filter((b) => b.type === 'text').map((b) => ('text' in b ? b.text : '')).join('\n');
+
+/**
+ * What the parent said about the END of each of its spawns, across the whole
+ * window — not just this exchange. A background sub-agent outlives the turn
+ * that started it, so its notification lands in a later one; scoping the search
+ * to one exchange would report finished agents as unfinished forever.
+ */
+function outcomes(turns: TraceTurn[]) {
+  const byId = new Map<string, { outcome: AgentOutcome; at?: number; tokens?: number; toolCalls?: number; durationMs?: number }>();
+  const receipts = new Map<string, { text: string; at?: number; failed?: boolean }>();
+  for (const t of turns) {
+    for (const b of t.blocks) {
+      if (b.type === 'tool_result' && b.id) receipts.set(b.id, { text: b.text || '', at: t.ts, failed: b.failed });
+    }
+    // The harness's own completion messages arrive as user text and the trace
+    // reader keeps them as `system` turns, which is why they are readable here.
+    const text = textOfTurn(t);
+    if (!text.includes('<task-notification>')) continue;
+    for (const part of text.split('<task-notification>').slice(1)) {
+      const id = NOTIFICATION_ID.exec(part);
+      const st = NOTIFICATION_STATUS.exec(part);
+      if (!id) continue;
+      const status = st && ['completed', 'failed', 'killed'].includes(st[1]) ? (st[1] as AgentOutcome) : 'completed';
+      const num = (re: RegExp) => { const m = re.exec(part); return m ? Number(m[1]) : undefined; };
+      byId.set(id[1], {
+        outcome: status, at: t.ts,
+        tokens: num(NOTIFICATION_TOKENS), toolCalls: num(NOTIFICATION_CALLS), durationMs: num(NOTIFICATION_MS),
+      });
+    }
+  }
+  return { byId, receipts };
+}
+
+/** The sub-agents THIS exchange spawned, with whatever the parent knows of their end. */
+export function agentSpawnsOf(x: Exchange, turns: TraceTurn[]): AgentSpawn[] {
+  const { byId, receipts } = outcomes(turns);
+  const out: AgentSpawn[] = [];
+  for (const t of x.steps) {
+    for (const b of t.blocks) {
+      if (b.type !== 'tool_use' || !AGENT_TOOLS.has(b.name) || !b.id) continue;
+      let input: { description?: string; subagent_type?: string; prompt?: string } = {};
+      try { input = JSON.parse(b.text || '{}'); } catch { /* the input was capped mid-JSON */ }
+      const receipt = receipts.get(b.id);
+      const background = !!receipt && LAUNCH_RECEIPT.test(receipt.text);
+      const note = byId.get(b.id);
+      const spawn: AgentSpawn = {
+        toolUseId: b.id,
+        description: input.description || (b.text || '').slice(0, 80) || 'sub-agent',
+        agentType: input.subagent_type || 'agent',
+        spawnedAt: t.ts,
+        background,
+      };
+      const idInReceipt = receipt && AGENT_ID_IN_RECEIPT.exec(receipt.text);
+      if (idInReceipt) spawn.agentId = idInReceipt[1];
+      if (note) {
+        spawn.outcome = note.outcome; spawn.outcomeAt = note.at;
+        spawn.tokens = note.tokens; spawn.toolCalls = note.toolCalls; spawn.durationMs = note.durationMs;
+      }
+      else if (receipt && !background) {
+        // A synchronous spawn hands its report back AS the result, so this one
+        // is genuinely an outcome — and the only kind of result that is.
+        spawn.outcome = receipt.failed ? 'failed' : 'reported';
+        spawn.outcomeAt = receipt.at;
+      }
+      out.push(spawn);
+    }
+  }
+  return out;
+}
+
+export const isFinished = (s: AgentSpawn) => !!s.outcome;
+
+/**
+ * The count for the summary line, and the reason it needs the pane's state.
+ *
+ * Three states, not two. A sub-agent with no recorded outcome is running only
+ * if the pane that spawned it is alive; if the pane was killed mid-task its
+ * sub-agents never finish and never write again, and a UI without the third
+ * state says "2 running" forever — wrong in the direction that makes the
+ * operator wait for something that will never arrive.
+ */
+export function agentCounts(list: AgentSpawn[], live: boolean) {
+  const done = list.filter((s) => s.outcome === 'completed' || s.outcome === 'reported').length;
+  const bad = list.filter((s) => s.outcome === 'failed' || s.outcome === 'killed').length;
+  const open = list.length - done - bad;
+  const bits: string[] = [];
+  if (done) bits.push(`${done} done`);
+  if (bad) bits.push(`${bad} failed`);
+  if (open) bits.push(`${open} ${live ? 'running' : 'unfinished'}`);
+  return {
+    total: list.length, done, bad, open,
+    label: `${list.length} sub-agent${list.length === 1 ? '' : 's'}${bits.length ? ` · ${bits.join(' · ')}` : ''}`,
+  };
+}
 
 /**
  * "14 steps · 9 tools · 42s · 21.0k tok" — the whole turn in one line. There is

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -536,6 +536,15 @@ export const anyLive = (statuses: AgentStatus[]) => statuses.some(isLive);
  * STATE. "…and 16 more running" would be a lie in the state the cap exists for,
  * where most of the hidden rows are done.
  */
+/**
+ * Which row in the strip gets the `└`. The rails are the file browser's, and
+ * they only read as a tree if the elbow is on whatever is actually last — with
+ * the cap in play that is the overflow line, not the last sub-agent, and an
+ * unclosed `├` at the bottom looks like a row that failed to render.
+ */
+export const railIsLast = (index: number, shownCount: number, hasOverflow: boolean) =>
+  !hasOverflow && index === shownCount - 1;
+
 export function capRows<T extends { status: AgentStatus }>(rows: T[], cap: number) {
   if (rows.length <= cap) return { shown: rows, hidden: [] as T[], note: '' };
   const giveWay = new Set(

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -442,8 +442,44 @@ export function agentStatus(
   return quiet > STALE_MS ? 'stalled' : 'running';
 }
 
-/** The rows the collapsed exchange shows under its working line: the live ones. */
+/** A sub-agent the parent has not heard back from, on a pane that is alive. */
 export const isLive = (st: AgentStatus) => st === 'running' || st === 'stalled';
+
+/**
+ * The strip under the working line is all-or-nothing: while ANY sub-agent of the
+ * turn is still going it lists them all, finished ones included, and when the
+ * last one lands it is gone and they are in the collapsed work with every other
+ * step. One appearance and one disappearance per turn, instead of one per
+ * sub-agent.
+ */
+export const anyLive = (statuses: AgentStatus[]) => statuses.some(isLive);
+
+/**
+ * Which of those rows fit, and what the line at the bottom says about the rest.
+ *
+ * Rows accumulate now, so the cap does real work: a release-video turn ends at
+ * 22 sub-agents and the-gatherer's busiest at 40. What gives way is the
+ * FINISHED rows, oldest first — the strip is about what is still going, and a
+ * landed sub-agent is one click away in the work. Two consequences worth having:
+ * the strip's height stops growing at the cap instead of resizing every time one
+ * completes, and the overflow line has to describe what it is holding back by
+ * STATE. "…and 16 more running" would be a lie in the state the cap exists for,
+ * where most of the hidden rows are done.
+ */
+export function capRows<T extends { status: AgentStatus }>(rows: T[], cap: number) {
+  if (rows.length <= cap) return { shown: rows, hidden: [] as T[], note: '' };
+  const giveWay = new Set(
+    [...rows]
+      .sort((a, b) => Number(isLive(a.status)) - Number(isLive(b.status)))   // finished first, order otherwise kept
+      .slice(0, rows.length - cap),
+  );
+  const shown = rows.filter((r) => !giveWay.has(r));
+  const hidden = rows.filter((r) => giveWay.has(r));
+  const liveHidden = hidden.filter((r) => isLive(r.status)).length;
+  const bits = [hidden.length - liveHidden ? `${hidden.length - liveHidden} done` : '', liveHidden ? `${liveHidden} running` : '']
+    .filter(Boolean).join(', ');
+  return { shown, hidden, note: `…and ${hidden.length} more${bits ? ` — ${bits}` : ''} — open the work to see them all` };
+}
 
 /**
  * The count for the summary line, and the reason it needs the pane's state.

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -153,41 +153,31 @@
   color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .cs-facts .dim { color: color-mix(in srgb, var(--muted) 72%, transparent); }
 .cs-facts .depth { color: color-mix(in srgb, var(--accent) 70%, var(--muted)); }
-/* The two states that are the ABSENCE of a record say so in words. Neither is a
-   failure: `failed` and `killed` are things the harness reported and keep the
-   red ✗; these are what a restarted pane or a lost notification leaves behind. */
-.cs-state { flex: none; font-family: var(--font-mono); font-size: 0.78em; padding: 0 5px;
-  border: 1px dashed var(--border); border-radius: var(--r-sm); color: var(--muted); white-space: nowrap; }
-/* the task the sub-agent was given, clamped: 3.4 kB is a normal prompt */
-.cs-task { margin: 2px 0 4px; padding: 6px 9px; border-radius: var(--r-sm); white-space: pre-wrap;
-  overflow-wrap: anywhere; font-size: 0.94em; color: var(--text);
-  background: color-mix(in srgb, var(--accent) 5%, transparent); }
-.cs-task.clamp { max-height: 7.4em; overflow: hidden;
-  mask-image: linear-gradient(to bottom, #000 70%, transparent); }
-.cs-more-btn { display: block; margin: 0 0 6px; padding: 0; background: none; border: none;
-  font: inherit; font-size: 0.78em; color: var(--accent); cursor: pointer; }
+/* The two states that are the ABSENCE of a record say so in words, in the same
+   quiet mono as the rest of the row's facts. They were pills with a dashed
+   border; a sub-agent does not get its own badge vocabulary — `failed` and
+   `killed` are already the rail's red ✗, and these two are the cases where
+   nothing was recorded at all. */
+.cs-state { flex: none; font-family: var(--font-mono); font-size: 0.8em; color: var(--muted); white-space: nowrap; }
+.cs.agent.stalled .cs-state { color: color-mix(in srgb, var(--danger) 60%, var(--muted)); }
 .ca-msg { padding: 3px 0 2px 1.2em; font-size: 0.82em; color: var(--muted); }
-/* one level down: the sub-agent's own transcript, drawn by the component that
-   drew the row — indent, hairline, nothing else new */
-.ca-trace { display: flex; flex-direction: column; gap: 2px;
-  border-left: 2px solid color-mix(in srgb, var(--accent) 30%, transparent); padding-left: 9px; }
-.ca-trace .cx { padding-left: 1.23em; }
+/* Nothing wraps the nested trace. The step body it sits in already indents it,
+   and that indent IS the hierarchy: what renders inside is an ordinary
+   exchange — the task as its own prompt band, then steps, tools and timings
+   exactly as the reader draws them at the top level. The rail, the clamped task
+   panel and the "show the whole task" button that used to live here were a
+   second visual language for content the reader can already draw. */
+.cs-body > .cx { padding-left: 1.23em; }
 
 /* ---------- the live strip: what is working under the working line ---------- */
-/* Collapsed exchange, mid-turn. The pane's spinner says it is working; these
-   say what is working underneath it, one line each, without expanding
-   anything. Same left edge as the working line so the two read as one block. */
+/* Collapsed exchange, mid-turn. The pane's spinner says it is working; these say
+   what is working underneath it, one line each, without expanding anything.
+   The strip is all-or-nothing: it holds every sub-agent of the turn — finished
+   ones included — until the last one lands, and then it is gone and they are in
+   the work with every other step. One appearance and one disappearance per turn
+   is why there is no fade here any more. */
 .cx-live { display: flex; flex-direction: column; padding: 1px 0 0; }
 .cx-live .cs-head { padding-top: 1px; padding-bottom: 1px; }
-/* A row that has just finished holds its place for a beat with its ✓ and its
-   duration, then fades out — rows vanishing under a live spinner is the shape
-   that produced the API-log flicker, and a fade is the cheapest way to let the
-   eye see WHY the strip shrank. */
-.cs.agent.leaving { animation: agent-leave 6s ease-in forwards; }
-@keyframes agent-leave {
-  0%, 55% { opacity: 1; }
-  100% { opacity: 0.25; }
-}
 .cx-live-more { padding: 1px 0 1px 1.2em; font-size: 0.8em; color: var(--muted); }
 /* the spinner, borrowed from the working line: same cell, same animation, so a
    sub-agent's "running" is the same statement the pane makes about itself */

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -153,6 +153,7 @@
   color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
 .cs-facts .dim { color: color-mix(in srgb, var(--muted) 72%, transparent); }
 .cs-facts .depth { color: color-mix(in srgb, var(--accent) 70%, var(--muted)); }
+.cs-facts .who { color: color-mix(in srgb, var(--accent) 60%, var(--muted)); }
 /* The two states that are the ABSENCE of a record say so in words, in the same
    quiet mono as the rest of the row's facts. They were pills with a dashed
    border; a sub-agent does not get its own badge vocabulary — `failed` and

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -141,6 +141,72 @@
 .cx-fold.on .cs-tri { color: var(--accent); }
 
 /* ---------- the work: a rail of one-line steps ---------- */
+/* ---------- sub-agents: the count in the meta row, and what it opens ---------- */
+/* A second control on the same line as the work fold. It is deliberately quiet
+   until there is something to say: the button only renders when the turn spawned
+   sub-agents, so a turn without them looks exactly as it did. */
+.cx-agents {
+  display: inline-flex; align-items: baseline; gap: 4px; flex: none;
+  margin-left: 10px; padding: 0; background: none; border: none;
+  font: inherit; color: var(--muted); cursor: pointer; white-space: nowrap;
+}
+.cx-agents:hover, .cx-agents.on { color: var(--text); }
+.cx-agents.on .cs-tri { color: var(--accent); }
+.cx-agents .cs-tri { font-size: 0.9em; }
+
+/* The list. Sized for tens of rows — three sessions on this machine hold 22, 38
+   and 10 — so it scrolls at about twelve rows rather than pushing the answer off
+   the screen. em, not px: a zoomed conversation should keep twelve rows. */
+.cx-agents-list {
+  display: flex; flex-direction: column; gap: 1px;
+  max-height: 24em; overflow-y: auto;
+  margin: 2px 0 4px; padding: 3px 0 3px 2px;
+  border-left: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
+}
+/* …but the cap lifts the moment a row is opened: a sub-agent's transcript inside
+   a 24em scroller is a window into a window, and the thing you just asked to
+   read arrives already cut off. The list is only long enough to need a cap while
+   it is a list. */
+.cx-agents-list:has(.ca-row.open) { max-height: none; overflow: visible; }
+.ca-row { display: flex; flex-direction: column; min-width: 0; }
+.ca-head {
+  display: flex; align-items: baseline; gap: 7px; min-width: 0; width: 100%;
+  padding: 2px 4px 2px 0; background: none; border: none; border-radius: var(--r-sm);
+  font: inherit; font-size: 0.96em; color: var(--text); text-align: left; cursor: pointer;
+}
+.ca-head:hover { background: var(--panel-2); }
+.ca-head:disabled { cursor: default; color: var(--muted); }
+.ca-head .spacer { flex: 1; min-width: 4px; }
+/* the task, in the reader's own voice — it is what a person wrote in the Agent
+   call, so it reads as prose and takes the room */
+.ca-what { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The status word carries the meaning, so it is a word and not a colour alone:
+   `running` is a claim about right now and only appears when the pane is alive. */
+.ca-state {
+  flex: none; font-family: var(--font-mono); font-size: 0.82em; letter-spacing: 0.01em;
+  padding: 0 5px; border-radius: var(--r-sm); border: 1px solid var(--border);
+  color: var(--muted);
+}
+.ca-state.done { color: var(--go); border-color: color-mix(in srgb, var(--go) 45%, var(--border)); }
+.ca-state.running {
+  color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+}
+.ca-state.failed, .ca-state.killed { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 45%, var(--border)); }
+/* "no result" is the third state, and it is not a failure — it is the absence of
+   a record, which is what a pane killed mid-task leaves behind. */
+.ca-state.no-result { font-style: italic; }
+.ca-type, .ca-num, .ca-depth { flex: none; font-size: 0.82em; color: var(--muted); }
+.ca-depth { color: color-mix(in srgb, var(--accent) 70%, var(--muted)); }
+.ca-num { font-variant-numeric: tabular-nums; }
+.ca-msg { padding: 3px 0 2px 1.2em; font-size: 0.82em; color: var(--muted); }
+/* One level down: the sub-agent's own transcript, rendered by the exchange
+   component that drew the row above it. The rule is the same one the step rail
+   uses — indent, hairline, and nothing else new. */
+.ca-body { padding: 2px 0 6px 1.2em; }
+.ca-trace { display: flex; flex-direction: column; gap: 2px; }
+.ca-trace .cx { padding-left: 1.23em; }
+
 .cx-steps { display: flex; flex-direction: column; padding: 1px 0; }
 .cs { min-width: 0; }
 .cs-head {

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -141,71 +141,64 @@
 .cx-fold.on .cs-tri { color: var(--accent); }
 
 /* ---------- the work: a rail of one-line steps ---------- */
-/* ---------- sub-agents: the count in the meta row, and what it opens ---------- */
-/* A second control on the same line as the work fold. It is deliberately quiet
-   until there is something to say: the button only renders when the turn spawned
-   sub-agents, so a turn without them looks exactly as it did. */
-.cx-agents {
-  display: inline-flex; align-items: baseline; gap: 4px; flex: none;
-  margin-left: 10px; padding: 0; background: none; border: none;
-  font: inherit; color: var(--muted); cursor: pointer; white-space: nowrap;
-}
-.cx-agents:hover, .cx-agents.on { color: var(--text); }
-.cx-agents.on .cs-tri { color: var(--accent); }
-.cx-agents .cs-tri { font-size: 0.9em; }
-
-/* The list. Sized for tens of rows — three sessions on this machine hold 22, 38
-   and 10 — so it scrolls at about twelve rows rather than pushing the answer off
-   the screen. em, not px: a zoomed conversation should keep twelve rows. */
-.cx-agents-list {
-  display: flex; flex-direction: column; gap: 1px;
-  max-height: 24em; overflow-y: auto;
-  margin: 2px 0 4px; padding: 3px 0 3px 2px;
-  border-left: 2px solid color-mix(in srgb, var(--accent) 35%, transparent);
-}
-/* …but the cap lifts the moment a row is opened: a sub-agent's transcript inside
-   a 24em scroller is a window into a window, and the thing you just asked to
-   read arrives already cut off. The list is only long enough to need a cap while
-   it is a list. */
-.cx-agents-list:has(.ca-row.open) { max-height: none; overflow: visible; }
-.ca-row { display: flex; flex-direction: column; min-width: 0; }
-.ca-head {
-  display: flex; align-items: baseline; gap: 7px; min-width: 0; width: 100%;
-  padding: 2px 4px 2px 0; background: none; border: none; border-radius: var(--r-sm);
-  font: inherit; font-size: 0.96em; color: var(--text); text-align: left; cursor: pointer;
-}
-.ca-head:hover { background: var(--panel-2); }
-.ca-head:disabled { cursor: default; color: var(--muted); }
-.ca-head .spacer { flex: 1; min-width: 4px; }
-/* the task, in the reader's own voice — it is what a person wrote in the Agent
-   call, so it reads as prose and takes the room */
-.ca-what { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-/* The status word carries the meaning, so it is a word and not a colour alone:
-   `running` is a claim about right now and only appears when the pane is alive. */
-.ca-state {
-  flex: none; font-family: var(--font-mono); font-size: 0.82em; letter-spacing: 0.01em;
-  padding: 0 5px; border-radius: var(--r-sm); border: 1px solid var(--border);
-  color: var(--muted);
-}
-.ca-state.done { color: var(--go); border-color: color-mix(in srgb, var(--go) 45%, var(--border)); }
-.ca-state.running {
-  color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border));
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-}
-.ca-state.failed, .ca-state.killed { color: var(--danger); border-color: color-mix(in srgb, var(--danger) 45%, var(--border)); }
-/* "no result" is the third state, and it is not a failure — it is the absence of
-   a record, which is what a pane killed mid-task leaves behind. */
-.ca-state.no-result { font-style: italic; }
-.ca-type, .ca-num, .ca-depth { flex: none; font-size: 0.82em; color: var(--muted); }
-.ca-depth { color: color-mix(in srgb, var(--accent) 70%, var(--muted)); }
-.ca-num { font-variant-numeric: tabular-nums; }
+/* ---------- sub-agents ---------- */
+/* A sub-agent is a step row with a life of its own, so it borrows the rail's
+   own anatomy — mark, label, detail — and adds the facts its completion
+   notification reported. No second list, no second disclosure: the count reads
+   in the summary line and the rows are in the step list where the spawn is. */
+.cs.agent .cs-label { color: var(--accent); }
+.cs.agent .cs-detail { color: var(--text); }
+.cs.agent.no-result .cs-detail, .cs.agent.stalled .cs-detail { color: var(--muted); }
+.cs-facts { flex: none; display: flex; gap: 9px; font-family: var(--font-mono); font-size: 0.8em;
+  color: var(--muted); font-variant-numeric: tabular-nums; white-space: nowrap; }
+.cs-facts .dim { color: color-mix(in srgb, var(--muted) 72%, transparent); }
+.cs-facts .depth { color: color-mix(in srgb, var(--accent) 70%, var(--muted)); }
+/* The two states that are the ABSENCE of a record say so in words. Neither is a
+   failure: `failed` and `killed` are things the harness reported and keep the
+   red ✗; these are what a restarted pane or a lost notification leaves behind. */
+.cs-state { flex: none; font-family: var(--font-mono); font-size: 0.78em; padding: 0 5px;
+  border: 1px dashed var(--border); border-radius: var(--r-sm); color: var(--muted); white-space: nowrap; }
+/* the task the sub-agent was given, clamped: 3.4 kB is a normal prompt */
+.cs-task { margin: 2px 0 4px; padding: 6px 9px; border-radius: var(--r-sm); white-space: pre-wrap;
+  overflow-wrap: anywhere; font-size: 0.94em; color: var(--text);
+  background: color-mix(in srgb, var(--accent) 5%, transparent); }
+.cs-task.clamp { max-height: 7.4em; overflow: hidden;
+  mask-image: linear-gradient(to bottom, #000 70%, transparent); }
+.cs-more-btn { display: block; margin: 0 0 6px; padding: 0; background: none; border: none;
+  font: inherit; font-size: 0.78em; color: var(--accent); cursor: pointer; }
 .ca-msg { padding: 3px 0 2px 1.2em; font-size: 0.82em; color: var(--muted); }
-/* One level down: the sub-agent's own transcript, rendered by the exchange
-   component that drew the row above it. The rule is the same one the step rail
-   uses — indent, hairline, and nothing else new. */
-.ca-body { padding: 2px 0 6px 1.2em; }
-.ca-trace { display: flex; flex-direction: column; gap: 2px; }
+/* one level down: the sub-agent's own transcript, drawn by the component that
+   drew the row — indent, hairline, nothing else new */
+.ca-trace { display: flex; flex-direction: column; gap: 2px;
+  border-left: 2px solid color-mix(in srgb, var(--accent) 30%, transparent); padding-left: 9px; }
 .ca-trace .cx { padding-left: 1.23em; }
+
+/* ---------- the live strip: what is working under the working line ---------- */
+/* Collapsed exchange, mid-turn. The pane's spinner says it is working; these
+   say what is working underneath it, one line each, without expanding
+   anything. Same left edge as the working line so the two read as one block. */
+.cx-live { display: flex; flex-direction: column; padding: 1px 0 0; }
+.cx-live .cs-head { padding-top: 1px; padding-bottom: 1px; }
+/* A row that has just finished holds its place for a beat with its ✓ and its
+   duration, then fades out — rows vanishing under a live spinner is the shape
+   that produced the API-log flicker, and a fade is the cheapest way to let the
+   eye see WHY the strip shrank. */
+.cs.agent.leaving { animation: agent-leave 6s ease-in forwards; }
+@keyframes agent-leave {
+  0%, 55% { opacity: 1; }
+  100% { opacity: 0.25; }
+}
+.cx-live-more { padding: 1px 0 1px 1.2em; font-size: 0.8em; color: var(--muted); }
+/* the spinner, borrowed from the working line: same cell, same animation, so a
+   sub-agent's "running" is the same statement the pane makes about itself */
+.cs-mark.spin::before {
+  content: '⠋'; display: inline-flex; align-items: center;
+  width: var(--mark-w); height: var(--mark-h);
+  font-family: var(--font-mono); font-size: var(--mark-size);
+  font-weight: var(--mark-weight); line-height: 1;
+  color: var(--accent); transform: translateY(var(--mark-optical-y));
+  animation: ov-spin 0.9s steps(1) infinite;
+}
 
 .cx-steps { display: flex; flex-direction: column; padding: 1px 0; }
 .cs { min-width: 0; }

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -177,9 +177,19 @@
    ones included — until the last one lands, and then it is gone and they are in
    the work with every other step. One appearance and one disappearance per turn
    is why there is no fade here any more. */
-.cx-live { display: flex; flex-direction: column; padding: 1px 0 0; }
-.cx-live .cs-head { padding-top: 1px; padding-bottom: 1px; }
-.cx-live-more { padding: 1px 0 1px 1.2em; font-size: 0.8em; color: var(--muted); }
+.cx-live { display: flex; flex-direction: column; padding: 1px 0 0;
+  /* the tree hangs off the working line's spinner, which lives in the gutter,
+     so the strip starts there too and the rail column lands under it */
+  margin-left: calc(-1 * var(--mark-w)); }
+.cx-live .cs-head { padding-top: 1px; padding-bottom: 1px; position: relative; }
+.cx-live-more { position: relative; padding: 1px 0; font-size: 0.8em; color: var(--muted); }
+/* the rails themselves are the file browser's — .rails/.rail in styles.css — so
+   there is one implementation of the tree in the app, not two */
+.cx-live .rail { width: var(--mark-w); }
+/* the rail cell is the mark cell wide, so the row pays exactly that much for it
+   — the em padding the file browser uses would leave the text 0.1em short and
+   the elbow would touch the spinner */
+.cx-live .cs-head.railed, .cx-live-more { padding-left: var(--mark-w) !important; }
 /* the spinner, borrowed from the working line: same cell, same animation, so a
    sub-agent's "running" is the same statement the pane makes about itself */
 .cs-mark.spin::before {

--- a/web/src/lib/subagentRoster.ts
+++ b/web/src/lib/subagentRoster.ts
@@ -1,0 +1,37 @@
+// The session's sub-agent roster, cached outside React.
+//
+// It is one directory listing per session (187 bytes per sub-agent) and it
+// carries what a trace window cannot: the agentId of a spawn whose launch
+// receipt has scrolled away, the depth, and when each sub-agent's transcript
+// last changed — the fact the "no write in 15m" rule needs.
+//
+// WHY A MODULE-LEVEL CACHE. The reader remounts often (the pane re-renders as
+// the trace window polls, and the exchange list is rebuilt when older turns
+// arrive), and an effect that owns the answer loses it every time: measured in
+// the browser, every single request was cancelled by its own cleanup before the
+// response landed, so rows kept saying "running" with no last-write time even
+// though the roster had been fetched a dozen times. Holding the answer here
+// means a remount starts from what we already know, and the in-flight promise is
+// shared instead of duplicated.
+import { getSubAgents, type SubAgentEntry } from '../api';
+
+const FRESH_MS = 15_000;
+const cache = new Map<string, { at: number; agents: SubAgentEntry[] }>();
+const inflight = new Map<string, Promise<SubAgentEntry[]>>();
+
+export const cachedRoster = (sessionId: string): SubAgentEntry[] | null => cache.get(sessionId)?.agents ?? null;
+
+export function loadRoster(sessionId: string, force = false): Promise<SubAgentEntry[]> {
+  const hit = cache.get(sessionId);
+  if (!force && hit && Date.now() - hit.at < FRESH_MS) return Promise.resolve(hit.agents);
+  const pending = inflight.get(sessionId);
+  if (pending) return pending;
+  const p = getSubAgents(sessionId)
+    .then((r) => {
+      cache.set(sessionId, { at: Date.now(), agents: r.agents });
+      return r.agents;
+    })
+    .finally(() => inflight.delete(sessionId));
+  inflight.set(sessionId, p);
+  return p;
+}

--- a/web/test/overviewSearch.test.mjs
+++ b/web/test/overviewSearch.test.mjs
@@ -43,6 +43,9 @@ const bundle = path.join(tmp, 'browser.js');
 const stub = path.join(tmp, 'api-stub.ts');
 fs.writeFileSync(stub, `
   export const getTracePage = () => Promise.reject(new Error('not used'));
+  // the reader's sub-agent strip reaches for these two; nothing here opens it
+  export const getSubAgents = () => Promise.resolve({ supported: true, agents: [] });
+  export const getSubAgentTrace = () => Promise.reject(new Error('not used'));
   export const sendInput = () => Promise.resolve({ ok: true });
 `);
 const sessions = [

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -28,7 +28,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, capRows, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
+const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, capRows, railIsLast, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -304,6 +304,18 @@ console.log('\nand the cap tells the truth about what it is holding back');
     assert.match(note, /2 done/);
     assert.doesNotMatch(note, /running/);
   });
+}
+
+console.log('\nand the tree closes on whatever is actually last');
+{
+  check('with no overflow line, the last row carries the elbow', () => {
+    assert.deepEqual([0, 1, 2].map((i) => railIsLast(i, 3, false)), [false, false, true]);
+  });
+  check('with one, the rows all continue and the line closes the tree', () => {
+    // otherwise the strip ends on a `├` that points at nothing
+    assert.deepEqual([0, 1, 2].map((i) => railIsLast(i, 3, true)), [false, false, false]);
+  });
+  check('and a single row closes it by itself', () => assert.equal(railIsLast(0, 1, false), true));
 }
 
 console.log('\nand codex, whose plumbing is different in every part');

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -28,7 +28,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
+const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, capRows, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -239,11 +239,70 @@ console.log('\nand the live strip only claims what it can');
     assert.equal(agentStatus(spawnOf('completed'), { live: true, lastWroteAt: now - 9e6, now }), 'done');
     assert.equal(agentStatus(spawnOf('killed'), { live: true, lastWroteAt: now, now }), 'killed');
   });
-  check('the strip shows the two live states and nothing else', () => {
+  check('two states count as still going, and four do not', () => {
     assert.deepEqual(['running', 'stalled', 'done', 'failed', 'killed', 'no-result'].filter(isLive), ['running', 'stalled']);
   });
   check('with no roster to read, a live pane still says running rather than guessing quiet', () => {
     assert.equal(agentStatus(spawnOf(), { live: true, now }), 'running');
+  });
+}
+
+console.log('\nand the strip comes and goes as one thing, not row by row');
+{
+  const rowsOf = (...statuses) => statuses.map((status, i) => ({ status, id: `t${i}` }));
+  check('while one is still going, the strip is shown', () => {
+    assert.equal(anyLive(['done', 'done', 'running']), true);
+    assert.equal(anyLive(['done', 'stalled']), true);
+  });
+  check('and when the last one lands it is gone — the rows are in the work', () => {
+    assert.equal(anyLive(['done', 'failed', 'killed']), false);
+    assert.equal(anyLive(['no-result']), false, 'a dead pane has nothing running under it');
+    assert.equal(anyLive([]), false);
+  });
+  check('a finished sub-agent does NOT leave while a sibling runs', () => {
+    // the rule the six-second linger used to soften, inverted: nothing is
+    // dropped for being finished, so there is nothing to soften.
+    const rows = rowsOf('done', 'running', 'done', 'running');
+    const { shown, hidden } = capRows(rows, 10);
+    assert.equal(shown.length, 4);
+    assert.equal(hidden.length, 0);
+  });
+}
+
+console.log('\nand the cap tells the truth about what it is holding back');
+{
+  const rowsOf = (...statuses) => statuses.map((status, i) => ({ status, id: `t${i}` }));
+  check('under the cap, everything shows and nothing is said', () => {
+    const { shown, note } = capRows(rowsOf('running', 'done'), 10);
+    assert.equal(shown.length, 2);
+    assert.equal(note, '');
+  });
+  check('over the cap, the finished rows give way and every live one is kept', () => {
+    // release-video's busiest turn: 22 sub-agents, 4 still going at the end
+    const rows = rowsOf(...Array(18).fill('done'), 'running', 'running', 'stalled', 'running');
+    const { shown, hidden, note } = capRows(rows, 10);
+    assert.equal(shown.length, 10);
+    assert.equal(shown.filter((r) => ['running', 'stalled'].includes(r.status)).length, 4, 'all four live rows survive');
+    assert.equal(hidden.length, 12);
+    assert.ok(hidden.every((r) => r.status === 'done'), 'only finished rows gave way');
+    assert.equal(note, '…and 12 more — 12 done — open the work to see them all');
+  });
+  check('…and the oldest finished go first, so the newest landings stay on screen', () => {
+    const rows = rowsOf('done', 'done', 'done', 'running');
+    const { shown } = capRows(rows, 2);
+    assert.deepEqual(shown.map((r) => r.id), ['t2', 't3'], 't0 and t1 are the oldest finished');
+  });
+  check('when even the live rows do not fit, the line counts them by state', () => {
+    const rows = rowsOf(...Array(6).fill('done'), ...Array(6).fill('running'));
+    const { shown, note } = capRows(rows, 4);
+    assert.equal(shown.length, 4);
+    assert.ok(shown.every((r) => r.status === 'running'), 'live rows are the last to go');
+    assert.equal(note, '…and 8 more — 6 done, 2 running — open the work to see them all');
+  });
+  check('and never says "running" about rows that are done', () => {
+    const { note } = capRows(rowsOf(...Array(12).fill('done')), 10);
+    assert.match(note, /2 done/);
+    assert.doesNotMatch(note, /running/);
   });
 }
 

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -28,7 +28,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, capRows, railIsLast, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
+const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, canOpenAgent, capRows, railIsLast, stepsOf, stepSummary, MAX_NEST, STALE_MS } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -303,6 +303,49 @@ console.log('\nand the cap tells the truth about what it is holding back');
     const { note } = capRows(rowsOf(...Array(12).fill('done')), 10);
     assert.match(note, /2 done/);
     assert.doesNotMatch(note, /running/);
+  });
+}
+
+console.log('\nand nothing can nest forever, whatever the data says');
+{
+  // The reader must not hang on a transcript that names itself as its own
+  // child. It happened for real: a Claude `fork` inherits the parent's history
+  // ending in the Agent call that created it, so the fork looked like its own
+  // sub-agent and every level below was the same file again. The parser no
+  // longer hands that over, and this is the backstop underneath it.
+  check('a row naming an agent already open above it cannot be opened', () => {
+    assert.equal(canOpenAgent('a69e', ['a69e']), false, 'itself');
+    assert.equal(canOpenAgent('a69e', ['root1', 'a69e']), false, 'an ancestor');
+  });
+  check('a fresh agent below one open row can', () => assert.equal(canOpenAgent('child', ['parent']), true));
+  check('and the nesting stops at the cap regardless', () => {
+    const deep = Array.from({ length: MAX_NEST }, (_, i) => `a${i}`);
+    assert.equal(canOpenAgent('fresh', deep), false, `${MAX_NEST} deep is as far as it goes`);
+    assert.equal(canOpenAgent('fresh', deep.slice(0, MAX_NEST - 1)), true);
+  });
+  check('a row with no agent id resolves to nothing openable',
+    () => assert.equal(canOpenAgent(undefined, []), false));
+}
+
+console.log('\nand a fork receipt is a receipt, not the fork\'s work');
+{
+  const spawnTurn = {
+    role: 'assistant', ts: at(4),
+    blocks: [
+      { type: 'tool_use', id: 'toolu_fork', name: 'Agent', text: JSON.stringify({ subagent_type: 'fork', description: 'Research Meta news' }) },
+      { type: 'tool_result', id: 'toolu_fork', text: 'Fork started — processing in background' },
+    ],
+  };
+  const turns = [prompt(0, 'research the week'), spawnTurn];
+  const [x] = splitExchanges(turns);
+  const [spawn] = agentSpawnsOf(x, turns);
+  check('"Fork started" does not mark it finished', () => {
+    assert.equal(spawn.outcome, undefined);
+    assert.equal(spawn.background, true);
+  });
+  check('so a live pane calls it running, and a dead one calls it unfinished', () => {
+    assert.equal(agentStatus(spawn, { live: true }), 'running');
+    assert.equal(agentCounts([spawn], false).label, '1 sub-agent · 1 unfinished');
   });
 }
 

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -28,7 +28,7 @@ await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
   outfile: out, format: 'esm', bundle: false, logLevel: 'error',
 });
-const { splitExchanges, agentSpawnsOf, agentCounts } = await import(pathToFileURL(out).href);
+const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, stepsOf, stepSummary, STALE_MS } = await import(pathToFileURL(out).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -173,6 +173,78 @@ console.log('\nand a prompt-shaped harness notification is not a prompt');
     prompt(30, '[SYSTEM NOTIFICATION - NOT USER INPUT] This is an automated message.\n<task-notification>\n<tool-use-id>toolu_Z</tool-use-id>\n<status>completed</status>\n</task-notification>'),
   ];
   check('it does not open a second exchange', () => assert.equal(splitExchanges(turns).length, 1));
+}
+
+console.log('\nand a spawn is its own step row, never grouped into one');
+{
+  // Three spawns in a row is the real shape: release-video's turn 24 spawned
+  // three inside ninety seconds. Grouped, they would be one `Agent ×3` row.
+  // The server files a result next to the call that made it (the stitcher), so
+  // a real spawn turn carries both blocks — which is also what makes grouping
+  // dangerous: three of these in a row are three consecutive `Agent` calls.
+  const spawnTurn = (sec, id, description, agentId) => ({
+    role: 'assistant', ts: at(sec),
+    blocks: [...spawn(sec, id, description).blocks, ...receipt(sec + 2, id, agentId).blocks],
+  });
+  const turns = [
+    prompt(0, 'rebuild the three scenes'),
+    spawnTurn(4, 'toolu_A', 'Recapture second-agent sequence', 'aaa1'),
+    spawnTurn(8, 'toolu_B', 'Rapid-fire feature captures', 'aaa2'),
+    spawnTurn(12, 'toolu_C', 'Add step legend to comms animation', 'aaa3'),
+    { role: 'assistant', ts: at(20), blocks: [
+      { type: 'tool_use', id: 'toolu_D', name: 'Bash', text: '{"command":"ffmpeg -v error -y"}' },
+      { type: 'tool_use', id: 'toolu_E', name: 'Bash', text: '{"command":"du -sh sift"}' },
+    ] },
+  ];
+  const steps = stepsOf(turns.slice(1));
+  check('three spawns are three rows', () => {
+    const agents = steps.filter((s) => s.kind === 'agent');
+    assert.equal(agents.length, 3);
+    assert.deepEqual(agents.map((a) => a.description),
+      ['Recapture second-agent sequence', 'Rapid-fire feature captures', 'Add step legend to comms animation']);
+  });
+  check('…while two Bash calls still collapse into one, as they always did', () => {
+    const tools = steps.filter((s) => s.kind === 'tools');
+    assert.equal(tools.length, 1);
+    assert.equal(tools[0].count, 2);
+  });
+  check('and the summary line counts them as sub-agents rather than twice', () => {
+    const [x] = splitExchanges(turns);
+    const spawns = agentSpawnsOf(x, turns);
+    const line = stepSummary(x, stepsOf(x.steps), spawns.length);
+    assert.match(line, /3 sub-agents/);
+    assert.match(line, /2 tools/, `the two Bash calls, not the five tool_uses: ${line}`);
+    assert.doesNotMatch(line, /5 tools/);
+  });
+}
+
+console.log('\nand the live strip only claims what it can');
+{
+  const spawnOf = (outcome) => ({ toolUseId: 't', description: 'Capture group view in reader', agentType: 'general-purpose', background: true, spawnedAt: at(0), ...(outcome ? { outcome } : {}) });
+  const now = at(10_000);
+  check('a live pane with a recent write is running', () => {
+    assert.equal(agentStatus(spawnOf(), { live: true, lastWroteAt: now - 30_000, now }), 'running');
+  });
+  check('the same row on a pane that is not running says no result, never running', () => {
+    assert.equal(agentStatus(spawnOf(), { live: false, lastWroteAt: now - 30_000, now }), 'no-result');
+  });
+  check('a silence longer than the threshold stops the claim', () => {
+    assert.equal(agentStatus(spawnOf(), { live: true, lastWroteAt: now - STALE_MS - 1000, now }), 'stalled');
+  });
+  check('…and the threshold clears the longest silence ever measured inside a live run (601s)', () => {
+    assert.ok(STALE_MS > 601_000 * 1.4, `${STALE_MS}ms must clear the 601s worst case with room`);
+    assert.equal(agentStatus(spawnOf(), { live: true, lastWroteAt: now - 601_000, now }), 'running');
+  });
+  check('an outcome always wins over any amount of silence', () => {
+    assert.equal(agentStatus(spawnOf('completed'), { live: true, lastWroteAt: now - 9e6, now }), 'done');
+    assert.equal(agentStatus(spawnOf('killed'), { live: true, lastWroteAt: now, now }), 'killed');
+  });
+  check('the strip shows the two live states and nothing else', () => {
+    assert.deepEqual(['running', 'stalled', 'done', 'failed', 'killed', 'no-result'].filter(isLive), ['running', 'stalled']);
+  });
+  check('with no roster to read, a live pane still says running rather than guessing quiet', () => {
+    assert.equal(agentStatus(spawnOf(), { live: true, now }), 'running');
+  });
 }
 
 console.log(failed ? `\n${failed} failed` : '\nall checks passed');

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -1,0 +1,179 @@
+// What the reader can honestly say about a sub-agent.
+//
+// The records here are the shapes real transcripts use, copied from the three
+// sessions on this machine that spawn sub-agents (release-video, the-gatherer,
+// rl-llm-wiki, CLI 2.1.181–2.1.209). Two of them are the whole point:
+//
+//   1. a BACKGROUND spawn's `tool_result` is a RECEIPT, not an outcome. It
+//      arrives two seconds after the call and says "Async agent launched
+//      successfully". Treating a result as completion marks every sub-agent
+//      finished the moment it starts — measured end to end on one agent, that
+//      would have been 4m26s early, and all 60 sub-agents in the two largest
+//      sessions here are background spawns.
+//   2. the completion is the `<task-notification>`, which also carries what the
+//      sub-agent spent — the only place that number is written down.
+//
+// Run with:  node test/subagents.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(HERE, '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const out = path.join(outDir, 'exchanges-subagents.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { splitExchanges, agentSpawnsOf, agentCounts } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const T0 = 1_787_000_000_000;
+const at = (s) => T0 + s * 1000;
+const spawn = (sec, id, description, type = 'general-purpose') => ({
+  role: 'assistant', ts: at(sec),
+  blocks: [{ type: 'tool_use', id, name: 'Agent', text: JSON.stringify({ description, subagent_type: type, run_in_background: true, prompt: 'do the thing' }, null, 2) }],
+});
+const receipt = (sec, id, agentId) => ({
+  role: 'assistant', ts: at(sec),
+  blocks: [{ type: 'tool_result', id, text:
+    'Async agent launched successfully. (This tool result is internal metadata — never quote or paste any part of it, including the agentId below, into a user-facing reply.)\n'
+    + `agentId: ${agentId} (internal ID - do not mention to user.)\nThe agent is working in the background.` }],
+});
+const notification = (sec, id, status, { tokens = 41_700, calls = 13, ms = 172_127 } = {}) => ({
+  role: 'system', ts: at(sec),
+  blocks: [{ type: 'text', text:
+    `<task-notification>\n<task-id>b6ctfcert</task-id>\n<tool-use-id>${id}</tool-use-id>\n<status>${status}</status>`
+    + `\n<usage><subagent_tokens>${tokens}</subagent_tokens><tool_uses>${calls}</tool_uses><duration_ms>${ms}</duration_ms></usage>\n</task-notification>` }],
+});
+const prompt = (sec, text) => ({ role: 'user', ts: at(sec), blocks: [{ type: 'text', text }] });
+const said = (sec, text) => ({ role: 'assistant', ts: at(sec), blocks: [{ type: 'text', text }] });
+
+console.log('a launch receipt is not a finished sub-agent');
+{
+  const turns = [
+    prompt(0, 'rebuild the four scenes'),
+    spawn(4, 'toolu_A', 'Rework the Scene 1 intro'),
+    receipt(6, 'toolu_A', 'ab2015f99ef3e7f43'),
+    said(8, 'It is running; I will report when it lands.'),
+  ];
+  const [x] = splitExchanges(turns);
+  const spawns = agentSpawnsOf(x, turns);
+  check('the spawn is seen, with the task the operator would recognise', () => {
+    assert.equal(spawns.length, 1);
+    assert.equal(spawns[0].description, 'Rework the Scene 1 intro');
+    assert.equal(spawns[0].agentType, 'general-purpose');
+  });
+  check('the agentId is read out of the receipt, so the row can open its transcript',
+    () => assert.equal(spawns[0].agentId, 'ab2015f99ef3e7f43'));
+  check('…and the receipt does NOT count as an outcome', () => {
+    assert.equal(spawns[0].outcome, undefined);
+    assert.equal(spawns[0].background, true);
+  });
+  check('so a live pane calls it running', () => assert.equal(agentCounts(spawns, true).label, '1 sub-agent · 1 running'));
+  check('and a dead pane calls it unfinished, which is the third state',
+    () => assert.equal(agentCounts(spawns, false).label, '1 sub-agent · 1 unfinished'));
+}
+
+console.log('\nthe notification is the outcome, and it says what was spent');
+{
+  const turns = [
+    prompt(0, 'four scenes'),
+    spawn(4, 'toolu_A', 'Rework the Scene 1 intro'),
+    receipt(6, 'toolu_A', 'ab2015f99ef3e7f43'),
+    spawn(8, 'toolu_B', 'Reshoot scene 3 with clean sidebar'),
+    receipt(10, 'toolu_B', 'a441b23d799f09ede'),
+    said(12, 'Both are running.'),
+    // …and these arrive in a LATER turn, which is why the search is over the
+    // window and not over the exchange.
+    notification(1361, 'toolu_A', 'completed'),
+    notification(940, 'toolu_B', 'failed'),
+    said(2100, 'One is back, one failed.'),
+  ];
+  const [x] = splitExchanges(turns);
+  const spawns = agentSpawnsOf(x, turns);
+  check('both spawns are attributed to the turn that started them', () => assert.equal(spawns.length, 2));
+  check('completed and failed are read from the notification, not guessed', () => {
+    assert.equal(spawns[0].outcome, 'completed');
+    assert.equal(spawns[1].outcome, 'failed');
+  });
+  check('the harness’s own duration, tool count and tokens come with it', () => {
+    assert.equal(spawns[0].durationMs, 172_127);
+    assert.equal(spawns[0].toolCalls, 13);
+    assert.equal(spawns[0].tokens, 41_700);
+  });
+  check('the count says done and failed separately — and the pane being dead changes nothing here',
+    () => {
+      assert.equal(agentCounts(spawns, true).label, '2 sub-agents · 1 done · 1 failed');
+      assert.equal(agentCounts(spawns, false).label, '2 sub-agents · 1 done · 1 failed');
+    });
+  check('a killed pane is neither done nor failed silently', () => {
+    const killed = agentSpawnsOf(x, [...turns.slice(0, 6), notification(500, 'toolu_A', 'killed')]);
+    assert.equal(killed[0].outcome, 'killed');
+    assert.equal(agentCounts(killed, true).label, '2 sub-agents · 1 failed · 1 running');
+  });
+}
+
+console.log('\na synchronous spawn is the one case where the result IS the outcome');
+{
+  const turns = [
+    prompt(0, 'review the deploy config'),
+    { role: 'assistant', ts: at(2), blocks: [{ type: 'tool_use', id: 'toolu_C', name: 'Task', text: JSON.stringify({ description: 'Review the deploy config', subagent_type: 'general-purpose' }, null, 2) }] },
+    { role: 'assistant', ts: at(300), blocks: [{ type: 'tool_result', id: 'toolu_C', text: 'Only the health-check path changed: /healthz → /api/health.' }] },
+  ];
+  const [x] = splitExchanges(turns);
+  const spawns = agentSpawnsOf(x, turns);
+  check('the report it handed back marks it finished', () => {
+    assert.equal(spawns[0].background, false);
+    assert.equal(spawns[0].outcome, 'reported');
+    assert.equal(spawns[0].outcomeAt, at(300));
+  });
+  check('and a failed result is a failure, not a report', () => {
+    const bad = agentSpawnsOf(x, [turns[0], turns[1], { ...turns[2], blocks: [{ ...turns[2].blocks[0], failed: true }] }]);
+    assert.equal(bad[0].outcome, 'failed');
+  });
+}
+
+console.log('\nand nothing else in a turn is mistaken for a sub-agent');
+{
+  const turns = [
+    prompt(0, 'check the timer'),
+    { role: 'assistant', ts: at(2), blocks: [
+      { type: 'tool_use', id: 'toolu_D', name: 'Bash', text: '{"command":"systemctl list-timers"}' },
+      { type: 'tool_use', id: 'toolu_E', name: 'Read', text: '{"file_path":"runner.js"}' },
+    ] },
+    // a background BASH command gets the same notification shape, and it is not
+    // a sub-agent: the strip counts spawns, and matches outcomes to them by id.
+    notification(30, 'toolu_D', 'completed'),
+  ];
+  const [x] = splitExchanges(turns);
+  check('a Bash and a Read are not sub-agents', () => assert.deepEqual(agentSpawnsOf(x, turns), []));
+  check('…and a background command’s notification does not invent one',
+    () => assert.equal(agentCounts(agentSpawnsOf(x, turns), true).total, 0));
+}
+
+console.log('\nand a prompt-shaped harness notification is not a prompt');
+{
+  // CLI 2.1.209 opens a task-notification inside a SUB-AGENT's transcript with
+  // this marker instead of the tag, so the reader would otherwise start a new
+  // exchange with harness noise in the prompt band.
+  const turns = [
+    prompt(0, 'review the articles'),
+    said(4, 'Reading them now.'),
+    prompt(30, '[SYSTEM NOTIFICATION - NOT USER INPUT] This is an automated message.\n<task-notification>\n<tool-use-id>toolu_Z</tool-use-id>\n<status>completed</status>\n</task-notification>'),
+  ];
+  check('it does not open a second exchange', () => assert.equal(splitExchanges(turns).length, 1));
+}
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -306,5 +306,96 @@ console.log('\nand the cap tells the truth about what it is holding back');
   });
 }
 
+console.log('\nand codex, whose plumbing is different in every part');
+{
+  // Record shapes from a real run on this machine (codex 0.149.1): three
+  // `collaboration.spawn_agent` calls, each answered with an acknowledgement,
+  // then one `agent_message` per child posting its FINAL_ANSWER back.
+  const spawnAgent = (sec, callId, task) => ({
+    role: 'assistant', ts: at(sec),
+    blocks: [
+      { type: 'tool_use', id: callId, name: 'spawn_agent', text: JSON.stringify({ task_name: task, fork_turns: 'all', message: 'gAAAAABqlYfWFbr-j04I4HN5d-YU…' }) },
+      { type: 'tool_result', id: callId, text: JSON.stringify({ task_name: `/root/${task}` }) },
+    ],
+  });
+  const waited = (sec, callId) => ({
+    role: 'assistant', ts: at(sec),
+    blocks: [
+      { type: 'tool_use', id: callId, name: 'wait_agent', text: '{"timeout_ms":3600000}' },
+      { type: 'tool_result', id: callId, text: '{"message":"Wait completed.","timed_out":false}' },
+    ],
+  });
+  const finalAnswer = (sec, task, payload) => ({
+    role: 'system', ts: at(sec),
+    blocks: [{ type: 'text', text: `Message Type: FINAL_ANSWER\nTask name: /root\nSender: /root/${task}\nPayload:\n${payload}` }],
+  });
+  // and the protocol documentation codex puts in its own developer prompt
+  const protocolDoc = {
+    role: 'system', ts: at(1),
+    blocks: [{ type: 'text', text: 'You are `/root`… Message Type: MESSAGE | FINAL_ANSWER\nTask name: <task>\nSender: <author>\nPayload: <text>' }],
+  };
+  // …and the same explanation written with a real task in it, which is what a
+  // loose match would happily read as "pty_summary finished".
+  const protocolDocWithExample = {
+    role: 'system', ts: at(1),
+    blocks: [{ type: 'text', text: 'Posts look like: Message Type: MESSAGE | FINAL_ANSWER\nTask name: /root\nSender: /root/pty_summary\nPayload: <text>' }],
+  };
+
+  const turns = [
+    protocolDoc,
+    prompt(2, 'spawn three subagents, one summary each'),
+    spawnAgent(18, 'call_nq41', 'pty_summary'),
+    spawnAgent(20, 'call_dYuG', 'jsonl_summary'),
+    spawnAgent(22, 'call_84zW', 'cron_summary'),
+    waited(25, 'call_zPXG'),
+    finalAnswer(28, 'pty_summary', 'A PTY is a software interface that behaves like a physical terminal.'),
+    finalAnswer(31, 'jsonl_summary', 'JSONL is a text format where each line is one JSON value.'),
+    said(40, 'All three are back.'),
+  ];
+  // codex opens with four system turns of its own, so the operator's prompt is
+  // not the first thing in the file — take the exchange the prompt opened.
+  const exchanges = splitExchanges(turns);
+  const x = exchanges[exchanges.length - 1];
+  const spawns = agentSpawnsOf(x, turns);
+  check('three spawn_agent calls are three sub-agents', () => {
+    assert.equal(spawns.length, 3);
+    assert.deepEqual(spawns.map((s) => s.description), ['pty_summary', 'jsonl_summary', 'cron_summary']);
+    assert.deepEqual(spawns.map((s) => s.taskName), ['pty_summary', 'jsonl_summary', 'cron_summary']);
+  });
+  check('the FINAL_ANSWER post is the completion, matched by task name', () => {
+    assert.equal(spawns[0].outcome, 'reported');
+    assert.equal(spawns[0].outcomeAt, at(28));
+    assert.equal(spawns[1].outcome, 'reported');
+  });
+  check('the spawn acknowledgement is NOT a completion', () => {
+    // `{"task_name":"/root/cron_summary"}` comes back instantly, like Claude's
+    // async receipt. Reading it as a result marks every codex sub-agent done
+    // the moment it starts.
+    assert.equal(spawns[2].outcome, undefined);
+    assert.equal(agentStatus(spawns[2], { live: true }), 'running');
+    assert.equal(agentStatus(spawns[2], { live: false }), 'no-result');
+  });
+  check('"Wait completed." marks nothing — it names no agent', () => {
+    const noPosts = agentSpawnsOf(x, turns.filter((t) => !(t.blocks[0].text || '').includes('FINAL_ANSWER')));
+    assert.deepEqual(noPosts.map((s) => s.outcome), [undefined, undefined, undefined]);
+  });
+  check('and the protocol documentation does not complete a phantom sub-agent', () => {
+    // "Message Type: MESSAGE | FINAL_ANSWER" with "Sender: <author>" is codex
+    // explaining the format to itself, in the same thread.
+    const noPostTurns = [protocolDoc, protocolDocWithExample, ...turns.slice(1, 6)];
+    const docEx = splitExchanges(noPostTurns);
+    const docOnly = agentSpawnsOf(docEx[docEx.length - 1], noPostTurns);
+    assert.deepEqual(docOnly.map((s) => s.outcome), [undefined, undefined, undefined]);
+  });
+  check('the count and the states read the same as Claude’s', () => {
+    assert.equal(agentCounts(spawns, true).label, '3 sub-agents · 2 done · 1 running');
+    assert.equal(agentCounts(spawns, false).label, '3 sub-agents · 2 done · 1 unfinished');
+  });
+  check('a wait_agent call is not itself a sub-agent row', () => {
+    const kinds = stepsOf(turns.slice(1)).filter((s) => s.kind === 'agent').map((s) => s.description);
+    assert.deepEqual(kinds, ['pty_summary', 'jsonl_summary', 'cron_summary']);
+  });
+}
+
 console.log(failed ? `\n${failed} failed` : '\nall checks passed');
 process.exit(failed ? 1 : 0);

--- a/web/test/tileGroupInline.test.mjs
+++ b/web/test/tileGroupInline.test.mjs
@@ -44,6 +44,9 @@ const WIDTHS = [225, 238, 276, 340];
 fs.writeFileSync(stub, `
   export const getMetaOne = () => new Promise(() => {});
   export const previewFile = () => new Promise(() => {});
+  // the reader's sub-agent strip imports these; no tile here opens one
+  export const getSubAgents = () => Promise.resolve({ supported: true, agents: [] });
+  export const getSubAgentTrace = () => new Promise(() => {});
 `);
 
 await build({


### PR DESCRIPTION
The operator: *"in the reader some info. e.g. how many subagents are done/running in the tool/steps/tok line and if expanding a way see the list of agents and possibility to expand them too"* — three levels, built as a PoC.

```
2 steps · 4 tools · 35m 0s · 5.1k tok   ▸ 4 sub-agents · 2 done · 1 failed · 1 unfinished
  ▸ completed  Rework the Scene 1 intro           general-purpose  22m 37s  27 calls  76.5k tok
  ▸ failed     Reshoot scene 3 with clean sidebar general-purpose  15m 31s  12 calls  31.9k tok
  ▾ no result  Build the browser overlay…         general-purpose  wrote 4m ago  365kB
      └ that sub-agent's own transcript, rendered by the reader itself
```

Screens of all three levels, plus a sub-agent that spawned five more: **https://lvwerra-agent-artifacts.static.hf.space/subagents-poc.html**

### The trap I hit, and a correction to the brief

The brief (and the parallel study) say: *finished = the parent has a `tool_result` for that `toolUseId`*. That holds for a **synchronous** spawn only. For a **background** spawn the `tool_result` arrives two seconds after the call and reads "Async agent launched successfully" — it is a receipt. Followed record by record on one agent in the-gatherer:

```
08:36:05  Agent tool_use          spawn
08:36:07  tool_result             "Async agent launched successfully… agentId: a000425…"
08:40:31  (child's last record)
08:40:33  <task-notification>     <tool-use-id>…</tool-use-id><status>completed</status>
```

Treating the result as completion would have marked that agent done **4m 26s early** — and background is the normal case, not the exception: 22/22 of release-video's spawns and 38/38 of the-gatherer's carry a launch receipt. If the study's 30-of-32 "resolve to a `tool_use` with a matching `tool_result`" was read as completion times, those times are spawn times.

So the rule here is: the **notification** is the outcome for a background spawn; the result is the outcome only when it is the agent's own report. Observed statuses: `completed`, `failed`, `killed`. A test pins it, and the mutation that gets it wrong (any result is an outcome) fails four checks.

**The notification pays for itself twice:** it also carries `<usage><subagent_tokens>…<tool_uses>…<duration_ms>…</usage>`, which is the only place a sub-agent's own spend is written down. That is where the rows' duration, call count and token total come from — reported as the sub-agent's own totals, not as cost, since nearly all of what these read was cache.

### Liveness, and the third state

`mtime` is never a verdict — measured silence inside a *live* sub-agent reached 601s. The row shows `wrote 4m ago` as a fact and stops there. Three states, because a pane killed mid-task leaves sub-agents that never finish and never write again: an outcome-less sub-agent reads `running` only while the pane's own process is alive, and `no result` / `unfinished` otherwise.

### Cost

Nothing reads a parent transcript. The roster is the directory beside it — 187 bytes per sub-agent naming the task, the spawning `toolUseId`, the parent agent and the depth — because the parents here are 292 MB / 101 MB / 10 MB. The statuses come from the window the reader already holds.

```
GET /api/agents/:id/subagents            the roster, from the directory
GET /api/agents/:id/subagents/:agentId   one sub-agent's transcript, as a trace
```

**The PoC's honest limit:** a completion recorded outside the loaded window is not seen, so an older sub-agent reads `unfinished` rather than `done`. The bounded-tail fix belongs on the roster endpoint — that is the next step, not a hidden flaw.

### Level three is the reader, one level down

A sub-agent's transcript is an ordinary trace, so it goes through `splitExchanges` and comes back as exchanges `ExchangeView` renders: task prompt in the prompt band, its own `18 steps · 16 tools · 10m 13s · 171k tok` line, its own fold, its report as markdown. Depth then comes free — rl-llm-wiki ran 3 sub-agents, one of which ran 5 more, and the nested strip reads `5 sub-agents · 5 done` with `↳2` on each row. The directory is flat, so the same endpoint answers for a child of a child.

Also: the count is **this turn's** spawns, and a session usually holds more (including agents that other agents started, which the parent's tool calls never mention). That is stated under the list — `5 more in this session, from other turns` — rather than folded into a number that would disagree with the rows above it.

### Two things the parser had to give up

- **A dropped record.** In a *sub-agent's* transcript (CLI 2.1.209) the completion notification carries `isMeta: true`; in a *parent's* it does not. Dropping it meant a sub-agent that spawned sub-agents could never show one as finished. Kept now, and only when `origin.kind === 'task-notification'`.
- **A prompt that was not one.** Those records open with `[SYSTEM NOTIFICATION - NOT USER INPUT]` instead of a tag, so once kept they read as operator input and opened a fresh exchange with harness noise in the prompt band. The marker joins the two the reader already knew about, on both sides of the wire.

### Codex — left out, deliberately, and not as a zero

Codex's sub-agents are real (a rollout with `parent_thread_id`, `sub_agent_activity` events) but differently shaped, there is exactly one such thread on this machine to test against, and no terminal event has been observed — so the "finished" half would have nothing to stand on. I did not fill the slot with peer-session data either: a `collaboration.spawn_agent` peer is a top-level session in the sidebar, and calling it a sub-agent would misreport it. The strip renders only when a turn actually spawned something, so a Codex pane shows **nothing**, not "0 sub-agents".

### State

Typecheck clean. 21 web suites green, including the new `test/subagents.test.mjs`; every new assertion mutation-checked (any-result-is-an-outcome → 4 fail, exchange-scoped search → 5, two-states-only → 1, Bash-counts-as-agent → 2). Two existing suites stub `../../api` and gained the two new exports.

`server/test/crons.test.mjs` #4 fails, and `server/mobile.test.mjs` — both on clean `4faae2f` as well; I verified by stashing. Not mine.

PoC quality as asked: no polling, no session-wide count, no cost panel. Not merged, not deployed.
