### PR TITLE
Refresh session state on browser return

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { hiddenSessionIds } from './lib/overviewHidden';
 import { paneOwnsBack } from './lib/mobileBack';
 import { isPassive, isRemote, isShareable } from './types';
 import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './components/icons';
+import { createLatestRefresh, observeAppReturns } from './lib/appRefresh';
 
 // `?vvdebug=1` — a phone has no devtools, and the keyboard layout is a guess
 // when the app is embedded cross-origin. Read once: it never changes mid-run,
@@ -399,8 +400,11 @@ export default function App() {
   // treeLoaded gates the selection check below: until the first tree actually
   // arrives, "your agent isn't in this tree" only means the tree is still empty.
   const [treeLoaded, setTreeLoaded] = useState(false);
-  const refresh = useCallback(async () => {
-    try { setTree(await api.getTree()); setTreeLoaded(true); } catch { /* offline */ }
+  const treeRefresh = useRef<ReturnType<typeof createLatestRefresh<Tree>> | null>(null);
+  // Mutations and foreground recovery replace any possibly frozen request.
+  // Ordinary polls use the manager directly below and coalesce instead.
+  const refresh = useCallback((): Promise<Tree | null> => {
+    return treeRefresh.current?.refresh('replace') ?? Promise.resolve(null);
   }, []);
 
   // Hide/unhide a group (or one agent) in the Overview. Optimistic, because the
@@ -417,13 +421,21 @@ export default function App() {
 
   useEffect(() => {
     api.getClis().then(setClis).catch(() => {});
-    refresh();
-    // Skip polling while the tab is hidden; catch up immediately on return.
-    const t = setInterval(() => { if (!document.hidden) refresh(); }, 2500);
-    const onVisible = () => { if (!document.hidden) refresh(); };
-    document.addEventListener('visibilitychange', onVisible);
-    return () => { clearInterval(t); document.removeEventListener('visibilitychange', onVisible); };
-  }, [refresh]);
+    const manager = createLatestRefresh(
+      (signal) => api.getTree(signal),
+      (next) => { setTree(next); setTreeLoaded(true); },
+    );
+    treeRefresh.current = manager;
+    void manager.refresh('replace');
+    // Same cadence and hidden-tab rule as before. Foreground catch-up is shared
+    // with metadata below so visibility/focus/pageshow/online cannot drift.
+    const t = setInterval(() => { if (!document.hidden) void manager.refresh('poll'); }, 2500);
+    return () => {
+      clearInterval(t);
+      if (treeRefresh.current === manager) treeRefresh.current = null;
+      manager.dispose();
+    };
+  }, []);
 
   // Live per-session digests, polled CONTINUOUSLY in the background (not only
   // while the Overview is open) so opening it is instant. Faster cadence when
@@ -435,12 +447,15 @@ export default function App() {
   const [ages, setAges] = useState<Record<string, number>>({});
   const overviewActiveRef = useRef(false);
   overviewActiveRef.current = activeRef === 'overview';
+  const metaRefresh = useRef<ReturnType<typeof createLatestRefresh<Awaited<ReturnType<typeof api.getMeta>>>> | null>(null);
+  const refreshMeta = useCallback(() => {
+    return metaRefresh.current?.refresh('replace') ?? Promise.resolve(null);
+  }, []);
   useEffect(() => {
-    let alive = true;
     let lastPayload = '';
-    const load = () => api.getMeta()
-      .then((r) => {
-        if (!alive) return;
+    const manager = createLatestRefresh(
+      (signal) => api.getMeta(signal),
+      (r) => {
         setMetaReady(true);
         const payload = JSON.stringify(r.sessions);
         if (payload === lastPayload) return;
@@ -449,19 +464,29 @@ export default function App() {
         setAges(Object.fromEntries(r.sessions.map((s) => [
           s.id, Math.max(s.digest?.lastAssistantTs || 0, s.digest?.lastPromptTs || 0),
         ])));
-      })
-      .catch(() => {});
-    load();
+      },
+    );
+    metaRefresh.current = manager;
+    void manager.refresh('replace');
     // One self-scheduling timer whose delay adapts to the active view, so we
     // never tear down / recreate the loop when navigating.
     let t: ReturnType<typeof setTimeout>;
     const tick = () => {
-      if (!document.hidden) load();
+      if (!document.hidden) void manager.refresh('poll');
       t = setTimeout(tick, overviewActiveRef.current ? 1500 : 8000);
     };
     t = setTimeout(tick, 1500);
-    return () => { alive = false; clearTimeout(t); };
+    return () => {
+      clearTimeout(t);
+      if (metaRefresh.current === manager) metaRefresh.current = null;
+      manager.dispose();
+    };
   }, []);
+
+  // Browser returns arrive as different (often clustered) event shapes across
+  // desktop, mobile and bfcache restoration. Refresh both independent resources
+  // once; the reader owns its own equivalent lifecycle and is not touched here.
+  useEffect(() => observeAppReturns(() => Promise.allSettled([refresh(), refreshMeta()])), [refresh, refreshMeta]);
 
   // Archive threshold from the operator config; refresh when settings closes
   // (that's where it's edited).
@@ -724,9 +749,11 @@ export default function App() {
   // leaving you on a single view of a session that has moved.
   const doMove = (ref: string, to: MoveTarget) => api.move(ref, to)
     .then(async () => {
-      const next = await api.getTree().catch(() => null);
-      if (!next) return refresh();
-      setTree(next);
+      const next = await refresh();
+      // Preserve the old post-move fallback: if its first read fails, make one
+      // more ordinary replacement attempt even though there is nothing safe to
+      // navigate against yet.
+      if (!next) return refresh().then(() => undefined);
       const watching = activeRef?.startsWith('s:') ? activeRef.slice(2) : null;
       if (!watching) return undefined;
       const home = next.groups.find((g) => g.sessionIds.includes(watching));

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -24,7 +24,7 @@ const json = (r: Response) => {
 };
 
 export const getClis = (): Promise<Cli[]> => fetch('/api/clis').then(json);
-export const getTree = (): Promise<Tree> => fetch('/api/tree').then(json);
+export const getTree = (signal?: AbortSignal): Promise<Tree> => fetch('/api/tree', { signal }).then(json);
 
 // Hide a group (or one agent) from the Overview. `ref` is a tree ref — `g:<id>`
 // or `s:<id>`. Persisted server-side, so it holds on every device.
@@ -218,8 +218,8 @@ export interface MetaDigest {
   turnsLog?: TurnEntry[];   // newest-first history of completed exchanges
 }
 export interface MetaSession extends Session { digest: MetaDigest | null }
-export const getMeta = (): Promise<{ sessions: MetaSession[]; generatedAt: string }> =>
-  fetch('/api/meta').then(json);
+export const getMeta = (signal?: AbortSignal): Promise<{ sessions: MetaSession[]; generatedAt: string }> =>
+  fetch('/api/meta', { signal }).then(json);
 // Targeted digest for one session (progressive tile fill); digest is null when
 // this CLI only resolves through the bulk pass.
 export const getMetaOne = (id: string): Promise<{ id: string; digest: MetaDigest | null }> =>

--- a/web/src/lib/appRefresh.ts
+++ b/web/src/lib/appRefresh.ts
@@ -24,8 +24,10 @@ const realClock: RefreshClock = {
  *
  * Polls coalesce behind a live read. Explicit refreshes replace it immediately:
  * abort is sent to the transport, while the local race and generation check
- * also retire transports/mocks that ignore abort. The deadline releases the
- * slot even if neither the request nor its abort ever settles.
+ * also retire transports/mocks that ignore abort. A superseded caller follows
+ * the replacing read, so mutation code awaiting freshness cannot continue
+ * against the stale tree merely because a return event arrived. The deadline
+ * releases the slot even if neither the request nor its abort ever settles.
  */
 export function createLatestRefresh<T>(
   read: (signal: AbortSignal) => Promise<T>,
@@ -36,15 +38,21 @@ export function createLatestRefresh<T>(
   const clock = options.clock ?? realClock;
   let disposed = false;
   let generation = 0;
-  let active: { generation: number; abort: AbortController; promise: Promise<T | null> } | null = null;
+  let active: {
+    generation: number;
+    abort: AbortController;
+    promise: Promise<T | null>;
+    supersedeWith(next: Promise<T | null>): void;
+  } | null = null;
 
   const refresh = (kind: RefreshKind = 'replace'): Promise<T | null> => {
     if (disposed) return Promise.resolve(null);
     if (kind === 'poll' && active) return Promise.resolve(null);
 
-    active?.abort.abort();
+    const previous = active;
     const mine = ++generation;
     const abort = new AbortController();
+    let supersededBy: Promise<T | null> | null = null;
     let timer: Timer;
     let rejectCanceled: (() => void) | null = null;
     const canceled = new Promise<never>((_, reject) => {
@@ -63,15 +71,25 @@ export function createLatestRefresh<T>(
       canceled,
       deadline,
     ]).then((value) => {
-      if (disposed || mine !== generation) return null;
+      if (disposed) return null;
+      if (mine !== generation) return supersededBy;
       publish(value);
       return value;
-    }).catch(() => null).finally(() => {
+    }).catch(() => supersededBy).finally(() => {
       clock.clearTimeout(timer);
       if (rejectCanceled) abort.signal.removeEventListener('abort', rejectCanceled);
       if (active?.generation === mine) active = null;
     });
-    active = { generation: mine, abort, promise };
+    active = {
+      generation: mine,
+      abort,
+      promise,
+      supersedeWith(next) {
+        supersededBy = next;
+        abort.abort();
+      },
+    };
+    previous?.supersedeWith(promise);
     return promise;
   };
 

--- a/web/src/lib/appRefresh.ts
+++ b/web/src/lib/appRefresh.ts
@@ -1,0 +1,156 @@
+/** The tree and metadata are small reads, but a fetch frozen with a backgrounded
+ * page must not own the publication slot forever. This matches the reader's
+ * bounded-read window without turning ordinary failures into visible UI. */
+export const APP_REFRESH_TIMEOUT_MS = 12_000;
+export const RETURN_EVENT_COALESCE_MS = 250;
+
+export type RefreshKind = 'replace' | 'poll';
+
+type Timer = ReturnType<typeof setTimeout>;
+export interface RefreshClock {
+  now(): number;
+  setTimeout(run: () => void, delay: number): Timer;
+  clearTimeout(timer: Timer): void;
+}
+
+const realClock: RefreshClock = {
+  now: () => Date.now(),
+  setTimeout: (run, delay) => setTimeout(run, delay),
+  clearTimeout: (timer) => clearTimeout(timer),
+};
+
+/**
+ * One publication slot for one app resource.
+ *
+ * Polls coalesce behind a live read. Explicit refreshes replace it immediately:
+ * abort is sent to the transport, while the local race and generation check
+ * also retire transports/mocks that ignore abort. The deadline releases the
+ * slot even if neither the request nor its abort ever settles.
+ */
+export function createLatestRefresh<T>(
+  read: (signal: AbortSignal) => Promise<T>,
+  publish: (value: T) => void,
+  options: { timeoutMs?: number; clock?: RefreshClock } = {},
+) {
+  const timeoutMs = options.timeoutMs ?? APP_REFRESH_TIMEOUT_MS;
+  const clock = options.clock ?? realClock;
+  let disposed = false;
+  let generation = 0;
+  let active: { generation: number; abort: AbortController; promise: Promise<T | null> } | null = null;
+
+  const refresh = (kind: RefreshKind = 'replace'): Promise<T | null> => {
+    if (disposed) return Promise.resolve(null);
+    if (kind === 'poll' && active) return Promise.resolve(null);
+
+    active?.abort.abort();
+    const mine = ++generation;
+    const abort = new AbortController();
+    let timer: Timer;
+    let rejectCanceled: (() => void) | null = null;
+    const canceled = new Promise<never>((_, reject) => {
+      rejectCanceled = () => reject(new Error('Refresh canceled'));
+      abort.signal.addEventListener('abort', rejectCanceled, { once: true });
+    });
+    const deadline = new Promise<never>((_, reject) => {
+      timer = clock.setTimeout(() => {
+        abort.abort();
+        reject(new Error('Refresh timed out'));
+      }, timeoutMs);
+    });
+
+    const promise = Promise.race([
+      Promise.resolve().then(() => read(abort.signal)),
+      canceled,
+      deadline,
+    ]).then((value) => {
+      if (disposed || mine !== generation) return null;
+      publish(value);
+      return value;
+    }).catch(() => null).finally(() => {
+      clock.clearTimeout(timer);
+      if (rejectCanceled) abort.signal.removeEventListener('abort', rejectCanceled);
+      if (active?.generation === mine) active = null;
+    });
+    active = { generation: mine, abort, promise };
+    return promise;
+  };
+
+  const dispose = () => {
+    if (disposed) return;
+    disposed = true;
+    generation++;
+    active?.abort.abort();
+    active = null;
+  };
+
+  return { refresh, dispose };
+}
+
+type ListenerTarget = Pick<EventTarget, 'addEventListener' | 'removeEventListener'>;
+
+/**
+ * Refresh on an actual return/reconnect, not on every focus-shaped event.
+ * `blur` and hidden visibility establish that focus/visibility is a return;
+ * initial focus and the ordinary non-persisted pageshow therefore do nothing.
+ * The first useful event starts immediately, and the rest of its browser-event
+ * burst are folded into it for a short window.
+ */
+export function observeAppReturns(
+  refresh: () => void | Promise<unknown>,
+  options: {
+    window?: ListenerTarget;
+    document?: ListenerTarget & { hidden: boolean };
+    clock?: Pick<RefreshClock, 'now'>;
+    coalesceMs?: number;
+  } = {},
+) {
+  const win = options.window ?? window;
+  const doc = options.document ?? document;
+  const clock = options.clock ?? realClock;
+  const coalesceMs = options.coalesceMs ?? RETURN_EVENT_COALESCE_MS;
+  let documentWasHidden = doc.hidden;
+  let windowWasBlurred = false;
+  // Initial tree/meta reads have just started. Treat this instant as fresh so
+  // browser startup noise cannot cancel and duplicate them.
+  let lastRefreshAt = clock.now();
+
+  const run = (force = false) => {
+    if (doc.hidden) { documentWasHidden = true; return; }
+    // Some browsers expose `hidden === false` to focus/pageshow/online before
+    // dispatching visibilitychange. Whichever visible event arrives first owns
+    // this return, so a later companion cannot force a duplicate refresh.
+    const returnedFromHidden = documentWasHidden;
+    documentWasHidden = false;
+    const now = clock.now();
+    if (!force && !returnedFromHidden && now - lastRefreshAt < coalesceMs) return;
+    lastRefreshAt = now;
+    void refresh();
+  };
+  const onVisibility = () => {
+    if (doc.hidden) { documentWasHidden = true; return; }
+    if (documentWasHidden) run();
+  };
+  const onBlur = () => { windowWasBlurred = true; };
+  const onFocus = () => {
+    if (!windowWasBlurred) return;
+    windowWasBlurred = false;
+    run();
+  };
+  const onPageShow = (event: Event) => {
+    if ((event as PageTransitionEvent).persisted) run();
+  };
+  const onOnline = () => run();
+
+  doc.addEventListener('visibilitychange', onVisibility);
+  win.addEventListener('blur', onBlur);
+  win.addEventListener('focus', onFocus);
+  win.addEventListener('pageshow', onPageShow);
+  win.addEventListener('online', onOnline);
+  return () => {
+    doc.removeEventListener('visibilitychange', onVisibility);
+    win.removeEventListener('blur', onBlur);
+    win.removeEventListener('focus', onFocus);
+    win.removeEventListener('pageshow', onPageShow);
+    win.removeEventListener('online', onOnline);
+  };
+}

--- a/web/test/appRefresh.test.mjs
+++ b/web/test/appRefresh.test.mjs
@@ -74,16 +74,19 @@ class FakeClock {
   }, (value) => published.push(value), { clock, timeoutMs: 1_000 });
 
   const old = manager.refresh('poll');
+  let oldSettled = false;
+  void old.then(() => { oldSettled = true; });
   await turn();
   const fresh = manager.refresh('replace');
   await turn();
   assert.equal(reads.length, 2, 'foreground replacement does not wait for an old read');
   assert.equal(reads[0].signal.aborted, true, 'the superseded transport is aborted');
+  assert.equal(oldSettled, false, 'the superseded caller waits for the replacing read');
   reads[1].pending.resolve('fresh');
   assert.equal(await fresh, 'fresh');
+  assert.equal(await old, 'fresh', 'the superseded caller receives the published replacement');
   assert.deepEqual(published, ['fresh']);
   reads[0].pending.resolve('obsolete');
-  assert.equal(await old, null);
   assert.deepEqual(published, ['fresh'], 'a late obsolete response cannot publish');
 
   // A regular poll coalesces rather than churning an in-flight request. Once a
@@ -271,6 +274,7 @@ try {
     const state = {
       version: 1,
       groupName: 'Return tests',
+      created: false,
       freeze: { tree: 0, meta: 0 },
       fail: { tree: 0, meta: 0 },
       frozen: { tree: [], meta: [] },
@@ -286,9 +290,15 @@ try {
       running: i === 1 && version === 1,
       state: i === 1 ? (version === 1 ? 'working' : 'waiting') : 'idle',
     });
+    const createdSession = {
+      id: 's99', name: 'fresh-agent', cli: 'claude', path: 'fresh-agent',
+      createdAt: '2026-09-09T12:00:00.000Z', everStarted: true, running: true, state: 'working',
+    };
     const treeFor = (version) => {
       const sessions = Array.from({ length: 12 }, (_, i) => session(i + 1, version));
-      return { order: ['g:g1'], groups: [{ id: 'g1', name: state.groupName, sessionIds: sessions.map((s) => s.id) }], sessions, hidden: [] };
+      const order = ['g:g1'];
+      if (state.created) { sessions.push(createdSession); order.push('s:s99'); }
+      return { order, groups: [{ id: 'g1', name: state.groupName, sessionIds: sessions.filter((s) => s.id !== 's99').map((s) => s.id) }], sessions, hidden: [] };
     };
     const metaFor = (version) => ({
       generatedAt: new Date().toISOString(),
@@ -328,6 +338,12 @@ try {
         state.groupName = JSON.parse(init.body).name;
         return Promise.resolve(response({ ok: true }));
       }
+      if (url === '/api/sessions' && init.method === 'POST') {
+        state.created = true;
+        return Promise.resolve(response(createdSession));
+      }
+      if (url.startsWith('/api/next-name')) return Promise.resolve(response({ cli: 'claude', name: 'claude-13' }));
+      if (url.startsWith('/api/folders')) return Promise.resolve(response({ path: '', folders: [] }));
       return Promise.resolve(response({ ok: true, sessions: [], messages: [] }));
     };
     const counts = () => ({
@@ -342,6 +358,7 @@ try {
       failNext(kind) { state.fail[kind]++; },
       frozen(kind) { return state.frozen[kind].length; },
       resolveFrozen(kind) { state.frozen[kind].shift()?.resolve(); },
+      resolveFrozenAt(kind, index) { state.frozen[kind].splice(index, 1)[0]?.resolve(); },
       setHidden(hidden) {
         Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
         Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => hidden ? 'hidden' : 'visible' });
@@ -512,6 +529,38 @@ try {
     const now = window.__refreshHarness.counts();
     return now.tree === before.tree + 1 && now.meta === before.meta + 1;
   }, beforeReconnect);
+
+  // A mutation caller awaits its replacement tree before navigating. A return
+  // event during quickstart used to settle the superseded promise as null,
+  // select s99 against the stale tree, and let reconciliation bounce back to
+  // Overview before the replacement finally published s99.
+  await page.click('.ov-row');
+  await page.waitForSelector('.ov-card');
+  await page.click('.add-btn');
+  await page.waitForSelector('.quick-prompt');
+  await page.fill('.quick-prompt', 'run the synthetic task');
+  await page.evaluate(() => { window.__refreshHarness.state.freeze.tree = 2; });
+  await page.press('.quick-prompt', 'Enter');
+  await page.waitForFunction(() => window.__refreshHarness.frozen('tree') === 1, null, { timeout: 5_000 });
+  await page.evaluate(() => {
+    window.__refreshHarness.setHidden(true);
+    window.__refreshHarness.setHidden(false);
+  });
+  await page.waitForFunction(() => window.__refreshHarness.frozen('tree') === 2, null, { timeout: 5_000 });
+  assert.equal(await page.evaluate(() => window.__refreshHarness.state.frozen.tree[0].call.aborted), true,
+    'the return supersedes quickstart\'s tree transport');
+  await page.waitForTimeout(100);
+  assert.equal(await page.evaluate(() => localStorage.getItem('am-active-ref')), 'overview',
+    'navigation waits while the replacement tree is still unresolved');
+  await page.evaluate(() => {
+    window.__refreshHarness.resolveFrozenAt('tree', 1);
+    window.__refreshHarness.resolveFrozenAt('tree', 0);
+  });
+  await page.waitForSelector('[data-pane-name]');
+  assert.equal(await page.textContent('[data-pane-name]'), 'fresh-agent');
+  assert.equal(await page.evaluate(() => localStorage.getItem('am-active-ref')), 's:s99',
+    'quickstart keeps its selected session when a return supersedes its refresh');
+  assert.equal(await page.$('.ov-name'), null, 'selection did not fall back to Overview');
 
   // Unmount removes all timers/listeners/publication rights; remount creates one
   // fresh set rather than accumulating another loop.

--- a/web/test/appRefresh.test.mjs
+++ b/web/test/appRefresh.test.mjs
@@ -1,0 +1,542 @@
+// App-level tree/meta freshness: race semantics under a controllable clock, then
+// the real App handlers in Chromium. The browser cannot enter Chromium's real
+// back/forward cache under automation, so it dispatches the PageTransitionEvent
+// that a persisted restore delivers — through the production listener, not a
+// test-only refresh path.
+//
+// Run with: node test/appRefresh.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'app-refresh-'));
+const libraryBundle = path.join(tmp, 'app-refresh.mjs');
+
+await build({
+  entryPoints: [path.join(WEB, 'src/lib/appRefresh.ts')],
+  outfile: libraryBundle,
+  bundle: true,
+  format: 'esm',
+  platform: 'node',
+  logLevel: 'error',
+});
+const { createLatestRefresh, observeAppReturns } = await import(`${pathToFileURL(libraryBundle)}?${Date.now()}`);
+
+const turn = () => new Promise((resolve) => setTimeout(resolve, 0));
+const deferred = () => {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+};
+class FakeClock {
+  nowValue = 1_000;
+  serial = 0;
+  timers = new Map();
+  now = () => this.nowValue;
+  setTimeout = (run, delay) => {
+    const id = ++this.serial;
+    this.timers.set(id, { at: this.nowValue + delay, run });
+    return id;
+  };
+  clearTimeout = (id) => this.timers.delete(id);
+  advance(ms) {
+    const end = this.nowValue + ms;
+    for (;;) {
+      const due = [...this.timers].filter(([, timer]) => timer.at <= end)
+        .sort((a, b) => a[1].at - b[1].at || a[0] - b[0])[0];
+      if (!due) break;
+      this.nowValue = due[1].at;
+      this.timers.delete(due[0]);
+      due[1].run();
+    }
+    this.nowValue = end;
+  }
+}
+
+// A replacement starts even when the prior transport ignores abort, and only
+// the replacement keeps publication rights.
+{
+  const clock = new FakeClock();
+  const reads = [];
+  const published = [];
+  const manager = createLatestRefresh((signal) => {
+    const pending = deferred();
+    reads.push({ signal, pending });
+    return pending.promise;
+  }, (value) => published.push(value), { clock, timeoutMs: 1_000 });
+
+  const old = manager.refresh('poll');
+  await turn();
+  const fresh = manager.refresh('replace');
+  await turn();
+  assert.equal(reads.length, 2, 'foreground replacement does not wait for an old read');
+  assert.equal(reads[0].signal.aborted, true, 'the superseded transport is aborted');
+  reads[1].pending.resolve('fresh');
+  assert.equal(await fresh, 'fresh');
+  assert.deepEqual(published, ['fresh']);
+  reads[0].pending.resolve('obsolete');
+  assert.equal(await old, null);
+  assert.deepEqual(published, ['fresh'], 'a late obsolete response cannot publish');
+
+  // A regular poll coalesces rather than churning an in-flight request. Once a
+  // deadline fires, even an abort-ignoring mock loses its slot and the next poll
+  // can proceed.
+  const frozen = manager.refresh('poll');
+  await turn();
+  assert.equal(reads.length, 3);
+  assert.equal(await manager.refresh('poll'), null);
+  assert.equal(reads.length, 3, 'polls preserve the existing single-flight cadence');
+  clock.advance(1_000);
+  await turn();
+  assert.equal(await frozen, null);
+  assert.equal(reads[2].signal.aborted, true, 'the deadline aborts the transport');
+  const recovered = manager.refresh('poll');
+  await turn();
+  assert.equal(reads.length, 4, 'the timed-out request did not retain the slot');
+  reads[3].pending.resolve('after-timeout');
+  assert.equal(await recovered, 'after-timeout');
+  manager.dispose();
+}
+
+// Failure and unmount are local to one resource: last-good data stays put, the
+// other resource publishes, and a disposed manager cannot publish later.
+{
+  let tree = 'tree-old';
+  let meta = 'meta-old';
+  const treeReads = [Promise.reject(new Error('tree offline')), Promise.resolve('tree-new')];
+  const metaReads = [Promise.resolve('meta-new')];
+  const treeManager = createLatestRefresh(() => treeReads.shift(), (next) => { tree = next; });
+  const metaManager = createLatestRefresh(() => metaReads.shift(), (next) => { meta = next; });
+  await Promise.all([treeManager.refresh(), metaManager.refresh()]);
+  assert.equal(tree, 'tree-old', 'a failed read retains that resource\'s last good value');
+  assert.equal(meta, 'meta-new', 'the other resource succeeds independently');
+  await treeManager.refresh('poll');
+  assert.equal(tree, 'tree-new', 'failure does not disable the next ordinary poll');
+
+  const late = deferred();
+  const disposed = [];
+  const manager = createLatestRefresh(() => late.promise, (next) => disposed.push(next));
+  const request = manager.refresh();
+  await turn();
+  manager.dispose();
+  late.resolve('too-late');
+  await request;
+  assert.deepEqual(disposed, [], 'unmount retires outstanding publication rights');
+  treeManager.dispose();
+  metaManager.dispose();
+}
+
+// The lifecycle itself is clock-controlled: return events are prompt, startup
+// noise is ignored, one browser event burst is one refresh, and hidden online
+// events defer until visibility returns.
+{
+  const clock = new FakeClock();
+  const win = new EventTarget();
+  const doc = new EventTarget();
+  doc.hidden = false;
+  let refreshes = 0;
+  const stop = observeAppReturns(() => { refreshes++; }, {
+    window: win, document: doc, clock, coalesceMs: 250,
+  });
+  const show = (persisted) => {
+    const event = new Event('pageshow');
+    Object.defineProperty(event, 'persisted', { value: persisted });
+    win.dispatchEvent(event);
+  };
+
+  win.dispatchEvent(new Event('focus'));
+  show(false);
+  assert.equal(refreshes, 0, 'initial focus/pageshow do not duplicate initial reads');
+  clock.advance(300);
+  win.dispatchEvent(new Event('blur'));
+  win.dispatchEvent(new Event('focus'));
+  assert.equal(refreshes, 1, 'returning focus refreshes immediately');
+  show(true);
+  win.dispatchEvent(new Event('online'));
+  assert.equal(refreshes, 1, 'the related event burst is coalesced');
+
+  clock.advance(300);
+  show(true);
+  assert.equal(refreshes, 2, 'a persisted pageshow refreshes without visibilitychange');
+  clock.advance(300);
+  win.dispatchEvent(new Event('online'));
+  assert.equal(refreshes, 3, 'online while visible is a refresh hint');
+
+  doc.hidden = true;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  clock.advance(1_000);
+  win.dispatchEvent(new Event('online'));
+  assert.equal(refreshes, 3, 'online while hidden performs no background work');
+  doc.hidden = false;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  assert.equal(refreshes, 4, 'the visible return catches up immediately');
+  // Chromium variants do not all order focus and visibilitychange alike. If
+  // focus observes the new visible state first, it consumes the hidden return;
+  // the later visibility event is only a companion and must not duplicate it.
+  doc.hidden = true;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  win.dispatchEvent(new Event('blur'));
+  clock.advance(1_000);
+  doc.hidden = false;
+  win.dispatchEvent(new Event('focus'));
+  doc.dispatchEvent(new Event('visibilitychange'));
+  assert.equal(refreshes, 5, 'event order does not split one return into two refreshes');
+  // A genuinely separate hidden/visible cycle is never swallowed merely because
+  // it is fast; only the companion focus/pageshow/online events are.
+  doc.hidden = true;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  doc.hidden = false;
+  doc.dispatchEvent(new Event('visibilitychange'));
+  assert.equal(refreshes, 6, 'repeated return cycles each refresh once');
+  stop();
+  clock.advance(1_000);
+  win.dispatchEvent(new Event('online'));
+  assert.equal(refreshes, 6, 'cleanup removes every listener');
+}
+
+// --- actual App wiring in Chromium ---
+
+const paneStub = path.join(tmp, 'PaneStub.tsx');
+fs.writeFileSync(paneStub, `
+  import React, { useEffect, useRef, useState } from 'react';
+  export default function Pane({ session }) {
+    const [draft, setDraft] = useState('');
+    const body = useRef(null);
+    useEffect(() => {
+      window.__paneMounts = (window.__paneMounts || 0) + 1;
+      return () => { window.__paneUnmounts = (window.__paneUnmounts || 0) + 1; };
+    }, []);
+    return <div className="slot pane-probe">
+      <div data-pane-name>{session.name}</div>
+      <div data-pane-scroll ref={body} style={{height: '40px', overflow: 'auto'}}>
+        <div style={{height: '300px'}}>pane history</div>
+      </div>
+      <textarea data-pane-draft value={draft} onChange={(e) => setDraft(e.target.value)} />
+    </div>;
+  }
+`);
+const appBundle = path.join(tmp, 'app.js');
+await build({
+  stdin: {
+    resolveDir: WEB,
+    loader: 'tsx',
+    contents: `
+      import React from 'react';
+      import { createRoot } from 'react-dom/client';
+      import App from './src/App.tsx';
+      let root;
+      window.__appMount = () => {
+        root = createRoot(document.getElementById('root'));
+        root.render(<App />);
+      };
+      window.__appUnmount = () => { root?.unmount(); root = undefined; };
+      window.__appMount();
+    `,
+  },
+  outfile: appBundle,
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  nodePaths: [path.join(WEB, 'node_modules')],
+  logLevel: 'error',
+  plugins: [{
+    name: 'pane-stubs',
+    setup(builder) {
+      builder.onResolve({ filter: /^\.\/components\/(TerminalPane|FilesPane|TracePane|RemotePane)$/ }, () => ({ path: paneStub }));
+    },
+  }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+const conversationCss = fs.readFileSync(path.join(WEB, 'src/conversation.css'), 'utf8');
+const browser = await chromium.launch(chromiumLaunchOptions());
+try {
+  const page = await browser.newPage({ viewport: { width: 1100, height: 620 } });
+  await page.route('http://app-refresh.test/', (route) => route.fulfill({
+    contentType: 'text/html',
+    body: `<style>${css}\n${conversationCss}</style><div id="root"></div>`,
+  }));
+  await page.goto('http://app-refresh.test/');
+  await page.evaluate(() => {
+    localStorage.setItem('am-active-ref', 'overview');
+    localStorage.setItem('am-ov-view', 'list');
+    const state = {
+      version: 1,
+      groupName: 'Return tests',
+      freeze: { tree: 0, meta: 0 },
+      fail: { tree: 0, meta: 0 },
+      frozen: { tree: [], meta: [] },
+      calls: [],
+    };
+    const session = (i, version) => ({
+      id: `s${i}`,
+      name: i === 1 ? `agent-${version}` : `filler-${i}`,
+      cli: 'claude',
+      path: `agent-${i}`,
+      createdAt: '2026-09-08T12:00:00.000Z',
+      everStarted: true,
+      running: i === 1 && version === 1,
+      state: i === 1 ? (version === 1 ? 'working' : 'waiting') : 'idle',
+    });
+    const treeFor = (version) => {
+      const sessions = Array.from({ length: 12 }, (_, i) => session(i + 1, version));
+      return { order: ['g:g1'], groups: [{ id: 'g1', name: state.groupName, sessionIds: sessions.map((s) => s.id) }], sessions, hidden: [] };
+    };
+    const metaFor = (version) => ({
+      generatedAt: new Date().toISOString(),
+      sessions: treeFor(version).sessions.map((s) => ({ ...s, digest: {
+        lastPromptText: `prompt-${version}`, lastPromptRaw: `prompt-${version}`, lastPromptTs: 100,
+        lastAssistantText: `answer-${version}`, lastAssistantMd: `answer-${version}`, lastAssistantTs: 200,
+        sinceTurns: 1, sinceToolCalls: 0, sinceTools: {}, sinceFiles: [], sinceTokens: 0, turnsLog: [],
+      } })),
+    });
+    const response = (body, ok = true) => new Response(JSON.stringify(body), {
+      status: ok ? 200 : 503, headers: { 'content-type': 'application/json' },
+    });
+    const resource = (url) => url === '/api/tree' ? 'tree' : url === '/api/meta' ? 'meta' : null;
+    window.fetch = (input, init = {}) => {
+      const url = typeof input === 'string' ? input : input.url;
+      const kind = resource(url);
+      const call = { url, method: init.method || 'GET', aborted: !!init.signal?.aborted };
+      state.calls.push(call);
+      init.signal?.addEventListener('abort', () => { call.aborted = true; }, { once: true });
+      if (kind) {
+        const version = state.version;
+        if (state.fail[kind] > 0) {
+          state.fail[kind]--;
+          return Promise.reject(new TypeError(`${kind} offline`));
+        }
+        const body = kind === 'tree' ? treeFor(version) : metaFor(version);
+        if (state.freeze[kind] > 0) {
+          state.freeze[kind]--;
+          return new Promise((resolve) => state.frozen[kind].push({ resolve: () => resolve(response(body)), call, version }));
+        }
+        return Promise.resolve(response(body));
+      }
+      if (url === '/api/info') return Promise.resolve(response({ locked: false, welcomeSeen: true, demoMode: false, spaceId: 'test/space', backup: null }));
+      if (url === '/api/clis') return Promise.resolve(response([{ id: 'claude', label: 'Claude Code', color: '#d97757', available: true, ready: true }]));
+      if (url === '/api/config') return Promise.resolve(response({ archive: { after: 'never' }, artifacts: { enabled: false, space: '', visibility: 'private' }, jobs: { askAboveUsd: 1 }, revive: { enabled: true, days: 3 }, backup: { every: 'never', dataset: '', exclude: [] } }));
+      if (url === '/api/groups/g1' && init.method === 'PUT') {
+        state.groupName = JSON.parse(init.body).name;
+        return Promise.resolve(response({ ok: true }));
+      }
+      return Promise.resolve(response({ ok: true, sessions: [], messages: [] }));
+    };
+    const counts = () => ({
+      tree: state.calls.filter((c) => c.url === '/api/tree').length,
+      meta: state.calls.filter((c) => c.url === '/api/meta').length,
+    });
+    window.__refreshHarness = {
+      state,
+      counts,
+      setVersion(version) { state.version = version; },
+      freezeNext(kind) { state.freeze[kind]++; },
+      failNext(kind) { state.fail[kind]++; },
+      frozen(kind) { return state.frozen[kind].length; },
+      resolveFrozen(kind) { state.frozen[kind].shift()?.resolve(); },
+      setHidden(hidden) {
+        Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+        Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => hidden ? 'hidden' : 'visible' });
+        document.dispatchEvent(new Event('visibilitychange'));
+      },
+      focusReturn() {
+        window.dispatchEvent(new Event('blur'));
+        window.dispatchEvent(new Event('focus'));
+      },
+      burst() {
+        window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }));
+        window.dispatchEvent(new Event('online'));
+        window.dispatchEvent(new Event('focus'));
+      },
+      initialPageShow() { window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: false })); },
+    };
+  });
+  await page.addScriptTag({ path: appBundle });
+  await page.waitForFunction(() => document.querySelector('.ov-name')?.textContent === 'agent-1');
+  await page.waitForFunction(() => document.querySelector('.ov-answer-wrap')?.textContent.includes('answer-1'));
+
+  const initial = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.evaluate(() => window.__refreshHarness.initialPageShow());
+  await page.waitForTimeout(30);
+  assert.deepEqual(await page.evaluate(() => window.__refreshHarness.counts()), initial,
+    'the ordinary initial pageshow does not duplicate initial tree/meta reads');
+  await page.waitForTimeout(300);
+  const beforePersistedShow = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.evaluate(() => window.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true })));
+  await page.waitForFunction((before) => {
+    const now = window.__refreshHarness.counts();
+    return now.tree === before.tree + 1 && now.meta === before.meta + 1;
+  }, beforePersistedShow);
+
+  // Hidden time crosses both Overview metadata (1.5s) and tree (2.5s) clocks,
+  // but adds no reads. Returning publishes both immediately, and companion
+  // lifecycle events do not multiply them.
+  await page.fill('.ov-card textarea', 'draft survives return');
+  // Composer focus deliberately calls scrollIntoView after the mobile keyboard
+  // animation window. Let that app behavior settle before measuring refresh.
+  await page.waitForTimeout(350);
+  const beforeScroll = await page.evaluate(() => {
+    const el = document.querySelector('.ov-wrap');
+    el.scrollTop = 180;
+    return el.scrollTop;
+  });
+  assert.ok(beforeScroll > 0, 'the fixture has real Overview scroll to preserve');
+  await page.evaluate(() => {
+    window.__refreshHarness.setHidden(true);
+    window.__refreshHarness.setVersion(2);
+  });
+  const hiddenCounts = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.waitForTimeout(2_700);
+  assert.deepEqual(await page.evaluate(() => window.__refreshHarness.counts()), hiddenCounts,
+    'hidden time does not add polling work');
+  await page.evaluate(() => {
+    window.__refreshHarness.setHidden(false);
+    window.__refreshHarness.burst();
+  });
+  await page.waitForFunction(() => document.querySelector('.ov-name')?.textContent === 'agent-2');
+  await page.waitForFunction(() => document.querySelector('.ov-answer-wrap')?.textContent.includes('answer-2'));
+  assert.deepEqual(await page.evaluate(() => window.__refreshHarness.counts()), {
+    tree: hiddenCounts.tree + 1, meta: hiddenCounts.meta + 1,
+  }, 'one return/reconnect burst performs one fresh read per resource');
+  assert.equal(await page.inputValue('.ov-card textarea'), 'draft survives return');
+  assert.equal(await page.evaluate(() => document.querySelector('.ov-wrap').scrollTop), beforeScroll,
+    'the refresh does not remount the feed or reset its scroll');
+
+  // Independent failure keeps last-good state. A later return recovers the
+  // failed side; neither failure occupies a slot permanently.
+  await page.waitForTimeout(300);
+  await page.evaluate(() => {
+    window.__refreshHarness.setVersion(3);
+    window.__refreshHarness.failNext('meta');
+    window.__refreshHarness.focusReturn();
+  });
+  await page.waitForFunction(() => document.querySelector('.row[data-ref="s:s1"] .name')?.textContent === 'agent-3');
+  assert.match(await page.textContent('.ov-answer-wrap'), /answer-2/, 'failed metadata keeps its last good card');
+  await page.waitForTimeout(300);
+  await page.evaluate(() => {
+    window.__refreshHarness.setVersion(4);
+    window.__refreshHarness.failNext('tree');
+    window.__refreshHarness.focusReturn();
+  });
+  await page.waitForFunction(() => document.querySelector('.ov-answer-wrap')?.textContent.includes('answer-4'));
+  assert.equal(await page.textContent('.row[data-ref="s:s1"] .name'), 'agent-3', 'failed tree keeps its last good sidebar');
+
+  // Freeze ordinary polls with a mock that records abort but deliberately does
+  // not reject. The visible return must still start both reads; late poll data
+  // then has no right to replace it.
+  await page.evaluate(() => {
+    window.__refreshHarness.freezeNext('tree');
+    window.__refreshHarness.freezeNext('meta');
+  });
+  await page.waitForFunction(() => window.__refreshHarness.frozen('tree') === 1
+    && window.__refreshHarness.frozen('meta') === 1, null, { timeout: 5_000 });
+  await page.evaluate(() => {
+    window.__refreshHarness.setVersion(5);
+    window.__refreshHarness.setHidden(true);
+    window.__refreshHarness.setHidden(false);
+  });
+  await page.waitForFunction(() => document.querySelector('.ov-name')?.textContent === 'agent-5');
+  await page.waitForFunction(() => document.querySelector('.ov-answer-wrap')?.textContent.includes('answer-5'));
+  assert.deepEqual(await page.evaluate(() => ({
+    tree: window.__refreshHarness.state.frozen.tree[0].call.aborted,
+    meta: window.__refreshHarness.state.frozen.meta[0].call.aborted,
+  })), { tree: true, meta: true }, 'return aborts both obsolete poll transports');
+  await page.evaluate(() => {
+    window.__refreshHarness.resolveFrozen('tree');
+    window.__refreshHarness.resolveFrozen('meta');
+  });
+  await page.waitForTimeout(50);
+  assert.equal(await page.textContent('.ov-name'), 'agent-5', 'late poll tree cannot overwrite the return result');
+  assert.match(await page.textContent('.ov-answer-wrap'), /answer-5/, 'late poll metadata cannot overwrite the return result');
+
+  // A post-mutation tree read uses the same replacement path. Start another
+  // frozen ordinary tree poll, rename the group through the real Sidebar, and
+  // verify its refresh neither waits for nor loses to the old poll.
+  await page.evaluate(() => window.__refreshHarness.freezeNext('tree'));
+  await page.waitForFunction(() => window.__refreshHarness.frozen('tree') === 1, null, { timeout: 4_000 });
+  await page.hover('.group-head');
+  await page.click('.group-head button[title="Rename"]');
+  await page.fill('.group-head input.rename', 'Renamed after mutation');
+  await page.press('.group-head input.rename', 'Enter');
+  await page.waitForFunction(() => document.querySelector('.group-head .name')?.textContent === 'Renamed after mutation');
+  assert.equal(await page.evaluate(() => window.__refreshHarness.state.frozen.tree[0].call.aborted), true,
+    'post-mutation refresh replaces an obsolete poll');
+  await page.evaluate(() => window.__refreshHarness.resolveFrozen('tree'));
+  await page.waitForTimeout(50);
+  assert.equal(await page.textContent('.group-head .name'), 'Renamed after mutation');
+
+  // Session view uses the slow metadata cadence, but the same immediate return
+  // path. The keyed pane stays mounted, keeping its local draft and scroll.
+  await page.click('.ov-card .ov-id');
+  await page.waitForSelector('[data-pane-name]');
+  await page.fill('[data-pane-draft]', 'unsent pane draft');
+  await page.evaluate(() => { document.querySelector('[data-pane-scroll]').scrollTop = 90; });
+  const mounts = await page.evaluate(() => window.__paneMounts);
+  await page.waitForTimeout(300);
+  const sessionCounts = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.evaluate(() => {
+    window.__refreshHarness.setVersion(6);
+    window.__refreshHarness.setHidden(true);
+    window.__refreshHarness.setHidden(false);
+    window.__refreshHarness.burst();
+  });
+  await page.waitForFunction(() => document.querySelector('[data-pane-name]')?.textContent === 'agent-6');
+  assert.deepEqual(await page.evaluate(() => window.__refreshHarness.counts()), {
+    tree: sessionCounts.tree + 1, meta: sessionCounts.meta + 1,
+  }, 'a hidden session view refreshes both resources once without waiting for its 8s metadata poll');
+  assert.equal(await page.inputValue('[data-pane-draft]'), 'unsent pane draft');
+  assert.equal(await page.evaluate(() => document.querySelector('[data-pane-scroll]').scrollTop), 90);
+  assert.equal(await page.evaluate(() => window.__paneMounts), mounts, 'the open pane was not remounted');
+  const recoveryCalls = await page.evaluate((from) => window.__refreshHarness.state.calls.slice(from),
+    await page.evaluate(() => window.__refreshHarness.state.calls.length - 2));
+  assert.ok(recoveryCalls.every((call) => call.method === 'GET' && ['/api/tree', '/api/meta'].includes(call.url)),
+    'return performs only the two approved reads — no prompt, session, trace or PTY action');
+
+  // Unlike visibility/bfcache, Chromium does expose a real offline transition
+  // in headless mode. Use it for the reconnect smoke rather than synthesizing
+  // the final `online` event.
+  await page.waitForTimeout(300);
+  const beforeReconnect = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.context().setOffline(true);
+  assert.equal(await page.evaluate(() => navigator.onLine), false);
+  await page.context().setOffline(false);
+  await page.waitForFunction((before) => {
+    const now = window.__refreshHarness.counts();
+    return now.tree === before.tree + 1 && now.meta === before.meta + 1;
+  }, beforeReconnect);
+
+  // Unmount removes all timers/listeners/publication rights; remount creates one
+  // fresh set rather than accumulating another loop.
+  await page.evaluate(() => window.__appUnmount());
+  const unmountedCounts = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.waitForTimeout(300);
+  await page.evaluate(() => window.__refreshHarness.focusReturn());
+  await page.waitForTimeout(30);
+  assert.deepEqual(await page.evaluate(() => window.__refreshHarness.counts()), unmountedCounts,
+    'unmounted App has no return listeners or pollers');
+  await page.evaluate(() => {
+    localStorage.setItem('am-active-ref', 'overview');
+    window.__appMount();
+  });
+  await page.waitForFunction(() => document.querySelector('.ov-name')?.textContent === 'agent-6');
+  const remounted = await page.evaluate(() => window.__refreshHarness.counts());
+  await page.waitForTimeout(300);
+  await page.evaluate(() => window.__refreshHarness.focusReturn());
+  await page.waitForFunction((before) => {
+    const now = window.__refreshHarness.counts();
+    return now.tree === before.tree + 1 && now.meta === before.meta + 1;
+  }, remounted);
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}
+
+console.log('app-refresh: ok');


### PR DESCRIPTION
Closes #124

## What changed

- Refreshes both `/api/tree` and `/api/meta` immediately when a hidden tab becomes visible, a blurred visible window regains focus, a persisted page is shown, or the browser comes online while visible.
- Coalesces the companion events from one return, including browsers that report focus before visibility, while a hidden `online` event waits for the visible return.
- Gives tree and metadata separate latest-read managers. Foreground and post-mutation reads abort/retire old work; generation checks prevent late publication; a 12-second local deadline releases the slot even when a transport ignores abort. Ordinary polls remain single-flight.
- Keeps the existing 2.5-second tree and 1.5/8-second metadata cadence, hidden-tab guard, metadata payload diffing, tree reconciliation, and mutation refresh behavior. Failed reads preserve each resource's last good value independently.
- Threads optional abort signals only through `getTree` and `getMeta`; lifecycle cleanup retires listeners, timers, and outstanding publication rights.

## Lifecycle contract

Initial tree/meta reads are the only startup reads; ordinary non-persisted `pageshow` and startup focus noise do not duplicate them. Polls coalesce behind an in-flight read. A real foreground/reconnect event starts replacement reads promptly, and the first visible event consumes a hidden return so later companion events cannot duplicate it. Reader lifecycle remains owned by `traceWindows`/`readerStore` from #119.

## Agreed boundary

Implemented only app-level tree/list and metadata/status freshness. Deliberately left out stale/reconnecting UI, last-updated labels, Retry controls, polling redesign/backoff, server push, unrelated pane/settings refreshes, page reloads, reader transcript changes, and any prompt/session/trace/PTY action.

Open PRs #118 and #120 also touch `App.tsx` (and #118 touches `api.ts`); this branch does not incorporate their unrelated work and may need a mechanical rebase if either lands first.

## Verification

- `cd web && node test/appRefresh.test.mjs` — passed. Uses controllable clocks/deferred reads plus the real App wiring in Chromium. Covers all four return hints, hidden deferral, event bursts/order, stale abort-ignoring reads, deadline release, tree/meta partial failure and recovery, ordinary polls, a real post-rename refresh, unmount/remount, Overview and session views, retained drafts/panes/scroll, and the absence of non-read side effects.
- `cd web && npm test` — 24/24 discovered suites passed.
- `cd web && npm run typecheck` — passed.
- `cd web && npm run build` — passed (existing chunk-size advisory only).
- Mutation check: making explicit replacement wait behind the old request fails `foreground replacement does not wait for an old read` (`1 !== 2`). Restoring replacement semantics passes.
- Mutation check: removing the App return observer fails the Chromium immediate-return assertion (tree remains at the pre-return request count instead of incrementing with metadata). Restoring it passes.

Headless Chromium cannot force an OS-level tab/app switch or a real BFCache entry. The browser test therefore dispatches visibility/focus and persisted `PageTransitionEvent` through the production listeners (not a test-only refresh path). Reconnect is additionally exercised with Playwright's actual browser-context offline-to-online transition and passed. No live sessions or deployment were used.
