### PR TITLE
Remote pane: the state above the input, receipts under their message

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "start": "node src/index.js",
     "dev": "node --watch src/index.js",
-    "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs",
+    "test:ui": "node terminal-ui.test.mjs && node screenshot-input.test.mjs && node reader-info.test.mjs && node remote-pane.test.mjs",
     "test:screenshots": "node screenshot-input.test.mjs",
     "test:mobile": "node mobile.test.mjs",
     "test": "node test/queued-prompts.test.mjs && node ../scripts/run-suites.mjs"

--- a/server/remote-pane.test.mjs
+++ b/server/remote-pane.test.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+/**
+ * The remote pane's state row and its receipts, against the real server and the
+ * real component:
+ *   - the state sits between the log and the composer, in all three states, and
+ *     the bottom context row no longer says it a second time;
+ *   - the mark is the app's `.state-mark`: `working` animates the braille
+ *     spinner, `listening` and `not connected` draw its completed path;
+ *   - a message's receipt sits under the message, on its text's left edge, and
+ *     says `pending` until a poll collects it and `delivered` after;
+ *   - that transition does not move the log — the two receipts are one height,
+ *     so nothing below a message shifts when its receipt lands;
+ *   - the mark grows with the pane's zoom control, like the rest of the pane.
+ *
+ * The states are produced the way the product produces them, not by poking
+ * classes on: `working` is an uncollected operator message, `listening` is the
+ * agent having answered it, `not connected` is Disconnect.
+ *
+ * Set REMOTE_PANE_PUBLIC_DIR to a prebuilt web/dist to skip the build,
+ * REMOTE_PANE_PORT to pin the port, and REMOTE_PANE_SHOTS to a directory to
+ * write PNGs of each state.
+ * am-test: manual — Chromium, a full web build and a free port; `npm run test:ui`.
+ */
+import fs from 'node:fs';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn, spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.dirname(HERE);
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-remote-pane-'));
+const DATA_DIR = path.join(TMP, 'data');
+const HOME = path.join(TMP, 'home');
+const PUBLIC_DIR = process.env.REMOTE_PANE_PUBLIC_DIR || path.join(TMP, 'public');
+const SHOTS = process.env.REMOTE_PANE_SHOTS || '';
+// A free port by default: this machine runs a fleet of these apps, and the
+// fixed-port suites here have already produced flakes that read as product bugs.
+const PORT = process.env.REMOTE_PANE_PORT || String(await new Promise((res) => {
+  const srv = net.createServer();
+  srv.listen(0, '127.0.0.1', () => { const { port } = srv.address(); srv.close(() => res(port)); });
+}));
+const API = `http://127.0.0.1:${PORT}`;
+const NAME = 'laptop-carver';
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+fs.mkdirSync(DATA_DIR, { recursive: true });
+fs.mkdirSync(HOME, { recursive: true });
+if (SHOTS) fs.mkdirSync(SHOTS, { recursive: true });
+
+let failures = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  if (!ok) failures += 1;
+};
+const waitFor = async (fn, timeout = 20_000) => {
+  const until = Date.now() + timeout;
+  while (Date.now() < until) {
+    try { if (await fn()) return true; } catch { /* not yet */ }
+    await sleep(100);
+  }
+  return false;
+};
+
+if (!process.env.REMOTE_PANE_PUBLIC_DIR) {
+  const build = spawnSync('npm', ['run', 'build', '--', '--outDir', PUBLIC_DIR], {
+    cwd: path.join(ROOT, 'web'), encoding: 'utf8',
+  });
+  if (build.status !== 0) throw new Error(`web build failed:\n${build.stdout}\n${build.stderr}`);
+}
+
+// A test server must not publish skills — see migration.test.mjs for why. And
+// PUBLIC_DIR is set in the Space this often runs inside: inherit it and the
+// whole suite measures the deployed bundle instead of the build under test.
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+const backend = spawn('node', ['src/index.js'], {
+  cwd: HERE,
+  env: {
+    ...BASE_ENV,
+    PORT, DATA_DIR, PUBLIC_DIR, HOME,
+    AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let logs = '';
+backend.stdout.on('data', (d) => { logs += d; });
+backend.stderr.on('data', (d) => { logs += d; });
+
+const json = async (p, opt) => {
+  const r = await fetch(API + p, opt);
+  const t = await r.text();
+  try { return JSON.parse(t); } catch { return t; }
+};
+const post = (p, body, type = 'application/json') =>
+  json(p, { method: 'POST', headers: { 'content-type': type }, body: type === 'application/json' ? JSON.stringify(body) : body });
+
+let browser;
+try {
+  if (!await waitFor(() => fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false), 60_000)) {
+    throw new Error(`server did not start:\n${logs.slice(-2000)}`);
+  }
+  await post('/api/welcome/seen', {});
+
+  const made = await post('/api/sessions', { name: NAME, cli: 'remote' });
+  if (!made.id) throw new Error(`could not create a remote agent: ${JSON.stringify(made)}`);
+  const id = made.id;
+  const say = (text) => post(`/api/sessions/${id}/input`, { text });
+  // `agent=1` is the agent's own short poll: it stamps liveness and marks
+  // everything it returns delivered. That is where a receipt comes from.
+  const agentPoll = (since) => json(`/api/remote/${NAME}/messages?agent=1&since=${since}`);
+  const agentSay = (text) => post(`/api/remote/${NAME}/messages`, text, 'text/plain');
+
+  await agentPoll(0);
+  await say('can you check the tokenizer on the 7B run?');
+  const collected = await agentPoll(0);
+  await agentSay('Checked — the merges file is stale. I rebuilt it and the eval matches now.');
+  const LONG = 'when you are back: pull the new cuts and re-render scene 4 at 60fps, '
+    + 'then tell me the render time and whether the audio drifted on the long take';
+  await say(LONG);
+
+  browser = await chromium.launch(chromiumLaunchOptions());
+  const page = await (await browser.newContext({
+    viewport: { width: 1200, height: 820 }, deviceScaleFactor: 2,
+  })).newPage();
+
+  const read = () => page.evaluate(() => {
+    const row = document.querySelector('.rp-staterow');
+    const mark = row?.querySelector('.state-mark');
+    const log = document.querySelector('.rp-body');
+    const composer = document.querySelector('.rp-composer');
+    const before = mark && getComputedStyle(mark, '::before');
+    const users = [...document.querySelectorAll('.rp-user')].map((u) => {
+      const text = u.querySelector('.rp-user-text').getBoundingClientRect();
+      const r = u.querySelector('.rp-receipt');
+      const box = r.getBoundingClientRect();
+      return {
+        words: u.querySelector('.rp-user-text').textContent,
+        receipt: r.textContent.trim(),
+        kind: r.className.replace('rp-receipt', '').trim(),
+        alignedLeft: Math.abs(box.x - text.x) < 1,
+        below: box.y >= text.y + text.height - 1,
+        height: u.getBoundingClientRect().height,
+      };
+    });
+    return {
+      state: row?.querySelector('.rp-state')?.textContent,
+      markClass: mark?.className,
+      markGlyph: before?.content,
+      markAnimation: before?.animationName,
+      markStroke: parseFloat(before?.borderTopWidth) || 0,
+      markSize: mark && parseFloat(getComputedStyle(mark).fontSize),
+      rowSize: row && parseFloat(getComputedStyle(row).fontSize),
+      belowLog: row && log && row.getBoundingClientRect().top >= log.getBoundingClientRect().bottom - 1,
+      aboveComposer: row && composer && row.getBoundingClientRect().bottom <= composer.getBoundingClientRect().top + 1,
+      bottomRow: document.querySelector('.rp-status')?.textContent || '',
+      users,
+      scroll: log && { top: log.scrollTop, height: log.scrollHeight },
+    };
+  });
+  const shot = async (file) => {
+    if (!SHOTS) return;
+    await (await page.$('.slot')).screenshot({ path: path.join(SHOTS, file) });
+  };
+
+  await page.goto(API, { waitUntil: 'domcontentloaded' });
+  const row = page.locator('.sidebar .row.session[data-ref^="s:"]').filter({ hasText: NAME }).first();
+  await row.waitFor({ timeout: 20_000 });
+  await row.click();
+  await page.waitForSelector('.rp-staterow', { timeout: 20_000 });
+  await sleep(600);
+
+  // ---- working: the newest word is the operator's, and it is not collected ----
+  const working = await read();
+  await shot('01-working-pending.png');
+  check('the state row is below the log', working.belowLog === true);
+  check('and above the composer', working.aboveComposer === true);
+  check('it says working', working.state === 'working', working.state);
+  check('the mark is the app state vocabulary', working.markClass === 'state-mark working', working.markClass);
+  check('working animates the shared spinner', working.markAnimation === 'ov-spin', working.markAnimation);
+  check('on a braille glyph from the contract', /[⠋⠙⠹⠸⠼⠴⠦⠧]/.test(working.markGlyph || ''), working.markGlyph);
+  check('the bottom row does not say the state again',
+    !/working|listening|not connected/.test(working.bottomRow), working.bottomRow);
+  check('and still says where the agent is, and when it was last heard from',
+    /remote-agents\/laptop-carver/.test(working.bottomRow) && /last seen/.test(working.bottomRow), working.bottomRow);
+
+  check('both messages carry a receipt', working.users.length === 2, `${working.users.length} messages`);
+  check('the collected one says delivered', working.users[0]?.receipt === 'delivered', working.users[0]?.receipt);
+  check('the uncollected one says pending', working.users[1]?.receipt === 'pending', working.users[1]?.receipt);
+  for (const [i, u] of working.users.entries()) {
+    check(`message ${i + 1}: the receipt is under its text`, u.below === true);
+    check(`message ${i + 1}: on the text's left edge`, u.alignedLeft === true);
+  }
+  check('the long message really did wrap', (working.users[1]?.height || 0) > (working.users[0]?.height || 0),
+    `${working.users[1]?.height} vs ${working.users[0]?.height}`);
+
+  // ---- the receipt lands: the log must not move ----
+  // Fill the log first. A receipt landing in a log that fits its box proves
+  // nothing about a pinned one, and this pane pins to the bottom.
+  for (let i = 0; i < 45; i++) {
+    await agentSay(`Frame ${i + 1}: colour pass done, waiting on the audio conform before the next take.`);
+  }
+  if (!await waitFor(() => page.evaluate(() => document.querySelectorAll(".rp-agent").length >= 46), 25_000)) {
+    throw new Error('the filler messages never arrived in the pane');
+  }
+  const beforeLand = await page.evaluate(() => {
+    const el = document.querySelector('.rp-body');
+    el.scrollTop = el.scrollHeight;      // as a pinned log sits
+    return { top: el.scrollTop, height: el.scrollHeight };
+  });
+  await agentPoll(collected.seq ?? 1);
+  if (!await waitFor(() => page.evaluate(() =>
+    [...document.querySelectorAll('.rp-receipt')].every((r) => r.classList.contains('ack'))), 25_000)) {
+    throw new Error('the receipt never landed');
+  }
+  const afterLand = await page.evaluate(() => {
+    const el = document.querySelector('.rp-body');
+    return { top: el.scrollTop, height: el.scrollHeight };
+  });
+  check('the log really is scrolled, so this measures a pinned one', beforeLand.top > 0,
+    `scrollTop ${beforeLand.top}`);
+  check('the log is exactly as tall after the receipt lands', beforeLand.height === afterLand.height,
+    `${beforeLand.height} -> ${afterLand.height}`);
+  check('and has not scrolled', beforeLand.top === afterLand.top, `${beforeLand.top} -> ${afterLand.top}`);
+
+  // ---- listening: the agent answered, so nothing is outstanding ----
+  await agentSay('Rendered scene 4 at 60fps in 3m12s. No audio drift on the long take.');
+  if (!await waitFor(() => page.evaluate(() =>
+    document.querySelector('.rp-staterow .rp-state')?.textContent === 'listening'), 25_000)) {
+    throw new Error(`state never fell back to listening: ${(await read()).state}`);
+  }
+  const listening = await read();
+  await shot('02-listening-delivered.png');
+  check('listening keeps the mark still', listening.markAnimation === 'none', listening.markAnimation);
+  check('and draws the completed path instead of a glyph',
+    listening.markGlyph === '""' && listening.markStroke >= 1, `${listening.markGlyph} / ${listening.markStroke}px`);
+  check('every receipt now says delivered',
+    listening.users.every((u) => u.receipt === 'delivered'), JSON.stringify(listening.users.map((u) => u.receipt)));
+
+  // ---- the pane's zoom moves the mark with everything else ----
+  for (let i = 0; i < 5; i++) await page.getByTitle('Zoom in').first().click();
+  await sleep(400);
+  const zoomed = await read();
+  await shot('03-listening-zoomed.png');
+  check('zooming the pane grows the row', zoomed.rowSize > listening.rowSize,
+    `${listening.rowSize}px -> ${zoomed.rowSize}px`);
+  check('and grows the mark by the same ratio',
+    Math.abs((zoomed.markSize / listening.markSize) - (zoomed.rowSize / listening.rowSize)) < 0.02,
+    `mark ${listening.markSize}px -> ${zoomed.markSize}px`);
+  for (let i = 0; i < 5; i++) await page.getByTitle('Zoom out').first().click();
+
+  // ---- not connected: Disconnect, the operator's own off switch ----
+  await post(`/api/sessions/${id}/remote/paused`, { paused: true });
+  if (!await waitFor(() => page.evaluate(() =>
+    document.querySelector('.rp-staterow .rp-state')?.textContent === 'not connected'), 25_000)) {
+    throw new Error('state never reported the disconnection');
+  }
+  const off = await read();
+  await shot('04-not-connected.png');
+  check('not connected draws the same still path', off.markGlyph === '""' && off.markStroke >= 1,
+    `${off.markGlyph} / ${off.markStroke}px`);
+  check('and is muted rather than shaped differently', off.markClass === 'state-mark stopped', off.markClass);
+  check('the row is still between the log and the composer', off.belowLog === true && off.aboveComposer === true);
+
+  console.log(failures ? `\n${failures} failed` : '\nremote pane: state row and receipts ok');
+} finally {
+  if (browser) await browser.close();
+  backend.kill('SIGKILL');
+  fs.rmSync(TMP, { recursive: true, force: true });
+}
+process.exit(failures ? 1 : 0);

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node ../scripts/run-suites.mjs",
-    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs && node test/remotePaneState.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import type { RemoteInfo, RemoteMessage, Session } from '../types';
 import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
@@ -57,8 +58,10 @@ export default function RemotePane({
   const atBottom = useRef(true);
   const autoOpened = useRef(false);
 
-  // One font size for the log, the composer and the status line, so the pane
-  // reads as one surface and the zoom control moves all of it together.
+  // One font size for the log, the state row, the composer and the status
+  // line, so the pane reads as one surface and the zoom control moves all of
+  // it together. The state row's braille mark restates --mark-size against
+  // this in CSS, since the shared contract declares it in absolute pixels.
   const fontSize = `${(13 * zoom) / 100}px`;
 
   const absorb = useCallback((incoming: RemoteMessage[]) => {
@@ -179,6 +182,15 @@ export default function RemotePane({
   const stateLabel = REMOTE_STATE_LABEL[state];
   const seenAgo = fmtAgo(info?.lastSeenAt);
 
+  // What the bottom row says about this agent, in order. Kept as a list so the
+  // dots between them can be interleaved and no leading dot is left behind when
+  // the peer has told us nothing yet.
+  const statusBits: { key: string; node: ReactNode }[] = [];
+  if (peer?.harness) statusBits.push({ key: 'harness', node: <span>{peer.harness}</span> });
+  if (peer?.cwd) statusBits.push({ key: 'cwd', node: <span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span> });
+  if (peer?.host) statusBits.push({ key: 'host', node: <span>on {peer.host}</span> });
+  if (!peer) statusBits.push({ key: 'inbox', node: <span className="rp-cwd">remote-agents/{name}/</span> });
+
   const MAX_ROWS = 10;
   useEffect(() => {
     const el = inputRef.current;
@@ -198,9 +210,12 @@ export default function RemotePane({
   return (
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
       {/* The standard three-column pane header: identity left, name centred,
-          actions right — same as every other agent's pane. Everything else the
-          operator might want to know lives in the status line under the
-          composer, the way a CLI keeps its context on one bottom row. */}
+          actions right — same as every other agent's pane. The left mark is a
+          StateLogo, so the state rides on the CLI tile exactly as it does in
+          the sidebar and every other pane; the row above the composer is the
+          one that says the state in words. Two shapes at opposite ends of the
+          pane: which agent this is, and what it is doing. The rest of the
+          context stays on the bottom row, the way a CLI keeps it. */}
       <div
         className={`pane-head${dragId ? ' draggable' : ''}`}
         draggable={!!dragId}
@@ -288,19 +303,39 @@ export default function RemotePane({
           ) : m.role === 'user' ? (
             <div key={m.seq} className="rp-user">
               <span className="rp-caret">❯</span>
-              <span className="rp-user-text">{m.text}</span>
-              {/* Both states come from the highest seq a poll actually returned,
-                  and claim nothing beyond it: the agent either has this message
-                  or has not collected it yet. */}
-              {m.seq <= (info?.deliveredThrough ?? 0)
-                ? <AckGlyph className="rp-ack" />
-                : <span className="rp-pending" title="the agent has not collected this yet">pending</span>}
+              {/* The message is a column: its words, then its receipt on a line
+                  of its own beneath them. A long message wraps to many lines and
+                  the receipt still belongs to the whole block, so it sits under
+                  it rather than trailing the last word. */}
+              <div className="rp-user-body">
+                <span className="rp-user-text">{m.text}</span>
+                {/* Both states come from the highest seq a poll actually returned,
+                    and claim nothing beyond it: the agent either has this message
+                    or has not collected it yet. */}
+                {m.seq <= (info?.deliveredThrough ?? 0)
+                  ? <span className="rp-receipt ack" title="the agent has collected this"><AckGlyph /> delivered</span>
+                  : <span className="rp-receipt pending" title="the agent has not collected this yet">pending</span>}
+              </div>
             </div>
           ) : (
             <div key={m.seq} className="rp-agent" dangerouslySetInnerHTML={{ __html: m.html }} />
           )
         ))}
         {err && <div className="rp-err">{err}</div>}
+      </div>
+
+      {/* The state, between the log and the line you type on: it is what you
+          check before sending, so it belongs next to the send, not on the
+          bottom row with the identity. The mark is the app's `.state-mark`
+          vocabulary, so `working` runs the same braille spinner the reader and
+          the cards run and every other state draws that motion's completed
+          path — one contract, not a second spinner. The header's StateLogo is
+          the identity mark and keeps carrying the state on its frame; this row
+          is the other kind of indicator, the one that says what is happening
+          right now in a word. */}
+      <div className="rp-staterow" style={{ fontSize }}>
+        <span className={`state-mark ${state}`} />
+        <span className={`rp-state ${state}`}>{stateLabel}</span>
       </div>
 
       <div className="rp-composer" style={{ fontSize }}>
@@ -316,14 +351,21 @@ export default function RemotePane({
         />
       </div>
 
-      {/* The bottom status row: state, where the agent actually is, when we last
-          heard from it. */}
+      {/* The bottom status row: which harness this is, where the agent actually
+          is, when we last heard from it. The state is no longer here — it moved
+          above the composer, and saying it twice forty pixels apart would read
+          as two opinions. `last seen` stays: it is the one place that narrates
+          time, and pairing it with the state would say when in two voices.
+
+          The separators are interleaved rather than written into each item,
+          because which item comes first depends on what the peer reported. */}
       <div className="rp-status" style={{ fontSize }}>
-        <span className={`rp-state ${state}`}>{stateLabel}</span>
-        {peer?.harness && <><span className="rp-dot">·</span><span>{peer.harness}</span></>}
-        {peer?.cwd && <><span className="rp-dot">·</span><span className="rp-cwd" title={peer.cwd}>{peer.cwd}</span></>}
-        {peer?.host && <><span className="rp-dot">·</span><span>on {peer.host}</span></>}
-        {!peer && <><span className="rp-dot">·</span><span className="rp-cwd">remote-agents/{name}/</span></>}
+        {statusBits.map((bit, i) => (
+          <Fragment key={bit.key}>
+            {i > 0 && <span className="rp-dot">·</span>}
+            {bit.node}
+          </Fragment>
+        ))}
         <span className="spacer" />
         {seenAgo && <span className="rp-seen">last seen {seenAgo}</span>}
         <span className="rp-hint">↵ send · ⇧↵ newline</span>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -620,23 +620,33 @@ body {
 
 /* A bare `.status` is a plain colour dot and has to stay one: UsagePanel and
    SettingsView use it with an inline `background` to carry a provider's or a
-   CLI's own colour, and no state class at all. The state vocabulary below is a
-   specialisation of this, never a replacement — anything drawn on bare
-   `.status` paints over those colours and they lose their identity. */
+   CLI's own colour, and no state class at all. Nothing else may draw on it —
+   anything painted here paints over those colours and they lose their
+   identity, which is why the state vocabulary below is a class of its own
+   rather than a `.status.working` specialisation of this one. */
 .status { width: 8px; height: 8px; border-radius: 50%; flex: none; display: inline-block; transition: background 0.2s, box-shadow 0.2s, opacity 0.2s; }
 
 /* ---- agent state: one path, moving or still ----
-   A working agent shows the braille spinner the reader and the cards already
-   run (`ov-spin`) — the same animation, not a second thing that also means
-   "busy". Every other state shows that motion's completed path: the same
-   square-cornered hollow rectangle, measured from the six-dot ink rather than
-   from the much larger layout cell. State comes only from colour/intensity.
+   `.state-mark` plus a state class. A working agent shows the braille spinner
+   the reader and the cards already run (`ov-spin`) — the same animation, not a
+   second thing that also means "busy". Every other state shows that motion's
+   completed path: the same square-cornered hollow rectangle, measured from the
+   six-dot ink rather than from the much larger layout cell. State comes only
+   from colour/intensity.
+
+   It is drawn by the remote pane's state row. An agent's *identity* mark —
+   sidebar row, pane header, overview card and tile — carries its state on the
+   StateLogo frame instead (#92), and stateLogo.test.mjs holds those surfaces to
+   it. This is the other kind of indicator: a widget that says, in a word and a
+   mark, what is happening right now, the way the reader's `.cx-running` line
+   does mid-turn.
 
    The type/cell/path values are declared once beside `ov-spin` and consumed by
    every renderer. The static path cannot drift away from the animation it
    stands in for because there is one measured contract and everyone reads it.
    Same principle as --cx-gutter (#71) and --ph-pad-y (#75). */
-.status.working, .status.waiting, .status.idle, .status.stopped {
+.state-mark.working, .state-mark.waiting, .state-mark.idle, .state-mark.stopped {
+  flex: none;
   width: var(--mark-w); height: var(--mark-h);
   font-family: var(--font-mono); font-size: var(--mark-size);
   font-weight: var(--mark-weight); line-height: 1;
@@ -644,17 +654,17 @@ body {
   display: inline-flex; align-items: center; position: relative;
   transition: color 0.2s, opacity 0.2s;
 }
-.status.working::before {
+.state-mark.working::before {
   display: inline-flex; align-items: center; box-sizing: border-box;
   width: 100%; height: 100%; background: none; border: none; box-shadow: none;
 }
 /* The same spinner, in the same cell. */
-.status.working { overflow: hidden; }
-.status.working::before {
+.state-mark.working { overflow: hidden; }
+.state-mark.working::before {
   content: '⠋'; transform: translateY(var(--mark-optical-y));
   animation: ov-spin 0.9s steps(1) infinite;
 }
-.status.waiting::before, .status.idle::before, .status.stopped::before {
+.state-mark.waiting::before, .state-mark.idle::before, .state-mark.stopped::before {
   content: ''; position: absolute;
   left: var(--mark-ink-x); top: var(--mark-ink-y);
   width: var(--mark-ink-w); height: var(--mark-ink-h);
@@ -662,9 +672,9 @@ body {
   border: var(--mark-stroke) solid currentColor; border-radius: 0; box-shadow: none;
 }
 /* working and your-turn are both the accent: one moves, one is asking. */
-.status.working, .status.waiting { color: var(--accent); }
-.status.idle, .status.stopped { color: var(--muted); }
-.status.stopped { opacity: 0.5; }
+.state-mark.working, .state-mark.waiting { color: var(--accent); }
+.state-mark.idle, .state-mark.stopped { color: var(--muted); }
+.state-mark.stopped { opacity: 0.5; }
 
 /* the create panel speaks the same dense mono voice as the rows */
 .controls .widget { gap: 6px; padding: 8px; border-radius: var(--r-md); }
@@ -1981,19 +1991,27 @@ a.btn-ghost { text-decoration: none; }
   padding: 3px 8px 3px 6px; margin: 1px 0;
 }
 .rp-caret { color: var(--accent); font-weight: 700; flex: none; }
-/* Not flex:1 — the tick sits immediately after the words, not pushed to the
-   far edge where it reads as unrelated furniture. */
+/* A message is a column: its words, then its receipt on a line of its own.
+   align-items keeps the receipt on the text's left edge whether the message is
+   one word or twelve wrapped lines — a receipt that trailed the last word
+   would land in a different place in every message. */
+.rp-user-body { display: flex; flex-direction: column; align-items: flex-start; min-width: 0; flex: 1; }
 .rp-user-text { white-space: pre-wrap; word-break: break-word; min-width: 0; }
-.rp-ack {
-  flex: none; width: 1.15em; height: 1.15em; color: var(--accent);
-  align-self: center; margin-left: 1px;
+
+/* pending -> delivered happens live, under a log that is pinned to the bottom.
+   Both receipts are this one element at this one line height, so the swap
+   changes the words and the colour and never the block's height: nothing below
+   it can shift, and a pinned log cannot jump. Sized in em, so it follows the
+   pane's zoom with the rest of the surface. */
+.rp-receipt {
+  display: inline-flex; align-items: center; gap: 4px; flex: none;
+  font-size: 0.78em; line-height: 1.5; height: 1.5em; white-space: nowrap;
 }
+.rp-receipt svg { width: 0.95em; height: 0.95em; }
+.rp-receipt.ack { color: var(--accent); }
 /* The other half of the tick: quiet, italic, and out of the way — it marks a
    normal waiting state, not a problem. */
-.rp-pending {
-  flex: none; font-style: italic; font-size: 0.8em; color: var(--muted);
-  opacity: 0.85; margin-left: 2px; white-space: nowrap;
-}
+.rp-receipt.pending { font-style: italic; color: var(--muted); opacity: 0.85; }
 
 .rp-agent { padding-left: 15px; word-break: break-word; }
 .rp-agent p { margin: 0 0 0.5em; }
@@ -2008,6 +2026,30 @@ a.btn-ghost { text-decoration: none; }
 .rp-agent ul, .rp-agent ol { margin: 0.3em 0; padding-left: 1.4em; }
 .rp-agent table { border-collapse: collapse; margin: 0.4em 0; }
 .rp-agent th, .rp-agent td { border: 1px solid var(--border); padding: 2px 7px; text-align: left; }
+
+/* The state, between the log and the line you type on. The mark is the shared
+   `.status` element, so `working` runs `ov-spin` and every other state draws
+   that motion's completed path — see the state vocabulary above.
+
+   --mark-size is the one absolute value in that contract: 12.5px, measured
+   against the bundled mono's braille ink, and declared exactly once (a lint
+   holds it to that). This pane zooms, so the mark is sized here as a ratio of
+   the pane's own font size instead — 0.96em of 13px is that same 12.5px at
+   100%, and every other --mark-* is already em against the mark, so the ink
+   follows on its own. Equal specificity with the vocabulary's own rule, won on
+   source order; what it actually computes to is measured in
+   remotePaneState.render.test.mjs rather than left to be assumed. */
+.rp-staterow {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 12px; border-top: 1px solid var(--border);
+  background: var(--term-bg); font-family: var(--font-mono);
+}
+.rp-staterow .state-mark { font-size: 0.96em; }
+.rp-staterow .rp-state { font-size: 0.9em; }
+/* The word takes the mark's colour, state for state, so the two never disagree:
+   working and your-turn are the accent, an idle or absent connection is muted. */
+.rp-state.working, .rp-state.waiting { color: var(--accent); }
+.rp-state.idle, .rp-state.stopped { color: var(--muted); }
 
 /* Composer: inherits the log's font size (set inline from zoom) so the two
    surfaces match at every zoom level. */
@@ -2025,7 +2067,8 @@ a.btn-ghost { text-decoration: none; }
 }
 .rp-input::placeholder { color: var(--muted); opacity: 0.7; }
 
-/* Bottom context row: state, where the agent is, when it last spoke. */
+/* Bottom context row: which harness this is, where the agent is, when it last
+   spoke. The state itself lives above the composer now. */
 .rp-status {
   display: flex; align-items: center; gap: 5px;
   padding: 4px 12px 5px; border-top: 1px solid var(--border);
@@ -2034,8 +2077,6 @@ a.btn-ghost { text-decoration: none; }
 }
 .rp-status .spacer { flex: 1; }
 .rp-status > span { font-size: 0.82em; }
-.rp-state.working, .rp-state.waiting { color: var(--accent); }
-.rp-state.stopped { color: var(--muted); }
 .rp-dot { opacity: 0.5; }
 .rp-cwd { overflow: hidden; text-overflow: ellipsis; min-width: 0; }
 .rp-seen { opacity: 0.8; }

--- a/web/test/remotePaneState.render.test.mjs
+++ b/web/test/remotePaneState.render.test.mjs
@@ -1,0 +1,206 @@
+// The remote pane's state row and its receipts, measured in a browser.
+//
+// Two claims here cannot be checked by reading CSS, and both are the ones that
+// would break quietly:
+//
+//  1. NO JUMP. `pending` becomes `delivered` while you watch, in a log that is
+//     pinned to the bottom. If the two receipts are not exactly the same height
+//     the whole log shifts by the difference the moment an agent collects a
+//     message. Measured, not reasoned about.
+//  2. ZOOM. The braille contract declares --mark-size in absolute pixels
+//     (12.5px, measured against Geist Mono's braille ink). This pane zooms, so
+//     the row restates it as a ratio; if that override is ever dropped the mark
+//     stays 12.5px while every other glyph around it grows, which reads as a
+//     rendering bug rather than a missing line of CSS.
+//
+// Plus the alignment the placement exists for: a receipt under a twelve-line
+// message still starts on the message's own left edge.
+//
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const css = ['styles.css', 'conversation.css']
+  .map((f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8')).join('\n');
+const geistMono = fs.readFileSync(path.join(HERE, '../public/fonts/GeistMono.woff2')).toString('base64');
+// setContent cannot serve /fonts; put an identical face after the sheet so this
+// measures the bundled font rather than whatever mono the runner happens to
+// have. Same device as statusMark.render.test.mjs.
+const embeddedFont = `@font-face {
+  font-family: 'Geist Mono Test'; font-style: normal; font-weight: 100 900;
+  src: url(data:font/woff2;base64,${geistMono}) format('woff2');
+}
+:root { --font-mono: 'Geist Mono Test'; }`;
+// The spinner is deliberately left running: `working` claiming ov-spin is one of
+// the things this suite checks, and steps(1) means whichever frame is showing is
+// a braille glyph from the contract either way.
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+// The markup RemotePane renders, with the receipt as the component writes it.
+const receipt = (kind) => kind === 'ack'
+  ? '<span class="rp-receipt ack"><svg viewBox="0 0 16 16"></svg> delivered</span>'
+  : '<span class="rp-receipt pending">pending</span>';
+const message = (id, kind, text) => `<div class="rp-user" id="${id}">
+  <span class="rp-caret">❯</span>
+  <div class="rp-user-body">
+    <span class="rp-user-text" id="${id}-text">${text}</span>
+    ${receipt(kind)}
+  </div>
+</div>`;
+
+const LONG = 'when you are back: pull the new cuts and re-render scene 4 at 60fps, '
+  + 'then tell me the render time and whether the audio drifted on the long take';
+
+const pane = (fontSize, width) => `<div class="slot" style="width:${width}px">
+  <div class="rp-body" style="font-size:${fontSize}px">
+    ${message('short-pending', 'pending', 'ping')}
+    ${message('short-ack', 'ack', 'ping')}
+    ${message('long-pending', 'pending', LONG)}
+    ${message('long-ack', 'ack', LONG)}
+  </div>
+  <div class="rp-staterow" id="row-working" style="font-size:${fontSize}px">
+    <span class="state-mark working" id="mark-working"></span><span class="rp-state working">working</span>
+  </div>
+  <div class="rp-staterow" id="row-waiting" style="font-size:${fontSize}px">
+    <span class="state-mark waiting" id="mark-waiting"></span><span class="rp-state waiting">listening</span>
+  </div>
+  <div class="rp-staterow" id="row-stopped" style="font-size:${fontSize}px">
+    <span class="state-mark stopped" id="mark-stopped"></span><span class="rp-state stopped">not connected</span>
+  </div>
+  <div class="rp-composer" style="font-size:${fontSize}px"><span class="rp-caret">❯</span></div>
+</div>`;
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await (await browser.newContext({ viewport: { width: 1000, height: 900 } })).newPage();
+
+const measure = async (fontSize, width) => {
+  await page.setContent(`<style>${css}\n${embeddedFont}</style>${pane(fontSize, width)}`);
+  await page.evaluate(() => document.fonts.ready);
+  return page.evaluate(() => {
+    const box = (id) => {
+      const el = document.getElementById(id);
+      const r = el.getBoundingClientRect();
+      return { x: r.x, y: r.y, w: r.width, h: r.height };
+    };
+    const mark = (id) => {
+      const el = document.getElementById(id);
+      const cs = getComputedStyle(el);
+      const before = getComputedStyle(el, '::before');
+      return {
+        fontSize: parseFloat(cs.fontSize),
+        content: before.content,
+        animation: before.animationName,
+        borderWidth: parseFloat(before.borderTopWidth) || 0,
+        ...box(id),
+      };
+    };
+    const receiptOf = (id) => {
+      const r = document.querySelector(`#${id} .rp-receipt`).getBoundingClientRect();
+      return { x: r.x, y: r.y, h: r.height };
+    };
+    return {
+      blocks: Object.fromEntries(['short-pending', 'short-ack', 'long-pending', 'long-ack']
+        .map((id) => [id, box(id)])),
+      texts: Object.fromEntries(['short-pending', 'short-ack', 'long-pending', 'long-ack']
+        .map((id) => [id, box(`${id}-text`)])),
+      receipts: Object.fromEntries(['short-pending', 'short-ack', 'long-pending', 'long-ack']
+        .map((id) => [id, receiptOf(id)])),
+      marks: { working: mark('mark-working'), waiting: mark('mark-waiting'), stopped: mark('mark-stopped') },
+      rows: { working: box('row-working'), waiting: box('row-waiting'), stopped: box('row-stopped') },
+      composer: document.querySelector('.rp-composer').getBoundingClientRect().y,
+      logBottom: document.querySelector('.rp-body').getBoundingClientRect().bottom,
+      // The text is a flex item, so it is blockified and reports one rect
+      // however many lines it has. A range over its contents reports the real
+      // line boxes.
+      textLines: (() => {
+        const r = document.createRange();
+        r.selectNodeContents(document.getElementById('long-pending-text'));
+        return r.getClientRects().length;
+      })(),
+    };
+  });
+};
+
+const wide = await measure(13, 620);
+const narrow = await measure(13, 260);
+const zoomed = await measure(26, 620);
+
+console.log('a receipt landing cannot move the log');
+for (const [what, m] of [['at 620px', wide], ['at 260px', narrow], ['at 200% zoom', zoomed]]) {
+  check(`${what}: a one-word message is the same height pending or delivered`, () => {
+    assert.equal(m.blocks['short-pending'].h, m.blocks['short-ack'].h);
+  });
+  check(`${what}: a wrapped message is the same height pending or delivered`, () => {
+    assert.equal(m.blocks['long-pending'].h, m.blocks['long-ack'].h);
+  });
+  check(`${what}: the receipt line itself is one height`, () => {
+    assert.equal(m.receipts['long-pending'].h, m.receipts['long-ack'].h);
+  });
+}
+
+console.log('\nthe receipt belongs to the message, on its left edge');
+check('the long message really does wrap at 260px', () => {
+  assert.ok(narrow.textLines >= 3, `wrapped to ${narrow.textLines} line(s)`);
+});
+for (const [what, m] of [['at 620px', wide], ['at 260px', narrow]]) {
+  for (const id of ['long-pending', 'long-ack']) {
+    check(`${what}: ${id} starts on the text's left edge`, () => {
+      assert.ok(Math.abs(m.receipts[id].x - m.texts[id].x) < 1,
+        `receipt x ${m.receipts[id].x} vs text x ${m.texts[id].x}`);
+    });
+    check(`${what}: ${id} sits below the last line of the text`, () => {
+      assert.ok(m.receipts[id].y >= m.texts[id].y + m.texts[id].h - 1,
+        `receipt y ${m.receipts[id].y} vs text bottom ${m.texts[id].y + m.texts[id].h}`);
+    });
+  }
+}
+
+console.log('\nthe state row is between the log and the composer');
+for (const state of ['working', 'waiting', 'stopped']) {
+  check(`the ${state} row is below the log and above the composer`, () => {
+    assert.ok(wide.rows[state].y >= wide.logBottom - 1, 'row is above the log');
+    assert.ok(wide.rows[state].y < wide.composer, 'row is below the composer');
+  });
+}
+
+console.log('\nthe mark is the shared one, and it zooms with the pane');
+check('working runs ov-spin on a braille glyph from the contract', () => {
+  assert.equal(wide.marks.working.animation, 'ov-spin');
+  assert.match(wide.marks.working.content, /[⠋⠙⠹⠸⠼⠴⠦⠧]/);
+});
+for (const state of ['waiting', 'stopped']) {
+  check(`${state} draws the completed path, not a glyph`, () => {
+    assert.equal(wide.marks[state].animation, 'none');
+    assert.equal(wide.marks[state].content, '""');
+    assert.ok(wide.marks[state].borderWidth >= 1, `stroke ${wide.marks[state].borderWidth}px`);
+  });
+}
+for (const state of ['working', 'waiting', 'stopped']) {
+  check(`${state}'s mark doubles when the pane doubles`, () => {
+    const ratio = zoomed.marks[state].fontSize / wide.marks[state].fontSize;
+    assert.ok(Math.abs(ratio - 2) < 0.05, `13px -> ${wide.marks[state].fontSize}px, 26px -> ${zoomed.marks[state].fontSize}px`);
+  });
+  check(`${state}'s mark is not pinned to the contract's absolute 12.5px`, () => {
+    assert.notEqual(zoomed.marks[state].fontSize, 12.5);
+  });
+}
+check('the mark is sized off the row, not off the root', () => {
+  // 0.96em of 13px: close to the 12.5px the contract measures, on purpose.
+  assert.ok(Math.abs(wide.marks.working.fontSize - 12.48) < 0.2, `${wide.marks.working.fontSize}px`);
+});
+
+await browser.close();
+console.log(failed ? `\n${failed} failed` : '\nall good');
+process.exit(failed ? 1 : 0);

--- a/web/test/remotePaneState.test.mjs
+++ b/web/test/remotePaneState.test.mjs
@@ -1,0 +1,141 @@
+// Where the remote pane says its state, and where a message's receipt sits.
+//
+// Two operator decisions are encoded in this layout, and both are the kind that
+// a later edit undoes without anything looking broken:
+//
+//   The state is said ONCE, between the log and the line you type on. It used
+//   to lead the bottom context row; leaving a copy there would put the same
+//   word twice, forty pixels apart, reading as two opinions about one
+//   connection. The header still carries the state, but as a StateLogo — the
+//   CLI tile every pane and the sidebar draw — not as a second word.
+//
+//   The receipt belongs to its message, underneath it. It used to trail the
+//   last word, which lands somewhere different in every message and strands
+//   itself under a wrapped one.
+//
+// And one contract: the mark is the shared `.status` element, so `working` runs
+// the same `ov-spin` the reader and the cards run. A pane that grew its own
+// spinner would be a second thing that also means busy — the failure the state
+// vocabulary in styles.css exists to prevent.
+//
+// Geometry — that the two receipts are the same height so a landing receipt
+// cannot move a bottom-pinned log, and that the mark follows the pane's zoom —
+// is measured in a browser by remotePaneState.render.test.mjs. This file is the
+// part that can be read from source, and it runs everywhere.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const read = (f) => fs.readFileSync(path.join(HERE, '../src', f), 'utf8');
+const tsx = read('components/RemotePane.tsx');
+const css = read('styles.css');
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+const rule = (selector) => {
+  const m = css.match(new RegExp(`^${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{[^}]*\\}`, 'm'));
+  assert.ok(m, `no rule for ${selector}`);
+  return m[0];
+};
+
+console.log('the state sits between the log and the composer');
+const iLog = tsx.indexOf('className="rp-body"');
+const iRow = tsx.indexOf('className="rp-staterow"');
+const iComposer = tsx.indexOf('className="rp-composer"');
+check('all three parts are there', () => {
+  assert.ok(iLog > 0 && iRow > 0 && iComposer > 0, `log ${iLog}, row ${iRow}, composer ${iComposer}`);
+});
+check('and the state row is written between them', () => {
+  assert.ok(iLog < iRow && iRow < iComposer);
+});
+check('the row carries the state word', () => {
+  const row = tsx.slice(iRow, iComposer);
+  assert.match(row, /className=\{`rp-state \$\{state\}`\}>\{stateLabel\}/);
+});
+
+console.log('\nand it is said once');
+check('the bottom context row no longer says the state', () => {
+  const bottom = tsx.slice(tsx.indexOf('className="rp-status"'));
+  assert.doesNotMatch(bottom, /rp-state|stateLabel/);
+});
+check('the header keeps the state on the CLI tile, not in a second word', () => {
+  const header = tsx.slice(tsx.indexOf('className="ph-left"'), iLog);
+  assert.match(header, /<StateLogo\s+cli="remote"\s+state=\{state\}/);
+});
+
+console.log('\nthe mark is the shared one');
+// The braille vocabulary is its own class, not `.status.working`: bare
+// `.status` dots carry inline provider colours (UsagePanel, SettingsView) and
+// stateLogo.test.mjs holds every pane to drawing *identity* state on a
+// StateLogo frame instead. This row is the other kind of indicator.
+check('the row uses the `state-mark` vocabulary', () => {
+  const row = tsx.slice(iRow, iComposer);
+  assert.match(row, /className=\{`state-mark \$\{state\}`\}/);
+});
+check('the pane does not draw a spinner of its own', () => {
+  // No braille glyph and no keyframes anywhere in the pane's own rules: the
+  // animation is declared once, beside the contract it is measured from.
+  const own = css.slice(css.indexOf('.rp-user {'), css.indexOf('.rp-pop-prompt'));
+  assert.doesNotMatch(own, /⠋|⠙|⠹|⠸|⠼|⠴|⠦|⠧|@keyframes/);
+  assert.doesNotMatch(tsx, /⠋|@keyframes/);
+});
+check('the row sizes the mark relative to the pane, so zoom carries it', () => {
+  // The contract's own --mark-size is absolute, measured against the font's
+  // braille ink, and declared exactly once (statusMark.test.mjs holds it to
+  // that). This pane zooms, so the row sizes the mark as a ratio of its own
+  // font size rather than redeclaring the contract's number.
+  const m = rule('.rp-staterow .state-mark').match(/font-size:\s*([^;]+);/);
+  assert.ok(m, '.rp-staterow does not size the mark');
+  assert.match(m[1].trim(), /em$/, `font-size: ${m[1].trim()} would not follow the zoom`);
+  assert.doesNotMatch(rule('.rp-staterow'), /--mark-/);
+});
+
+console.log('\nthe receipt belongs to its message');
+check('it is written inside the message body, after the text', () => {
+  const block = tsx.slice(tsx.indexOf('className="rp-user"'), tsx.indexOf('className="rp-agent"'));
+  const iBody = block.indexOf('className="rp-user-body"');
+  const iText = block.indexOf('className="rp-user-text"');
+  const iReceipt = block.indexOf('className="rp-receipt');
+  assert.ok(iBody > 0 && iBody < iText && iText < iReceipt, `body ${iBody}, text ${iText}, receipt ${iReceipt}`);
+});
+check('the body is a column, so the receipt lands under the text', () => {
+  const r = rule('.rp-user-body');
+  assert.match(r, /flex-direction:\s*column/);
+});
+check('both states are the same element, so nothing else can differ', () => {
+  const block = tsx.slice(tsx.indexOf('className="rp-user"'), tsx.indexOf('className="rp-agent"'));
+  assert.match(block, /className="rp-receipt ack"/);
+  assert.match(block, /className="rp-receipt pending"/);
+});
+check('and neither variant resizes itself', () => {
+  // One height for both, or a receipt landing shifts every line below it.
+  for (const v of ['.rp-receipt.ack', '.rp-receipt.pending']) {
+    assert.doesNotMatch(rule(v), /font-size|line-height|height|padding|margin/, `${v} changes its own box`);
+  }
+  assert.match(rule('.rp-receipt'), /line-height/);
+  assert.match(rule('.rp-receipt'), /height:/);
+});
+check('and it still claims only what a poll returned', () => {
+  // The wording is the whole guarantee: `deliveredThrough` is the highest seq a
+  // poll actually handed over. Nothing here knows whether the agent read it.
+  assert.match(tsx, /highest seq a poll actually returned/);
+  assert.match(tsx, /m\.seq <= \(info\?\.deliveredThrough \?\? 0\)/);
+});
+
+console.log('\nno dead rules left behind');
+for (const gone of ['.rp-ack', '.rp-pending']) {
+  check(`${gone} is gone from the stylesheet`, () => {
+    assert.doesNotMatch(css, new RegExp(`\\${gone}\\b`));
+    assert.doesNotMatch(tsx, new RegExp(`\\${gone.slice(1)}"`));
+  });
+}
+
+console.log(failed ? `\n${failed} failed` : '\nall good');
+process.exit(failed ? 1 : 0);

--- a/web/test/statusMark.render.test.mjs
+++ b/web/test/statusMark.render.test.mjs
@@ -32,7 +32,7 @@ const embeddedFont = `@font-face {
 .parity-sidebar { display:flex; align-items:center; font-weight:400; }
 .parity-overview { display:flex; align-items:center; font-weight:700; }
 .mark-baseline { display:inline-block; width:0; height:0; padding:0; margin:0; }
-.status.working::before, .ov-busy::before,
+.state-mark.working::before, .ov-busy::before,
 .cx-running::before { animation:none !important; }`;
 
 let failed = 0;
@@ -49,22 +49,22 @@ const page = await (await browser.newContext({ viewport: { width: 900, height: 6
 // carry a colour of their own (UsagePanel.tsx, SettingsView.tsx).
 await page.setContent(`<style>${css}\n${embeddedFont}</style>
   <div class="row" style="font-size:16px">
-    <span class="status working" id="working"></span>
-    <span class="status waiting" id="waiting"></span>
-    <span class="status idle" id="idle"></span>
-    <span class="status stopped" id="stopped"></span>
+    <span class="state-mark working" id="working"></span>
+    <span class="state-mark waiting" id="waiting"></span>
+    <span class="state-mark idle" id="idle"></span>
+    <span class="state-mark stopped" id="stopped"></span>
     <span class="status" id="provider" style="background: rgb(214, 69, 69)"></span>
     <span class="status" id="ready" style="background: rgb(46, 158, 91)"></span>
   </div>
-  <div class="parity-sidebar"><span class="status working" id="sidebar-working"></span></div>
+  <div class="parity-sidebar"><span class="state-mark working" id="sidebar-working"></span></div>
   <div class="parity-overview">
-    <span class="status working" id="overview-working"></span>
-    <span class="status waiting" id="overview-waiting"></span>
+    <span class="state-mark working" id="overview-working"></span>
+    <span class="state-mark waiting" id="overview-waiting"></span>
   </div>
   <div class="pane-head" style="width:600px">
     <span class="ph-left"></span>
     <span class="ph-title">
-      <span class="status working" id="header-working"></span>
+      <span class="state-mark working" id="header-working"></span>
       <span class="ph-name">claude-code-4</span>
     </span>
     <span class="ph-right"></span>
@@ -72,7 +72,7 @@ await page.setContent(`<style>${css}\n${embeddedFont}</style>
   <div class="pane-head" style="width:600px">
     <span class="ph-left"></span>
     <span class="ph-title" id="header-static-wrap">
-      <span class="status waiting" id="header-waiting"></span>
+      <span class="state-mark waiting" id="header-waiting"></span>
       <span class="ph-name">claude-code-4<span class="mark-baseline" id="header-baseline"></span></span>
     </span>
     <span class="ph-right"></span>

--- a/web/test/statusMark.test.mjs
+++ b/web/test/statusMark.test.mjs
@@ -74,7 +74,7 @@ check('none of them restates a width', () => {
 });
 check('every spinner consumes the shared type, weight and cell contract', () => {
   for (const spinner of spinners) {
-    if (spinner.selector === '.status.working::before') {
+    if (spinner.selector === '.state-mark.working::before') {
       assert.match(spinner.body, /content:\s*'⠋'/, 'working lost the shared braille family');
       assert.match(spinner.body, /translateY\(var\(--mark-optical-y\)\)/, 'working lost the optical correction');
       continue; // its parent owns the contract; the mark fills it below
@@ -92,7 +92,7 @@ check('every spinner consumes the shared type, weight and cell contract', () => 
 console.log('\nand so does every state that stands in for it');
 
 const STATES = ['working', 'waiting', 'idle', 'stopped'];
-const stateRules = rules.filter((r) => STATES.some((s) => r.selector.includes(`.status.${s}`)));
+const stateRules = rules.filter((r) => STATES.some((s) => r.selector.includes(`.state-mark.${s}`)));
 check('the four states are sized from the cell', () => {
   const sized = stateRules.filter((r) => /width\s*:\s*var\(--mark-w\)/.test(r.body)
     && /height\s*:\s*var\(--mark-h\)/.test(r.body)
@@ -123,12 +123,12 @@ check('no state rule restates a length for its box', () => {
   assert.deepEqual(offenders, [], `these restate the box: ${offenders.join(', ')}`);
 });
 check('working fills the shared cell', () => {
-  const working = rules.find((r) => r.selector === '.status.working::before' && /width\s*:\s*100%/.test(r.body));
+  const working = rules.find((r) => r.selector === '.state-mark.working::before' && /width\s*:\s*100%/.test(r.body));
   assert.ok(working, 'working does not fill the shared cell');
   assert.match(working.body, /height\s*:\s*100%/);
 });
 check('every non-working state uses one measured hollow rectangle', () => {
-  const statics = rules.filter((r) => ['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));
+  const statics = rules.filter((r) => ['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.state-mark.${s}::before`)));
   assert.equal(statics.length, 1, `found ${statics.length} shared static path rules`);
   const body = statics[0].body;
   for (const [prop, variable] of [
@@ -143,8 +143,8 @@ check('every non-working state uses one measured hollow rectangle', () => {
   assert.match(body, /border-radius\s*:\s*0/, 'the path is rounded');
 });
 check('no non-working state overrides that rectangle with its own shape', () => {
-  const offenders = rules.filter((r) => /\.status\.(waiting|idle|stopped)::before/.test(r.selector))
-    .filter((r) => !['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.status.${s}::before`)));
+  const offenders = rules.filter((r) => /\.state-mark\.(waiting|idle|stopped)::before/.test(r.selector))
+    .filter((r) => !['waiting', 'idle', 'stopped'].every((s) => r.selector.includes(`.state-mark.${s}::before`)));
   assert.deepEqual(offenders.map((r) => r.selector), []);
 });
 
@@ -166,14 +166,14 @@ console.log('\nand only working animates');
 
 check('the states that are not working carry no animation', () => {
   for (const state of ['waiting', 'idle', 'stopped']) {
-    for (const r of rules.filter((x) => x.selector.includes(`.status.${state}`))) {
-      assert.doesNotMatch(r.body, /animation:/, `.status.${state} animates`);
+    for (const r of rules.filter((x) => x.selector.includes(`.state-mark.${state}`))) {
+      assert.doesNotMatch(r.body, /animation:/, `.state-mark.${state} animates`);
     }
   }
 });
 check('working runs the same animation the rest of the app runs', () => {
-  const w = rules.find((r) => r.selector === '.status.working::before' && /animation:/.test(r.body));
-  assert.ok(w, 'no `.status.working::before` rule');
+  const w = rules.find((r) => r.selector === '.state-mark.working::before' && /animation:/.test(r.body));
+  assert.ok(w, 'no `.state-mark.working::before` rule');
   assert.match(w.body, /animation:\s*ov-spin/, 'working does not use ov-spin');
 });
 


### PR DESCRIPTION
The operator: *"the status (waiting/working/offline etc) should be between input prompt and messages field (like the working widget in the terminal traces, also with the same braille). also the read/pending signs should be at the bottom of the message field it concerns, not on the right."*

Mock, with screenshots of the built thing: **https://lvwerra-agent-artifacts.static.hf.space/remote-pane-state.html**

## What changed

**The state moves above the composer.** A row of its own between `.rp-body` and `.rp-composer` — the reader's working widget, brought to this pane. `working` runs the shared `ov-spin` braille spinner; `listening` and `not connected` draw that motion's completed path, state carried by colour. The app's own words for the three, unchanged: `REMOTE_STATE_LABEL` says `working` / `listening` / `not connected`, because a remote agent has no process here to be "stopped".

**Receipts move under their message.** `.rp-user` is now a caret plus a column: the words, then the receipt on a line of its own, left-aligned with the text. A receipt that trailed the last word landed in a different place in every message and stranded itself under a wrapped one.

## The braille vocabulary had no renderer, and that is why this touches `.status`

The spinner-and-completed-path vocabulary was written as `.status.working` / `.waiting` / `.idle` / `.stopped`. Nothing in the app drew it:

- bare `.status` is a plain colour dot carrying inline provider/CLI colours (`UsagePanel.tsx:92`, `SettingsView.tsx:362`), and its own comment warns that anything drawn on it paints over those;
- `stateLogo.test.mjs:100-105` holds Overview, Sidebar, TerminalPane, RemotePane and Locked to drawing *identity* state on a `StateLogo` frame instead, asserting none of them renders a state-classed `.status`.

So the class the operator's braille mark lives in was one the panes are forbidden to use. Rather than duplicate the spinner and the rectangle under a pane-private name — the "second thing that also means busy" the block exists to prevent — the vocabulary now has a name of its own: **`.state-mark` plus a state class**. Same rules, same measured `--mark-*` contract, no bare-dot baggage, and one live consumer. `stateLogo.test.mjs` is untouched and still green: this is not an identity mark.

Renamed in `styles.css` and in the two suites that name the selectors (`statusMark.test.mjs`, `statusMark.render.test.mjs`); their content is unchanged, and both still lint and measure the same contract. No renderer existed, so nothing's appearance changed anywhere else.

## Two judgement calls

**The state is said once.** It led the bottom context row before, and I removed it there rather than leaving a copy: the same word twice, forty pixels apart, reads as two opinions about one connection. The bottom row keeps what it is for — harness, working directory, host, `last seen`, the key legend. `last seen` in particular stays put, so one place narrates time. Its separators are now interleaved instead of prefixed to each item, because with the state gone the first item varies and a prefixed dot would leave a leading `·`.

**The header keeps its `StateLogo`.** Not a duplicate: it is the CLI tile whose frame carries the state, the mark every pane and every sidebar row draws, and dropping it here would make remote panes the odd one out. Two different shapes at opposite ends of the pane — *which agent this is* at the top, *what it is doing right now* above the input. Terminal panes already pair a header mark with a working line in the body. (The note that `RemotePane.tsx:208` paints a `.status` dot is not so — it is `<StateLogo cli="remote" state={state} …>`.)

## The watch-outs, measured

| Risk | Result |
|---|---|
| a receipt landing moves a bottom-pinned log | both receipts are one element at one line height. In the running app, **727px into a 1351px log, scrollTop and scrollHeight are identical** before and after. Giving them different heights shifts the log 2px — that is how the check was proved |
| a long message strands or misaligns its receipt | the receipt starts on the text's left edge at 620px and at 260px, wrapped to 3+ lines, in both states |
| the mark ignores the pane's zoom | `--mark-size` is the contract's one absolute value (12.5px, measured against Geist Mono's braille ink) and a lint holds it to a single declaration. So the row sizes the *mark* as `0.96em` of the pane instead — 12.5px at 100%, **18.72px at 150%**, growing by exactly the row's ratio |

## Tests

Three, each mutation-tested (break the source, watch the check fail):

- `web/test/remotePaneState.test.mjs` — source invariants, in the default run: the row is written between the log and the composer, the bottom row does not say the state again, the header keeps the StateLogo, the mark is `.state-mark` and the pane declares no spinner of its own, the receipt is inside the message body after the text, neither receipt variant resizes itself, and the `deliveredThrough` wording is intact. Five mutations, all caught.
- `web/test/remotePaneState.render.test.mjs` — Chromium geometry: block heights equal pending vs delivered at 620px, 260px and 200%; receipt alignment under a wrapped message; the row's position; `ov-spin` on a contract braille glyph vs the still path; the mark doubling with the pane. Three mutations, all caught.
- `server/remote-pane.test.mjs` — the real server and the real component, 27 checks, states produced the way the product produces them (an uncollected message, the agent answering, Disconnect). Includes the pinned-log measurement above. Manual, in `npm run test:ui`, with a free port, `PUBLIC_DIR` pinned to the build under test — inheriting the Space's `PUBLIC_DIR=/app/public` silently measures the deployed bundle, which cost an hour here.

`web: 21 suites passed`, `npm run test:render` green, typecheck and build clean. Server suites all pass except `test/crons.test.mjs` #4, which is red on `e492f8a` before this branch and is being handled elsewhere.
