### PR TITLE
Preview reader and terminal file links inside sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ on local POSIX storage and is restored/checkpointed by
 database backups rather than copying live WAL files. See
 [`docs/agent-state-checkpoints.md`](docs/agent-state-checkpoints.md).
 Scheduled prompts are documented in [`docs/cron-jobs.md`](docs/cron-jobs.md).
+Reader and terminal file links open previews in new tabs; supported paths and
+additional file locations are documented in [`docs/file-links.md`](docs/file-links.md).
 
 ## Architecture
 

--- a/docs/file-links.md
+++ b/docs/file-links.md
@@ -1,0 +1,76 @@
+# File links
+
+File references in the reader and terminal open a read-only preview in a **new
+browser tab**. Web links also open new tabs. The originating session, scroll
+position and composer stay in place; the preview does not start or attach to an
+agent. Markdown, source code, images, HTML and PDFs use the existing Files viewer.
+Unknown binary files offer a download. Transcript JSONL files open as source.
+
+## Supported references
+
+- Markdown links: `[readme](./README.md)`, absolute filesystem paths, and
+  `[source](src/app.ts:42:3)` or `[source](src/app.ts#L42)`.
+- Inline code containing a path, such as `` `docs/notes.md` ``. Fenced code
+  blocks are left alone.
+- Plain paths in terminal output, including soft-wrapped paths and optional
+  line/column suffixes. Explicit OSC 8 `file:///…` hyperlinks also work, including
+  paths with spaces. HTTP(S) OSC 8 links and detected web URLs open new tabs.
+- Relative links and images inside a Markdown preview resolve beside that file.
+
+Relative references from a local session resolve against its configured working
+folder, not the folder of whichever agent is currently selected. `workspace/`
+explicitly means the workspace root. `./workspace/` names an actual subdirectory
+of the session folder. A trace of a local session uses that source session;
+imported traces and remote conversations report that their files are unavailable
+here. Shell `cd` commands and historical per-tool working directories are not
+inferred. Use an absolute path when an agent works outside its configured folder.
+
+After resolving a reference, the preview URL becomes, for example:
+
+```text
+/#file=my-project%2FREADME.md&root=workspace&line=42
+```
+
+“Copy link” copies this URL. It identifies a named file location, independent of
+the originating session. Session rename or deletion does not invalidate it, but
+moving/deleting the file does. It opens the current file contents, not a snapshot.
+The link uses the same private Agent Manager access as the rest of the app.
+
+## Additional file locations
+
+The workspace directory is available as `workspace`. Operators can make other
+directories available for **read-only previews** by setting a JSON map before
+starting the server:
+
+```sh
+AM_FILE_LINK_ROOTS='{"checkouts":"/home/node/local/git"}'
+```
+
+An absolute path under that directory resolves to a stable `root=checkouts` link.
+Only explicitly configured roots are available; names must start with a lowercase
+letter and contain only lowercase letters, numbers, hyphens or underscores.
+`workspace` is reserved, and filesystem roots such as `/` are rejected. Invalid
+configuration fails at startup. This does not add editing access to those roots.
+
+The server checks both the lexical and real path on every resolution, preview,
+raw and download request. Symlinks cannot leave their selected root. Previews
+cap text reads at 512 KiB and disclose truncation. HTML retains the existing
+opaque-origin sandbox and starts with scripts disabled. Missing files, folders,
+unknown locations and unavailable remote files have explicit error states.
+
+Plain terminal detection is intentionally conservative: whitespace and surrounding
+punctuation delimit paths, and wrapped scans are bounded. Use an explicit OSC 8
+link or a Markdown link for filenames with spaces or delimiter characters.
+
+## Verification
+
+```sh
+cd server && node test/file-links.test.mjs
+cd ../web && node test/fileLinks.test.mjs
+npm run build
+```
+
+The server suite checks scope, additional roots, symlinks, missing files, special
+characters, truncation and raw/download headers. The browser suite clicks actual
+reader and xterm links and verifies new tabs, unchanged source state, file URI
+links, nested Markdown assets, source-line navigation, mobile layout and errors.

--- a/docs/file-links.md
+++ b/docs/file-links.md
@@ -1,10 +1,25 @@
 # File links
 
-File references in the reader and terminal open a read-only preview in a **new
-browser tab**. Web links also open new tabs. The originating session, scroll
-position and composer stay in place; the preview does not start or attach to an
-agent. Markdown, source code, images, HTML and PDFs use the existing Files viewer.
+File references in the reader and terminal open a read-only preview **inside the
+originating session pane**. Back/Escape returns through followed links; Close
+returns directly to the session. The session stays mounted, at the same size,
+with its scroll position and composer intact. Other panes remain usable.
+Previewing does not create a session or start/attach to another agent.
+Markdown, source code, images, HTML and PDFs use the existing Files viewer.
 Unknown binary files offer a download. Transcript JSONL files open as source.
+
+**Open in file viewer** keeps the resolved file in a separate Files pane in the
+app, in the originating group when present. It creates a passive Files session
+(not a terminal), or reuses a pane already showing that file. It never replaces
+another pane's unsaved edits. The file selection is remembered in this browser
+across pane switches and reloads, like the existing Files browser; when browser
+storage is unavailable it lasts only until reload. Additional configured roots
+remain read-only in the retained viewer too.
+
+External web links still open new browser tabs with `noopener noreferrer`.
+Modifier-clicks on file links and copied preview URLs can explicitly open a
+standalone preview tab. Ordinary file clicks do not change the browser URL or
+replace the session.
 
 ## Supported references
 
@@ -25,7 +40,8 @@ imported traces and remote conversations report that their files are unavailable
 here. Shell `cd` commands and historical per-tool working directories are not
 inferred. Use an absolute path when an agent works outside its configured folder.
 
-After resolving a reference, the preview URL becomes, for example:
+After resolving a reference, “Copy link” provides a standalone preview URL, for
+example (an embedded preview does not change the app's URL):
 
 ```text
 /#file=my-project%2FREADME.md&root=workspace&line=42
@@ -67,10 +83,12 @@ link or a Markdown link for filenames with spaces or delimiter characters.
 ```sh
 cd server && node test/file-links.test.mjs
 cd ../web && node test/fileLinks.test.mjs
+node test/sessionFilePreview.test.mjs
 npm run build
 ```
 
 The server suite checks scope, additional roots, symlinks, missing files, special
 characters, truncation and raw/download headers. The browser suite clicks actual
-reader and xterm links and verifies new tabs, unchanged source state, file URI
+reader and xterm links and verifies in-pane previews, unchanged source state,
+back/close/focus, retained Files panes and reloads, external new tabs, file URI
 links, nested Markdown assets, source-line navigation, mobile layout and errors.

--- a/server/src/file-links.js
+++ b/server/src/file-links.js
@@ -1,0 +1,110 @@
+// Read-only file links have stable, named roots rather than depending on the
+// lifetime of a Files session. Never use a caller-supplied directory as a root.
+import fs from 'node:fs';
+import path from 'node:path';
+import express from 'express';
+import { kindOfFile, mimeOf, readTextHead } from './preview.js';
+
+export function fileLinkRoots(workspaces, extra = process.env.AM_FILE_LINK_ROOTS || '{}') {
+  const configured = JSON.parse(extra);
+  if (!configured || Array.isArray(configured) || typeof configured !== 'object') {
+    throw new Error('AM_FILE_LINK_ROOTS must be a JSON object of names to absolute directories');
+  }
+  const roots = new Map([['workspace', path.resolve(workspaces)]]);
+  for (const [name, dir] of Object.entries(configured)) {
+    if (!/^[a-z][a-z0-9_-]*$/.test(name) || name === 'workspace'
+      || typeof dir !== 'string' || !path.isAbsolute(dir) || path.resolve(dir) === path.parse(dir).root) {
+      throw new Error('Invalid AM_FILE_LINK_ROOTS entry: ' + name);
+    }
+    roots.set(name, path.resolve(dir));
+  }
+  return roots;
+}
+
+const inside = (root, file) => file === root || file.startsWith(root + path.sep);
+const fail = (message, status = 404) => Object.assign(new Error(message), { status });
+
+function checkedFile(roots, name, relative) {
+  const root = roots.get(name);
+  if (!root) throw fail('This file location is not available here.');
+  const file = path.resolve(root, relative);
+  if (!inside(root, file)) throw fail('This path is outside the available file locations.', 403);
+  let real, stat;
+  try {
+    real = fs.realpathSync(file);
+    if (!inside(fs.realpathSync(root), real)) throw fail('This link leaves its available file location.', 403);
+    stat = fs.statSync(real);
+  } catch (error) {
+    if (error.status) throw error;
+    throw fail('File not found. It may have moved or been deleted.');
+  }
+  if (!stat.isFile()) throw fail('This reference points to a folder. Open it in Files.', 400);
+  return { root: name, path: path.relative(root, file), absolute: file, real, stat };
+}
+
+export function resolveFileLink(roots, getSession, query) {
+  const ref = query.file;
+  if (typeof ref !== 'string' || !ref || ref.length > 8192 || /[\x00-\x1f\\]/.test(ref)) {
+    throw fail('Invalid file reference.', 400);
+  }
+  if (query.root !== undefined) {
+    if (typeof query.root !== 'string' || path.isAbsolute(ref)) throw fail('Invalid file location.', 400);
+    return checkedFile(roots, query.root, ref);
+  }
+
+  let session;
+  if (query.session !== undefined) {
+    if (typeof query.session !== 'string') throw fail('Invalid session.', 400);
+    session = getSession(query.session);
+    if (session?.cli === 'trace') {
+      session = session.traceSource?.kind === 'session' ? getSession(session.traceSource.ref) : null;
+    }
+    if (!session || session.cli === 'remote' || session.cli === 'trace') {
+      throw fail('File unavailable here: this conversation has no local working folder.');
+    }
+  }
+  // Absolute references must map to an explicitly allowed root. Prefer the
+  // most specific root when an operator configured overlapping directories.
+  if (path.isAbsolute(ref)) {
+    const file = path.resolve(ref);
+    const entry = [...roots].sort((a, b) => b[1].length - a[1].length).find(([, root]) => inside(root, file));
+    if (!entry) throw fail('This file is outside the available locations. Configure AM_FILE_LINK_ROOTS to include its folder.', 403);
+    return checkedFile(roots, entry[0], path.relative(entry[1], file));
+  }
+  // `workspace/` is the same explicit workspace-root label shown in the UI.
+  if (ref.startsWith('workspace/')) return checkedFile(roots, 'workspace', ref.slice(10));
+  if (!session) throw fail('This relative reference needs its originating session.');
+  const base = session.cli === 'files' && !session.path ? '' : session.path ?? session.id;
+  return checkedFile(roots, 'workspace', path.join(base, ref));
+}
+
+export function fileLinksRouter({ roots, getSession }) {
+  const router = express.Router();
+  // Every request rechecks the real path, including requests for raw bytes.
+  // No write, delete, or agent-start operation is exposed through this router.
+  router.get('/:action', (req, res, next) => {
+    if (!['resolve', 'preview', 'raw', 'download'].includes(req.params.action)) return next();
+    try {
+      const target = resolveFileLink(roots, getSession, req.query);
+      const { root, path: relative, absolute, real, stat } = target;
+      const publicTarget = { root, path: relative, absolute };
+      res.setHeader('cache-control', 'no-store');
+      if (req.params.action === 'resolve') return res.json(publicTarget);
+      const kind = kindOfFile(real);
+      if (req.params.action === 'preview') {
+        const meta = { path: relative, name: path.basename(absolute), size: stat.size, mtime: stat.mtimeMs, kind, mime: mimeOf(real, kind) };
+        if (kind === 'text' || kind === 'markdown') Object.assign(meta, readTextHead(real));
+        return res.json(meta);
+      }
+      if (req.params.action === 'download') return res.download(real, path.basename(absolute), { dotfiles: 'allow' });
+      res.setHeader('content-type', mimeOf(real, kind));
+      res.setHeader('x-content-type-options', 'nosniff');
+      res.setHeader('content-security-policy', 'sandbox allow-scripts allow-popups allow-forms allow-modals');
+      res.setHeader('content-disposition', `inline; filename="${path.basename(absolute).replace(/[^\w.\- ]/g, '_')}"`);
+      return res.sendFile(real, { dotfiles: 'allow' });
+    } catch (error) {
+      return res.status(error.status || 500).json({ error: error.status ? error.message : 'Could not read this file.' });
+    }
+  });
+  return router;
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -46,6 +46,7 @@ import {
 import * as runstate from './runstate.js';
 import { installSlowFsProbe } from './slowfs.js';
 import { operationMiddleware, readOperations } from './operations.js';
+import { fileLinkRoots, fileLinksRouter } from './file-links.js';
 
 // Before anything else touches the mount: a sync fs call to /data is ~85ms of
 // frozen event loop here, and nothing else in the stack can see it. See slowfs.js.
@@ -1745,6 +1746,8 @@ app.delete('/api/skills/:name', (req, res) => {
 });
 
 // ---------- file browser (for the Files agent) ----------
+app.use('/api/file-links', fileLinksRouter({ roots: fileLinkRoots(WORKSPACES_DIR), getSession: store.get }));
+
 function folderPathOf(session) {
   // A Files agent without a chosen location browses the whole workspace root.
   if (session.cli === 'files' && !session.path) return WORKSPACES_DIR;

--- a/server/test/file-links.test.mjs
+++ b/server/test/file-links.test.mjs
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import express from 'express';
+import { fileLinkRoots, fileLinksRouter, resolveFileLink } from '../src/file-links.js';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'am-file-links-'));
+const workspace = path.join(tmp, 'workspaces'), checkouts = path.join(tmp, 'checkouts');
+fs.mkdirSync(path.join(workspace, 'team', 'docs'), { recursive: true });
+fs.mkdirSync(checkouts);
+fs.writeFileSync(path.join(workspace, 'team', 'README.md'), '# Workspace readme');
+fs.writeFileSync(path.join(workspace, 'team', 'docs', 'a #1%.md'), 'Spaces, percent and hash');
+fs.writeFileSync(path.join(workspace, 'team', 'page.html'), '<script>parent.fetch("/api/sessions")</script>');
+fs.writeFileSync(path.join(workspace, 'team', '.notes'), 'hidden by convention, not forbidden');
+fs.writeFileSync(path.join(workspace, 'team', 'large.txt'), 'x'.repeat(600 * 1024));
+fs.writeFileSync(path.join(checkouts, 'README.md'), 'Checkout readme');
+fs.writeFileSync(path.join(tmp, 'private.txt'), 'not in an allowed root');
+fs.symlinkSync(path.join(tmp, 'private.txt'), path.join(workspace, 'team', 'escape.txt'));
+fs.symlinkSync(path.join(workspace, 'team', 'README.md'), path.join(workspace, 'team', 'safe.md'));
+const roots = fileLinkRoots(workspace, JSON.stringify({ checkouts }));
+const sessions = new Map([
+  ['a', { id: 'a', cli: 'claude', path: 'team' }],
+  ['b', { id: 'b', cli: 'codex', path: 'team/docs' }],
+  ['shared', { id: 'shared', cli: 'codex', path: 'team' }],
+  ['root', { id: 'root', cli: 'files', path: null }],
+  ['remote', { id: 'remote', cli: 'remote', path: 'team' }],
+  ['import', { id: 'import', cli: 'trace', path: 'team', traceSource: { kind: 'bundle', ref: 'bundle' } }],
+  ['trace', { id: 'trace', cli: 'trace', traceSource: { kind: 'session', ref: 'a' } }],
+]);
+const getSession = (id) => sessions.get(id);
+const resolve = (query) => resolveFileLink(roots, getSession, query);
+const app = express();
+app.use('/api/file-links', fileLinksRouter({ roots, getSession }));
+const server = app.listen(0, '127.0.0.1');
+await new Promise((resolve) => server.once('listening', resolve));
+const base = `http://127.0.0.1:${server.address().port}/api/file-links`;
+const get = (action, query) => fetch(`${base}/${action}?${new URLSearchParams(query)}`);
+try {
+  for (const session of ['a', 'shared', 'trace']) assert.equal(resolve({ session, file: 'README.md' }).path, 'team/README.md');
+  assert.equal(resolve({ session: 'b', file: '../README.md' }).path, 'team/README.md');
+  assert.equal(resolve({ session: 'a', file: 'workspace/team/README.md' }).path, 'team/README.md');
+  assert.equal(resolve({ session: 'root', file: 'team/README.md' }).path, 'team/README.md');
+  assert.equal(resolve({ file: path.join(checkouts, 'README.md') }).root, 'checkouts');
+  assert.equal(resolve({ file: path.join(workspace, 'team/README.md') }).root, 'workspace');
+  assert.equal(resolve({ root: 'workspace', file: 'team/safe.md' }).path, 'team/safe.md');
+  for (const query of [
+    { root: 'workspace', file: '../private.txt' },
+    { root: 'workspace', file: 'team/escape.txt' },
+    { root: 'workspace', file: '/etc/passwd' },
+    { file: path.join(tmp, 'private.txt') },
+    { file: path.join(tmp, 'workspaces-other', 'file.txt') },
+    { root: 'missing', file: 'README.md' },
+    { file: 'README.md' },
+    { session: 'remote', file: 'README.md' },
+    { session: 'import', file: path.join(workspace, 'team/README.md') },
+    { session: 'deleted', file: 'README.md' },
+    { file: ['README.md', 'private.txt'] },
+    { root: 'workspace', file: 'team\u0000/README.md' },
+    { root: 'workspace', file: 'team' },
+  ]) assert.throws(() => resolve(query), undefined, JSON.stringify(query));
+  for (const config of ['[]', 'null', '{"workspace":"/tmp"}', '{"all":"/"}', '{"local":"relative"}']) {
+    assert.throws(() => fileLinkRoots(workspace, config));
+  }
+  const canonical = { root: 'workspace', file: 'team/README.md' };
+  sessions.delete('a');
+  assert.equal((await (await get('preview', canonical)).json()).text, '# Workspace readme', 'canonical links survive source deletion');
+  const special = await get('raw', { root: 'workspace', file: 'team/docs/a #1%.md' });
+  assert.equal(await special.text(), 'Spaces, percent and hash');
+  const large = await (await get('preview', { root: 'workspace', file: 'team/large.txt' })).json();
+  assert.equal(large.truncated, true); assert.ok(large.text.length <= 512 * 1024);
+  const html = await get('raw', { root: 'workspace', file: 'team/page.html' });
+  assert.match(html.headers.get('content-security-policy'), /^sandbox /);
+  assert.doesNotMatch(html.headers.get('content-security-policy'), /allow-same-origin/);
+  assert.equal(html.headers.get('x-content-type-options'), 'nosniff');
+  assert.match(html.headers.get('content-type'), /^text\/html/);
+  assert.equal((await get('raw', { root: 'workspace', file: 'team/.notes' })).status, 200);
+  assert.equal((await get('raw', { root: 'workspace', file: 'team/escape.txt' })).status, 403);
+  assert.equal((await get('raw', { root: 'workspace', file: 'team/missing.md' })).status, 404);
+  const download = await get('download', canonical);
+  assert.match(download.headers.get('content-disposition'), /attachment/);
+  assert.equal((await fetch(`${base}/write?${new URLSearchParams(canonical)}`, { method: 'PUT', body: 'bad' })).status, 404);
+  assert.equal(fs.readFileSync(path.join(workspace, 'team/README.md'), 'utf8'), '# Workspace readme');
+  console.log('file-links: session and canonical resolution, additional roots, bounded previews, sandboxing, and read-only access passed');
+} finally {
+  await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,9 @@ import Sidebar from './components/Sidebar';
 import type { QuickStartAttachmentOptions } from './components/Sidebar';
 import TerminalPane from './components/TerminalPane';
 import FilesPane from './components/FilesPane';
+import PaneFilePreview from './components/PaneFilePreview';
+import { retainFileViewer } from './lib/fileViewer';
+import type { FileLinkRequest } from './lib/fileLinks';
 import TracePane from './components/TracePane';
 import RemotePane from './components/RemotePane';
 import SettingsView from './components/SettingsView';
@@ -777,12 +780,12 @@ export default function App() {
     }
   };
   // Clicking a session: nested → open its group with that pane focused; loose → solo view.
-  const openSession = (sid: string, groupId?: string) => {
+  const openSession = (sid: string, groupId?: string, navigationTree = tree) => {
     if (groupId) {
       setActiveRef(`g:${groupId}`);
       setFocusedId(sid);
       // Land on the page that actually contains this agent's pane.
-      const g = groupById[groupId];
+      const g = navigationTree.groups.find((group) => group.id === groupId);
       const idx = g?.sessionIds.indexOf(sid) ?? -1;
       const gg = isMobile ? { cols: 1, rows: 1 } : (g?.layout ?? autoGrid(g?.sessionIds.length ?? 1));
       setPage(idx >= 0 ? Math.floor(idx / (gg.cols * gg.rows)) : 0);
@@ -796,6 +799,16 @@ export default function App() {
     setActiveRef(ref);
     setPage(0);
     if (isMobile) setMobileStage(true);
+  };
+  const openInFileViewer = async (request: FileLinkRequest, sourceId: string) => {
+    const groupId = tree.groups.find((group) => group.sessionIds.includes(sourceId))?.id;
+    const pane = await retainFileViewer(request, tree.sessions, groupId);
+    const next = await api.getTree();
+    setTree(next);
+    const destination = next.groups.find((group) => group.sessionIds.includes(pane.id));
+    // Use the refreshed group to find the appended pane, including fixed grids
+    // whose new file viewer lands on a later page.
+    openSession(pane.id, destination?.id, next);
   };
   // Someone shared a session as a Hub dataset: pull it down, then open a pane on
   // it. Errors propagate so the sidebar can show the server's own reason inline
@@ -923,6 +936,7 @@ export default function App() {
               style={shown ? slotStyle(slot) : undefined}
               {...(shown && activeGroup ? tileDnd(slot, true) : {})}
             >
+              <PaneFilePreview onOpenInViewer={(request) => openInFileViewer(request, s.id)}>
               <TerminalPane
                 session={s}
                 onShare={isShareable(s.cli) ? () => setShareId(s.id) : undefined}
@@ -942,6 +956,7 @@ export default function App() {
                 onRename={(name) => renameSession(s.id, name)}
                 onClose={() => closePane(s.id)}
               />
+              </PaneFilePreview>
             </div>
           );
         })}
@@ -952,7 +967,7 @@ export default function App() {
             style={slotStyle(i)}
             {...(activeGroup ? tileDnd(i, !!s) : {})}
           >
-            {s && (s.cli === 'files' ? (
+            {s && <PaneFilePreview onOpenInViewer={(request) => openInFileViewer(request, s.id)}>{s.cli === 'files' ? (
               <FilesPane
                 session={s}
                 zoom={zoom}
@@ -995,7 +1010,7 @@ export default function App() {
                 onHandover={() => setHandoverFor(s.id)}
                 onClose={() => closePane(s.id)}
               />
-            ))}
+            )}</PaneFilePreview>}
           </div>
         )))}
         {ghost && (

--- a/web/src/components/CodeView.tsx
+++ b/web/src/components/CodeView.tsx
@@ -43,9 +43,11 @@ export type CodeViewProps = {
   theme: 'light' | 'dark';
   /** Soft-wrap long lines instead of scrolling sideways. */
   wrap?: boolean;
+  line?: number;
+  column?: number;
 };
 
-export default function CodeView({ text, name, editable, onChange, onSave, theme, wrap = false }: CodeViewProps) {
+export default function CodeView({ text, name, editable, onChange, onSave, theme, wrap = false, line, column }: CodeViewProps) {
   const host = useRef<HTMLDivElement | null>(null);
   const view = useRef<any>(null);
   const core = useRef<CM | null>(null);
@@ -97,6 +99,9 @@ export default function CodeView({ text, name, editable, onChange, onSave, theme
   useEffect(() => { if (view.current) core.current?.setEditable(view.current, editable); }, [editable]);
   useEffect(() => { if (view.current) core.current?.setWrap(view.current, wrap); }, [wrap]);
   useEffect(() => { if (view.current) core.current?.setTheme(view.current, theme); }, [theme]);
+  useEffect(() => {
+    if (ready && view.current && line) core.current?.revealLine(view.current, line, column);
+  }, [ready, line, column]);
 
   return (
     <div className="fv-code-host">

--- a/web/src/components/FileLinkContent.tsx
+++ b/web/src/components/FileLinkContent.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { fileLinkUrl, fileRequest, looksLikeFile, requestFromHash, type FileLinkContext } from '../lib/fileLinks';
+
+const Context = createContext<FileLinkContext>({});
+export function FileLinkScope({ session, root, base, unavailable, children }: FileLinkContext & { children: ReactNode }) {
+  const value = useMemo(() => ({ session, root, base, unavailable }), [session, root, base, unavailable]);
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+}
+
+// `html` has already passed through renderMarkdown's sanitizer. Only generated
+// app URLs are added here; no untrusted HTML or attributes are inserted.
+export function linkFileContent(html: string, context: FileLinkContext): string {
+  // Static renders have no browser navigation to decorate.
+  if (typeof document === 'undefined') return html;
+  const host = document.createElement('div');
+  host.innerHTML = html;
+  const decorate = (anchor: HTMLAnchorElement, value: string, encoded: boolean) => {
+    // renderMarkdown protects file:// links before sanitizing them.
+    const protectedRef = value.startsWith('#file=') ? requestFromHash(value) : null;
+    const request = protectedRef?.root || protectedRef?.session ? protectedRef
+      : fileRequest(protectedRef?.file || value, context, protectedRef ? false : encoded);
+    if (!request) return;
+    if (protectedRef?.line) request.line = protectedRef.line;
+    if (protectedRef?.column) request.column = protectedRef.column;
+    anchor.href = fileLinkUrl(request);
+    anchor.dataset.fileLink = 'true';
+    anchor.title = `Open ${request.file}${request.line ? `:${request.line}` : ''}`;
+  };
+  host.querySelectorAll('a[href]').forEach((anchor) => {
+    decorate(anchor as HTMLAnchorElement, anchor.getAttribute('href')!, true);
+    anchor.setAttribute('target', '_blank');
+    anchor.setAttribute('rel', 'noopener noreferrer');
+  });
+  host.querySelectorAll('code').forEach((code) => {
+    if (code.closest('pre, a') || !looksLikeFile(code.textContent || '')) return;
+    const anchor = document.createElement('a');
+    decorate(anchor, code.textContent!, false);
+    if (!anchor.dataset.fileLink) return;
+    anchor.target = '_blank'; anchor.rel = 'noopener noreferrer';
+    code.replaceWith(anchor); anchor.append(code);
+  });
+  return host.innerHTML;
+}
+
+export default function FileLinkContent({ html, className }: { html: string; className?: string }) {
+  const context = useContext(Context);
+  const linked = useMemo(() => linkFileContent(html, context), [html, context]);
+  return <div className={className} dangerouslySetInnerHTML={{ __html: linked }} />;
+}

--- a/web/src/components/FileLinkContent.tsx
+++ b/web/src/components/FileLinkContent.tsx
@@ -1,5 +1,9 @@
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
-import { fileLinkUrl, fileRequest, looksLikeFile, requestFromHash, type FileLinkContext } from '../lib/fileLinks';
+import { fileLinkUrl, fileRequest, looksLikeFile, requestFromHash, type FileLinkContext, type FileLinkRequest } from '../lib/fileLinks';
+
+// Separate from path resolution: nested Markdown scopes keep the pane's opener.
+export const FilePreviewContext = createContext<((request: FileLinkRequest) => void) | undefined>(undefined);
+export const useFilePreview = () => useContext(FilePreviewContext);
 
 const Context = createContext<FileLinkContext>({});
 export function FileLinkScope({ session, root, base, unavailable, children }: FileLinkContext & { children: ReactNode }) {
@@ -44,6 +48,13 @@ export function linkFileContent(html: string, context: FileLinkContext): string 
 
 export default function FileLinkContent({ html, className }: { html: string; className?: string }) {
   const context = useContext(Context);
+  const open = useFilePreview();
   const linked = useMemo(() => linkFileContent(html, context), [html, context]);
-  return <div className={className} dangerouslySetInnerHTML={{ __html: linked }} />;
+  return <div className={className} dangerouslySetInnerHTML={{ __html: linked }} onClick={(event) => {
+    if (!open || event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+    const anchor = (event.target as Element).closest<HTMLAnchorElement>('a[data-file-link]');
+    const request = anchor && requestFromHash(anchor.hash);
+    if (!request) return;
+    event.preventDefault(); event.stopPropagation(); open(request);
+  }} />;
 }

--- a/web/src/components/FileLinkPage.tsx
+++ b/web/src/components/FileLinkPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FileView, type LinkedFileSource, type ViewInfo } from './FilesPane';
+import FileWrapToggle from './FileWrapToggle';
+import { fileLinkUrl, fileResourceUrl, resolveFileLink, type FileLinkRequest, type FileLinkTarget } from '../lib/fileLinks';
+import { DownloadGlyph, FileGlyph, RefreshGlyph } from './icons';
+import '../file-links.css';
+
+// Opened in its own browser tab. No App or terminal is mounted, so following a
+// link cannot start/claim a PTY, change the selected session, or lose a draft.
+export default function FileLinkPage({ request }: { request: FileLinkRequest }) {
+  const [target, setTarget] = useState<FileLinkTarget | null>(null);
+  const [error, setError] = useState('');
+  const [reload, setReload] = useState(0);
+  const [raw, setRaw] = useState(!!request.line);
+  const [info, setInfo] = useState<ViewInfo>({ meta: null, extra: [] });
+  const [copied, setCopied] = useState('');
+  const resolved = useRef({ original: request, current: request });
+  if (resolved.current.original !== request) resolved.current = { original: request, current: request };
+
+  useEffect(() => {
+    let theme: string | null = null;
+    try { theme = localStorage.getItem('am-theme'); } catch { /* private storage */ }
+    document.documentElement.dataset.theme = theme || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+  }, []);
+
+  useEffect(() => {
+    let alive = true;
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => controller.abort(), 12_000);
+    setError(''); setTarget(null); setInfo({ meta: null, extra: [] });
+    resolveFileLink(resolved.current.current, controller.signal).then((next) => {
+      if (controller.signal.aborted) return;
+      setTarget(next);
+      const canonical = { file: next.path, root: next.root, line: request.line, column: request.column };
+      resolved.current.current = canonical;
+      history.replaceState(null, '', fileLinkUrl(canonical));
+      document.title = next.path.split('/').pop() + ' · Agent Manager';
+    }).catch((err) => {
+      if (!alive) return;
+      setError(controller.signal.aborted ? 'The file request timed out. Try again.' : String(err.message || err));
+    }).finally(() => clearTimeout(timer));
+    return () => { alive = false; clearTimeout(timer); controller.abort(); };
+  }, [request, reload]);
+
+  const source = useMemo<LinkedFileSource | undefined>(() => {
+    if (!target) return undefined;
+    const file = { file: target.path, root: target.root };
+    return {
+      root: target.root,
+      preview: async () => {
+        const response = await fetch(fileResourceUrl('preview', file), { signal: AbortSignal.timeout(12_000) });
+        const body = await response.json();
+        if (!response.ok) throw new Error(body.error || 'Could not read this file.');
+        return body;
+      },
+      rawUrl: fileResourceUrl('raw', file),
+      downloadUrl: fileResourceUrl('download', file),
+    };
+  }, [target]);
+
+  const copy = async (value: string, label: string) => {
+    try { await navigator.clipboard.writeText(value); setCopied(label); }
+    catch { setCopied('Copy unavailable in this browser'); }
+  };
+  const kind = info.meta?.kind;
+  return <main className="file-link-page">
+    <header className="file-link-head">
+      <FileGlyph />
+      <div className="file-link-title">
+        <h1>{target?.path.split('/').pop() || 'File preview'}</h1>
+        <div className="file-link-path" title={target?.absolute || request.file}>{target?.absolute || request.file}</div>
+      </div>
+      <a className="mini-btn" href={location.pathname + location.search} target="_blank" rel="noopener noreferrer">Agent Manager ↗</a>
+    </header>
+    <div className="file-link-tools">
+      {kind && <span className="mono">{kind} · read-only</span>}
+      {info.extra.map((text) => <span className="mono" key={text}>{text}</span>)}
+      {!!request.line && <span className="mono">line {request.line}{request.column ? `:${request.column}` : ''}</span>}
+      <span className="spacer" />
+      {(kind === 'markdown' || kind === 'html') && <button className="mini-btn" onClick={() => setRaw(!raw)}>{raw ? 'Preview' : 'Source'}</button>}
+      {info.showWrap && info.edit && <FileWrapToggle wrap={info.edit.wrap} onChange={info.edit.setWrap} />}
+      <button className="mini-btn" onClick={() => setReload((n) => n + 1)} title="Reload file"><RefreshGlyph /></button>
+      {target && <>
+        <button className="mini-btn" onClick={() => void copy(target.absolute, 'Path copied')}>Copy path</button>
+        <button className="mini-btn" onClick={() => void copy(location.href, 'Link copied')}>Copy link</button>
+        <a className="mini-btn" href={source?.downloadUrl} download><DownloadGlyph /> Download</a>
+      </>}
+    </div>
+    {copied && <div className="file-link-notice" role="status">{copied}</div>}
+    {error ? <div className="fv-empty" role="alert">Could not open this file.<div className="fv-sub">{error}</div>
+      <button className="mini-btn" onClick={() => setReload((n) => n + 1)}>Retry</button>
+    </div> : target && source ? <FileView key={`${target.root}:${target.path}:${reload}`} sessionId="file-link-preview"
+      path={target.path} source={source} zoom={100} raw={raw} scripts={false} line={raw || kind === 'text' ? request.line : undefined}
+      column={request.column} onInfo={setInfo} /> : <div className="fv-empty" role="status">Locating file…</div>}
+  </main>;
+}

--- a/web/src/components/FileLinkPage.tsx
+++ b/web/src/components/FileLinkPage.tsx
@@ -2,26 +2,38 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { FileView, type LinkedFileSource, type ViewInfo } from './FilesPane';
 import FileWrapToggle from './FileWrapToggle';
 import { fileLinkUrl, fileResourceUrl, resolveFileLink, type FileLinkRequest, type FileLinkTarget } from '../lib/fileLinks';
-import { DownloadGlyph, FileGlyph, RefreshGlyph } from './icons';
+import { BackGlyph, CloseGlyph, DownloadGlyph, FileGlyph, RefreshGlyph } from './icons';
 import '../file-links.css';
 
-// Opened in its own browser tab. No App or terminal is mounted, so following a
-// link cannot start/claim a PTY, change the selected session, or lose a draft.
-export default function FileLinkPage({ request }: { request: FileLinkRequest }) {
+// Shared read-only surface: transient session preview, retained Files pane, or
+// a copied link opened directly. Embedded previews never change browser history.
+export default function FileLinkPage({ request, embedded = false, onBack, onClose, onOpenInViewer, dragId, onDragActive, closeLabel = 'Close preview' }: {
+  request: FileLinkRequest;
+  embedded?: boolean;
+  onBack?: () => void;
+  onClose?: () => void;
+  onOpenInViewer?: (request: FileLinkRequest) => Promise<void>;
+  dragId?: string;
+  onDragActive?: (dragging: boolean) => void;
+  closeLabel?: string;
+}) {
   const [target, setTarget] = useState<FileLinkTarget | null>(null);
   const [error, setError] = useState('');
   const [reload, setReload] = useState(0);
   const [raw, setRaw] = useState(!!request.line);
   const [info, setInfo] = useState<ViewInfo>({ meta: null, extra: [] });
   const [copied, setCopied] = useState('');
+  const [keeping, setKeeping] = useState(false);
+  const [keepError, setKeepError] = useState('');
   const resolved = useRef({ original: request, current: request });
   if (resolved.current.original !== request) resolved.current = { original: request, current: request };
 
   useEffect(() => {
+    if (embedded) return;
     let theme: string | null = null;
     try { theme = localStorage.getItem('am-theme'); } catch { /* private storage */ }
     document.documentElement.dataset.theme = theme || (matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
-  }, []);
+  }, [embedded]);
 
   useEffect(() => {
     let alive = true;
@@ -29,18 +41,20 @@ export default function FileLinkPage({ request }: { request: FileLinkRequest }) 
     const timer = window.setTimeout(() => controller.abort(), 12_000);
     setError(''); setTarget(null); setInfo({ meta: null, extra: [] });
     resolveFileLink(resolved.current.current, controller.signal).then((next) => {
-      if (controller.signal.aborted) return;
+      if (!alive || controller.signal.aborted) return;
       setTarget(next);
       const canonical = { file: next.path, root: next.root, line: request.line, column: request.column };
       resolved.current.current = canonical;
-      history.replaceState(null, '', fileLinkUrl(canonical));
-      document.title = next.path.split('/').pop() + ' · Agent Manager';
+      if (!embedded) {
+        history.replaceState(null, '', fileLinkUrl(canonical));
+        document.title = next.path.split('/').pop() + ' · Agent Manager';
+      }
     }).catch((err) => {
       if (!alive) return;
       setError(controller.signal.aborted ? 'The file request timed out. Try again.' : String(err.message || err));
     }).finally(() => clearTimeout(timer));
     return () => { alive = false; clearTimeout(timer); controller.abort(); };
-  }, [request, reload]);
+  }, [request, reload, embedded]);
 
   const source = useMemo<LinkedFileSource | undefined>(() => {
     if (!target) return undefined;
@@ -63,34 +77,44 @@ export default function FileLinkPage({ request }: { request: FileLinkRequest }) 
     catch { setCopied('Copy unavailable in this browser'); }
   };
   const kind = info.meta?.kind;
-  return <main className="file-link-page">
-    <header className="file-link-head">
-      <FileGlyph />
+  return <section className={`file-link-page${embedded ? ' file-link-embedded' : ''}`} aria-label="File preview">
+    <header className={`file-link-head${dragId ? ' draggable' : ''}`} draggable={!!dragId}
+      onDragStart={dragId ? (event) => { event.dataTransfer.setData('text/plain', dragId); event.dataTransfer.effectAllowed = 'move'; onDragActive?.(true); } : undefined}
+      onDragEnd={dragId ? () => onDragActive?.(false) : undefined}>
+      {onBack ? <button className="mini-btn" onClick={onBack} title="Back" aria-label="Back"><BackGlyph /></button> : <FileGlyph />}
       <div className="file-link-title">
         <h1>{target?.path.split('/').pop() || 'File preview'}</h1>
         <div className="file-link-path" title={target?.absolute || request.file}>{target?.absolute || request.file}</div>
       </div>
-      <a className="mini-btn" href={location.pathname + location.search} target="_blank" rel="noopener noreferrer">Agent Manager ↗</a>
+      {onClose && <button className="mini-btn" onClick={onClose} title={closeLabel} aria-label={closeLabel}><CloseGlyph /></button>}
+      {!embedded && <a className="mini-btn" href={location.pathname + location.search} target="_blank" rel="noopener noreferrer">Agent Manager ↗</a>}
     </header>
     <div className="file-link-tools">
       {kind && <span className="mono">{kind} · read-only</span>}
       {info.extra.map((text) => <span className="mono" key={text}>{text}</span>)}
       {!!request.line && <span className="mono">line {request.line}{request.column ? `:${request.column}` : ''}</span>}
       <span className="spacer" />
+      {onOpenInViewer && <button className="mini-btn" disabled={!target || keeping} onClick={async () => {
+        setKeeping(true); setKeepError('');
+        try { await onOpenInViewer(resolved.current.current); }
+        catch (err) { setKeepError(err instanceof Error ? err.message : 'Could not open the file viewer. Try again.'); }
+        finally { setKeeping(false); }
+      }}><FileGlyph /> {keeping ? 'Opening…' : 'Open in file viewer'}</button>}
       {(kind === 'markdown' || kind === 'html') && <button className="mini-btn" onClick={() => setRaw(!raw)}>{raw ? 'Preview' : 'Source'}</button>}
       {info.showWrap && info.edit && <FileWrapToggle wrap={info.edit.wrap} onChange={info.edit.setWrap} />}
       <button className="mini-btn" onClick={() => setReload((n) => n + 1)} title="Reload file"><RefreshGlyph /></button>
       {target && <>
         <button className="mini-btn" onClick={() => void copy(target.absolute, 'Path copied')}>Copy path</button>
-        <button className="mini-btn" onClick={() => void copy(location.href, 'Link copied')}>Copy link</button>
+        <button className="mini-btn" onClick={() => void copy(new URL(fileLinkUrl(resolved.current.current), location.href).href, 'Link copied')}>Copy link</button>
         <a className="mini-btn" href={source?.downloadUrl} download><DownloadGlyph /> Download</a>
       </>}
     </div>
     {copied && <div className="file-link-notice" role="status">{copied}</div>}
+    {keepError && <div className="file-link-notice" role="alert">{keepError}</div>}
     {error ? <div className="fv-empty" role="alert">Could not open this file.<div className="fv-sub">{error}</div>
       <button className="mini-btn" onClick={() => setReload((n) => n + 1)}>Retry</button>
     </div> : target && source ? <FileView key={`${target.root}:${target.path}:${reload}`} sessionId="file-link-preview"
       path={target.path} source={source} zoom={100} raw={raw} scripts={false} line={raw || kind === 'text' ? request.line : undefined}
       column={request.column} onInfo={setInfo} /> : <div className="fv-empty" role="status">Locating file…</div>}
-  </main>;
+  </section>;
 }

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { recall, remember, readWrap, writeWrap } from './filesMemory';
 import type { Session } from '../types';
 import * as api from '../api';
@@ -6,7 +6,7 @@ import { Rails, railPad } from './Rails';
 import type { FileEntry, FileKind, FilePreview } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
-import FileLinkContent, { FileLinkScope } from './FileLinkContent';
+import FileLinkContent, { FileLinkScope, FilePreviewContext } from './FileLinkContent';
 import { fileRequest, fileResourceUrl } from '../lib/fileLinks';
 import CodeView from './CodeView';
 import FileWrapToggle from './FileWrapToggle';
@@ -884,7 +884,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved,
   );
 }
 
-export default function FilesPane({
+function FilesBrowser({
   session, focused, zoom = 100, dragId, onDragActive, onFocus, onClose,
 }: {
   session: Session;
@@ -1337,4 +1337,28 @@ export default function FilesPane({
       </div>
     </div>
   );
+}
+
+const LinkedFileView = lazy(() => import('./FileLinkPage'));
+
+export default function FilesPane(props: Parameters<typeof FilesBrowser>[0]) {
+  const linkedPane = useRef<HTMLDivElement>(null);
+  const [trail, setTrail] = useState(() => {
+    const request = recall(props.session.id).linkedFile;
+    return request ? [request] : [];
+  });
+  const current = trail[trail.length - 1];
+  useEffect(() => { remember(props.session.id, { linkedFile: current || null }); }, [props.session.id, current]);
+  useEffect(() => { if (current) linkedPane.current?.focus({ preventScroll: true }); }, [current]);
+  const back = () => setTrail((old) => old.slice(0, -1));
+  if (!current) return <FilesBrowser {...props} />;
+  return <FilePreviewContext.Provider value={(request) => setTrail((old) => [...old, request])}>
+    <div className={`slot${props.focused ? ' focused' : ''}`} ref={linkedPane} onMouseDown={props.onFocus} tabIndex={-1}
+      onKeyDown={(event) => { if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); back(); } }}>
+      <Suspense fallback={<div className="fv-empty">Loading file viewer…</div>}>
+        <LinkedFileView key={trail.length} embedded request={current} onBack={back} onClose={props.onClose}
+          dragId={props.dragId} onDragActive={props.onDragActive} closeLabel="Close file viewer" />
+      </Suspense>
+    </div>
+  </FilePreviewContext.Provider>;
 }

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -6,6 +6,8 @@ import { Rails, railPad } from './Rails';
 import type { FileEntry, FileKind, FilePreview } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
+import FileLinkContent, { FileLinkScope } from './FileLinkContent';
+import { fileRequest, fileResourceUrl } from '../lib/fileLinks';
 import CodeView from './CodeView';
 import FileWrapToggle from './FileWrapToggle';
 import PdfView from './PdfView';
@@ -38,16 +40,6 @@ const fmtWhen = (ms: number) => {
 const fmtStamp = (ms: number) => (ms ? new Date(ms).toLocaleString() : 'unknown');
 
 const join = (a: string, b: string) => (a ? `${a}/${b}` : b);
-// Resolve a relative reference (from markdown) against a folder.
-const joinRel = (dir: string, rel: string) => {
-  const out = dir ? dir.split('/') : [];
-  for (const part of rel.split('/')) {
-    if (!part || part === '.') continue;
-    if (part === '..') out.pop();
-    else out.push(part);
-  }
-  return out.join('/');
-};
 const dirOf = (p: string) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '');
 
 type SortKey = 'name' | 'size' | 'time';
@@ -429,19 +421,21 @@ function Cols({ sort, onSort }: { sort: Sort; onSort: (k: SortKey) => void }) {
 // Rendered markdown shares the document with the app, so its references have to
 // be repointed: a relative <img> means a sibling file in the workspace, and a
 // relative <a> must not navigate the app away.
-function resolveMarkdown(html: string, sessionId: string, filePath: string) {
+function resolveMarkdown(html: string, sessionId: string, filePath: string, source?: LinkedFileSource) {
   const base = dirOf(filePath);
   const host = document.createElement('div');
   host.innerHTML = html; // already sanitized by renderMarkdown
   const external = (u: string) => /^([a-z]+:|\/\/|\/)/i.test(u);
   host.querySelectorAll('img').forEach((img) => {
     const src = img.getAttribute('src') || '';
-    if (src && !external(src)) img.setAttribute('src', api.rawUrl(sessionId, joinRel(base, src)));
+    if (src && (!external(src) || src.startsWith('/') && !src.startsWith('//'))) {
+      const request = fileRequest(src, { session: source ? undefined : sessionId, root: source?.root, base });
+      if (request) img.setAttribute('src', fileResourceUrl('raw', request));
+    }
   });
   host.querySelectorAll('a').forEach((a) => {
     const href = a.getAttribute('href') || '';
     if (!href || href.startsWith('#')) return; // in-page anchors stay in-page
-    if (!external(href)) a.setAttribute('href', api.rawUrl(sessionId, joinRel(base, href)));
     a.setAttribute('target', '_blank');
     a.setAttribute('rel', 'noopener noreferrer');
   });
@@ -461,7 +455,7 @@ function useTheme(): 'light' | 'dark' {
   return theme;
 }
 
-type ViewInfo = {
+export type ViewInfo = {
   meta: FilePreview | null; extra: string[]; edit?: SaveState; trace?: TraceInfo;
   /** True when a text surface is on screen, so wrapping means something. */
   showWrap?: boolean;
@@ -515,11 +509,25 @@ export type SaveState = {
 // The viewer for one file. Kinds it can't render fall back to an honest
 // "download it instead" card rather than an empty box. The view mode (`raw`,
 // `scripts`) belongs to the pane, which draws the toggles in its info strip.
-export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved }: {
+export type LinkedFileSource = {
+  root: string;
+  preview: () => Promise<FilePreview>;
+  rawUrl: string;
+  downloadUrl: string;
+};
+
+export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved, source: linkedSource, line, column }: {
   sessionId: string; path: string; zoom: number; raw: boolean; scripts: boolean;
   onInfo: (info: ViewInfo) => void;
   onSaved?: () => void;
+  /** Shared file links are read-only and never adopt a Files pane's draft. */
+  source?: LinkedFileSource;
+  line?: number;
+  column?: number;
 }) {
+  const readOnly = !!linkedSource;
+  const rawSrc = linkedSource?.rawUrl ?? api.rawUrl(sessionId, path);
+  const downloadSrc = linkedSource?.downloadUrl ?? api.downloadUrl(sessionId, path);
   const [meta, setMeta] = useState<FilePreview | null>(null);
   const [err, setErr] = useState<string | null>(null);
   const [source, setSource] = useState<string | null>(null);
@@ -534,11 +542,11 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
   // always writable, but a file nobody touched has nothing to save.
   const [wrap, setWrapPref] = useState(readWrap);
   const [draft, setDraft] = useState<string | null>(() => {
-    const kept = recall(sessionId).draft;
+    const kept = readOnly ? null : recall(sessionId).draft;
     return kept && kept.path === path ? kept.text : null;
   });
   const [status, setStatus] = useState<SaveState['status']>(() => {
-    const kept = recall(sessionId).draft;
+    const kept = readOnly ? null : recall(sessionId).draft;
     return kept && kept.path === path ? 'dirty' : 'clean';
   });
   const [saveErr, setSaveErr] = useState<string | null>(null);
@@ -555,7 +563,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
   const restoredFor = useRef<string | null>(null);
   if (restoredFor.current !== path) {
     restoredFor.current = path;
-    const kept = recall(sessionId).draft;
+    const kept = readOnly ? null : recall(sessionId).draft;
     pending.current = kept && kept.path === path ? { text: kept.text, base: kept.base } : null;
   }
 
@@ -565,32 +573,32 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
     setSaveErr(null); setConflict(false); setFmtErr(null);
     // A buffer kept across a pane switch survives the reload of its own file —
     // dropping it here is exactly the loss this is meant to prevent.
-    const kept = recall(sessionId).draft;
+    const kept = readOnly ? null : recall(sessionId).draft;
     if (kept && kept.path === path) { setDraft(kept.text); setStatus('dirty'); }
     else { setDraft(null); setStatus('clean'); }
     setTraceHead(null); setTraceQuery('');
-    api.previewFile(sessionId, path)
+    (linkedSource ? linkedSource.preview() : api.previewFile(sessionId, path))
       .then((m) => { if (alive) setMeta(m); })
       .catch((e) => { if (alive) setErr(String(e?.message || e)); });
     return () => { alive = false; };
-  }, [sessionId, path]);
+  }, [sessionId, path, linkedSource, readOnly]);
 
   // html source isn't in the preview payload (the iframe reads the bytes
   // itself) — fetch it only if the source view is asked for.
   useEffect(() => {
     if (!raw || meta?.kind !== 'html' || source !== null) return;
     let alive = true;
-    fetch(api.rawUrl(sessionId, path)).then((r) => r.text())
+    fetch(rawSrc).then((r) => r.text())
       .then((t) => { if (alive) setSource(t.slice(0, 512 * 1024)); })
       .catch(() => { if (alive) setSource('(could not read source)'); });
     return () => { alive = false; };
-  }, [raw, meta?.kind, sessionId, path, source]);
+  }, [raw, meta?.kind, rawSrc, source]);
 
   const kind = meta?.kind;
   const md = useMemo(
     () => (kind === 'markdown' && meta?.text != null && !raw
-      ? resolveMarkdown(renderMarkdown(meta.text), sessionId, path) : ''),
-    [kind, meta?.text, raw, sessionId, path],
+      ? resolveMarkdown(renderMarkdown(meta.text), sessionId, path, linkedSource) : ''),
+    [kind, meta?.text, raw, sessionId, path, linkedSource],
   );
 
   // The text currently on screen: the draft while editing, the file otherwise.
@@ -617,7 +625,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
   // from, and an autosaving editor one stray keystroke away from it is a bad
   // trade for a file nobody needs to hand-edit.
   const editKind = !!meta && (meta.kind === 'text' || meta.kind === 'markdown' || meta.kind === 'html');
-  const canEdit = editKind && !meta?.truncated;
+  const canEdit = !readOnly && editKind && !meta?.truncated;
   const saved = meta?.kind === 'html' ? (source ?? '') : (meta?.text ?? '');
 
   // Read at fire time by a callback that outlives the render that made it.
@@ -773,11 +781,11 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
   if (err) return <div className="fv-empty">Could not open this file.<div className="fv-sub">{err}</div></div>;
   if (!meta) return <div className="fv-empty">Loading…</div>;
 
-  const rawSrc = api.rawUrl(sessionId, path);
   const code = (text: string) => (
     <CodeView
       text={text} name={meta.name} theme={theme}
       wrap={wrap}
+      line={line} column={column}
       editable={canEdit}
       onChange={onEdit}
       onSave={() => flush()}   // ⌘S still works; it just beats the timer
@@ -789,16 +797,18 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
       // face of the same file, one toggle away.
       return raw
         ? code(shown)
-        : <div className="markdown fv-md" dangerouslySetInnerHTML={{ __html: md }} />;
+        : <FileLinkScope session={linkedSource ? undefined : sessionId} root={linkedSource?.root} base={dirOf(path)}>
+            <FileLinkContent className="markdown fv-md" html={md} />
+          </FileLinkScope>;
     }
     if (meta.kind === 'trace') {
       // Same two faces as markdown: the rendered conversation, or the JSONL
       // underneath it.
       return raw ? code(shown) : (
-        <TraceView
+        <FileLinkScope unavailable><TraceView
           src={traceSrc} srcKey={`file:${sessionId}:${path}`} zoom={zoom} query={traceQuery}
           onHead={setTraceHead} onNav={(go) => { traceNav.current = go; }}
-        />
+        /></FileLinkScope>
       );
     }
     if (meta.kind === 'text') return code(shown);
@@ -838,7 +848,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
       <div className="fv-empty">
         No preview for this kind of file.
         <div className="fv-sub">{meta.reason || `${fmtSize(meta.size)} · ${meta.mime}`}</div>
-        <button className="mini-btn" onClick={() => triggerDownload(api.downloadUrl(sessionId, path), meta.name)}>
+        <button className="mini-btn" onClick={() => triggerDownload(downloadSrc, meta.name)}>
           <DownloadGlyph /> Download
         </button>
       </div>
@@ -865,7 +875,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
       {headOnly && (
         <div className="fv-foot">
           Showing the first {fmtSize((shown || '').length)} of {fmtSize(meta.size)}.{' '}
-          <button className="link-btn" onClick={() => triggerDownload(api.downloadUrl(sessionId, path), meta.name)}>
+          <button className="link-btn" onClick={() => triggerDownload(downloadSrc, meta.name)}>
             Download the whole file
           </button>
         </div>

--- a/web/src/components/PaneFilePreview.tsx
+++ b/web/src/components/PaneFilePreview.tsx
@@ -1,0 +1,50 @@
+import { lazy, Suspense, useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react';
+import { FilePreviewContext } from './FileLinkContent';
+import type { FileLinkRequest } from '../lib/fileLinks';
+import '../file-links.css';
+
+const FileLinkPage = lazy(() => import('./FileLinkPage'));
+
+// A preview belongs to its originating tile, not the window. Keep the session
+// mounted at the same size while covering it, but make it inert to avoid typing
+// into a hidden terminal or composer. Other tiles remain usable.
+export default function PaneFilePreview({ children, onOpenInViewer }: {
+  children: ReactNode;
+  onOpenInViewer: (request: FileLinkRequest) => Promise<void>;
+}) {
+  const [trail, setTrail] = useState<FileLinkRequest[]>([]);
+  const open = useCallback((request: FileLinkRequest) => setTrail((old) => [...old, request]), []);
+  const overlay = useRef<HTMLDivElement>(null);
+  const session = useRef<HTMLDivElement>(null);
+  const opened = trail.length > 0;
+  const back = () => setTrail((old) => old.slice(0, -1));
+  useLayoutEffect(() => {
+    if (!opened) return;
+    const previous = document.activeElement as HTMLElement | null;
+    const surface = session.current, preview = overlay.current;
+    if (surface) surface.inert = true;
+    preview?.focus({ preventScroll: true });
+    return () => {
+      if (surface) surface.inert = false;
+      // Do not steal focus from a different pane the user has since selected.
+      if (previous?.isConnected && (document.activeElement === document.body || preview?.contains(document.activeElement))) {
+        previous.focus({ preventScroll: true });
+      }
+    };
+  }, [opened]);
+
+  return <FilePreviewContext.Provider value={open}>
+    <div className="pane-file-host">
+      <div className="pane-file-session" ref={session}>{children}</div>
+      {opened && <div className="pane-file-overlay" ref={overlay} tabIndex={-1} role="dialog" aria-label="File preview"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); back(); }
+        }}>
+        <Suspense fallback={<div className="fv-empty" role="status">Loading file preview…</div>}>
+          <FileLinkPage key={trail.length} embedded request={trail[trail.length - 1]} onBack={back} onClose={() => setTrail([])}
+            onOpenInViewer={async (request) => { await onOpenInViewer(request); setTrail([]); }} />
+        </Suspense>
+      </div>}
+    </div>
+  </FilePreviewContext.Provider>;
+}

--- a/web/src/components/RemotePane.tsx
+++ b/web/src/components/RemotePane.tsx
@@ -4,6 +4,7 @@ import { REMOTE_STATE_LABEL } from '../types';
 import * as api from '../api';
 import StateLogo from './StateLogo';
 import { renderMarkdown } from '../lib/markdown';
+import FileLinkContent, { FileLinkScope } from './FileLinkContent';
 import { groupLabel, sessionTitle } from '../lib/sessionTitle';
 import { BackGlyph, CloseGlyph, StopGlyph, PlayGlyph, ShareGlyph, AckGlyph } from './icons';
 
@@ -206,6 +207,7 @@ export default function RemotePane({
   );
 
   return (
+    <FileLinkScope session={session.id}>
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
       {/* The standard three-column pane header: identity left, name centred,
           actions right — same as every other agent's pane. Everything else the
@@ -315,7 +317,7 @@ export default function RemotePane({
               </div>
             </div>
           ) : (
-            <div key={m.seq} className="rp-agent" dangerouslySetInnerHTML={{ __html: m.html }} />
+            <FileLinkContent key={m.seq} className="rp-agent" html={m.html} />
           )
         ))}
         {/* The reader's running line, in this log, as its last child — directly
@@ -377,5 +379,6 @@ export default function RemotePane({
         <span className="rp-hint">↵ send · ⇧↵ newline</span>
       </div>
     </div>
+    </FileLinkScope>
   );
 }

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -4,7 +4,7 @@ import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { ClipboardAddon, Base64 } from '@xterm/addon-clipboard';
 import { WebLinksAddon } from '@xterm/addon-web-links';
-import { FileLinkScope } from './FileLinkContent';
+import { FileLinkScope, useFilePreview } from './FileLinkContent';
 import { installTerminalFileLinks, terminalLinkHandler, openTerminalLink } from '../lib/terminalFileLinks';
 import '@xterm/xterm/css/xterm.css';
 import type { Cli, Session } from '../types';
@@ -213,6 +213,7 @@ export default function TerminalPane({
   onRename?: (name: string) => void;
   onClose: () => void;
 }) {
+  const openFilePreview = useFilePreview();
   const hostRef = useRef<HTMLDivElement>(null);
   // Focus, unless the conversation is covering the terminal. Several paths grab
   // it — becoming active, the header, the key bar — and some fire after the mode
@@ -481,7 +482,7 @@ export default function TerminalPane({
       // Let users make a local selection even when an agent TUI has grabbed
       // the mouse: ⌥-drag on macOS, Shift-drag elsewhere.
       macOptionClickForcesSelection: true,
-      linkHandler: terminalLinkHandler(session.id),
+      linkHandler: terminalLinkHandler(session.id, openFilePreview),
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -510,9 +511,9 @@ export default function TerminalPane({
     // succeeded or was blocked, so there is no way to tell, and layering a
     // fallback behind it opens the link twice. noopener/noreferrer keep the
     // opened page from reaching back into the app through window.opener.
-    term.loadAddon(new WebLinksAddon((event, uri) => openTerminalLink(event, uri, session.id)));
+    term.loadAddon(new WebLinksAddon((event, uri) => openTerminalLink(event, uri, session.id, openFilePreview)));
     term.open(hostRef.current!);
-    installTerminalFileLinks(term, session.id);
+    installTerminalFileLinks(term, session.id, openFilePreview);
     termRef.current = term;
     const host = hostRef.current!;
 

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -4,6 +4,8 @@ import { Terminal, type ITheme } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { ClipboardAddon, Base64 } from '@xterm/addon-clipboard';
 import { WebLinksAddon } from '@xterm/addon-web-links';
+import { FileLinkScope } from './FileLinkContent';
+import { installTerminalFileLinks, terminalLinkHandler, openTerminalLink } from '../lib/terminalFileLinks';
 import '@xterm/xterm/css/xterm.css';
 import type { Cli, Session } from '../types';
 import { STATE_LABEL, isRemote } from '../types';
@@ -479,6 +481,7 @@ export default function TerminalPane({
       // Let users make a local selection even when an agent TUI has grabbed
       // the mouse: ⌥-drag on macOS, Shift-drag elsewhere.
       macOptionClickForcesSelection: true,
+      linkHandler: terminalLinkHandler(session.id),
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
@@ -507,18 +510,9 @@ export default function TerminalPane({
     // succeeded or was blocked, so there is no way to tell, and layering a
     // fallback behind it opens the link twice. noopener/noreferrer keep the
     // opened page from reaching back into the app through window.opener.
-    term.loadAddon(new WebLinksAddon((event, uri) => {
-      if (event?.defaultPrevented) return;
-      const a = document.createElement('a');
-      a.href = uri;
-      a.target = '_blank';
-      a.rel = 'noopener noreferrer';
-      a.style.display = 'none';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-    }));
+    term.loadAddon(new WebLinksAddon((event, uri) => openTerminalLink(event, uri, session.id)));
     term.open(hostRef.current!);
+    installTerminalFileLinks(term, session.id);
     termRef.current = term;
     const host = hostRef.current!;
 
@@ -1072,6 +1066,7 @@ export default function TerminalPane({
   const pathLabel = workspaceLabel(session.path);
   const group = groupLabel(groupName);
   return (
+    <FileLinkScope session={session.id}>
     <div
       className={`slot${focused ? ' focused' : ''}`}
       style={focused && tint ? { borderColor: `color-mix(in srgb, ${tint} 45%, var(--border))` } : undefined}
@@ -1332,5 +1327,6 @@ export default function TerminalPane({
         </div>
       )}
     </div>
+    </FileLinkScope>
   );
 }

--- a/web/src/components/TracePane.tsx
+++ b/web/src/components/TracePane.tsx
@@ -20,6 +20,7 @@ import * as api from '../api';
 import type { TraceBlock, TraceTurn } from '../api';
 import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../lib/traceWindows';
 import { renderMarkdown } from '../lib/markdown';
+import FileLinkContent, { FileLinkScope } from './FileLinkContent';
 import Logo from './Logo';
 import { CloseGlyph, ShareGlyph, HandoverGlyph } from './icons';
 
@@ -77,7 +78,7 @@ function TextBlock({ text, more, markdown }: { text: string; more?: number; mark
   // truncated answer reads as a complete one.
   return (
     <>
-      <div className="tv-md" dangerouslySetInnerHTML={{ __html: html }} />
+      <FileLinkContent className="tv-md" html={html} />
       {!!more && <div className="tv-msg">…{moreLabel(more)}</div>}
     </>
   );
@@ -604,6 +605,7 @@ export default function TracePane({
     : `${fmtNum(head.loaded)} turn${head.loaded === 1 ? '' : 's'} loaded`);
 
   return (
+    <FileLinkScope session={session.id}>
     <div className={`slot${focused ? ' focused' : ''}`} onMouseDown={onFocus}>
       <div
         className={`pane-head trace-head${dragId ? ' draggable' : ''}`}
@@ -648,5 +650,6 @@ export default function TracePane({
 
       <TraceView src={src} srcKey={`session:${session.id}`} zoom={zoom} query={query} live={sourceLive} onHead={setHead} onNav={onNav} />
     </div>
+    </FileLinkScope>
   );
 }

--- a/web/src/components/cm-core.ts
+++ b/web/src/components/cm-core.ts
@@ -203,6 +203,13 @@ export function setDoc(view: EditorView, text: string) {
   }
 }
 
+export function revealLine(view: EditorView, number: number, column = 1) {
+  const line = view.state.doc.line(Math.min(Math.max(1, number), view.state.doc.lines));
+  const from = Math.min(line.to, line.from + Math.max(0, column - 1));
+  view.dispatch({ selection: { anchor: from, head: column === 1 ? line.to : from },
+    effects: EditorView.scrollIntoView(from, { y: 'center' }) });
+}
+
 export function setWrap(view: EditorView, wrap: boolean) {
   view.dispatch({ effects: wrapComp.reconfigure(wrap ? EditorView.lineWrapping : []) });
 }

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -15,6 +15,7 @@ import { useTraceWindows, type TraceSource } from '../../lib/traceWindows';
 import { useVirtualRows } from './useVirtualRows';
 import { Rails } from '../Rails';
 import { renderMarkdown } from '../../lib/markdown';
+import FileLinkContent from '../FileLinkContent';
 import type { Exchange, Step } from './exchanges';
 import { agentSpawnsOf, agentStatus, anyLive, canOpenAgent, capRows, railIsLast, fmtClock, fmtDur, fmtTok, oneLine, proseOf, splitExchanges, stepSummary, stepText, stepsOf } from './exchanges';
 import type { AgentSpawn, AgentStatus } from './exchanges';
@@ -152,7 +153,7 @@ function StepRow({ s, q }: { s: Step; q?: string }) {
               emits, so a cut tail cannot leave an open block that swallows the
               rest of the panel — pinned in test/stepMarkdown.test.mjs. */}
           {proseHtml ? (
-            <div className="markdown cs-md" dangerouslySetInnerHTML={{ __html: proseHtml }} />
+            <FileLinkContent className="markdown cs-md" html={proseHtml} />
           ) : null}
           {!!full && !!more && <div className="cs-more mono">…{moreLabel(more)}</div>}
           {s.kind === 'tools' && s.blocks.map((b, i) => (
@@ -210,7 +211,7 @@ function PromptBand({ text, q, queued }: { text: string; q?: string; queued?: bo
   const html = useMemo(() => highlightHtml(renderMarkdown(text, { breaks: true }), q), [text, q]);
   return (
     <div className="cx-prompt">
-      <div className="markdown cx-pmd" dangerouslySetInnerHTML={{ __html: html }} />
+      <FileLinkContent className="markdown cx-pmd" html={html} />
       {/* Read from a queue record rather than a message: it was typed while the
           agent was working. Labelled because those records cannot say whether it
           was then consumed or cancelled — see TraceTurn.queued. It stays a
@@ -600,7 +601,7 @@ export function ExchangeView({
           between the two runs of steps instead of under work it predates. */}
       {answerHtml ? (
         <div className="cx-answer">
-          <div className="markdown cx-md" dangerouslySetInnerHTML={{ __html: answerHtml }} />
+          <FileLinkContent className="markdown cx-md" html={answerHtml} />
           {!!answerMore && <div className="cx-note mono">…{moreLabel(answerMore)}</div>}
         </div>
       ) : null}

--- a/web/src/components/filesMemory.ts
+++ b/web/src/components/filesMemory.ts
@@ -8,6 +8,7 @@
 // The in-memory map is what makes a pane switch lossless. localStorage is the
 // second line: it also survives a reload of the whole app, which is the other
 // way people lose a buffer they never asked to lose.
+import type { FileLinkRequest } from '../lib/fileLinks';
 
 export interface Draft {
   path: string;
@@ -22,6 +23,7 @@ export interface FilesMemory {
   target: string | null;
   sort?: { key: 'name' | 'size' | 'time'; desc: boolean };
   draft: Draft | null;
+  linkedFile?: FileLinkRequest | null;
 }
 
 const EMPTY: FilesMemory = { root: '', viewing: null, target: null, draft: null };

--- a/web/src/file-links.css
+++ b/web/src/file-links.css
@@ -1,6 +1,7 @@
 .file-link-page { display: flex; flex-direction: column; width: 100%; height: 100%; min-height: 0; background: var(--panel); }
 .file-link-head { display: flex; align-items: center; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--border); }
 .file-link-head > svg { width: 20px; height: 20px; flex: none; color: var(--muted); }
+.file-link-head.draggable { cursor: grab; }
 .file-link-title { flex: 1; min-width: 0; }
 .file-link-title h1 { margin: 0 0 5px; font-size: 16px; font-weight: 600; }
 .file-link-path { font: 11px var(--font-mono); color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
@@ -8,6 +9,13 @@
 .file-link-page a.mini-btn { text-decoration: none; }
 .file-link-notice { padding: 5px 20px; font-size: 12px; color: var(--muted); }
 .file-link-page .fv-empty { flex: 1; }
+.pane-file-host, .pane-file-session { display: flex; flex-direction: column; flex: 1; min-width: 0; min-height: 0; }
+.pane-file-host { position: relative; height: 100%; }
+.pane-file-session > .slot { flex: 1; }
+.pane-file-overlay { position: absolute; inset: 0; z-index: 10; display: flex; background: var(--panel); border: 1px solid var(--border); border-radius: var(--r-xl); overflow: hidden; outline: none; }
+.file-link-embedded .file-link-head { padding: 9px 12px; gap: 8px; }
+.file-link-embedded .file-link-title h1 { font-size: 13px; }
+.file-link-embedded .file-link-tools { padding: 6px 12px; gap: 8px; }
 @media (max-width: 720px) {
   .file-link-head { padding: 12px; gap: 8px; }
   .file-link-tools { padding: 8px 12px; gap: 8px; }

--- a/web/src/file-links.css
+++ b/web/src/file-links.css
@@ -1,0 +1,15 @@
+.file-link-page { display: flex; flex-direction: column; width: 100%; height: 100%; min-height: 0; background: var(--panel); }
+.file-link-head { display: flex; align-items: center; gap: 12px; padding: 16px 20px; border-bottom: 1px solid var(--border); }
+.file-link-head > svg { width: 20px; height: 20px; flex: none; color: var(--muted); }
+.file-link-title { flex: 1; min-width: 0; }
+.file-link-title h1 { margin: 0 0 5px; font-size: 16px; font-weight: 600; }
+.file-link-path { font: 11px var(--font-mono); color: var(--muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.file-link-tools { display: flex; align-items: center; flex-wrap: wrap; gap: 10px; padding: 8px 20px; border-bottom: 1px solid var(--border); color: var(--muted); font-size: 11px; }
+.file-link-page a.mini-btn { text-decoration: none; }
+.file-link-notice { padding: 5px 20px; font-size: 12px; color: var(--muted); }
+.file-link-page .fv-empty { flex: 1; }
+@media (max-width: 720px) {
+  .file-link-head { padding: 12px; gap: 8px; }
+  .file-link-tools { padding: 8px 12px; gap: 8px; }
+  .file-link-tools .spacer { display: none; }
+}

--- a/web/src/lib/fileLinks.ts
+++ b/web/src/lib/fileLinks.ts
@@ -87,7 +87,10 @@ export async function resolveFileLink(request: FileLinkRequest, signal: AbortSig
   return body;
 }
 
-export function activateFileLink(_event: MouseEvent, request: FileLinkRequest) {
+export function activateFileLink(event: MouseEvent, request: FileLinkRequest, open?: (request: FileLinkRequest) => void) {
+  if (open && !event.metaKey && !event.ctrlKey && !event.shiftKey && !event.altKey) {
+    event.preventDefault(); open(request); return;
+  }
   const anchor = document.createElement('a');
   anchor.href = fileLinkUrl(request); anchor.target = '_blank'; anchor.rel = 'noopener noreferrer';
   document.body.appendChild(anchor); anchor.click(); anchor.remove();

--- a/web/src/lib/fileLinks.ts
+++ b/web/src/lib/fileLinks.ts
@@ -1,0 +1,94 @@
+export type FileLinkContext = { session?: string; root?: string; base?: string; unavailable?: boolean };
+export type FileLinkRequest = { file: string; session?: string; root?: string; line?: number; column?: number; unavailable?: boolean };
+export type FileLinkTarget = { root: string; path: string; absolute: string };
+
+// Parse only file references, never reinterpret a network or executable URL.
+// Decode URL paths once; literal paths in code spans/terminals stay literal.
+export function parseFileReference(value: string, encoded = true): { file: string; line?: number; column?: number } | null {
+  let file = value.trim();
+  if (!file || file.startsWith('#') || file.startsWith('//') || /[\x00-\x1f]/.test(file)) return null;
+  if (/^(?:https?|javascript|vbscript|data|mailto|tel|ftp|vscode):/i.test(file)) return null;
+  if (/^file:\/\//i.test(file)) {
+    try {
+      const url = new URL(file);
+      if (url.hostname && url.hostname !== 'localhost') return null;
+      file = url.pathname + url.hash;
+    } catch { return null; }
+  } else if (/^[a-z][a-z\d+.-]*:/i.test(file) && !/^[^/\s]+:\d+(?::\d+)?$/.test(file)) return null;
+  const suffix = file.match(/(?:#L(\d+)(?:C(\d+)|-L?\d+)?|:(\d+)(?::(\d+))?)$/i);
+  const line = suffix ? Number(suffix[1] || suffix[3]) : undefined;
+  const column = suffix && (suffix[2] || suffix[4]) ? Number(suffix[2] || suffix[4]) : undefined;
+  if (suffix) file = file.slice(0, -suffix[0].length);
+  // Other fragments belong to rendered Markdown, but are not file names.
+  if (encoded) {
+    file = file.split('#')[0].split('?')[0];
+    try { file = decodeURIComponent(file); } catch { return null; }
+  }
+  if (!file || /[\x00-\x1f\\]/.test(file)) return null;
+  return { file, ...(line && Number.isSafeInteger(line) ? { line } : {}), ...(column && Number.isSafeInteger(column) ? { column } : {}) };
+}
+
+export function looksLikeFile(value: string): boolean {
+  const ref = parseFileReference(value, false);
+  return !!ref && !/\s/.test(value) && (
+    /^(?:\.{0,2}\/|workspace\/)/.test(ref.file)
+    || /(?:^|\/)[\w.@+-]+\.[a-zA-Z][\w-]{0,15}$/.test(ref.file)
+  );
+}
+
+export function fileRequest(value: string, context: FileLinkContext = {}, encoded = true): FileLinkRequest | null {
+  const ref = parseFileReference(value, encoded);
+  if (!ref) return null;
+  const { session, root, base, unavailable } = context;
+  if (root && !ref.file.startsWith('/')) {
+    // Keep .. segments for the server's root check; do not silently clamp them.
+    return { ...ref, file: base ? `${base}/${ref.file}` : ref.file, root, ...(unavailable ? { unavailable } : {}) };
+  }
+  return { ...ref, file: base && !ref.file.startsWith('/') ? `${base}/${ref.file}` : ref.file,
+    ...(session ? { session } : {}), ...(unavailable ? { unavailable } : {}) };
+}
+
+export function fileLinkHash(request: FileLinkRequest): string {
+  const params = new URLSearchParams({ file: request.file });
+  for (const key of ['root', 'session', 'line', 'column', 'unavailable'] as const) {
+    if (request[key] !== undefined) params.set(key, String(request[key]));
+  }
+  return '#' + params;
+}
+
+export function requestFromHash(hash: string): FileLinkRequest | null {
+  const params = new URLSearchParams(hash.replace(/^#/, ''));
+  const file = params.get('file');
+  if (!file) return null;
+  const positive = (key: string) => {
+    const n = Number(params.get(key));
+    return Number.isSafeInteger(n) && n > 0 ? n : undefined;
+  };
+  return { file, root: params.get('root') || undefined, session: params.get('session') || undefined,
+    line: positive('line'), column: positive('column'), unavailable: params.get('unavailable') === 'true' || undefined };
+}
+
+export function fileLinkUrl(request: FileLinkRequest): string {
+  return location.pathname + location.search + fileLinkHash(request);
+}
+
+export function fileResourceUrl(action: 'resolve' | 'preview' | 'raw' | 'download', request: FileLinkRequest): string {
+  const params = new URLSearchParams({ file: request.file });
+  if (request.root) params.set('root', request.root);
+  if (request.session) params.set('session', request.session);
+  return `/api/file-links/${action}?${params}`;
+}
+
+export async function resolveFileLink(request: FileLinkRequest, signal: AbortSignal): Promise<FileLinkTarget> {
+  if (request.unavailable) throw new Error('File unavailable here: this conversation has no local working folder.');
+  const response = await fetch(fileResourceUrl('resolve', request), { signal });
+  const body = await response.json();
+  if (!response.ok) throw new Error(body.error || 'Could not locate this file.');
+  return body;
+}
+
+export function activateFileLink(_event: MouseEvent, request: FileLinkRequest) {
+  const anchor = document.createElement('a');
+  anchor.href = fileLinkUrl(request); anchor.target = '_blank'; anchor.rel = 'noopener noreferrer';
+  document.body.appendChild(anchor); anchor.click(); anchor.remove();
+}

--- a/web/src/lib/fileViewer.ts
+++ b/web/src/lib/fileViewer.ts
@@ -1,0 +1,17 @@
+import * as api from '../api';
+import { recall, remember } from '../components/filesMemory';
+import type { Session } from '../types';
+import { fileLinkHash, type FileLinkRequest } from './fileLinks';
+
+// Only the explicit "Open in file viewer" action creates a passive session.
+// Never repoint an unrelated Files pane: it may contain an unsaved editor.
+export async function retainFileViewer(request: FileLinkRequest, sessions: Session[], groupId?: string) {
+  const existing = sessions.find((session) => {
+    const linked = session.cli === 'files' && !session.archivedAt && recall(session.id).linkedFile;
+    return linked && fileLinkHash(linked) === fileLinkHash(request);
+  });
+  if (existing) return existing;
+  const pane = await api.createSession(`File: ${request.file.split('/').pop()}`, 'files', groupId, '.');
+  remember(pane.id, { linkedFile: request });
+  return pane;
+}

--- a/web/src/lib/markdown.ts
+++ b/web/src/lib/markdown.ts
@@ -1,5 +1,6 @@
-import { marked } from 'marked';
+import { marked, Renderer } from 'marked';
 import DOMPurify from 'dompurify';
+import { fileLinkHash, parseFileReference } from './fileLinks';
 
 // Render markdown to SANITIZED HTML. Agent output and skill files can contain
 // untrusted content (an agent may echo something it read from the web or a
@@ -15,6 +16,14 @@ import DOMPurify from 'dompurify';
 // every multi-line prompt in the reader into one paragraph, which is a silent
 // loss of what was typed rather than a rendering choice.
 export function renderMarkdown(md: string, opts?: { breaks?: boolean }): string {
-  const html = marked.parse(md ?? '', { async: false, breaks: !!opts?.breaks }) as string;
+  const renderer = new Renderer();
+  const link = renderer.link;
+  renderer.link = function (token) {
+    // file:// and a bare `app.ts:42` look like protocols to the sanitizer.
+    // Convert recognized file references to safe app fragments first.
+    const ref = /^[^/]*:/.test(token.href) ? parseFileReference(token.href) : null;
+    return link.call(this, ref ? { ...token, href: fileLinkHash(ref) } : token);
+  };
+  const html = marked.parse(md ?? '', { async: false, breaks: !!opts?.breaks, renderer }) as string;
   return DOMPurify.sanitize(html);
 }

--- a/web/src/lib/terminalFileLinks.ts
+++ b/web/src/lib/terminalFileLinks.ts
@@ -1,0 +1,55 @@
+import type { Terminal, ILink, ILinkHandler } from '@xterm/xterm';
+import { activateFileLink, fileRequest, looksLikeFile } from './fileLinks';
+
+export function terminalLinkHandler(session: string): ILinkHandler {
+  return {
+    allowNonHttpProtocols: true,
+    activate: (event, text) => openTerminalLink(event, text, session),
+  };
+}
+
+export function openTerminalLink(event: MouseEvent, text: string, session: string) {
+  if (event.defaultPrevented) return;
+  const request = fileRequest(text, { session });
+  if (request) return activateFileLink(event, request);
+  // OSC 8 can contain arbitrary protocols; only web links open externally.
+  if (!/^https?:\/\//i.test(text)) return;
+  const anchor = document.createElement('a');
+  anchor.href = text; anchor.target = '_blank'; anchor.rel = 'noopener noreferrer';
+  document.body.appendChild(anchor); anchor.click(); anchor.remove();
+}
+
+export function installTerminalFileLinks(term: Terminal, session: string) {
+  return term.registerLinkProvider({
+    provideLinks(lineNumber, callback) {
+      const buffer = term.buffer.active;
+      let first = lineNumber - 1, last = first;
+      // Join soft wraps, with a bound so a giant output line stays cheap to hover.
+      while (first > 0 && last - first < 8 && buffer.getLine(first)?.isWrapped) first--;
+      while (last - first < 8 && buffer.getLine(last + 1)?.isWrapped) last++;
+      let text = '';
+      const positions: { x: number; y: number }[] = [];
+      for (let y = first; y <= last; y++) {
+        const row = buffer.getLine(y);
+        if (!row) break;
+        for (let x = 0; x < row.length; x++) {
+          const cell = row.getCell(x);
+          if (!cell || cell.getWidth() === 0) continue;
+          const chars = cell.getChars() || ' ';
+          for (let i = 0; i < chars.length; i++) positions.push({ x: x + 1, y: y + 1 });
+          text += chars;
+        }
+      }
+      const links: ILink[] = [];
+      for (const match of text.matchAll(/[^\s<>"'`()\[\]{}]+/g)) {
+        const value = match[0].replace(/[.,;:]+$/, '');
+        if (!looksLikeFile(value)) continue;
+        const request = fileRequest(value, { session }, false);
+        const start = positions[match.index!], end = positions[match.index! + value.length - 1];
+        if (!request || !start || !end || lineNumber < start.y || lineNumber > end.y) continue;
+        links.push({ text: value, range: { start, end }, activate: (event) => activateFileLink(event, request) });
+      }
+      callback(links);
+    },
+  });
+}

--- a/web/src/lib/terminalFileLinks.ts
+++ b/web/src/lib/terminalFileLinks.ts
@@ -1,17 +1,19 @@
 import type { Terminal, ILink, ILinkHandler } from '@xterm/xterm';
-import { activateFileLink, fileRequest, looksLikeFile } from './fileLinks';
+import { activateFileLink, fileRequest, looksLikeFile, type FileLinkRequest } from './fileLinks';
 
-export function terminalLinkHandler(session: string): ILinkHandler {
+type OpenPreview = (request: FileLinkRequest) => void;
+
+export function terminalLinkHandler(session: string, open?: OpenPreview): ILinkHandler {
   return {
     allowNonHttpProtocols: true,
-    activate: (event, text) => openTerminalLink(event, text, session),
+    activate: (event, text) => openTerminalLink(event, text, session, open),
   };
 }
 
-export function openTerminalLink(event: MouseEvent, text: string, session: string) {
+export function openTerminalLink(event: MouseEvent, text: string, session: string, open?: OpenPreview) {
   if (event.defaultPrevented) return;
   const request = fileRequest(text, { session });
-  if (request) return activateFileLink(event, request);
+  if (request) return activateFileLink(event, request, open);
   // OSC 8 can contain arbitrary protocols; only web links open externally.
   if (!/^https?:\/\//i.test(text)) return;
   const anchor = document.createElement('a');
@@ -19,7 +21,7 @@ export function openTerminalLink(event: MouseEvent, text: string, session: strin
   document.body.appendChild(anchor); anchor.click(); anchor.remove();
 }
 
-export function installTerminalFileLinks(term: Terminal, session: string) {
+export function installTerminalFileLinks(term: Terminal, session: string, open?: OpenPreview) {
   return term.registerLinkProvider({
     provideLinks(lineNumber, callback) {
       const buffer = term.buffer.active;
@@ -47,7 +49,7 @@ export function installTerminalFileLinks(term: Terminal, session: string) {
         const request = fileRequest(value, { session }, false);
         const start = positions[match.index!], end = positions[match.index! + value.length - 1];
         if (!request || !start || !end || lineNumber < start.y || lineNumber > end.y) continue;
-        links.push({ text: value, range: { start, end }, activate: (event) => activateFileLink(event, request) });
+        links.push({ text: value, range: { start, end }, activate: (event) => activateFileLink(event, request, open) });
       }
       callback(links);
     },

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,7 +1,8 @@
-import { Component } from 'react';
+import { Component, lazy, Suspense, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
+import { requestFromHash } from './lib/fileLinks';
 import './styles.css';
 import './conversation.css';
 
@@ -31,7 +32,21 @@ class Boundary extends Component<{ children: ReactNode }, { err: unknown }> {
 }
 
 // No StrictMode: it double-mounts in dev, which would open duplicate WebSockets.
-createRoot(document.getElementById('root')!).render(<Boundary><App /></Boundary>);
+const FileLinkPage = lazy(() => import('./components/FileLinkPage'));
+function Entry() {
+  const [hash, setHash] = useState(location.hash);
+  useEffect(() => {
+    const changed = () => setHash(location.hash);
+    window.addEventListener('hashchange', changed);
+    return () => window.removeEventListener('hashchange', changed);
+  }, []);
+  // Keep request identity stable while the page renders metadata or copies a URL.
+  const request = useMemo(() => requestFromHash(hash), [hash]);
+  return request
+    ? <Suspense fallback={<div className="fv-empty">Loading file preview…</div>}><FileLinkPage key={hash} request={request} /></Suspense>
+    : <App />;
+}
+createRoot(document.getElementById('root')!).render(<Boundary><Entry /></Boundary>);
 
 // Push notifications ride on this worker (agents message the operator on request).
 if ('serviceWorker' in navigator) {

--- a/web/test/fileLinks.test.mjs
+++ b/web/test/fileLinks.test.mjs
@@ -1,5 +1,5 @@
-// Real Markdown, xterm hyperlinks and previews. Every activation must create a
-// new browser tab while preserving the originating reader/terminal and draft.
+// Standalone/copied-link fallback without a session preview host. The in-pane
+// flow is covered by sessionFilePreview.test.mjs; explicit tabs stay supported.
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';

--- a/web/test/fileLinks.test.mjs
+++ b/web/test/fileLinks.test.mjs
@@ -1,0 +1,195 @@
+// Real Markdown, xterm hyperlinks and previews. Every activation must create a
+// new browser tab while preserving the originating reader/terminal and draft.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'file-link-browser-'));
+const bundle = path.join(tmp, 'fixture.js');
+const markdown = '[Readme](./readme.md) · [Website](https://example.test/guide) · [Line](./code.ts:42:3) · [Bare line](code.ts:42) · [File URI](file:///data/workspaces/team/readme.md) · [Spaces](docs/a%20%231%25.md)\n\n`docs/next.md`\n\n```sh\n./not-a-link.sh\n```\n\n[Bad](javascript:alert(1))';
+await build({
+  stdin: { resolveDir: web, loader: 'tsx', contents: `
+    import React, { useEffect, useState } from 'react'; import { createRoot } from 'react-dom/client';
+    import FileLinkContent, { FileLinkScope, linkFileContent } from './src/components/FileLinkContent';
+    import FileLinkPage from './src/components/FileLinkPage';
+    import { renderMarkdown } from './src/lib/markdown';
+    import * as links from './src/lib/fileLinks';
+    import { Terminal } from '@xterm/xterm';
+    import { WebLinksAddon } from '@xterm/addon-web-links';
+    import { installTerminalFileLinks, terminalLinkHandler, openTerminalLink } from './src/lib/terminalFileLinks';
+    import '@xterm/xterm/css/xterm.css';
+    window.testLinks = { ...links, renderMarkdown, linkFileContent };
+    const request = links.requestFromHash(location.hash);
+    function FileRoute() {
+      const [hash,setHash]=useState(location.hash);
+      useEffect(()=>{const changed=()=>setHash(location.hash); window.addEventListener('hashchange',changed);return()=>window.removeEventListener('hashchange',changed);},[]);
+      const next=React.useMemo(()=>links.requestFromHash(hash),[hash]);
+      return <FileLinkPage key={hash} request={next}/>;
+    }
+    if (request) createRoot(document.getElementById('root')).render(<FileRoute/>);
+    else {
+      createRoot(document.getElementById('root')).render(<main>
+        <FileLinkScope session="team"><FileLinkContent className="markdown" html={renderMarkdown(${JSON.stringify(markdown)})}/></FileLinkScope>
+        <textarea aria-label="Draft" defaultValue="Keep this draft"/>
+        <div style={{height:1200}}>Conversation below the links</div>
+      </main>);
+      const term = new Terminal({ cols:80,rows:8,fontSize:14,linkHandler:terminalLinkHandler('team') });
+      term.loadAddon(new WebLinksAddon((event,uri)=>openTerminalLink(event,uri,'team')));
+      term.open(document.getElementById('terminal')); installTerminalFileLinks(term,'team');
+      term.write('docs/next.md:42\\r\\nhttps://example.test/terminal\\r\\n\\x1b]8;;file:///data/workspaces/team/readme.md\\x1b\\\\open readme\\x1b]8;;\\x1b\\\\');
+      window.term=term;
+      window.osc=(text)=>terminalLinkHandler('team').activate(new MouseEvent('click'),text);
+    }
+  ` }, bundle: true, outfile: bundle, format: 'iife', platform: 'browser',
+  define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent',
+});
+const files = {
+  'team/readme.md': { kind: 'markdown', text: '# Readme preview\n\n[Next](docs/next.md)\n\n![Picture](docs/pixel.svg)' },
+  'team/docs/next.md': { kind: 'markdown', text: '# Nested document\n\n[Parent](../readme.md)' },
+  'team/docs/a #1%.md': { kind: 'markdown', text: '# Special characters' },
+  'team/code.ts': { kind: 'text', text: Array.from({ length: 100 }, (_, i) => `const line${i + 1} = ${i + 1};`).join('\n') },
+};
+const calls = [];
+const css = ['styles.css', 'conversation.css'].map((name) => fs.readFileSync(path.join(web, 'src', name), 'utf8')).join('\n');
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://fixture');
+  if (url.pathname === '/fixture.js') { res.setHeader('content-type', 'text/javascript'); return res.end(fs.readFileSync(bundle)); }
+  if (url.pathname === '/fixture.css') { res.setHeader('content-type', 'text/css'); return res.end(css + fs.readFileSync(bundle.replace('.js', '.css'))); }
+  if (url.pathname.startsWith('/api/')) {
+    calls.push({ method: req.method, path: url.pathname, query: Object.fromEntries(url.searchParams) });
+    res.setHeader('content-type', 'application/json');
+    let file = url.searchParams.get('file') || '';
+    if (file.startsWith('/data/workspaces/')) file = file.slice('/data/workspaces/'.length);
+    else if (!url.searchParams.has('root')) file = path.posix.join('team', file);
+    file = path.posix.normalize(file);
+    const entry = files[file];
+    if (url.searchParams.get('session') === 'remote') { res.statusCode = 404; return res.end(JSON.stringify({ error: 'File unavailable here: remote conversation.' })); }
+    if (url.pathname.endsWith('/raw') && file === 'team/docs/pixel.svg') {
+      res.setHeader('content-type', 'image/svg+xml'); return res.end('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"/>');
+    }
+    if (!entry) { res.statusCode = 404; return res.end(JSON.stringify({ error: 'File not found.' })); }
+    if (url.pathname.endsWith('/resolve')) return res.end(JSON.stringify({ root: 'workspace', path: file, absolute: '/data/workspaces/' + file }));
+    if (url.pathname.endsWith('/preview')) return res.end(JSON.stringify({ ...entry, path: file, name: path.basename(file), size: entry.text.length, mtime: 1 }));
+    return res.end(entry.text);
+  }
+  if (url.pathname.startsWith('/fonts/')) { res.statusCode = 404; return res.end(); }
+  res.setHeader('content-type', 'text/html');
+  res.end('<!doctype html><link rel="stylesheet" href="/fixture.css"><style>body:has(#terminal:not(:empty)){overflow:auto}#terminal{position:fixed;bottom:0;right:0;background:white;z-index:2}</style><div id="root"></div><div id="terminal"></div><script src="/fixture.js"></script>');
+});
+server.listen(0, '127.0.0.1');
+await new Promise((resolve) => server.once('listening', resolve));
+const origin = `http://127.0.0.1:${server.address().port}`;
+const browser = await chromium.launch(chromiumLaunchOptions());
+const context = await browser.newContext({ viewport: { width: 1000, height: 760 } });
+context.setDefaultTimeout(10_000);
+await context.route('https://example.test/**', (route) => route.fulfill({ body: 'External destination' }));
+const errors = [];
+context.on('page', (page) => page.on('pageerror', (error) => errors.push(error.message)));
+const page = await context.newPage();
+const popup = async (action) => {
+  const pending = context.waitForEvent('page');
+  await action();
+  const tab = await pending; await tab.waitForLoadState('domcontentloaded');
+  return tab;
+};
+try {
+  await page.goto(origin);
+  console.log('file-links: fixture loaded');
+  await page.getByRole('link', { name: 'Readme', exact: true }).waitFor();
+  assert.deepEqual(await page.evaluate(() => {
+    const { parseFileReference: parse, fileRequest, fileLinkHash, requestFromHash } = window.testLinks;
+    return [parse('src/main.ts:42:3'), parse('src/main.ts#L12-L15'), parse('docs/a%20%231%25.md'),
+      parse('https://example.test'), parse('file://other-host/x.md'), parse('javascript:alert(1)'),
+      fileRequest('../readme.md', { root: 'workspace', base: 'team/docs' }),
+      requestFromHash(fileLinkHash({ file: 'team/a #1%.md', root: 'workspace', line: 7 }))];
+  }), [{ file: 'src/main.ts', line: 42, column: 3 }, { file: 'src/main.ts', line: 12 }, { file: 'docs/a #1%.md' },
+    null, null, null, { file: 'team/docs/../readme.md', root: 'workspace' },
+    { file: 'team/a #1%.md', root: 'workspace', line: 7, column: undefined, session: undefined, unavailable: undefined }]);
+  assert.equal(await page.locator('pre a').count(), 0, 'code blocks do not gain file links');
+  assert.equal(await page.locator('a[href^="javascript:"]').count(), 0);
+  for (const anchor of await page.locator('a[href]').all()) {
+    assert.equal(await anchor.getAttribute('target'), '_blank');
+    assert.match(await anchor.getAttribute('rel'), /noopener/);
+  }
+  const original = page.url();
+  let tab = await popup(() => page.getByRole('link', { name: 'Readme', exact: true }).click());
+  await tab.getByRole('heading', { name: 'Readme preview' }).waitFor();
+  assert.equal(await tab.evaluate(() => window.opener), null);
+  assert.equal(page.url(), original); assert.equal(await page.getByRole('textbox', { name: 'Draft' }).inputValue(), 'Keep this draft');
+  assert.equal(await tab.locator('.xterm').count(), 0, 'file tab does not mount a terminal');
+  assert.match(tab.url(), /root=workspace/); assert.doesNotMatch(tab.url(), /session=/);
+  await tab.waitForFunction(() => document.querySelector('.fv-md img')?.naturalWidth === 20);
+  if (process.env.FILE_LINK_SHOTS) {
+    fs.mkdirSync(process.env.FILE_LINK_SHOTS, { recursive: true });
+    await tab.screenshot({ path: path.join(process.env.FILE_LINK_SHOTS, 'file-preview-desktop.png') });
+  }
+  let nested = await popup(() => tab.getByRole('link', { name: 'Next', exact: true }).click());
+  await nested.getByRole('heading', { name: 'Nested document' }).waitFor();
+  assert.match(nested.url(), /team%2Fdocs%2Fnext.md/); await nested.close();
+  await tab.setViewportSize({ width: 390, height: 844 });
+  assert.equal(await tab.evaluate(() => document.documentElement.scrollWidth > innerWidth), false, 'mobile preview fits');
+  if (process.env.FILE_LINK_SHOTS) await tab.screenshot({ path: path.join(process.env.FILE_LINK_SHOTS, 'file-preview-mobile.png') });
+  await tab.close();
+  console.log('file-links: Markdown preview and nested links passed');
+  tab = await popup(() => page.getByRole('link', { name: 'Line', exact: true }).click());
+  await tab.locator('.cm-activeLine').filter({ hasText: 'const line42' }).waitFor();
+  assert.equal(await tab.locator('.cm-content').getAttribute('contenteditable'), 'false');
+  const lineBox = await tab.locator('.cm-activeLine').boundingBox();
+  assert.ok(lineBox.y > 0 && lineBox.y < 760, 'line reference is revealed'); await tab.close();
+  tab = await popup(() => page.getByRole('link', { name: 'Bare line', exact: true }).click());
+  await tab.locator('.cm-activeLine').filter({ hasText: 'const line42' }).waitFor(); await tab.close();
+  for (const [label, heading] of [['File URI', 'Readme preview'], ['Spaces', 'Special characters'], ['docs/next.md', 'Nested document']]) {
+    tab = await popup(() => page.getByRole('link', { name: label, exact: true }).click());
+    await tab.getByRole('heading', { name: heading }).waitFor(); await tab.close();
+  }
+  tab = await popup(() => page.getByRole('link', { name: 'Website' }).click());
+  assert.equal(tab.url(), 'https://example.test/guide'); await tab.close();
+  console.log('file-links: reader links passed');
+
+  // Real hit testing in xterm, including OSC 8 links that are not visible paths.
+  await page.waitForFunction(() => window.term?.buffer.active.getLine(2)?.translateToString(true).includes('open readme'));
+  const clickCell = async (x, y) => {
+    const box = await page.locator('.xterm-screen').boundingBox();
+    await page.mouse.move(box.x + (x + 0.5) * box.width / 80, box.y + (y + 0.5) * box.height / 8);
+    await page.waitForTimeout(100);
+    await page.mouse.down(); await page.mouse.up();
+  };
+  for (const [row, expected] of [[0, 'Nested document'], [1, 'external'], [2, 'Readme preview']]) {
+    console.log('file-links: terminal row', row);
+    tab = await popup(() => clickCell(3, row));
+    if (expected === 'external') assert.equal(tab.url(), 'https://example.test/terminal');
+    else if (row === 0) await tab.locator('.cm-content').waitFor(); // :42 requests source
+    else await tab.getByRole('heading', { name: expected }).waitFor();
+    assert.equal(page.url(), original); await tab.close();
+  }
+  await page.evaluate(() => window.osc('javascript:alert(1)'));
+  assert.equal(context.pages().length, 1, 'unsafe OSC 8 URLs do not open');
+  // The link starts after a wide glyph and wraps to another row. Click its
+  // continuation to verify both the joined path and terminal cell mapping.
+  const wrappedPath = 'docs/' + 'a'.repeat(90) + '.md';
+  await page.evaluate((value) => new Promise((resolve) => {
+    window.term.reset(); window.term.write('🔎 ' + value, resolve);
+  }), wrappedPath);
+  tab = await popup(() => clickCell(3, 1));
+  await tab.getByRole('alert').filter({ hasText: 'File not found' }).waitFor();
+  assert.equal(new URLSearchParams(new URL(tab.url()).hash.slice(1)).get('file'), wrappedPath);
+  await tab.close();
+  tab = await context.newPage();
+  await tab.goto(origin + '/#file=missing.md&session=team');
+  await tab.getByRole('alert').filter({ hasText: 'File not found' }).waitFor();
+  await tab.goto(origin + '/#file=readme.md&session=remote');
+  await tab.getByRole('alert').filter({ hasText: 'File unavailable here' }).waitFor(); await tab.close();
+  assert.ok(calls.every((call) => call.method === 'GET' && call.path.startsWith('/api/file-links/')), 'no file writes or agent APIs');
+  assert.deepEqual(errors, []);
+  console.log('file-links: reader + terminal new tabs, canonical URLs, Markdown assets, line jumps, mobile layout, and errors passed');
+} finally {
+  await browser.close(); await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/web/test/sessionFilePreview.test.mjs
+++ b/web/test/sessionFilePreview.test.mjs
@@ -1,0 +1,202 @@
+// Real pane-scoped reader/xterm clicks, plus the explicit retained Files pane.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'session-file-preview-'));
+const bundle = path.join(tmp, 'fixture.js');
+await build({ stdin: { resolveDir: web, loader: 'tsx', contents: `
+  import React, { useEffect, useRef, useState } from 'react'; import { createRoot } from 'react-dom/client';
+  import PaneFilePreview from './src/components/PaneFilePreview';
+  import Manager from './src/App';
+  import FileLinkContent, { FileLinkScope, useFilePreview } from './src/components/FileLinkContent';
+  import FilesPane from './src/components/FilesPane';
+  import { retainFileViewer } from './src/lib/fileViewer';
+  import { recall, remember } from './src/components/filesMemory';
+  import { renderMarkdown } from './src/lib/markdown';
+  import { Terminal } from '@xterm/xterm'; import { WebLinksAddon } from '@xterm/addon-web-links';
+  import { installTerminalFileLinks, terminalLinkHandler, openTerminalLink } from './src/lib/terminalFileLinks';
+  import '@xterm/xterm/css/xterm.css';
+  window.recall = recall;
+  function Source() {
+    const open = useFilePreview(), host=useRef(null);
+    useEffect(()=>{
+      window.mounts=(window.mounts||0)+1;
+      const term=new Terminal({cols:60,rows:5,fontSize:14,linkHandler:terminalLinkHandler('team',open)});
+      term.loadAddon(new WebLinksAddon((event,text)=>openTerminalLink(event,text,'team',open)));
+      term.open(host.current); installTerminalFileLinks(term,'team',open);
+      term.write('code.ts:42:3\\r\\nhttps://example.test/terminal\\r\\n\\x1b]8;;file:///data/workspaces/team/readme.md\\x1b\\\\open readme\\x1b]8;;\\x1b\\\\');
+      window.term=term; return ()=>term.dispose();
+    },[open]);
+    return <div className="slot">
+      <header className="pane-head">Research session</header>
+      <div id="conversation" style={{overflow:'auto',flex:1,padding:16}}>
+        <div style={{height:300}}>Earlier conversation</div>
+        <FileLinkScope session="team"><FileLinkContent html={renderMarkdown('[Readme](./readme.md) · [Code](./code.ts:42:3) · [Missing](./missing.md) · [Website](https://example.test/reader)')}/></FileLinkScope>
+        <textarea aria-label="Draft" defaultValue="Keep this draft"/>
+        <div style={{height:700}}>Later conversation</div>
+      </div>
+      <div ref={host}/>
+    </div>;
+  }
+  function App() {
+    const [pane,setPane]=useState(()=>JSON.parse(localStorage.getItem('fixture-pane')||'null'));
+    const [shown,setShown]=useState(!!pane);
+    const [fail,setFail]=useState(false);
+    window.failKeep=()=>setFail(true);
+    return <div style={{display:'flex',height:'100%',gap:12,padding:12}}>
+      <div className="tile" style={{width:'100%',maxWidth:700}}><PaneFilePreview onOpenInViewer={async (request)=>{
+        if(fail){setFail(false);throw new Error('Viewer unavailable — retry');}
+        const next=await retainFileViewer(request,pane?[pane]:[],'group-1');
+        setPane(next);setShown(true);localStorage.setItem('fixture-pane',JSON.stringify(next));
+      }}><Source/></PaneFilePreview></div>
+      <aside style={{display:'flex',flexDirection:'column',width:500,minWidth:0}}>
+        <button onClick={()=>setShown(!shown)}>Toggle retained viewer</button>
+        <button id="neighbor">Other session</button>
+        {shown&&pane&&<FilesPane session={pane} onClose={()=>setShown(false)}/>}
+      </aside>
+    </div>;
+  }
+  createRoot(document.getElementById('root')).render(location.search.includes('manager') ? <Manager/> : <App/>);
+` }, bundle: true, outfile: bundle, format: 'iife', platform: 'browser', define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent' });
+const css = ['styles.css', 'conversation.css'].map((name) => fs.readFileSync(path.join(web, 'src', name), 'utf8')).join('\n');
+const calls = [];
+const managerTree = { order: ['g:group-1'], hidden: [],
+  groups: [{ id: 'group-1', name: 'Research', sessionIds: ['team'], layout: { cols: 1, rows: 1 } }],
+  sessions: [{ id: 'team', name: 'Research session', cli: 'remote', path: 'team', state: 'waiting', running: false,
+    createdAt: new Date().toISOString(), remote: { name: 'research', paused: false } }],
+};
+const files = {
+  'team/readme.md': { kind: 'markdown', text: '# Readme preview\n\n[Next](next.md)\n\n![Picture](pixel.svg)' },
+  'team/next.md': { kind: 'markdown', text: '# Nested document' },
+  'team/code.ts': { kind: 'text', text: Array.from({ length: 100 }, (_, i) => `const line${i + 1} = ${i + 1};`).join('\n') },
+};
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://fixture');
+  if (url.pathname === '/fixture.js') { res.setHeader('content-type', 'text/javascript'); return res.end(fs.readFileSync(bundle)); }
+  if (url.pathname === '/fixture.css') { res.setHeader('content-type', 'text/css'); return res.end(css + fs.readFileSync(bundle.replace('.js', '.css'))); }
+  if (url.pathname.startsWith('/api/')) {
+    const call = { method: req.method, path: url.pathname }; calls.push(call);
+    res.setHeader('content-type', 'application/json');
+    if (url.pathname === '/api/tree') return res.end(JSON.stringify(managerTree));
+    if (url.pathname === '/api/clis') return res.end(JSON.stringify([{id:'remote',label:'Remote',available:true,ready:true},{id:'files',label:'Files',available:true,ready:true}]));
+    if (url.pathname === '/api/info') return res.end(JSON.stringify({locked:false,welcomeSeen:true}));
+    if (url.pathname === '/api/config') return res.end(JSON.stringify({archive:{after:'never'}}));
+    if (url.pathname === '/api/meta') return res.end(JSON.stringify({sessions:[]}));
+    if (url.pathname.endsWith('/remote')) return res.end(JSON.stringify({connected:true,name:'research',paused:false,peer:null,state:'waiting',seq:1,deliveredThrough:1,
+      messages:[{seq:1,role:'agent',ts:Date.now(),text:'[Readme](./readme.md)'}]}));
+    if (req.method === 'POST' && url.pathname === '/api/sessions') {
+      let body='';req.on('data',(part)=>body+=part);req.on('end',()=>{
+        call.body=JSON.parse(body);
+        const created={id:'retained',...call.body,state:'idle',running:false,createdAt:new Date().toISOString()};
+        managerTree.sessions.push(created);managerTree.groups[0].sessionIds.push(created.id);
+        res.end(JSON.stringify(created));
+      }); return;
+    }
+    let file=url.searchParams.get('file')||'';
+    if(file.startsWith('/data/workspaces/'))file=file.slice('/data/workspaces/'.length);
+    else if(!url.searchParams.has('root'))file='team/'+file;
+    file=path.posix.normalize(file);
+    if(url.pathname.endsWith('/raw')&&file==='team/pixel.svg'){
+      res.setHeader('content-type','image/svg+xml');return res.end('<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20"/>');
+    }
+    const entry=files[file];
+    if(!entry){res.statusCode=404;return res.end(JSON.stringify({error:'File not found.'}));}
+    if(url.pathname.endsWith('/resolve'))return res.end(JSON.stringify({root:'workspace',path:file,absolute:'/data/workspaces/'+file}));
+    return res.end(JSON.stringify({...entry,path:file,name:path.basename(file),size:entry.text.length,mtime:1}));
+  }
+  res.setHeader('content-type','text/html');res.end('<!doctype html><link rel="stylesheet" href="/fixture.css"><div id="root"></div><script src="/fixture.js"></script>');
+});
+server.listen(0,'127.0.0.1');await new Promise((resolve)=>server.once('listening',resolve));
+const origin=`http://127.0.0.1:${server.address().port}`;
+const browser=await chromium.launch(chromiumLaunchOptions());
+const context=await browser.newContext({viewport:{width:1200,height:800}});
+context.setDefaultTimeout(10_000);
+await context.route('https://example.test/**',(route)=>route.fulfill({body:'External destination'}));
+const errors=[];context.on('page',(page)=>page.on('pageerror',(error)=>errors.push(error.message)));
+const page=await context.newPage();
+try {
+  await page.goto(origin);
+  const original=page.url(), title=await page.title();
+  const reader=page.locator('#conversation'), dialog=page.getByRole('dialog',{name:'File preview'});
+  await reader.getByRole('link',{name:'Readme',exact:true}).scrollIntoViewIfNeeded();
+  const scroll=await reader.evaluate((el)=>el.scrollTop);
+  const openReadme=async()=>{await reader.getByRole('link',{name:'Readme',exact:true}).click();await dialog.getByRole('heading',{name:'Readme preview'}).waitFor();};
+  await openReadme();
+  assert.equal(context.pages().length,1);assert.equal(page.url(),original);assert.equal(await page.title(),title);
+  assert.equal(await page.evaluate(()=>window.mounts),1);
+  assert.equal(await page.locator('.pane-file-session').evaluate((el)=>el.inert),true);
+  assert.equal(await page.locator('.xterm').count(),1,'original terminal stays mounted');
+  await page.locator('#neighbor').click(); // other tiles are not blocked
+  await dialog.getByRole('link',{name:'Next',exact:true}).click();
+  await dialog.getByRole('heading',{name:'Nested document'}).waitFor();
+  await dialog.getByRole('button',{name:'Back',exact:true}).click();
+  await dialog.getByRole('heading',{name:'Readme preview'}).waitFor();
+  if(process.env.FILE_LINK_SHOTS){fs.mkdirSync(process.env.FILE_LINK_SHOTS,{recursive:true});await page.screenshot({path:path.join(process.env.FILE_LINK_SHOTS,'session-preview-desktop.png')});}
+  await dialog.getByRole('button',{name:'Close preview',exact:true}).click();
+  assert.equal(await reader.evaluate((el)=>el.scrollTop),scroll);
+  assert.equal(await reader.getByRole('textbox',{name:'Draft'}).inputValue(),'Keep this draft');
+  assert.equal(await page.locator('.pane-file-session').evaluate((el)=>el.inert),false);
+  assert.equal(await reader.getByRole('link',{name:'Readme',exact:true}).evaluate((el)=>el===document.activeElement),true,'focus returns to source');
+  const clickCell=async(row)=>{
+    const box=await page.locator('.xterm-screen').boundingBox();
+    await page.mouse.move(box.x+3.5*box.width/60,box.y+(row+.5)*box.height/5);
+    await page.waitForTimeout(100);await page.mouse.down();await page.mouse.up();
+  };
+  await clickCell(0);await dialog.locator('.cm-activeLine').filter({hasText:'const line42'}).waitFor();
+  assert.equal(await dialog.locator('.cm-content').getAttribute('contenteditable'),'false');
+  await page.keyboard.press('Escape');await dialog.waitFor({state:'hidden'});
+  await clickCell(2);await dialog.getByRole('heading',{name:'Readme preview'}).waitFor();
+  await page.keyboard.press('Escape');await dialog.waitFor({state:'hidden'});
+  for(const action of [()=>clickCell(1),()=>reader.getByRole('link',{name:'Website'}).click()]){
+    const next=context.waitForEvent('page');await action();const tab=await next;await tab.waitForLoadState();
+    assert.equal(await tab.evaluate(()=>window.opener),null);await tab.close();assert.equal(page.url(),original);
+  }
+  await reader.getByRole('link',{name:'Missing'}).click();await dialog.getByRole('alert').filter({hasText:'File not found'}).waitFor();
+  assert.equal(await dialog.getByRole('button',{name:'Open in file viewer'}).isDisabled(),true);
+  await page.keyboard.press('Escape');await dialog.waitFor({state:'hidden'});
+  assert.ok(calls.every((call)=>call.method==='GET'),'transient previews make no writes');
+  await openReadme();await page.evaluate(()=>window.failKeep());
+  await dialog.getByRole('button',{name:'Open in file viewer'}).click();await dialog.getByRole('alert').filter({hasText:'Viewer unavailable'}).waitFor();
+  await dialog.getByRole('button',{name:'Open in file viewer'}).click();await dialog.waitFor({state:'hidden'});
+  await page.locator('aside').getByRole('heading',{name:'Readme preview'}).waitFor();
+  assert.deepEqual(calls.filter((call)=>call.method==='POST').map((call)=>call.body),[{name:'File: readme.md',cli:'files',groupId:'group-1',path:'.'}]);
+  assert.equal(context.pages().length,1);assert.equal(await page.evaluate(()=>window.mounts),1);
+  await page.getByRole('button',{name:'Toggle retained viewer'}).click();await page.getByRole('button',{name:'Toggle retained viewer'}).click();
+  await page.locator('aside').getByRole('heading',{name:'Readme preview'}).waitFor();
+  await page.reload();await page.locator('aside').getByRole('heading',{name:'Readme preview'}).waitFor();
+  await openReadme();await dialog.getByRole('button',{name:'Open in file viewer'}).click();await dialog.waitFor({state:'hidden'});
+  assert.equal(calls.filter((call)=>call.method==='POST').length,1,'same retained file reuses its pane');
+  await page.setViewportSize({width:390,height:844});await page.locator('aside').evaluate((el)=>el.style.display='none');
+  await openReadme();assert.equal(await page.evaluate(()=>document.documentElement.scrollWidth>innerWidth),false);
+  assert.equal(await dialog.getByRole('button',{name:'Open in file viewer'}).isVisible(),true);
+  if(process.env.FILE_LINK_SHOTS)await page.screenshot({path:path.join(process.env.FILE_LINK_SHOTS,'session-preview-mobile.png')});
+  // Exercise the actual App wrappers/navigation too. Fixed 1x1 groups must
+  // reveal the newly appended viewer on page 2, not leave it off screen.
+  const app = await context.newPage();
+  await app.goto(origin);await app.evaluate(()=>{
+    localStorage.clear();localStorage.setItem('am-active-ref','g:group-1');localStorage.setItem('am-focused-id','team');
+  });
+  managerTree.sessions=managerTree.sessions.slice(0,1);managerTree.groups[0].sessionIds=['team'];
+  await app.goto(origin+'/?manager');
+  await app.locator('.rp-agent').getByRole('link',{name:'Readme'}).click();
+  await app.getByRole('dialog').getByRole('heading',{name:'Readme preview'}).waitFor();
+  assert.equal(await app.locator('.rp-agent').count(),1,'actual session remains mounted behind the preview');
+  await app.getByRole('dialog').getByRole('button',{name:'Open in file viewer'}).click();
+  await app.getByRole('dialog').waitFor({state:'hidden'});
+  await app.locator('.tile .file-link-page').getByRole('heading',{name:'Readme preview'}).waitFor();
+  assert.equal(await app.getByRole('dialog').count(),0);
+  assert.equal(await app.locator('.rp-agent').count(),0,'group pager selects the new Files pane');
+  assert.equal(await app.evaluate(()=>localStorage.getItem('am-focused-id')),'retained');
+  if(process.env.FILE_LINK_SHOTS)await app.screenshot({path:path.join(process.env.FILE_LINK_SHOTS,'app-retained-viewer.png')});
+  await app.close();
+  assert.deepEqual(errors,[]);
+  console.log('session-file-preview: in-pane reader + terminal/OSC8, back/close, source state, retained viewer/reload/reuse, external tabs, errors and mobile passed');
+} finally {await browser.close();await new Promise((resolve)=>server.close(resolve));fs.rmSync(tmp,{recursive:true,force:true});}


### PR DESCRIPTION
Agents frequently mention workspace files, but reader links are treated as browser paths and terminals only detect web URLs. File references now open a read-only preview inside the originating session pane, preserving its mounted reader/terminal, scroll position and draft. Back/Escape returns through followed links; Close returns to the session. External web links still open new browser tabs.

- Reader Markdown links and inline-code paths resolve against their originating session. Absolute paths, `file:///` links, and `:line:column` / `#L42` references are supported.
- Terminal output gains clickable file paths, including soft wraps and wide-character positioning. Explicit OSC 8 file hyperlinks use the same in-pane preview; HTTP(S) links open new tabs with `noopener noreferrer`.
- **Open in file viewer** creates a retained, passive Files pane in the app (or reuses one already showing that file). It never repoints an unrelated editor. The file selection survives navigation/reloads in the same browser, using existing Files memory; configured extra roots remain read-only.
- The preview reuses the existing Files viewer and styling for Markdown, code, images, HTML and PDFs. It offers source/preview, wrapping, copy path/link and download. Previewing alone never creates a session or attaches another terminal.
- Resolved URLs identify a named root and file independently of the originating session. Relative links and images in Markdown resolve beside the document.
- A read-only API validates lexical and real paths on every request, caps text previews, and preserves the existing HTML sandbox. Optional `AM_FILE_LINK_ROOTS` exposes additional named directories; workspace access is available by default.

Relative paths use the session's configured folder; shell `cd` commands are not inferred. Remote/imported conversations without a local source show an unavailable-file message. Paths outside configured roots must be enabled explicitly. Filenames with spaces or delimiter characters in terminals need an OSC 8 link. These behaviors and configuration are documented in `docs/file-links.md`.

Validation:

- `cd server && node test/file-links.test.mjs` — resolution, additional roots, symlinks, special characters, missing files, bounded reads, download headers and read-only access.
- `cd web && npm test` — all 25 suites pass, including actual reader/xterm clicks opening in-pane previews, preserved source state, canonical URLs, Markdown assets, line jumps and mobile previews.
- `cd web && node test/sessionFilePreview.test.mjs` — retained viewer creation/reuse/reload, failure recovery, focus restoration, and full App navigation to a new Files pane on page 2 of a fixed 1×1 group.
- `cd web && node ../scripts/run-suites.mjs --manual promptBand.render remotePaneState.render` — focused rendering regressions.
- `cd web && npm run build` — TypeScript and production build.

Live preview: [DEV 3](https://lvwerra-am-dev-3.hf.space) (private), source `ae5854a`, deployment `a71565b`.

Live checks passed for in-pane code and PDF previews, unchanged source/URL, mobile layout, and retained viewer navigation/reload. The live test used existing demo files and simulated only passive-pane creation in its browser, leaving no extra sessions or writes behind. Local tests exercise the full creation request and fixed-grid navigation.

The release-video Space (`lvwerra/agent-manager-dev`) is left unchanged.
