### PR TITLE
Remote pane: the state line in the log, receipts under their message

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node ../scripts/run-suites.mjs",
-    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs && node test/remotePaneState.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RemoteInfo, RemoteMessage, Session } from '../types';
 import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
@@ -179,6 +179,17 @@ export default function RemotePane({
   const stateLabel = REMOTE_STATE_LABEL[state];
   const seenAgo = fmtAgo(info?.lastSeenAt);
 
+  // Whichever of these the connection actually knows, in order. Built as a list
+  // so the dots can join them rather than prefix them: with the state gone from
+  // this row, a prefixing dot would leave whatever comes first starting with a
+  // stray separator.
+  const facts = [
+    peer?.harness && { key: 'harness', node: <span>{peer.harness}</span> },
+    peer?.cwd && { key: 'cwd', node: <span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span> },
+    peer?.host && { key: 'host', node: <span>on {peer.host}</span> },
+    !peer && { key: 'path', node: <span className="rp-cwd">remote-agents/{name}/</span> },
+  ].filter((f): f is { key: string; node: JSX.Element } => !!f);
+
   const MAX_ROWS = 10;
   useEffect(() => {
     const el = inputRef.current;
@@ -288,19 +299,48 @@ export default function RemotePane({
           ) : m.role === 'user' ? (
             <div key={m.seq} className="rp-user">
               <span className="rp-caret">❯</span>
-              <span className="rp-user-text">{m.text}</span>
-              {/* Both states come from the highest seq a poll actually returned,
-                  and claim nothing beyond it: the agent either has this message
-                  or has not collected it yet. */}
-              {m.seq <= (info?.deliveredThrough ?? 0)
-                ? <AckGlyph className="rp-ack" />
-                : <span className="rp-pending" title="the agent has not collected this yet">pending</span>}
+              <div className="rp-user-body">
+                <span className="rp-user-text">{m.text}</span>
+                {/* The receipt sits at the foot of the message it is about, on
+                    the text column, so a wrapped message does not leave it
+                    stranded wherever the last line happened to end.
+
+                    Both states come from the highest seq a poll actually
+                    returned, and claim nothing beyond it: the agent either has
+                    this message or has not collected it yet. */}
+                <span className="rp-receipt">
+                  {m.seq <= (info?.deliveredThrough ?? 0)
+                    ? <AckGlyph className="rp-ack" />
+                    : <span className="rp-pending" title="the agent has not collected this yet">pending</span>}
+                </span>
+              </div>
             </div>
           ) : (
             <div key={m.seq} className="rp-agent" dangerouslySetInnerHTML={{ __html: m.html }} />
           )
         ))}
         {err && <div className="rp-err">{err}</div>}
+      </div>
+
+      {/* The one fact here that changes while you watch, so it sits against the
+          conversation rather than down in the context row. Drawn the way the
+          trace reader draws its `working` line: the mark hangs in the gutter and
+          the word starts on the message text column, on the log's own
+          background with no rule above it, so it reads as the last line of the
+          log rather than as a second bar of chrome.
+
+          The mark reads the app's one state-mark contract (--mark-* beside
+          ov-spin in styles.css): the braille spinner while working, and that
+          motion's completed path when it is not. It is `.rp-mark`, not
+          `.status` — a pane's own identity slot is a StateLogo frame (#92) and
+          no component renders a state-classed `.status` any more; this is the
+          other family, the one .cx-running and .ov-busy belong to.
+
+          Nothing follows the word: RemoteInfo carries no "what it is doing
+          now", and a made-up one would be worse than none. */}
+      <div className="rp-state-line" style={{ fontSize }}>
+        <span className={`rp-mark ${state}`} aria-hidden="true" />
+        <span className={`rp-state ${state}`}>{stateLabel}</span>
       </div>
 
       <div className="rp-composer" style={{ fontSize }}>
@@ -316,14 +356,21 @@ export default function RemotePane({
         />
       </div>
 
-      {/* The bottom status row: state, where the agent actually is, when we last
-          heard from it. */}
+      {/* The bottom context row: where the agent actually is, when we last heard
+          from it, and how to send. These are settings and facts about the
+          connection rather than things that change as you watch — the CLI
+          bottom row that carries them — so the state left and they did not.
+
+          The separators join the facts rather than prefixing them, so whichever
+          one comes first does not start with a stray dot now that the state is
+          no longer always there to lead. */}
       <div className="rp-status" style={{ fontSize }}>
-        <span className={`rp-state ${state}`}>{stateLabel}</span>
-        {peer?.harness && <><span className="rp-dot">·</span><span>{peer.harness}</span></>}
-        {peer?.cwd && <><span className="rp-dot">·</span><span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span></>}
-        {peer?.host && <><span className="rp-dot">·</span><span>on {peer.host}</span></>}
-        {!peer && <><span className="rp-dot">·</span><span className="rp-cwd">remote-agents/{name}/</span></>}
+        {facts.map((f, i) => (
+          <Fragment key={f.key}>
+            {i > 0 && <span className="rp-dot">·</span>}
+            {f.node}
+          </Fragment>
+        ))}
         <span className="spacer" />
         {seenAgo && <span className="rp-seen">last seen {seenAgo}</span>}
         <span className="rp-hint">↵ send · ⇧↵ newline</span>

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RemoteInfo, RemoteMessage, Session } from '../types';
 import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
@@ -51,6 +51,10 @@ export default function RemotePane({
   const [copied, setCopied] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
+  // Declared up here rather than with the other derived values because the
+  // scroll-pinning effect below depends on it.
+  const state = info?.state || session.state;
+  const running = state === 'working';
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const popRef = useRef<HTMLDivElement | null>(null);
   const cursor = useRef(0);
@@ -94,10 +98,19 @@ export default function RemotePane({
 
   // Stay pinned to the newest message unless the operator has scrolled up to
   // read something — then leave their scroll position alone.
+  //
+  // `running` is in here because the running line lives inside the log, so the
+  // log's height now changes on something other than a message. In practice
+  // every transition you can trigger by hand also delivers a message, so this
+  // is belt-and-braces rather than a fix for an observed jump: the flips it
+  // actually covers are the time-driven ones — a working agent going quiet for
+  // WORKING_WINDOW_MS, which drops the line with nothing else changing. Keeping
+  // it means the dependency list matches what the effect reads, so a later
+  // change to the state machine cannot quietly reintroduce the problem.
   useEffect(() => {
     const el = bodyRef.current;
     if (el && atBottom.current) el.scrollTop = el.scrollHeight;
-  }, [messages]);
+  }, [messages, running]);
 
   const loadPrompt = useCallback(async () => {
     if (!name) return;
@@ -173,22 +186,10 @@ export default function RemotePane({
     if (next && next !== session.name) onRename?.(next);
   };
 
-  const state = info?.state || session.state;
   const paused = info?.paused ?? !!session.remote?.paused;
   const peer = info?.peer || null;
   const stateLabel = REMOTE_STATE_LABEL[state];
   const seenAgo = fmtAgo(info?.lastSeenAt);
-
-  // Whichever of these the connection actually knows, in order. Built as a list
-  // so the dots can join them rather than prefix them: with the state gone from
-  // this row, a prefixing dot would leave whatever comes first starting with a
-  // stray separator.
-  const facts = [
-    peer?.harness && { key: 'harness', node: <span>{peer.harness}</span> },
-    peer?.cwd && { key: 'cwd', node: <span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span> },
-    peer?.host && { key: 'host', node: <span>on {peer.host}</span> },
-    !peer && { key: 'path', node: <span className="rp-cwd">remote-agents/{name}/</span> },
-  ].filter((f): f is { key: string; node: JSX.Element } => !!f);
 
   const MAX_ROWS = 10;
   useEffect(() => {
@@ -319,28 +320,21 @@ export default function RemotePane({
             <div key={m.seq} className="rp-agent" dangerouslySetInnerHTML={{ __html: m.html }} />
           )
         ))}
+        {/* The reader's running line, in this log, as its last child — directly
+            after the message it follows, with no rule, no gap and no container
+            of its own. Same class the reader renders (Exchange.tsx), so the two
+            are one spinner rather than two that resemble each other.
+
+            Only while working. In the reader this line exists only while a turn
+            is running; `listening` and `not connected` are resting conditions,
+            not events, so they stay on the bottom row rather than becoming a
+            braille glyph that holds still and pretends to spin.
+
+            No second half either. The reader appends the latest step when it has
+            one and renders the bare word when it does not (Exchange.tsx:352);
+            a remote agent reports no steps, so the bare form is the honest one. */}
+        {running && <div className="cx-running mono">working</div>}
         {err && <div className="rp-err">{err}</div>}
-      </div>
-
-      {/* The one fact here that changes while you watch, so it sits against the
-          conversation rather than down in the context row. Drawn the way the
-          trace reader draws its `working` line: the mark hangs in the gutter and
-          the word starts on the message text column, on the log's own
-          background with no rule above it, so it reads as the last line of the
-          log rather than as a second bar of chrome.
-
-          The mark reads the app's one state-mark contract (--mark-* beside
-          ov-spin in styles.css): the braille spinner while working, and that
-          motion's completed path when it is not. It is `.rp-mark`, not
-          `.status` — a pane's own identity slot is a StateLogo frame (#92) and
-          no component renders a state-classed `.status` any more; this is the
-          other family, the one .cx-running and .ov-busy belong to.
-
-          Nothing follows the word: RemoteInfo carries no "what it is doing
-          now", and a made-up one would be worse than none. */}
-      <div className="rp-state-line" style={{ fontSize }}>
-        <span className={`rp-mark ${state}`} aria-hidden="true" />
-        <span className={`rp-state ${state}`}>{stateLabel}</span>
       </div>
 
       <div className="rp-composer" style={{ fontSize }}>
@@ -356,21 +350,15 @@ export default function RemotePane({
         />
       </div>
 
-      {/* The bottom context row: where the agent actually is, when we last heard
-          from it, and how to send. These are settings and facts about the
-          connection rather than things that change as you watch — the CLI
-          bottom row that carries them — so the state left and they did not.
-
-          The separators join the facts rather than prefixing them, so whichever
-          one comes first does not start with a stray dot now that the state is
-          no longer always there to lead. */}
+      {/* The bottom status row: state, where the agent actually is, when we last
+          heard from it. The state stays here as the connection's resting
+          readout; the log carries the running line while it is working. */}
       <div className="rp-status" style={{ fontSize }}>
-        {facts.map((f, i) => (
-          <Fragment key={f.key}>
-            {i > 0 && <span className="rp-dot">·</span>}
-            {f.node}
-          </Fragment>
-        ))}
+        <span className={`rp-state ${state}`}>{stateLabel}</span>
+        {peer?.harness && <><span className="rp-dot">·</span><span>{peer.harness}</span></>}
+        {peer?.cwd && <><span className="rp-dot">·</span><span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span></>}
+        {peer?.host && <><span className="rp-dot">·</span><span>on {peer.host}</span></>}
+        {!peer && <><span className="rp-dot">·</span><span className="rp-cwd">remote-agents/{name}/</span></>}
         <span className="spacer" />
         {seenAgo && <span className="rp-seen">last seen {seenAgo}</span>}
         <span className="rp-hint">↵ send · ⇧↵ newline</span>

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { RemoteInfo, RemoteMessage, Session } from '../types';
 import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
@@ -51,10 +51,6 @@ export default function RemotePane({
   const [copied, setCopied] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const bodyRef = useRef<HTMLDivElement | null>(null);
-  // Declared up here rather than with the other derived values because the
-  // scroll-pinning effect below depends on it.
-  const state = info?.state || session.state;
-  const running = state === 'working';
   const inputRef = useRef<HTMLTextAreaElement | null>(null);
   const popRef = useRef<HTMLDivElement | null>(null);
   const cursor = useRef(0);
@@ -99,18 +95,10 @@ export default function RemotePane({
   // Stay pinned to the newest message unless the operator has scrolled up to
   // read something — then leave their scroll position alone.
   //
-  // `running` is in here because the running line lives inside the log, so the
-  // log's height now changes on something other than a message. In practice
-  // every transition you can trigger by hand also delivers a message, so this
-  // is belt-and-braces rather than a fix for an observed jump: the flips it
-  // actually covers are the time-driven ones — a working agent going quiet for
-  // WORKING_WINDOW_MS, which drops the line with nothing else changing. Keeping
-  // it means the dependency list matches what the effect reads, so a later
-  // change to the state machine cannot quietly reintroduce the problem.
   useEffect(() => {
     const el = bodyRef.current;
     if (el && atBottom.current) el.scrollTop = el.scrollHeight;
-  }, [messages, running]);
+  }, [messages]);
 
   const loadPrompt = useCallback(async () => {
     if (!name) return;
@@ -186,10 +174,20 @@ export default function RemotePane({
     if (next && next !== session.name) onRename?.(next);
   };
 
+  const state = info?.state || session.state;
   const paused = info?.paused ?? !!session.remote?.paused;
   const peer = info?.peer || null;
   const stateLabel = REMOTE_STATE_LABEL[state];
   const seenAgo = fmtAgo(info?.lastSeenAt);
+
+  // Whichever of these the connection actually knows, in order — see the bottom
+  // row below for why they are a list rather than a run of conditionals.
+  const facts = [
+    peer?.harness && { key: 'harness', node: <span>{peer.harness}</span> },
+    peer?.cwd && { key: 'cwd', node: <span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span> },
+    peer?.host && { key: 'host', node: <span>on {peer.host}</span> },
+    !peer && { key: 'path', node: <span className="rp-cwd">remote-agents/{name}/</span> },
+  ].filter((f): f is { key: string; node: JSX.Element } => !!f);
 
   const MAX_ROWS = 10;
   useEffect(() => {
@@ -322,18 +320,26 @@ export default function RemotePane({
         ))}
         {/* The reader's running line, in this log, as its last child — directly
             after the message it follows, with no rule, no gap and no container
-            of its own. Same class the reader renders (Exchange.tsx), so the two
-            are one spinner rather than two that resemble each other.
+            of its own. Same class the reader renders (Exchange.tsx), so the line
+            itself is one thing rather than two that resemble each other.
 
-            Only while working. In the reader this line exists only while a turn
-            is running; `listening` and `not connected` are resting conditions,
-            not events, so they stay on the bottom row rather than becoming a
-            braille glyph that holds still and pretends to spin.
+            Unlike the reader's, it is always here, because a remote agent always
+            has a state worth reading. Only `working` moves: the mark is the
+            app's settled state mark, which is the braille spinner while working
+            and that motion's completed path when it is not — accent while the
+            agent is there, grey once it is gone. Nothing else animates.
 
-            No second half either. The reader appends the latest step when it has
-            one and renders the bare word when it does not (Exchange.tsx:352);
-            a remote agent reports no steps, so the bare form is the honest one. */}
-        {running && <div className="cx-running mono">working</div>}
+            The mark is the line's content rather than its ::before, so the three
+            states share one drawing; .rp-run turns off the pseudo-element the
+            reader uses for its own spinner.
+
+            No second half. The reader appends the latest step when it has one
+            and renders the bare word when it does not (Exchange.tsx:352); a
+            remote agent reports no steps, so the bare form is the honest one. */}
+        <div className="cx-running mono rp-run">
+          <span className={`status ${state}`} aria-hidden="true" />
+          {stateLabel}
+        </div>
         {err && <div className="rp-err">{err}</div>}
       </div>
 
@@ -350,15 +356,22 @@ export default function RemotePane({
         />
       </div>
 
-      {/* The bottom status row: state, where the agent actually is, when we last
-          heard from it. The state stays here as the connection's resting
-          readout; the log carries the running line while it is working. */}
+      {/* The bottom context row: where the agent is, when we last heard from it,
+          and how to send. The state is NOT here any more — the log says it, and
+          the same word twice forty pixels apart is one of them being ignored.
+          What is left is the connection's standing facts, which the log never
+          carried.
+
+          The dots join the facts rather than prefixing them: with the state no
+          longer leading, a prefixing dot would leave whichever fact comes first
+          starting with a stray separator. */}
       <div className="rp-status" style={{ fontSize }}>
-        <span className={`rp-state ${state}`}>{stateLabel}</span>
-        {peer?.harness && <><span className="rp-dot">·</span><span>{peer.harness}</span></>}
-        {peer?.cwd && <><span className="rp-dot">·</span><span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span></>}
-        {peer?.host && <><span className="rp-dot">·</span><span>on {peer.host}</span></>}
-        {!peer && <><span className="rp-dot">·</span><span className="rp-cwd">remote-agents/{name}/</span></>}
+        {facts.map((f, i) => (
+          <Fragment key={f.key}>
+            {i > 0 && <span className="rp-dot">·</span>}
+            {f.node}
+          </Fragment>
+        ))}
         <span className="spacer" />
         {seenAgo && <span className="rp-seen">last seen {seenAgo}</span>}
         <span className="rp-hint">↵ send · ⇧↵ newline</span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -635,7 +635,15 @@ body {
    The type/cell/path values are declared once beside `ov-spin` and consumed by
    every renderer. The static path cannot drift away from the animation it
    stands in for because there is one measured contract and everyone reads it.
-   Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
+   Same principle as --cx-gutter (#71) and --ph-pad-y (#75).
+
+   Two vocabularies read this and they are not interchangeable. A mark in a
+   cell is this; a pane's or row's own identity slot is StateLogo's frame
+   instead (#92), which is why no component renders a state-classed `.status`
+   any more (web/test/stateLogo.test.mjs pins that). The remote pane's state
+   line is a mark in a cell — the trace reader's `working` line generalised to
+   hold still as well as move — and it re-anchors the type size because it sits
+   inside a zoomable surface; see .rp-mark. */
 .status.working, .status.waiting, .status.idle, .status.stopped {
   width: var(--mark-w); height: var(--mark-h);
   font-family: var(--font-mono); font-size: var(--mark-size);
@@ -1981,18 +1989,22 @@ a.btn-ghost { text-decoration: none; }
   padding: 3px 8px 3px 6px; margin: 1px 0;
 }
 .rp-caret { color: var(--accent); font-weight: 700; flex: none; }
-/* Not flex:1 — the tick sits immediately after the words, not pushed to the
-   far edge where it reads as unrelated furniture. */
+/* The message and its receipt stack, so the receipt lands at the foot of the
+   block on the text column rather than trailing off the end of whatever line
+   the text happened to stop on. */
+.rp-user-body { flex: 1; min-width: 0; display: flex; flex-direction: column; }
 .rp-user-text { white-space: pre-wrap; word-break: break-word; min-width: 0; }
-.rp-ack {
-  flex: none; width: 1.15em; height: 1.15em; color: var(--accent);
-  align-self: center; margin-left: 1px;
-}
+/* One fixed height for both receipts. `pending` is small italic text and the
+   tick is a glyph box, so without this the block would change height the moment
+   a receipt lands — and a log pinned to the newest message would jump under the
+   operator while they were reading. */
+.rp-receipt { display: flex; align-items: center; height: 1.25em; margin-top: 1px; }
+.rp-ack { flex: none; width: 1.05em; height: 1.05em; color: var(--accent); }
 /* The other half of the tick: quiet, italic, and out of the way — it marks a
    normal waiting state, not a problem. */
 .rp-pending {
   flex: none; font-style: italic; font-size: 0.8em; color: var(--muted);
-  opacity: 0.85; margin-left: 2px; white-space: nowrap;
+  opacity: 0.85; white-space: nowrap;
 }
 
 .rp-agent { padding-left: 15px; word-break: break-word; }
@@ -2008,6 +2020,55 @@ a.btn-ghost { text-decoration: none; }
 .rp-agent ul, .rp-agent ol { margin: 0.3em 0; padding-left: 1.4em; }
 .rp-agent table { border-collapse: collapse; margin: 0.4em 0; }
 .rp-agent th, .rp-agent td { border: 1px solid var(--border); padding: 2px 7px; text-align: left; }
+
+/* The state, between the log and the composer. Same shape as the trace reader's
+   `working` line: the mark hangs in the gutter so the word starts on the
+   message text column, and it sits on the log's own background with no rule
+   above it, so it reads as the last line of the conversation instead of a
+   second bar of chrome.
+
+   The mark below carries the zoom: see .rp-mark. */
+.rp-state-line {
+  display: flex; align-items: center;
+  padding: 1px 12px 7px; background: var(--term-bg);
+  font-family: var(--font-mono); color: var(--muted);
+}
+
+/* The state mark, on the shared contract with one difference: its type size is
+   the surface's, not the fixed chrome anchor.
+   Every other mark in the app is chrome at a constant size, so it takes
+   --mark-size. This one lives inside a surface the operator zooms from 50% to
+   200%, and a mark that stayed 12.5px would be twice the text at one end and
+   half of it at the other. `font-size: 1em` re-anchors only that: the cell, the
+   ink box, the stroke and the optical correction are the same em ratios as
+   everywhere else, so the drawing cannot drift from the animation it stands in
+   for. statusMark.test.mjs allows exactly this and no more. */
+.rp-mark { flex: none; }
+.rp-mark.working, .rp-mark.waiting, .rp-mark.idle, .rp-mark.stopped {
+  width: var(--mark-w); height: var(--mark-h);
+  font-family: var(--font-mono); font-size: 1em;
+  font-weight: var(--mark-weight); line-height: 1;
+  display: inline-flex; align-items: center; position: relative;
+}
+.rp-mark.working { overflow: hidden; }
+.rp-mark.working::before {
+  content: '⠋'; display: inline-flex; align-items: center; box-sizing: border-box;
+  width: 100%; height: 100%;
+  font-family: var(--font-mono); font-size: 1em;
+  font-weight: var(--mark-weight); line-height: 1;
+  transform: translateY(var(--mark-optical-y));
+  animation: ov-spin 0.9s steps(1) infinite;
+}
+.rp-mark.waiting::before, .rp-mark.idle::before, .rp-mark.stopped::before {
+  content: ''; position: absolute;
+  left: var(--mark-ink-x); top: var(--mark-ink-y);
+  width: var(--mark-ink-w); height: var(--mark-ink-h);
+  box-sizing: border-box; border: var(--mark-stroke) solid currentColor;
+}
+.rp-mark.working, .rp-mark.waiting { color: var(--accent); }
+.rp-mark.idle, .rp-mark.stopped { color: var(--muted); }
+.rp-mark.stopped { opacity: 0.5; }
+.rp-state-line .rp-state { font-size: 0.96em; }
 
 /* Composer: inherits the log's font size (set inline from zoom) so the two
    surfaces match at every zoom level. */
@@ -2025,7 +2086,9 @@ a.btn-ghost { text-decoration: none; }
 }
 .rp-input::placeholder { color: var(--muted); opacity: 0.7; }
 
-/* Bottom context row: state, where the agent is, when it last spoke. */
+/* Bottom context row: where the agent is and when it last spoke. The state used
+   to lead this row and now lives above the composer, next to the conversation
+   it describes. */
 .rp-status {
   display: flex; align-items: center; gap: 5px;
   padding: 4px 12px 5px; border-top: 1px solid var(--border);
@@ -2035,6 +2098,7 @@ a.btn-ghost { text-decoration: none; }
 .rp-status .spacer { flex: 1; }
 .rp-status > span { font-size: 0.82em; }
 .rp-state.working, .rp-state.waiting { color: var(--accent); }
+.rp-state.idle { color: var(--muted); }
 .rp-state.stopped { color: var(--muted); }
 .rp-dot { opacity: 0.5; }
 .rp-cwd { overflow: hidden; text-overflow: ellipsis; min-width: 0; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -635,15 +635,7 @@ body {
    The type/cell/path values are declared once beside `ov-spin` and consumed by
    every renderer. The static path cannot drift away from the animation it
    stands in for because there is one measured contract and everyone reads it.
-   Same principle as --cx-gutter (#71) and --ph-pad-y (#75).
-
-   Two vocabularies read this and they are not interchangeable. A mark in a
-   cell is this; a pane's or row's own identity slot is StateLogo's frame
-   instead (#92), which is why no component renders a state-classed `.status`
-   any more (web/test/stateLogo.test.mjs pins that). The remote pane's state
-   line is a mark in a cell — the trace reader's `working` line generalised to
-   hold still as well as move — and it re-anchors the type size because it sits
-   inside a zoomable surface; see .rp-mark. */
+   Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
 .status.working, .status.waiting, .status.idle, .status.stopped {
   width: var(--mark-w); height: var(--mark-h);
   font-family: var(--font-mono); font-size: var(--mark-size);
@@ -2021,54 +2013,13 @@ a.btn-ghost { text-decoration: none; }
 .rp-agent table { border-collapse: collapse; margin: 0.4em 0; }
 .rp-agent th, .rp-agent td { border: 1px solid var(--border); padding: 2px 7px; text-align: left; }
 
-/* The state, between the log and the composer. Same shape as the trace reader's
-   `working` line: the mark hangs in the gutter so the word starts on the
-   message text column, and it sits on the log's own background with no rule
-   above it, so it reads as the last line of the conversation instead of a
-   second bar of chrome.
-
-   The mark below carries the zoom: see .rp-mark. */
-.rp-state-line {
-  display: flex; align-items: center;
-  padding: 1px 12px 7px; background: var(--term-bg);
-  font-family: var(--font-mono); color: var(--muted);
-}
-
-/* The state mark, on the shared contract with one difference: its type size is
-   the surface's, not the fixed chrome anchor.
-   Every other mark in the app is chrome at a constant size, so it takes
-   --mark-size. This one lives inside a surface the operator zooms from 50% to
-   200%, and a mark that stayed 12.5px would be twice the text at one end and
-   half of it at the other. `font-size: 1em` re-anchors only that: the cell, the
-   ink box, the stroke and the optical correction are the same em ratios as
-   everywhere else, so the drawing cannot drift from the animation it stands in
-   for. statusMark.test.mjs allows exactly this and no more. */
-.rp-mark { flex: none; }
-.rp-mark.working, .rp-mark.waiting, .rp-mark.idle, .rp-mark.stopped {
-  width: var(--mark-w); height: var(--mark-h);
-  font-family: var(--font-mono); font-size: 1em;
-  font-weight: var(--mark-weight); line-height: 1;
-  display: inline-flex; align-items: center; position: relative;
-}
-.rp-mark.working { overflow: hidden; }
-.rp-mark.working::before {
-  content: '⠋'; display: inline-flex; align-items: center; box-sizing: border-box;
-  width: 100%; height: 100%;
-  font-family: var(--font-mono); font-size: 1em;
-  font-weight: var(--mark-weight); line-height: 1;
-  transform: translateY(var(--mark-optical-y));
-  animation: ov-spin 0.9s steps(1) infinite;
-}
-.rp-mark.waiting::before, .rp-mark.idle::before, .rp-mark.stopped::before {
-  content: ''; position: absolute;
-  left: var(--mark-ink-x); top: var(--mark-ink-y);
-  width: var(--mark-ink-w); height: var(--mark-ink-h);
-  box-sizing: border-box; border: var(--mark-stroke) solid currentColor;
-}
-.rp-mark.working, .rp-mark.waiting { color: var(--accent); }
-.rp-mark.idle, .rp-mark.stopped { color: var(--muted); }
-.rp-mark.stopped { opacity: 0.5; }
-.rp-state-line .rp-state { font-size: 0.96em; }
+/* The reader's running line, drawn in this log. Not a copy of it — literally
+   `.cx-running` (conversation.css), so there is one spinner in the app and one
+   place to change it. The reader pulls it left by a cell so `working` lands on
+   its text column; this log has no mark gutter to pull into, so the pull would
+   hang the spinner outside the log's padding. Neutralising that one declaration
+   is the whole difference between the two homes. */
+.rp-body .cx-running { margin-left: 0; }
 
 /* Composer: inherits the log's font size (set inline from zoom) so the two
    surfaces match at every zoom level. */
@@ -2086,9 +2037,9 @@ a.btn-ghost { text-decoration: none; }
 }
 .rp-input::placeholder { color: var(--muted); opacity: 0.7; }
 
-/* Bottom context row: where the agent is and when it last spoke. The state used
-   to lead this row and now lives above the composer, next to the conversation
-   it describes. */
+/* Bottom context row: state, where the agent is, when it last spoke. The state
+   stays here — it is the connection's resting condition, and a condition is not
+   an event. What the log gets is the running line, and only while running. */
 .rp-status {
   display: flex; align-items: center; gap: 5px;
   padding: 4px 12px 5px; border-top: 1px solid var(--border);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2014,12 +2014,27 @@ a.btn-ghost { text-decoration: none; }
 .rp-agent th, .rp-agent td { border: 1px solid var(--border); padding: 2px 7px; text-align: left; }
 
 /* The reader's running line, drawn in this log. Not a copy of it — literally
-   `.cx-running` (conversation.css), so there is one spinner in the app and one
-   place to change it. The reader pulls it left by a cell so `working` lands on
-   its text column; this log has no mark gutter to pull into, so the pull would
-   hang the spinner outside the log's padding. Neutralising that one declaration
-   is the whole difference between the two homes. */
+   `.cx-running` (conversation.css), so the line is one thing with one place to
+   change it. The reader pulls it left by a cell so `working` lands on its text
+   column; this log has no mark gutter to pull into, so the pull would hang the
+   mark outside the log's padding. Neutralising that one declaration is the
+   whole difference between the two homes.
+
+   Two things differ from the reader beyond that, both because a remote agent
+   always has a state worth reading while a reader turn is either running or
+   over: the line is always present, and its mark is a real element carrying the
+   state rather than the reader's always-spinning ::before. `.status` is that
+   mark — the app's settled one, spinner while working and the completed path
+   otherwise — so the three states are one drawing and only `working` moves. */
 .rp-body .cx-running { margin-left: 0; }
+/* The line's own mark is turned off, because here the mark is a real element
+   that carries the state. Two classes deep because `.cx-running::before` lives
+   in the other stylesheet and a single-class override would tie on specificity
+   and lose to whichever file loads last; and `animation: none` because
+   `ov-spin` sets `content` in its keyframes, and an animated declaration wins
+   over a plain one no matter how specific — without it the reader's spinner
+   kept drawing behind this line's mark. */
+.rp-body .rp-run::before { content: none; animation: none; }
 
 /* Composer: inherits the log's font size (set inline from zoom) so the two
    surfaces match at every zoom level. */
@@ -2037,9 +2052,9 @@ a.btn-ghost { text-decoration: none; }
 }
 .rp-input::placeholder { color: var(--muted); opacity: 0.7; }
 
-/* Bottom context row: state, where the agent is, when it last spoke. The state
-   stays here — it is the connection's resting condition, and a condition is not
-   an event. What the log gets is the running line, and only while running. */
+/* Bottom context row: where the agent is, when it last spoke, how to send. The
+   state is not here — the log's running line carries it, and saying the same
+   word twice forty pixels apart just teaches the eye to skip one of them. */
 .rp-status {
   display: flex; align-items: center; gap: 5px;
   padding: 4px 12px 5px; border-top: 1px solid var(--border);

--- a/web/test/remotePaneState.render.test.mjs
+++ b/web/test/remotePaneState.render.test.mjs
@@ -1,0 +1,158 @@
+// The remote pane's state line and its message receipts, in a browser.
+//
+// Two things here cannot be checked by reading the source:
+//
+//   1. The receipt sits at the foot of the message it belongs to, and `pending`
+//      and the tick occupy exactly the same height. That equality is the whole
+//      reason a log pinned to the newest message does not jump when a receipt
+//      lands mid-read — the two states are different kinds of thing (small
+//      italic text, and a glyph box) and only a layout engine can say whether
+//      they came out the same size.
+//   2. The state mark scales with the pane's zoom. The pane threads one font
+//      size through log, state line and composer; the shared mark contract is
+//      em-based apart from one absolute anchor (--mark-size), so the state line
+//      redefines that anchor in em. If someone later gives it a px value the
+//      mark silently stops following the zoom control, and nothing else breaks.
+//
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const css = ['styles.css', 'conversation.css']
+  .map((f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8')).join('\n');
+const geistMono = fs.readFileSync(path.join(HERE, '../public/fonts/GeistMono.woff2')).toString('base64');
+const embeddedFont = `@font-face {
+  font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
+  src: url(data:font/woff2;base64,${geistMono}) format('woff2');
+}
+:root { --font-mono: 'Geist Mono Test'; }
+.status.working::before, .rp-mark.working::before, .cx-running::before { animation: none !important; }`;
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+// The markup RemotePane renders, at two zoom levels. `pending` and `ack` carry
+// the same message text so any height difference is the receipt's alone.
+const pane = (fontSize, id) => `
+  <div class="slot" id="${id}" style="width:420px">
+    <div class="rp-body" style="font-size:${fontSize}">
+      <div class="rp-user" id="${id}-pending">
+        <span class="rp-caret">❯</span>
+        <div class="rp-user-body">
+          <span class="rp-user-text">rerun the failing suite and paste the first error you see</span>
+          <span class="rp-receipt"><span class="rp-pending">pending</span></span>
+        </div>
+      </div>
+      <div class="rp-user" id="${id}-ack">
+        <span class="rp-caret">❯</span>
+        <div class="rp-user-body">
+          <span class="rp-user-text">rerun the failing suite and paste the first error you see</span>
+          <span class="rp-receipt"><svg class="rp-ack" viewBox="0 0 16 16"><path d="M2 9l3.5 3.5"/></svg></span>
+        </div>
+      </div>
+      <div class="rp-agent" id="${id}-agent"><p>on it</p></div>
+    </div>
+    <div class="rp-state-line" style="font-size:${fontSize}">
+      <span class="rp-mark working" id="${id}-mark"></span>
+      <span class="rp-state working" id="${id}-word">working</span>
+    </div>
+    <div class="rp-composer" style="font-size:${fontSize}"><span class="rp-caret">❯</span></div>
+  </div>`;
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await (await browser.newContext({ viewport: { width: 900, height: 900 } })).newPage();
+await page.setContent(`<style>${css}\n${embeddedFont}</style>
+  ${pane('13px', 'z100')}
+  ${pane('26px', 'z200')}
+  <div class="cx-running mono" id="trace" style="font-size:13px">working</div>`);
+await page.waitForTimeout(120);
+
+const m = await page.evaluate(() => {
+  const box = (sel) => {
+    const e = document.querySelector(sel);
+    const b = e.getBoundingClientRect();
+    return { w: b.width, h: b.height, left: b.left, top: b.top, bottom: b.bottom };
+  };
+  const before = (sel, prop) => getComputedStyle(document.querySelector(sel), '::before').getPropertyValue(prop);
+  // The rendered text's own box, not its container's — the container is a flex
+  // column as wide as the block, so its edges say nothing about the glyphs.
+  const textBox = (sel) => {
+    const r = document.createRange();
+    r.selectNodeContents(document.querySelector(sel));
+    return r.getBoundingClientRect();
+  };
+  const textLeft = (sel) => textBox(sel).left;
+  return {
+    pend100: box('#z100-pending'), ack100: box('#z100-ack'),
+    pend200: box('#z200-pending'), ack200: box('#z200-ack'),
+    receipt100: box('#z100-pending .rp-receipt'),
+    msgText100: textLeft('#z100-pending .rp-user-text'),
+    msgTextBottom100: textBox('#z100-pending .rp-user-text').bottom,
+    receiptText100: textLeft('#z100-pending .rp-pending'),
+    mark100: box('#z100-mark'), mark200: box('#z200-mark'),
+    markContent: before('#z100-mark', 'content'),
+    traceContent: before('#trace', 'content'),
+    word100: box('#z100-word'),
+    line100: box('#z100 .rp-state-line'),
+    body100: box('#z100 .rp-body'),
+    composer100: box('#z100 .rp-composer'),
+    lineBg: getComputedStyle(document.querySelector('#z100 .rp-state-line')).backgroundColor,
+    bodyBg: getComputedStyle(document.querySelector('#z100 .rp-body')).backgroundColor,
+    lineBorderTop: getComputedStyle(document.querySelector('#z100 .rp-state-line')).borderTopWidth,
+  };
+});
+
+console.log('\na receipt does not change the height of the message it is on');
+check('pending and acknowledged are the same height at 100%', () => {
+  assert.equal(Math.round(m.pend100.h), Math.round(m.ack100.h));
+});
+check('…and at 200% zoom, where a fixed-px receipt would drift', () => {
+  assert.equal(Math.round(m.pend200.h), Math.round(m.ack200.h));
+});
+check('the block really did grow with the zoom (so the check above is not vacuous)', () => {
+  assert.ok(m.pend200.h > m.pend100.h * 1.5, `${m.pend100.h} → ${m.pend200.h}`);
+});
+
+console.log('\nthe receipt is under the message, on its text column');
+check('it starts below the last line of the message, not beside it', () => {
+  assert.ok(m.receipt100.top >= m.msgTextBottom100 - 0.5,
+    `receipt top ${m.receipt100.top.toFixed(1)} vs message text bottom ${m.msgTextBottom100.toFixed(1)}`);
+});
+check('and starts on the message text column, not the caret gutter', () => {
+  assert.ok(Math.abs(m.receiptText100 - m.msgText100) < 1.5,
+    `receipt at ${m.receiptText100}, text at ${m.msgText100}`);
+});
+
+console.log('\nthe state mark is the trace reader\'s braille, and it scales with the pane');
+check('the mark draws the same braille glyph the trace widget draws', () => {
+  assert.equal(m.markContent, m.traceContent);
+  assert.equal(m.markContent.replace(/"/g, ''), '⠋');
+});
+check('the mark doubles when the pane font doubles', () => {
+  const ratio = m.mark200.w / m.mark100.w;
+  assert.ok(Math.abs(ratio - 2) < 0.06, `width ratio ${ratio.toFixed(3)} (${m.mark100.w} → ${m.mark200.w})`);
+});
+
+console.log('\nthe line reads as the last line of the log, not as another bar');
+check('it sits between the log and the composer', () => {
+  assert.ok(m.line100.top >= m.body100.bottom - 1, `line ${m.line100.top} vs log bottom ${m.body100.bottom}`);
+  assert.ok(m.line100.bottom <= m.composer100.top + 1, `line ${m.line100.bottom} vs composer ${m.composer100.top}`);
+});
+check('on the log\'s own background, with no rule above it', () => {
+  assert.equal(m.lineBg, m.bodyBg);
+  assert.equal(m.lineBorderTop, '0px');
+});
+
+await browser.close();
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/remotePaneState.render.test.mjs
+++ b/web/test/remotePaneState.render.test.mjs
@@ -8,6 +8,10 @@
 // difference. A copy would pass a source lint and still look wrong; only a
 // layout engine can say the two lines match.
 //
+// Unlike the reader's, this line is always present: a remote agent always has a
+// state worth reading. So it also pins that only `working` moves, and that the
+// resting states are the same mark holding still rather than a second design.
+//
 // It also pins the receipts: `pending` and the tick occupy exactly the same
 // height, which is what keeps a bottom-pinned log from jumping when a receipt
 // lands mid-read.
@@ -28,7 +32,11 @@ const embeddedFont = `@font-face {
   font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
   src: url(data:font/woff2;base64,${geistMono}) format('woff2');
 }
-:root { --font-mono: 'Geist Mono Test'; }`;
+:root { --font-mono: 'Geist Mono Test'; }
+/* Frozen, not disabled: the animation still reports its name (which is what the
+   "only working moves" checks read) but every frame reads as the first one, so
+   asserting the glyph is not a race against the clock. */
+.status.working::before, .cx-running::before { animation-play-state: paused; }`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -48,7 +56,7 @@ const message = (receipt) => `
   </div>`;
 const TICK = '<svg class="rp-ack" viewBox="0 0 16 16"><path d="M2 9l3.5 3.5"/></svg>';
 const PENDING = '<span class="rp-pending">pending</span>';
-const RUN = '<div class="cx-running mono">working</div>';
+const run = (state, label) => `<div class="cx-running mono rp-run"><span class="status ${state}"></span>${label}</div>`;
 
 const browser = await chromium.launch(chromiumLaunchOptions());
 const page = await (await browser.newContext({ viewport: { width: 900, height: 900 } })).newPage();
@@ -64,11 +72,15 @@ await page.setContent(`<style>${css}\n${embeddedFont}</style>
   <div class="rp-body" id="log" style="font-size:13px;width:420px;height:200px">
     ${message(PENDING)}
     <div class="rp-agent" id="last-msg"><p>Running it now.</p></div>
-    ${RUN.replace('class=', 'id="pane-run" class=')}
+    ${run('working', 'working').replace('<div class=', '<div id="pane-run" class=')}
   </div>
-  <div class="rp-body" id="log-quiet" style="font-size:13px;width:420px;height:200px">
-    ${message(TICK)}
-    <div class="rp-agent"><p>Running it now.</p></div>
+  <div class="rp-body" id="log-listening" style="font-size:13px;width:420px">
+    <div class="rp-agent"><p>Done.</p></div>
+    ${run('waiting', 'listening').replace('<div class=', '<div id="listening-run" class=')}
+  </div>
+  <div class="rp-body" id="log-off" style="font-size:13px;width:420px">
+    <div class="rp-agent"><p>Done.</p></div>
+    ${run('stopped', 'not connected').replace('<div class=', '<div id="off-run" class=')}
   </div>
   <div class="rp-body" id="heights" style="font-size:13px;width:420px">
     ${message(PENDING).replace('class="rp-user"', 'id="h-pending" class="rp-user"')}
@@ -85,14 +97,23 @@ const m = await page.evaluate(() => {
   const read = (id) => {
     const e = document.getElementById(id);
     const cs = getComputedStyle(e);
-    const bf = getComputedStyle(e, '::before');
-    const r = document.createRange(); r.selectNodeContents(e);
+    const markEl = e.querySelector('.status');
+    const bf = markEl ? getComputedStyle(markEl, '::before') : getComputedStyle(e, '::before');
+    const markCs = markEl ? getComputedStyle(markEl) : null;
+    // The word itself, not the element: the pane's line has the mark span as its
+    // first child, so selecting the whole element would start the range at the
+    // mark and report 0 where the reader reports the cell's width.
+    const textNode = [...e.childNodes].filter((n) => n.nodeType === 3 && n.textContent.trim()).pop();
+    const r = document.createRange(); r.selectNode(textNode);
     const word = r.getBoundingClientRect();
     return {
       gapAbove: +(e.getBoundingClientRect().top - e.previousElementSibling.getBoundingClientRect().bottom).toFixed(2),
       fontSize: cs.fontSize, color: cs.color, marginLeft: cs.marginLeft,
       borderTopWidth: cs.borderTopWidth, background: cs.backgroundColor,
-      spinner: { content: bf.content, width: bf.width, height: bf.height, color: bf.color, animation: bf.animationName },
+      spinner: { content: bf.content, width: bf.width, height: bf.height,
+        color: markCs ? markCs.color : bf.color, animation: bf.animationName },
+      markBox: markEl ? { w: +markEl.getBoundingClientRect().width.toFixed(2) } : null,
+      ownBefore: getComputedStyle(e, '::before').content,
       wordOffset: +(word.left - e.getBoundingClientRect().left).toFixed(2),
     };
   };
@@ -101,7 +122,7 @@ const m = await page.evaluate(() => {
     reader: read('reader-run'), pane: read('pane-run'),
     lastChildIsRun: log.lastElementChild.id === 'pane-run',
     runInsideLog: log.contains(document.getElementById('pane-run')),
-    quietHasNoRun: !document.getElementById('log-quiet').querySelector('.cx-running'),
+    listening: read('listening-run'), off: read('off-run'),
     pend: box('#h-pending'), ack: box('#h-ack'),
     pend2: box('#h2-pending'), ack2: box('#h2-ack'),
     receiptLeft: box('#h-pending .rp-receipt').left,
@@ -124,21 +145,50 @@ check('it sits exactly as far below its message as the reader\'s does', () => {
   assert.equal(m.pane.gapAbove, m.reader.gapAbove);
 });
 check('same type size, same colour, same word position as the reader', () => {
-  assert.equal(m.pane.fontSize, m.reader.fontSize);
-  assert.equal(m.pane.color, m.reader.color);
-  assert.equal(m.pane.wordOffset, m.reader.wordOffset);
+  assert.equal(m.pane.fontSize, m.reader.fontSize, 'type size');
+  assert.equal(m.pane.color, m.reader.color, 'colour');
+  assert.equal(m.pane.wordOffset, m.reader.wordOffset,
+    `word offset: reader ${m.reader.wordOffset}, pane ${m.pane.wordOffset}`);
 });
-check('and literally the same spinner — glyph, cell, colour, animation', () => {
-  assert.deepEqual(m.pane.spinner, m.reader.spinner);
-  assert.equal(m.pane.spinner.animation, 'ov-spin');
+check('and while working, literally the reader\'s spinner — glyph, cell, animation', () => {
+  assert.equal(m.pane.spinner.content, m.reader.spinner.content);
+  assert.equal(m.pane.spinner.width, m.reader.spinner.width);
+  assert.equal(m.pane.spinner.height, m.reader.spinner.height);
+  assert.equal(m.pane.spinner.color, m.reader.spinner.color);
+  assert.equal(m.pane.spinner.animation, m.reader.spinner.animation);
 });
 check('the only declaration that differs is the reader\'s pull into its gutter', () => {
   assert.notEqual(m.pane.marginLeft, m.reader.marginLeft);
   assert.equal(m.pane.marginLeft, '0px');
   assert.match(m.reader.marginLeft, /^-/);
 });
-check('a log that is not working carries no running line at all', () => {
-  assert.ok(m.quietHasNoRun, 'a resting state drew a line in the log');
+console.log('\nall three states use the line; only working moves');
+check('listening and not connected draw in the same place, the same way', () => {
+  for (const s of [m.listening, m.off]) {
+    assert.equal(s.fontSize, m.pane.fontSize);
+    assert.equal(s.wordOffset, m.pane.wordOffset);
+    assert.equal(s.color, m.pane.color);
+  }
+});
+check('only working animates — the resting states hold still', () => {
+  assert.equal(m.pane.spinner.animation, 'ov-spin');
+  assert.equal(m.listening.spinner.animation, 'none');
+  assert.equal(m.off.spinner.animation, 'none');
+});
+check('the resting mark is the traced path, not a frozen braille frame', () => {
+  for (const s of [m.listening, m.off]) assert.equal(s.spinner.content, '""');
+  assert.equal(m.pane.spinner.content, '"⠋"');
+});
+check('the mark carries the state: accent while the agent is there, grey once gone', () => {
+  assert.equal(m.listening.spinner.color, m.pane.spinner.color);
+  assert.notEqual(m.off.spinner.color, m.pane.spinner.color);
+});
+check('the line does not also draw the reader\'s own spinner behind the mark', () => {
+  assert.equal(m.pane.ownBefore, 'none');
+});
+check('every state occupies the same cell, so the word never shifts', () => {
+  assert.equal(m.listening.markBox.w, m.pane.markBox.w);
+  assert.equal(m.off.markBox.w, m.pane.markBox.w);
 });
 
 console.log('\na receipt does not change the height of the message it is on');

--- a/web/test/remotePaneState.render.test.mjs
+++ b/web/test/remotePaneState.render.test.mjs
@@ -1,18 +1,16 @@
-// The remote pane's state line and its message receipts, in a browser.
+// The remote pane's running line and its message receipts, in a browser.
 //
-// Two things here cannot be checked by reading the source:
+// The running line is not a lookalike of the reader's — it is the reader's, the
+// same `.cx-running` class rendered inside the remote log, so there is one
+// spinner in the app rather than two that drift apart. What this pins is that
+// the two really do come out the same, and that the one declaration the remote
+// log neutralises (the reader's pull into its mark gutter) is the only
+// difference. A copy would pass a source lint and still look wrong; only a
+// layout engine can say the two lines match.
 //
-//   1. The receipt sits at the foot of the message it belongs to, and `pending`
-//      and the tick occupy exactly the same height. That equality is the whole
-//      reason a log pinned to the newest message does not jump when a receipt
-//      lands mid-read — the two states are different kinds of thing (small
-//      italic text, and a glyph box) and only a layout engine can say whether
-//      they came out the same size.
-//   2. The state mark scales with the pane's zoom. The pane threads one font
-//      size through log, state line and composer; the shared mark contract is
-//      em-based apart from one absolute anchor (--mark-size), so the state line
-//      redefines that anchor in em. If someone later gives it a px value the
-//      mark silently stops following the zoom control, and nothing else breaks.
+// It also pins the receipts: `pending` and the tick occupy exactly the same
+// height, which is what keeps a bottom-pinned log from jumping when a receipt
+// lands mid-read.
 //
 // am-test: manual — needs Chromium; run with `npm run test:render`.
 import assert from 'node:assert/strict';
@@ -30,8 +28,7 @@ const embeddedFont = `@font-face {
   font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
   src: url(data:font/woff2;base64,${geistMono}) format('woff2');
 }
-:root { --font-mono: 'Geist Mono Test'; }
-.status.working::before, .rp-mark.working::before, .cx-running::before { animation: none !important; }`;
+:root { --font-mono: 'Geist Mono Test'; }`;
 
 let failed = 0;
 const check = (what, fn) => {
@@ -41,116 +38,124 @@ const check = (what, fn) => {
   }
 };
 
-// The markup RemotePane renders, at two zoom levels. `pending` and `ack` carry
-// the same message text so any height difference is the receipt's alone.
-const pane = (fontSize, id) => `
-  <div class="slot" id="${id}" style="width:420px">
-    <div class="rp-body" style="font-size:${fontSize}">
-      <div class="rp-user" id="${id}-pending">
-        <span class="rp-caret">❯</span>
-        <div class="rp-user-body">
-          <span class="rp-user-text">rerun the failing suite and paste the first error you see</span>
-          <span class="rp-receipt"><span class="rp-pending">pending</span></span>
-        </div>
-      </div>
-      <div class="rp-user" id="${id}-ack">
-        <span class="rp-caret">❯</span>
-        <div class="rp-user-body">
-          <span class="rp-user-text">rerun the failing suite and paste the first error you see</span>
-          <span class="rp-receipt"><svg class="rp-ack" viewBox="0 0 16 16"><path d="M2 9l3.5 3.5"/></svg></span>
-        </div>
-      </div>
-      <div class="rp-agent" id="${id}-agent"><p>on it</p></div>
+const message = (receipt) => `
+  <div class="rp-user">
+    <span class="rp-caret">❯</span>
+    <div class="rp-user-body">
+      <span class="rp-user-text">rerun the failing suite and paste the first error you see</span>
+      <span class="rp-receipt">${receipt}</span>
     </div>
-    <div class="rp-state-line" style="font-size:${fontSize}">
-      <span class="rp-mark working" id="${id}-mark"></span>
-      <span class="rp-state working" id="${id}-word">working</span>
-    </div>
-    <div class="rp-composer" style="font-size:${fontSize}"><span class="rp-caret">❯</span></div>
   </div>`;
+const TICK = '<svg class="rp-ack" viewBox="0 0 16 16"><path d="M2 9l3.5 3.5"/></svg>';
+const PENDING = '<span class="rp-pending">pending</span>';
+const RUN = '<div class="cx-running mono">working</div>';
 
 const browser = await chromium.launch(chromiumLaunchOptions());
 const page = await (await browser.newContext({ viewport: { width: 900, height: 900 } })).newPage();
+// The reader and the remote log, drawing the same line, at the same base size.
 await page.setContent(`<style>${css}\n${embeddedFont}</style>
-  ${pane('13px', 'z100')}
-  ${pane('26px', 'z200')}
-  <div class="cx-running mono" id="trace" style="font-size:13px">working</div>`);
-await page.waitForTimeout(120);
+  <div class="cxv" style="--cx-base:13px;width:420px">
+    <div class="cx">
+      <div class="cx-prompt">rerun the failing suite</div>
+      <div class="cx-answer"><div class="markdown cx-md"><p>Running it now.</p></div></div>
+      <div class="cx-running mono" id="reader-run">working</div>
+    </div>
+  </div>
+  <div class="rp-body" id="log" style="font-size:13px;width:420px;height:200px">
+    ${message(PENDING)}
+    <div class="rp-agent" id="last-msg"><p>Running it now.</p></div>
+    ${RUN.replace('class=', 'id="pane-run" class=')}
+  </div>
+  <div class="rp-body" id="log-quiet" style="font-size:13px;width:420px;height:200px">
+    ${message(TICK)}
+    <div class="rp-agent"><p>Running it now.</p></div>
+  </div>
+  <div class="rp-body" id="heights" style="font-size:13px;width:420px">
+    ${message(PENDING).replace('class="rp-user"', 'id="h-pending" class="rp-user"')}
+    ${message(TICK).replace('class="rp-user"', 'id="h-ack" class="rp-user"')}
+  </div>
+  <div class="rp-body" id="heights2" style="font-size:26px;width:420px">
+    ${message(PENDING).replace('class="rp-user"', 'id="h2-pending" class="rp-user"')}
+    ${message(TICK).replace('class="rp-user"', 'id="h2-ack" class="rp-user"')}
+  </div>`);
+await page.waitForTimeout(150);
 
 const m = await page.evaluate(() => {
-  const box = (sel) => {
-    const e = document.querySelector(sel);
-    const b = e.getBoundingClientRect();
-    return { w: b.width, h: b.height, left: b.left, top: b.top, bottom: b.bottom };
+  const box = (sel) => { const b = document.querySelector(sel).getBoundingClientRect(); return { w: b.width, h: b.height, top: b.top, left: b.left, bottom: b.bottom }; };
+  const read = (id) => {
+    const e = document.getElementById(id);
+    const cs = getComputedStyle(e);
+    const bf = getComputedStyle(e, '::before');
+    const r = document.createRange(); r.selectNodeContents(e);
+    const word = r.getBoundingClientRect();
+    return {
+      gapAbove: +(e.getBoundingClientRect().top - e.previousElementSibling.getBoundingClientRect().bottom).toFixed(2),
+      fontSize: cs.fontSize, color: cs.color, marginLeft: cs.marginLeft,
+      borderTopWidth: cs.borderTopWidth, background: cs.backgroundColor,
+      spinner: { content: bf.content, width: bf.width, height: bf.height, color: bf.color, animation: bf.animationName },
+      wordOffset: +(word.left - e.getBoundingClientRect().left).toFixed(2),
+    };
   };
-  const before = (sel, prop) => getComputedStyle(document.querySelector(sel), '::before').getPropertyValue(prop);
-  // The rendered text's own box, not its container's — the container is a flex
-  // column as wide as the block, so its edges say nothing about the glyphs.
-  const textBox = (sel) => {
-    const r = document.createRange();
-    r.selectNodeContents(document.querySelector(sel));
-    return r.getBoundingClientRect();
-  };
-  const textLeft = (sel) => textBox(sel).left;
+  const log = document.getElementById('log');
   return {
-    pend100: box('#z100-pending'), ack100: box('#z100-ack'),
-    pend200: box('#z200-pending'), ack200: box('#z200-ack'),
-    receipt100: box('#z100-pending .rp-receipt'),
-    msgText100: textLeft('#z100-pending .rp-user-text'),
-    msgTextBottom100: textBox('#z100-pending .rp-user-text').bottom,
-    receiptText100: textLeft('#z100-pending .rp-pending'),
-    mark100: box('#z100-mark'), mark200: box('#z200-mark'),
-    markContent: before('#z100-mark', 'content'),
-    traceContent: before('#trace', 'content'),
-    word100: box('#z100-word'),
-    line100: box('#z100 .rp-state-line'),
-    body100: box('#z100 .rp-body'),
-    composer100: box('#z100 .rp-composer'),
-    lineBg: getComputedStyle(document.querySelector('#z100 .rp-state-line')).backgroundColor,
-    bodyBg: getComputedStyle(document.querySelector('#z100 .rp-body')).backgroundColor,
-    lineBorderTop: getComputedStyle(document.querySelector('#z100 .rp-state-line')).borderTopWidth,
+    reader: read('reader-run'), pane: read('pane-run'),
+    lastChildIsRun: log.lastElementChild.id === 'pane-run',
+    runInsideLog: log.contains(document.getElementById('pane-run')),
+    quietHasNoRun: !document.getElementById('log-quiet').querySelector('.cx-running'),
+    pend: box('#h-pending'), ack: box('#h-ack'),
+    pend2: box('#h2-pending'), ack2: box('#h2-ack'),
+    receiptLeft: box('#h-pending .rp-receipt').left,
+    receiptTop: box('#h-pending .rp-receipt').top,
+    textLeft: (() => { const r = document.createRange(); r.selectNodeContents(document.querySelector('#h-pending .rp-user-text')); return r.getBoundingClientRect().left; })(),
+    textBottom: (() => { const r = document.createRange(); r.selectNodeContents(document.querySelector('#h-pending .rp-user-text')); return r.getBoundingClientRect().bottom; })(),
   };
+});
+
+console.log('\nthe running line is the reader\'s line, in this log');
+check('it lives inside the log, as its last child', () => {
+  assert.ok(m.runInsideLog, 'the line is not inside the scrollable log');
+  assert.ok(m.lastChildIsRun, 'the line is not the last thing in the log');
+});
+check('nothing divides it from the message above — no rule, no band', () => {
+  assert.equal(m.pane.borderTopWidth, '0px');
+  assert.equal(m.pane.background, 'rgba(0, 0, 0, 0)');
+});
+check('it sits exactly as far below its message as the reader\'s does', () => {
+  assert.equal(m.pane.gapAbove, m.reader.gapAbove);
+});
+check('same type size, same colour, same word position as the reader', () => {
+  assert.equal(m.pane.fontSize, m.reader.fontSize);
+  assert.equal(m.pane.color, m.reader.color);
+  assert.equal(m.pane.wordOffset, m.reader.wordOffset);
+});
+check('and literally the same spinner — glyph, cell, colour, animation', () => {
+  assert.deepEqual(m.pane.spinner, m.reader.spinner);
+  assert.equal(m.pane.spinner.animation, 'ov-spin');
+});
+check('the only declaration that differs is the reader\'s pull into its gutter', () => {
+  assert.notEqual(m.pane.marginLeft, m.reader.marginLeft);
+  assert.equal(m.pane.marginLeft, '0px');
+  assert.match(m.reader.marginLeft, /^-/);
+});
+check('a log that is not working carries no running line at all', () => {
+  assert.ok(m.quietHasNoRun, 'a resting state drew a line in the log');
 });
 
 console.log('\na receipt does not change the height of the message it is on');
-check('pending and acknowledged are the same height at 100%', () => {
-  assert.equal(Math.round(m.pend100.h), Math.round(m.ack100.h));
+check('pending and acknowledged are the same height', () => {
+  assert.equal(Math.round(m.pend.h), Math.round(m.ack.h));
 });
 check('…and at 200% zoom, where a fixed-px receipt would drift', () => {
-  assert.equal(Math.round(m.pend200.h), Math.round(m.ack200.h));
+  assert.equal(Math.round(m.pend2.h), Math.round(m.ack2.h));
 });
 check('the block really did grow with the zoom (so the check above is not vacuous)', () => {
-  assert.ok(m.pend200.h > m.pend100.h * 1.5, `${m.pend100.h} → ${m.pend200.h}`);
+  assert.ok(m.pend2.h > m.pend.h * 1.5, `${m.pend.h} → ${m.pend2.h}`);
 });
-
-console.log('\nthe receipt is under the message, on its text column');
-check('it starts below the last line of the message, not beside it', () => {
-  assert.ok(m.receipt100.top >= m.msgTextBottom100 - 0.5,
-    `receipt top ${m.receipt100.top.toFixed(1)} vs message text bottom ${m.msgTextBottom100.toFixed(1)}`);
-});
-check('and starts on the message text column, not the caret gutter', () => {
-  assert.ok(Math.abs(m.receiptText100 - m.msgText100) < 1.5,
-    `receipt at ${m.receiptText100}, text at ${m.msgText100}`);
-});
-
-console.log('\nthe state mark is the trace reader\'s braille, and it scales with the pane');
-check('the mark draws the same braille glyph the trace widget draws', () => {
-  assert.equal(m.markContent, m.traceContent);
-  assert.equal(m.markContent.replace(/"/g, ''), '⠋');
-});
-check('the mark doubles when the pane font doubles', () => {
-  const ratio = m.mark200.w / m.mark100.w;
-  assert.ok(Math.abs(ratio - 2) < 0.06, `width ratio ${ratio.toFixed(3)} (${m.mark100.w} → ${m.mark200.w})`);
-});
-
-console.log('\nthe line reads as the last line of the log, not as another bar');
-check('it sits between the log and the composer', () => {
-  assert.ok(m.line100.top >= m.body100.bottom - 1, `line ${m.line100.top} vs log bottom ${m.body100.bottom}`);
-  assert.ok(m.line100.bottom <= m.composer100.top + 1, `line ${m.line100.bottom} vs composer ${m.composer100.top}`);
-});
-check('on the log\'s own background, with no rule above it', () => {
-  assert.equal(m.lineBg, m.bodyBg);
-  assert.equal(m.lineBorderTop, '0px');
+check('the receipt starts below the message text, on its text column', () => {
+  assert.ok(m.receiptTop >= m.textBottom - 0.5,
+    `receipt top ${m.receiptTop.toFixed(1)} vs message text bottom ${m.textBottom.toFixed(1)}`);
+  assert.ok(Math.abs(m.receiptLeft - m.textLeft) < 0.5,
+    `receipt at ${m.receiptLeft}, text at ${m.textLeft}`);
 });
 
 await browser.close();

--- a/web/test/stateLogo.test.mjs
+++ b/web/test/stateLogo.test.mjs
@@ -87,8 +87,15 @@ assert.equal(headerSvg.props.viewBox, '0 0 22 22');
 // Which surfaces have opted in. #92 shipped the frame to the sidebar, both pane
 // headers and the mock, and deliberately left Overview on the old standalone
 // mark; the operator has since asked for Overview too, so all three of its
-// state slots — card, tile and the group's peek strip — are frames now, and the
-// state-classed `.status` has no renderer left anywhere in the app.
+// state slots — card, tile and the group's peek strip — are frames now.
+//
+// What that settled is about IDENTITY slots: wherever a session is named, its
+// state is drawn as a frame around its logo, never as a mark beside the name.
+// The state-classed `.status` mark is not dead — it is the app's spinner and
+// still-path vocabulary — and the remote pane's running line renders it, which
+// is not an identity slot but a line of the conversation saying what the agent
+// is doing. That one renderer is pinned below so the exemption stays a single
+// known place rather than a hole.
 //
 // This one reads source rather than rendering, because Overview needs the whole
 // API surface to mount. It is written to survive reformatting: it counts and
@@ -97,11 +104,22 @@ const overview = fs.readFileSync(path.join(HERE, '../src/components/Overview.tsx
 const frames = (overview.match(/<StateLogo\b/g) || []).length;
 assert.ok(frames >= 3, `Overview should draw a frame in all three slots, found ${frames}`);
 assert.ok(/frameOnly/.test(overview), 'the group strip has no icon to frame, so it needs the frame-only form');
+const STATE_MARK = /className=\{?[`"']status [^`"']*\$\{/g;
 for (const file of ['components/Overview.tsx', 'components/Sidebar.tsx', 'components/TerminalPane.tsx',
-  'components/RemotePane.tsx', 'components/Locked.tsx']) {
+  'components/Locked.tsx']) {
   const text = fs.readFileSync(path.join(HERE, '../src', file), 'utf8');
-  assert.doesNotMatch(text, /className=\{?[`"']status [^`"']*\$\{/,
-    `${file} still renders a state-classed .status mark`);
+  assert.doesNotMatch(text, STATE_MARK, `${file} still renders a state-classed .status mark`);
+}
+// The one exemption, kept honest: exactly one mark, and it is the running line's
+// — not a state slipped in beside the pane's name, which is what the frame is
+// for. If a second one appears here, this fails and someone has to justify it.
+{
+  const remote = fs.readFileSync(path.join(HERE, '../src/components/RemotePane.tsx'), 'utf8');
+  const marks = remote.match(STATE_MARK) || [];
+  assert.equal(marks.length, 1, `RemotePane draws ${marks.length} state-classed marks, expected exactly the running line's`);
+  assert.match(remote, /cx-running[^]{0,200}className=\{`status \$\{state\}`\}/,
+    'the mark is not inside the running line');
+  assert.match(remote, /<StateLogo\b/, 'the pane header still needs its identity frame');
 }
 
 console.log('state-logo: real tiles keep logos, 12px legend frames are border-only, and every state slot is a frame');

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -8,6 +8,9 @@
 //
 // So this lints the contract, not the numbers: type, cell, measured ink box and
 // derived stroke are declared once, and every spinner/static renderer reads them.
+// One value may be re-chosen and only one — the type anchor, and only between
+// the fixed chrome size and the surface's own size, for a mark that lives inside
+// something the operator zooms. See .rp-mark in styles.css.
 // What the marks actually PAINT is a separate question this cannot answer. That
 // is statusMark.render.test.mjs.
 //
@@ -62,30 +65,79 @@ check('they are declared with the animation, not with one of its consumers', () 
 console.log('\nevery renderer of the spinner reads it');
 
 const spinners = rules.filter((r) => /animation:\s*ov-spin/.test(r.body));
+// A spinner gets its box one of two legitimate ways: it takes the cell from
+// --mark-w/--mark-h, or it fills a parent that already did (100%). What it must
+// never do is name a length of its own — that is how a renderer drifts.
+const FILLS_PARENT = /width\s*:\s*100%/;
+// A mark's declarations are spread over several rules — `.status.working::before`
+// is two of them, and its cell is declared on a four-state list — so read the
+// cascade the way the browser does: everything targeting one element, merged.
+const declaredOn = (selector) => rules
+  .filter((r) => r.selector.split(',').some((sel) => sel.trim() === selector))
+  .map((r) => r.body).join(';');
+// Whichever element actually owns the cell: the pseudo-element itself, or — when
+// it fills 100% of its parent — the parent it fills.
+const cellOwnerOf = (spinner) => {
+  const own = declaredOn(spinner.selector);
+  if (!FILLS_PARENT.test(own)) return { selector: spinner.selector, body: own };
+  const parent = spinner.selector.replace(/::before\b/g, '').trim();
+  return { selector: parent, body: declaredOn(parent) };
+};
+
 check('there is more than one spinner renderer to keep in step', () => {
   assert.ok(spinners.length >= 3, `found ${spinners.length}`);
 });
-check('none of them restates a width', () => {
+check('none of them names a box size of its own', () => {
   const offenders = spinners
+    .map((r) => ({ selector: r.selector, body: declaredOn(r.selector) }))
     .filter((r) => /(?:^|;|\s)width\s*:/.test(r.body))
-    .filter((r) => !/width\s*:\s*var\(--mark-w\)/.test(r.body))
+    .filter((r) => !/width\s*:\s*var\(--mark-w\)/.test(r.body) && !FILLS_PARENT.test(r.body))
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these size the spinner themselves: ${offenders.join(', ')}`);
 });
+check('a spinner that fills its parent gets the box from that parent', () => {
+  for (const spinner of spinners.filter((r) => FILLS_PARENT.test(declaredOn(r.selector)))) {
+    assert.match(declaredOn(spinner.selector), /height\s*:\s*100%/, `${spinner.selector} fills one axis only`);
+    const owner = cellOwnerOf(spinner);
+    assert.match(owner.body, /width\s*:\s*var\(--mark-w\)/,
+      `nothing sizes ${owner.selector} from the cell, so ${spinner.selector} fills nothing`);
+    assert.match(owner.body, /height\s*:\s*var\(--mark-h\)/, `${owner.selector} sizes one axis only`);
+  }
+});
+// The type anchor is the one value a renderer may re-choose, and only between
+// two options: the fixed chrome size, or the surface's own size. Every mark in
+// the app is constant-size chrome and takes --mark-size; the remote pane's
+// state line sits inside a surface the operator zooms 50%-200%, where a
+// constant mark would be twice the text at one end and half of it at the other.
+// Nothing else may vary — the cell, ink box, stroke and optical correction stay
+// the shared em ratios, which is what keeps the still path and the animation
+// the same drawing.
+const ANCHOR = /font-size\s*:\s*(var\(--mark-size\)|1em|inherit)\s*[;}]/;
 check('every spinner consumes the shared type, weight and cell contract', () => {
   for (const spinner of spinners) {
-    if (spinner.selector === '.status.working::before') {
-      assert.match(spinner.body, /content:\s*'⠋'/, 'working lost the shared braille family');
-      assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, 'working lost the optical correction');
-      continue; // its parent owns the contract; the mark fills it below
-    }
-    assert.match(spinner.body, /font-family\s*:\s*var\(--font-mono\)/, `${spinner.selector} inherits its font family`);
-    assert.match(spinner.body, /font-size\s*:\s*var\(--mark-size\)/, `${spinner.selector} has its own type size`);
-    assert.match(spinner.body, /font-weight\s*:\s*var\(--mark-weight\)/, `${spinner.selector} inherits its weight`);
-    assert.match(spinner.body, /line-height\s*:\s*1/, `${spinner.selector} inherits its line height`);
-    assert.match(spinner.body, /width\s*:\s*var\(--mark-w\)/, `${spinner.selector} has its own width`);
-    assert.match(spinner.body, /height\s*:\s*var\(--mark-h\)/, `${spinner.selector} has its own height`);
+    assert.match(spinner.body, /content:\s*'⠋'/, `${spinner.selector} lost the shared braille family`);
     assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, `${spinner.selector} lost the optical correction`);
+    // The type and cell are asserted on whichever rule owns them, so a mark
+    // drawn as cell + filling pseudo-element is held to the same contract as
+    // one drawn in a single rule.
+    const owner = cellOwnerOf(spinner);
+    assert.match(owner.body, ANCHOR, `${owner.selector} invents a type size`);
+    assert.match(owner.body, /font-family\s*:\s*var\(--font-mono\)/, `${owner.selector} inherits its font family`);
+    assert.match(owner.body, /font-weight\s*:\s*var\(--mark-weight\)/, `${owner.selector} inherits its weight`);
+    assert.match(owner.body, /line-height\s*:\s*1/, `${owner.selector} inherits its line height`);
+    assert.match(owner.body, /width\s*:\s*var\(--mark-w\)/, `${owner.selector} has its own width`);
+    assert.match(owner.body, /height\s*:\s*var\(--mark-h\)/, `${owner.selector} has its own height`);
+  }
+});
+check('a re-anchored mark still takes its cell and ink from the contract', () => {
+  const reanchored = rules.filter((r) => /font-size\s*:\s*(1em|inherit)\s*[;}]/.test(r.body)
+    && /var\(--mark-/.test(r.body));
+  assert.ok(reanchored.length >= 1, 'no renderer re-anchors its type size, so this allowance is dead');
+  for (const r of reanchored) {
+    const lengths = [...r.body.matchAll(/(?:^|;|\s)(width|height|left|top|border)\s*:\s*([^;]+)/g)]
+      .filter(([, , value]) => LENGTH.test(value) && !/var\(--mark-|100%/.test(value))
+      .map(([, prop]) => prop);
+    assert.deepEqual(lengths, [], `${r.selector} names its own ${lengths.join(', ')}`);
   }
 });
 
@@ -142,6 +194,31 @@ check('every non-working state uses one measured hollow rectangle', () => {
   assert.match(body, /background\s*:\s*none/, 'the path has a fill');
   assert.match(body, /border-radius\s*:\s*0/, 'the path is rounded');
 });
+// The check above is about `.status`, which also has a bare colour-dot form to
+// override. Any other family that draws the moving path must draw the still one
+// too, from the same measured ink — otherwise a second family could re-anchor
+// its type size legitimately and then guess its rectangle by eye, and the two
+// drawings would stop being one mark.
+check('every family that spins also stands still, from the same ink box', () => {
+  const familyOf = (selector) => selector.match(/(\.[a-z][a-z0-9-]*)\.working::before/)?.[1];
+  const spinning = [...new Set(spinners.map((r) => familyOf(r.selector)).filter(Boolean))];
+  assert.ok(spinning.length >= 2, `only ${spinning.length} state-classed spinner family; this allowance is dead`);
+  for (const family of spinning) {
+    const still = rules.filter((r) => ['waiting', 'idle', 'stopped']
+      .every((state) => r.selector.includes(`${family}.${state}::before`)));
+    assert.equal(still.length, 1, `${family} has ${still.length} still-path rules, not one shared`);
+    const body = still[0].body;
+    for (const [prop, variable] of [
+      ['left', '--mark-ink-x'], ['top', '--mark-ink-y'],
+      ['width', '--mark-ink-w'], ['height', '--mark-ink-h'],
+    ]) {
+      assert.match(body, new RegExp(`${prop}\\s*:\\s*var\\(${variable}\\)`), `${family} still path: ${prop} does not read ${variable}`);
+    }
+    assert.match(body, /border\s*:\s*var\(--mark-stroke\)\s+solid\s+currentColor/, `${family} still path does not use the derived dot stroke`);
+    assert.match(body, /content\s*:\s*['"]{2}/, `${family} still path is a glyph, not the traced box`);
+  }
+});
+
 check('no non-working state overrides that rectangle with its own shape', () => {
   const offenders = rules.filter((r) => /\.status\.(waiting|idle|stopped)::before/.test(r.selector))
     .filter((r) => !['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -8,9 +8,6 @@
 //
 // So this lints the contract, not the numbers: type, cell, measured ink box and
 // derived stroke are declared once, and every spinner/static renderer reads them.
-// One value may be re-chosen and only one — the type anchor, and only between
-// the fixed chrome size and the surface's own size, for a mark that lives inside
-// something the operator zooms. See .rp-mark in styles.css.
 // What the marks actually PAINT is a separate question this cannot answer. That
 // is statusMark.render.test.mjs.
 //
@@ -65,79 +62,30 @@ check('they are declared with the animation, not with one of its consumers', () 
 console.log('\nevery renderer of the spinner reads it');
 
 const spinners = rules.filter((r) => /animation:\s*ov-spin/.test(r.body));
-// A spinner gets its box one of two legitimate ways: it takes the cell from
-// --mark-w/--mark-h, or it fills a parent that already did (100%). What it must
-// never do is name a length of its own — that is how a renderer drifts.
-const FILLS_PARENT = /width\s*:\s*100%/;
-// A mark's declarations are spread over several rules — `.status.working::before`
-// is two of them, and its cell is declared on a four-state list — so read the
-// cascade the way the browser does: everything targeting one element, merged.
-const declaredOn = (selector) => rules
-  .filter((r) => r.selector.split(',').some((sel) => sel.trim() === selector))
-  .map((r) => r.body).join(';');
-// Whichever element actually owns the cell: the pseudo-element itself, or — when
-// it fills 100% of its parent — the parent it fills.
-const cellOwnerOf = (spinner) => {
-  const own = declaredOn(spinner.selector);
-  if (!FILLS_PARENT.test(own)) return { selector: spinner.selector, body: own };
-  const parent = spinner.selector.replace(/::before\b/g, '').trim();
-  return { selector: parent, body: declaredOn(parent) };
-};
-
 check('there is more than one spinner renderer to keep in step', () => {
   assert.ok(spinners.length >= 3, `found ${spinners.length}`);
 });
-check('none of them names a box size of its own', () => {
+check('none of them restates a width', () => {
   const offenders = spinners
-    .map((r) => ({ selector: r.selector, body: declaredOn(r.selector) }))
     .filter((r) => /(?:^|;|\s)width\s*:/.test(r.body))
-    .filter((r) => !/width\s*:\s*var\(--mark-w\)/.test(r.body) && !FILLS_PARENT.test(r.body))
+    .filter((r) => !/width\s*:\s*var\(--mark-w\)/.test(r.body))
     .map((r) => r.selector);
   assert.deepEqual(offenders, [], `these size the spinner themselves: ${offenders.join(', ')}`);
 });
-check('a spinner that fills its parent gets the box from that parent', () => {
-  for (const spinner of spinners.filter((r) => FILLS_PARENT.test(declaredOn(r.selector)))) {
-    assert.match(declaredOn(spinner.selector), /height\s*:\s*100%/, `${spinner.selector} fills one axis only`);
-    const owner = cellOwnerOf(spinner);
-    assert.match(owner.body, /width\s*:\s*var\(--mark-w\)/,
-      `nothing sizes ${owner.selector} from the cell, so ${spinner.selector} fills nothing`);
-    assert.match(owner.body, /height\s*:\s*var\(--mark-h\)/, `${owner.selector} sizes one axis only`);
-  }
-});
-// The type anchor is the one value a renderer may re-choose, and only between
-// two options: the fixed chrome size, or the surface's own size. Every mark in
-// the app is constant-size chrome and takes --mark-size; the remote pane's
-// state line sits inside a surface the operator zooms 50%-200%, where a
-// constant mark would be twice the text at one end and half of it at the other.
-// Nothing else may vary — the cell, ink box, stroke and optical correction stay
-// the shared em ratios, which is what keeps the still path and the animation
-// the same drawing.
-const ANCHOR = /font-size\s*:\s*(var\(--mark-size\)|1em|inherit)\s*[;}]/;
 check('every spinner consumes the shared type, weight and cell contract', () => {
   for (const spinner of spinners) {
-    assert.match(spinner.body, /content:\s*'⠋'/, `${spinner.selector} lost the shared braille family`);
+    if (spinner.selector === '.status.working::before') {
+      assert.match(spinner.body, /content:\s*'⠋'/, 'working lost the shared braille family');
+      assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, 'working lost the optical correction');
+      continue; // its parent owns the contract; the mark fills it below
+    }
+    assert.match(spinner.body, /font-family\s*:\s*var\(--font-mono\)/, `${spinner.selector} inherits its font family`);
+    assert.match(spinner.body, /font-size\s*:\s*var\(--mark-size\)/, `${spinner.selector} has its own type size`);
+    assert.match(spinner.body, /font-weight\s*:\s*var\(--mark-weight\)/, `${spinner.selector} inherits its weight`);
+    assert.match(spinner.body, /line-height\s*:\s*1/, `${spinner.selector} inherits its line height`);
+    assert.match(spinner.body, /width\s*:\s*var\(--mark-w\)/, `${spinner.selector} has its own width`);
+    assert.match(spinner.body, /height\s*:\s*var\(--mark-h\)/, `${spinner.selector} has its own height`);
     assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, `${spinner.selector} lost the optical correction`);
-    // The type and cell are asserted on whichever rule owns them, so a mark
-    // drawn as cell + filling pseudo-element is held to the same contract as
-    // one drawn in a single rule.
-    const owner = cellOwnerOf(spinner);
-    assert.match(owner.body, ANCHOR, `${owner.selector} invents a type size`);
-    assert.match(owner.body, /font-family\s*:\s*var\(--font-mono\)/, `${owner.selector} inherits its font family`);
-    assert.match(owner.body, /font-weight\s*:\s*var\(--mark-weight\)/, `${owner.selector} inherits its weight`);
-    assert.match(owner.body, /line-height\s*:\s*1/, `${owner.selector} inherits its line height`);
-    assert.match(owner.body, /width\s*:\s*var\(--mark-w\)/, `${owner.selector} has its own width`);
-    assert.match(owner.body, /height\s*:\s*var\(--mark-h\)/, `${owner.selector} has its own height`);
-  }
-});
-check('a re-anchored mark still takes its cell and ink from the contract', () => {
-  const reanchored = rules.filter((r) => /font-size\s*:\s*(1em|inherit)\s*[;}]/.test(r.body)
-    && /var\(--mark-/.test(r.body));
-  assert.ok(reanchored.length >= 1, 'no renderer re-anchors its type size, so this allowance is dead');
-  for (const r of reanchored) {
-    const lengths = [...r.body.matchAll(/(?:^|;|\s)(width|height|left|top|border)\s*:\s*([^;]+)/g)]
-      .filter(([, , value]) => LENGTH.test(value) && !/var\(--mark-|100%/.test(value))
-      .map(([, prop]) => prop);
-    assert.deepEqual(lengths, [], `${r.selector} names its own ${lengths.join(', ')}`);
   }
 });
 
@@ -194,31 +142,6 @@ check('every non-working state uses one measured hollow rectangle', () => {
   assert.match(body, /background\s*:\s*none/, 'the path has a fill');
   assert.match(body, /border-radius\s*:\s*0/, 'the path is rounded');
 });
-// The check above is about `.status`, which also has a bare colour-dot form to
-// override. Any other family that draws the moving path must draw the still one
-// too, from the same measured ink — otherwise a second family could re-anchor
-// its type size legitimately and then guess its rectangle by eye, and the two
-// drawings would stop being one mark.
-check('every family that spins also stands still, from the same ink box', () => {
-  const familyOf = (selector) => selector.match(/(\.[a-z][a-z0-9-]*)\.working::before/)?.[1];
-  const spinning = [...new Set(spinners.map((r) => familyOf(r.selector)).filter(Boolean))];
-  assert.ok(spinning.length >= 2, `only ${spinning.length} state-classed spinner family; this allowance is dead`);
-  for (const family of spinning) {
-    const still = rules.filter((r) => ['waiting', 'idle', 'stopped']
-      .every((state) => r.selector.includes(`${family}.${state}::before`)));
-    assert.equal(still.length, 1, `${family} has ${still.length} still-path rules, not one shared`);
-    const body = still[0].body;
-    for (const [prop, variable] of [
-      ['left', '--mark-ink-x'], ['top', '--mark-ink-y'],
-      ['width', '--mark-ink-w'], ['height', '--mark-ink-h'],
-    ]) {
-      assert.match(body, new RegExp(`${prop}\\s*:\\s*var\\(${variable}\\)`), `${family} still path: ${prop} does not read ${variable}`);
-    }
-    assert.match(body, /border\s*:\s*var\(--mark-stroke\)\s+solid\s+currentColor/, `${family} still path does not use the derived dot stroke`);
-    assert.match(body, /content\s*:\s*['"]{2}/, `${family} still path is a glyph, not the traced box`);
-  }
-});
-
 check('no non-working state overrides that rectangle with its own shape', () => {
   const offenders = rules.filter((r) => /\.status\.(waiting|idle|stopped)::before/.test(r.selector))
     .filter((r) => !['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));


### PR DESCRIPTION
> **PR numbers:** feedback has twice been relayed against #117. That is a different branch (`feat/remote-pane-state-row`) — another agent's parallel implementation of the same task, and the one that renamed the spinner vocabulary to `.state-mark`. This is #116, updated in place. **#116 and #117 do the same job and cannot both land**: same files, including a same-named `web/test/remotePaneState.render.test.mjs`. Someone should pick one.

**Mock and measurements:** https://lvwerra-agent-artifacts.static.hf.space/remote-state.html

## The state line, in the log

It sits **inside the message log, as the log's last child** — directly after the message it follows, no rule, no band, no container of its own. It scrolls with the messages, because it is one of them. The line itself is `.cx-running`, the class the reader renders, so it is one line with one place to change it rather than two that resemble each other.

**All three states use it. Only `working` moves.** The mark is `.status`, the app's settled state mark: the braille spinner while working, that motion's completed path when it is not, accent while the agent is there and grey once it is gone.

| measured | working | listening | not connected |
|---|---|---|---|
| animation | `ov-spin` | none | none |
| mark content | braille glyph | traced box | traced box |
| mark cell | 15px | 15px | 15px |
| word starts at | 15px | 15px | 15px |
| line height | 18.7px | 18.8px | 18.8px |

Same cell and same word offset in all three, so nothing shifts as the state changes. Against the reader, while working: same 7px gap above, same 12.48px type, same colour, same word offset, same spinner glyph, cell, colour and animation. The only declaration that differs is the reader's pull into its mark gutter, which this log has none of.

## Two consequences, handled

**The bottom row lost the state word.** With the state in the log, keeping it below too is the same word twice forty pixels apart — which teaches the eye to skip one. #117 was right to call that out. What stays is what the log never carried: harness, working directory, host, last seen, and the key legend. Its separators now join those facts rather than prefixing them, so whichever comes first has no stray leading `·`.

**Scrolling is a simpler picture than last round's.** The line no longer enters and leaves the log — it changes in place. That makes the `running` dependency I added to the pin effect dead weight, so **it is gone**; the effect depends on `messages` again, exactly as on main. Re-driven against a live remote agent in a log tall enough to scroll:

| situation | result |
|---|---|
| line height across all three states | 18.7 / 18.8 / 18.8px — a state change moves nothing |
| pinned to the bottom, state changes | distance from bottom stayed **0** at every transition |
| scrolled up to read, state changes | `scrollTop` 0 → **0**, no yank |

## The call that was overridden, and what I got wrong

I had said `listening` and `not connected` should stay on the bottom row, because a still braille glyph would be a spinner that does not spin. That was right about *animation* and wrong about *location* — the answer was a non-spinning mark, which the codebase already had. Corrected.

The other two calls stand: **no second half** (the reader already renders the bare word when it has no step, `Exchange.tsx:352`; a remote agent reports no steps and `RemoteInfo` has no field for one), and **share `.cx-running` rather than factor it**.

## One thing that needed handling, and one assertion narrowed

Reusing `.status` means no new CSS for the mark at all. But the mark is now the line's *content*, so `.cx-running`'s own always-spinning `::before` had to be turned off — and `content: none` was not enough. `ov-spin` sets `content` in its keyframes, and an animated declaration beats a plain one however specific, so **the reader's spinner kept drawing behind this line's mark**. It needs `animation: none` alongside, two classes deep because `.cx-running` lives in the other stylesheet and a one-class override ties on specificity and loses to load order. The render test caught this; a review would not have.

`stateLogo.test.mjs` claimed the state-classed `.status` had no renderer left anywhere in the app. What #92 actually settled is about **identity slots** — wherever a session is named, its state is a frame around its logo — and a line of the conversation saying what the agent is doing is not one. So the claim is narrowed to what it protects, and **the single exemption is pinned rather than left as a hole**: RemotePane must render exactly one such mark, it must be inside the running line, and the pane header must still use its frame. All three mutations of that fail (a second mark; the mark moved out of the line; an identity slot reverting to a bare mark).

Also still true from the round before: `.rp-mark` stays deleted and `statusMark.test.mjs` stays as it is on `main`. There is one fewer way to draw a spinner than before this branch.

## Receipts

Unchanged: at the foot of the message they belong to, on its text column, meaning untouched. `pending` and the tick share one fixed row height, so a message does not change height when a receipt lands.

## Tests

`web/test/remotePaneState.render.test.mjs` renders the reader's line and the log's line on one page and asserts they match property for property while working; that all three states share the cell, the word position and the colour rule; that only `working` animates and the resting mark is the traced path rather than a frozen braille frame; that the line draws no second spinner of its own; and the receipt heights at 100% and 200%.

Green: typecheck, web 20/20, all four `test:render` suites, every server suite except `server/test/crons.test.mjs`, which is red on clean `main` and is not mine.

Not merged, not deployed.