### PR TITLE
Protect managed skills with file ownership and revision-checked mutations

### DIFF
--- a/docs/managed-skills.md
+++ b/docs/managed-skills.md
@@ -1,0 +1,152 @@
+# Managed skills
+
+The manager owns a source file and explicitly recorded generated `SKILL.md`
+files. A matching directory name does not establish ownership. Support files,
+other installations and configured roots are never recursively deleted.
+Deletion is permanent. There is no trash, backup, snapshot, undo or content
+history in this service.
+
+## Identity and destinations
+
+`server/src/skills.js` is the shared lifecycle service for the HTTP routes,
+startup redistribution and generated `environment.md`. Its queue serializes
+these callers within one manager process, including their reads and revision
+checks. Do not run two managers against the same source/state roots.
+
+The installation ID retains the previous mapping: strip the last extension,
+lowercase, normalize punctuation/whitespace to `-`, trim edge hyphens, truncate
+to 40 characters. Invalid/path-like filenames and empty IDs are rejected.
+Distinct sources that collide after case, extension, normalization or truncation
+are rejected before either source or installation bytes change. The global
+session/group `slugify` function is unchanged.
+
+Distribution is still enabled only by `SPACE_ID` or `AM_DISTRIBUTE_SKILLS=1`.
+The destinations remain ordinary `HOME/.agents/skills`, Claude's configured
+skills directory, `HOME/.hermes/skills`, and the `.agents/skills` directories
+under configured Gemini and OpenClaw homes. There are no new destinations.
+The source, state and target roots are canonicalized; configured root aliases
+are supported and duplicate destinations are coalesced. Overlapping ownership
+roots are refused. Managed entries, including dangling symlinks and temporary
+entries, must not redirect through symlinks. Replacing an already resolved root
+with a redirect is also refused. These checks prevent accidental redirection;
+they do not isolate files against arbitrary hostile same-user filesystem races.
+
+## Ownership and existing installations
+
+The version 1 manifest is stored at `DATA_DIR/state/skills/skills-v1.json`.
+It binds the canonical source root and each source filename to its installation
+ID, current source digest, exact target roots/files, and generated-file digests.
+It records which skill directories the operation creates; adopted directories
+are never owned. Recorded paths are checked against current configured roots
+and reconstructed expected filenames before use. A changed source root, unknown
+manifest version, corrupt/unreadable manifest or invalid path disables mutations.
+An unwritable manifest cannot authorize a new operation.
+
+On first startup without a manifest, a unique valid source may be adopted.
+An existing destination is adopted **only** when its `SKILL.md` is byte-identical
+to the rendering of that source. Only that file is adopted, never its directory
+or support files. Missing destinations can be installed. A modified destination
+or ambiguous source makes the whole skill conflict before writes. Other skills
+continue independently, and the server reports degraded distribution without
+stopping its other functions. The editor explains when ownership is not
+established. Generated environment content follows the same checks, using the
+existing source to verify a legacy installation before publishing new content.
+
+Name matching alone cannot authorize deletion, even when the source is absent.
+After losing a manifest, removal returns not-found until ownership has been
+narrowly verified again. Never delete the manifest to force an overwrite. To
+resolve a legacy conflict, choose a noncolliding source name or deliberately
+resolve the independent installation outside the manager, then restart
+redistribution. For a file modified after ownership was established, the manager
+refuses to overwrite/delete it; restore the recorded current content or resolve
+its ownership deliberately outside this API. There is no force-adopt endpoint.
+A removed/redirected configured destination must be restored before operations
+on records that still reference it can proceed.
+
+## HTTP mutation contract
+
+All calls still require the usual operation origin (`?from=…`, or the existing
+operator header used by the web client). Origin attribution is not authentication.
+
+| Call | Contract |
+| --- | --- |
+| `GET /api/skills` | Lists source names and pending operations, including records whose source is missing. |
+| `GET /api/skills/:name` | Returns content, an opaque `revision`, ownership/pending state, and exact managed installation paths with their current presence. |
+| `POST /api/skills/:name` | Create only, with a plain-text body. Existing source or installation-ID collisions return 409. |
+| `PUT /api/skills/:name` | Explicit save, with a plain-text body and `If-Match` set to the exact returned `revision`. Missing tags return 428; stale tags return 409. |
+| `DELETE /api/skills/:name` | Permanent removal of the recorded files, with the same required `If-Match` revision. No record returns 404 and removes nothing. |
+
+Revisions include current source content, ownership/operation metadata, observed
+installation contents and the configured target set. A stale tab or changed
+confirmation cannot overwrite/delete the new state. Current revision tags do
+not override detected external changes to an owned installation. Repeated
+already-completed deletions return the same documented 404/no-mutation outcome.
+
+The UI uploads/creates via POST. Conflicts offer another name or cancellation;
+users open the managed skill to edit it. Failed saves retain the selected source
+and entered text. Refreshing its revision preserves that text and displays the
+current saved source for comparison before another explicit Save.
+
+Deletion has its own modal showing the exact filename and installation paths,
+with a permanent-deletion notice. Cancel receives initial focus. Opening it,
+Cancel and Escape do not mutate. Its captured identity/revision cannot follow a
+changed selection, and duplicate submissions are disabled immediately. A stale
+confirmation must be refreshed. Partial deletion displays remaining/absent
+installations before a scope-limited retry.
+
+## Atomic publication, partial outcomes and retries
+
+Before changing content, the service atomically publishes an operation record
+containing the intended source/target hashes and the exact target set. No
+historical content is stored. Source and generated replacements are written to
+exclusive operation-owned temporary files, flushed, checked, and renamed into
+place. A failed replacement preserves the preceding file. New files are checked for absence immediately before rename; the manager queue
+prevents concurrent create calls from passing that check for the same name.
+Publication does not require hard-link support on bucket-backed roots.
+Cleanup never removes a pre-existing or substituted temporary path.
+
+Multi-target distribution is not a filesystem transaction. HTTP 207 results
+carry `ok: false`, separate `source` and `manifest` outcomes, per-target
+`installed`/`removed`/`absent`/`failed`/`not-attempted` outcomes, and the current
+skill snapshot where available. A failed manifest commit is distinguished from
+successful content publication. A persisted intent lets the service recognize
+either the previous or intended hashes after interruption, without claiming
+ownership of differently modified files.
+
+Retry an incomplete create/save by GET followed by PUT with the same intended
+content and current revision. A create whose source write failed may have a
+pending ownership record and no source yet. POST remains create-only; it cannot
+silently turn that pending create into an overwrite. Startup can resume a pending
+save only when its intended source content is available. It leaves a missing
+source or different content alone. Incomplete operations never add destinations
+on retry; newly configured destinations wait for a subsequent ordinary save or
+startup redistribution after the operation finishes.
+
+Deletion persists its intent **before** unlinking targets and removes the source
+**last**, only after every recorded target file is absent. Empty directories may
+be removed only if the manager created them; a failed optional directory cleanup
+is returned as `directoryError`, and the directory is retained. Extra files
+always remain. A target-file failure retains the source and pending record.
+Startup never republishes a pending deletion and does not automatically finish
+it. GET followed by DELETE retries only the originally recorded targets, checking
+their contents again; an external replacement is a conflict. Even if source
+removal succeeded but the final manifest commit failed, the pending record is
+sufficient to finish that same deletion after restart.
+
+## Verification
+
+The discovered suites are `server/test/skills.test.mjs`,
+`server/test/skills-api.test.mjs` and `web/test/skills.browser.test.mjs`.
+The API/browser fixture clears inherited credentials, Space settings and harness
+homes, injects five disposable destinations, verifies them before opting into
+distribution, and starts no real harnesses. Its fault preload exists only in the
+test fixture and is not used by the application.
+
+Run focused discovery with `npm test --prefix server -- skills` and
+`npm test --prefix web -- skills`, and the full suites with `npm test` in each
+package. `npm run build --prefix web` includes the production typecheck.
+`node scripts/mutation-check-skills.mjs` and
+`node scripts/mutation-check-skills-ui.mjs` deliberately remove the important
+guards in disposable code copies and require regression failures. Set
+`AM_SKILLS_SCREENSHOTS` to a disposable output folder when running the browser
+suite to capture its conflict, confirmation and partial-deletion states.

--- a/docs/managed-skills.md
+++ b/docs/managed-skills.md
@@ -48,23 +48,42 @@ to the rendering of that source. Only that file is adopted, never its directory
 or support files. Missing destinations can be installed. A modified destination
 or ambiguous source makes the whole skill conflict before writes. Other skills
 continue independently, and the server reports degraded distribution without
-stopping its other functions. Deleting a generated skill also disables automatic
-generation of that name; an explicit create re-enables it. This stores only a
-name flag, so a later startup cannot recreate a deliberately deleted environment
-skill. The editor explains when ownership is not
-established. Generated environment content follows the same checks, using the
-existing source to verify a legacy installation before publishing new content.
+stopping its other functions. Deleting a generated skill disables automatic
+generation of that name. Explicit recreation publishes the user's content but
+keeps automatic generation disabled. Saving changed generated content also
+pauses regeneration, so Settings changes and startup cannot erase those edits.
+These decisions store only a name flag, never a content copy. The editor explains
+this behavior before editing a generated skill and shows when regeneration is
+paused. Ordinary explicit saves and redistribution still publish the customized
+skill; there is no automatic resumption that can overwrite it. Generation cannot
+take over an existing user-created managed skill. Legacy environment content
+follows the same adoption checks, using the existing source to verify its
+installation before publishing new generated content.
 
 Name matching alone cannot authorize deletion, even when the source is absent.
 After losing a manifest, removal returns not-found until ownership has been
 narrowly verified again. Never delete the manifest to force an overwrite. To
 resolve a legacy conflict, choose a noncolliding source name or deliberately
 resolve the independent installation outside the manager, then restart
-redistribution. For a file modified after ownership was established, the manager
-refuses to overwrite/delete it; restore the recorded current content or resolve
-its ownership deliberately outside this API. There is no force-adopt endpoint.
+redistribution. An externally modified installed copy still blocks saves and
+deletion, even with a fresh revision; resolve that independent installation
+deliberately outside this API. There is no force-adopt endpoint.
 A removed/redirected configured destination must be restored before operations
 on records that still reference it can proceed.
+
+An external edit to a managed **source** (including edits through Files or by an
+agent) invalidates old revisions and stops automatic republication. Open or
+refresh it in Skills, review the current contents, then explicitly Save or
+confirm permanent deletion. A matching current revision authorizes exactly those
+source bytes. The service persists their accepted hash with the operation intent
+before any mutation; installed-file ownership checks remain unchanged. A source
+edit after that snapshot still conflicts. Retrying a pending operation can
+likewise accept a freshly reviewed source, while retaining the original target
+set and, for saves, the original intended content. No historical bytes need to
+be restored to unblock an explicit operation.
+This does not claim a new file that appears after an initial source creation
+failed: without a previously owned source hash, only byte-identical intended
+content can be recognized as an interrupted publication.
 
 ## HTTP mutation contract
 

--- a/docs/managed-skills.md
+++ b/docs/managed-skills.md
@@ -48,17 +48,38 @@ to the rendering of that source. Only that file is adopted, never its directory
 or support files. Missing destinations can be installed. A modified destination
 or ambiguous source makes the whole skill conflict before writes. Other skills
 continue independently, and the server reports degraded distribution without
-stopping its other functions. Deleting a generated skill disables automatic
-generation of that name. Explicit recreation publishes the user's content but
-keeps automatic generation disabled. Saving changed generated content also
-pauses regeneration, so Settings changes and startup cannot erase those edits.
-These decisions store only a name flag, never a content copy. The editor explains
-this behavior before editing a generated skill and shows when regeneration is
-paused. Ordinary explicit saves and redistribution still publish the customized
-skill; there is no automatic resumption that can overwrite it. Generation cannot
-take over an existing user-created managed skill. Legacy environment content
-follows the same adoption checks, using the existing source to verify its
-installation before publishing new generated content.
+stopping its other functions.
+
+### Generated skills are read-only
+
+`environment.md` is derived from the Space configuration: the manager rebuilds
+it on every start and whenever secret descriptions or settings change. There is
+no authored content in it to protect, so it is **read-only**: `POST`, `PUT` and
+`DELETE /api/skills/environment.md` answer `403` with an explanation whatever
+revision is presented, and the editor offers no Edit, Save or Delete for it and
+says why. Keep your own instructions in a separate skill. The service is told
+which names are generated (`generated: ['environment.md']`); a record created
+by generation is read-only even before the name is configured.
+
+For a generated skill the **newest generated content is always authoritative**.
+The retry-with-the-same-content rule that protects hand-authored saves does not
+apply, because nobody can reproduce an earlier generation's bytes on purpose:
+when a generation finds the intent of an interrupted earlier one, it adopts the
+files that carry that intent's bytes (they were written by this manager), drops
+the intent, and publishes the new content. An installation that was modified by
+someone else is still refused by the ordinary ownership checks. Generation still
+cannot take over a user-created managed skill of the same name, and legacy
+environment content follows the same adoption checks, using the existing source
+to verify its installation before publishing new generated content.
+
+**Upgrading from the previous contract**, under which generated skills could be
+edited or deleted: a customized `environment.md` (recorded as
+`disabledGenerated`) is honoured for exactly one more generation — the editor
+shows that the edits are still in place and will be replaced next time — and
+replaced on the following one, after which the editor says the edits were
+replaced. Copy anything worth keeping into another skill during that window.
+A deleted `environment.md` is regenerated at the next generation; nothing is
+lost. Only a name flag is stored, never a content copy.
 
 Name matching alone cannot authorize deletion, even when the source is absent.
 After losing a manifest, removal returns not-found until ownership has been
@@ -93,10 +114,10 @@ operator header used by the web client). Origin attribution is not authenticatio
 | Call | Contract |
 | --- | --- |
 | `GET /api/skills` | Lists source names and pending operations, including records whose source is missing. |
-| `GET /api/skills/:name` | Returns content, an opaque `revision`, ownership/pending state, and exact managed installation paths with their current presence. |
-| `POST /api/skills/:name` | Create only, with a plain-text body. Existing source or installation-ID collisions return 409. |
-| `PUT /api/skills/:name` | Explicit save, with a plain-text body and `If-Match` set to the exact returned `revision`. Missing tags return 428; stale tags return 409. |
-| `DELETE /api/skills/:name` | Permanent removal of the recorded files, with the same required `If-Match` revision. No record returns 404 and removes nothing. |
+| `GET /api/skills/:name` | Returns content, an opaque `revision`, ownership/pending state, `readOnly` for generated skills (with the explanation in `problem`), and exact managed installation paths with their current presence. |
+| `POST /api/skills/:name` | Create only, with a plain-text body. Existing source or installation-ID collisions return 409. A generated name returns 403. |
+| `PUT /api/skills/:name` | Explicit save, with a plain-text body and `If-Match` set to the exact returned `revision`. Missing tags return 428; stale tags return 409. A generated skill returns 403 regardless of the tag. |
+| `DELETE /api/skills/:name` | Permanent removal of the recorded files, with the same required `If-Match` revision. No record returns 404 and removes nothing. A generated skill returns 403. |
 
 Revisions include current source content, ownership/operation metadata, observed
 installation contents and the configured target set. A stale tab or changed

--- a/docs/managed-skills.md
+++ b/docs/managed-skills.md
@@ -35,7 +35,7 @@ they do not isolate files against arbitrary hostile same-user filesystem races.
 
 The version 1 manifest is stored at `DATA_DIR/state/skills/skills-v1.json`.
 It binds the canonical source root and each source filename to its installation
-ID, current source digest, exact target roots/files, and generated-file digests.
+ID, a unique creation identity, current source digest, exact target roots/files, and generated-file digests.
 It records which skill directories the operation creates; adopted directories
 are never owned. Recorded paths are checked against current configured roots
 and reconstructed expected filenames before use. A changed source root, unknown
@@ -48,7 +48,10 @@ to the rendering of that source. Only that file is adopted, never its directory
 or support files. Missing destinations can be installed. A modified destination
 or ambiguous source makes the whole skill conflict before writes. Other skills
 continue independently, and the server reports degraded distribution without
-stopping its other functions. The editor explains when ownership is not
+stopping its other functions. Deleting a generated skill also disables automatic
+generation of that name; an explicit create re-enables it. This stores only a
+name flag, so a later startup cannot recreate a deliberately deleted environment
+skill. The editor explains when ownership is not
 established. Generated environment content follows the same checks, using the
 existing source to verify a legacy installation before publishing new content.
 
@@ -78,7 +81,8 @@ operator header used by the web client). Origin attribution is not authenticatio
 
 Revisions include current source content, ownership/operation metadata, observed
 installation contents and the configured target set. A stale tab or changed
-confirmation cannot overwrite/delete the new state. Current revision tags do
+confirmation cannot overwrite/delete the new state. A newly created skill has
+a new identity even when it reuses a deleted filename and identical content. Current revision tags do
 not override detected external changes to an owned installation. Repeated
 already-completed deletions return the same documented 404/no-mutation outcome.
 

--- a/scripts/mutation-check-skills-ui.mjs
+++ b/scripts/mutation-check-skills-ui.mjs
@@ -10,6 +10,7 @@ const mutants = [
   ['deletion on opening', 'setConfirmDel(await api.getSkill(loaded.name));', 'await api.deleteSkill(loaded.name, loaded.revision);'],
   ['duplicate submission guard', 'if (working.current) return;', ''],
   ['failed save discards buffer', 'await api.saveSkill(loaded.name, content, loaded.revision)', "await api.saveSkill(loaded.name, content, loaded.revision).catch((e) => { setContent(''); throw e; })"],
+  ['generated skill editable in the UI', "disabled={busy || loaded?.pending === 'delete' || loaded?.readOnly}", "disabled={busy || loaded?.pending === 'delete'}"],
 ];
 let failed = 0;
 for (const [name, from, to] of mutants) {

--- a/scripts/mutation-check-skills-ui.mjs
+++ b/scripts/mutation-check-skills-ui.mjs
@@ -1,0 +1,33 @@
+// Real browser mutants, each in an isolated source copy; the fixture always
+// launches a disposable backend with cleared harness homes and credentials.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const mutants = [
+  ['deletion on opening', 'setConfirmDel(await api.getSkill(loaded.name));', 'await api.deleteSkill(loaded.name, loaded.revision);'],
+  ['duplicate submission guard', 'if (working.current) return;', ''],
+  ['failed save discards buffer', 'await api.saveSkill(loaded.name, content, loaded.revision)', "await api.saveSkill(loaded.name, content, loaded.revision).catch((e) => { setContent(''); throw e; })"],
+];
+let failed = 0;
+for (const [name, from, to] of mutants) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-skills-ui-mutant-'));
+  try {
+    fs.mkdirSync(path.join(root, 'web/test'), { recursive: true });
+    fs.cpSync(path.join(repo, 'web/src'), path.join(root, 'web/src'), { recursive: true });
+    fs.copyFileSync(path.join(repo, 'web/test/skills.browser.test.mjs'), path.join(root, 'web/test/skills.browser.test.mjs'));
+    for (const dir of ['server', 'scripts', 'web/node_modules']) fs.symlinkSync(path.join(repo, dir), path.join(root, dir));
+    const file = path.join(root, 'web/src/components/SkillsEditor.tsx');
+    const source = fs.readFileSync(file, 'utf8');
+    if (!source.includes(from)) throw new Error(`Mutation point missing: ${name}`);
+    fs.writeFileSync(file, source.replace(from, to));
+    const { AM_SKILLS_SCREENSHOTS, ...env } = process.env;
+    const result = spawnSync(process.execPath, [path.join(root, 'web/test/skills.browser.test.mjs')], { env, encoding: 'utf8', timeout: 60000 });
+    const killed = result.status !== 0 && /AssertionError|TimeoutError/.test(result.stderr);
+    console.log(`${killed ? 'KILLED' : 'SURVIVED'} ${name}`);
+    if (!killed) { failed++; console.log((result.stderr || result.stdout).slice(-1200)); }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+}
+if (failed) process.exitCode = 1;

--- a/scripts/mutation-check-skills.mjs
+++ b/scripts/mutation-check-skills.mjs
@@ -8,6 +8,8 @@ const repo = fileURLToPath(new URL('..', import.meta.url));
 const source = fs.readFileSync(path.join(repo, 'server/src/skills.js'), 'utf8');
 const suite = fs.readFileSync(path.join(repo, 'server/test/skills.test.mjs'), 'utf8');
 const mutations = [
+  ['recreated skill identity', 'instance: nonce()', "instance: 'reused'"],
+  ['generated deletion flag', 'if (load().disabledGenerated.includes(name))', 'if (false)'],
   ['create overwrite guard', 'if (create && (r || existing !== null))', 'if (false)'],
   ['normalized collision guard', 'if (other.toLowerCase() === name.toLowerCase() || otherId === id)', 'if (false)'],
   ['stale revision guard', 'if (snapshot(name, m).revision !== revision)', 'if (false)'],

--- a/scripts/mutation-check-skills.mjs
+++ b/scripts/mutation-check-skills.mjs
@@ -1,0 +1,35 @@
+// Each mutant gets a disposable service + unit suite. No working-tree edits.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+const repo = fileURLToPath(new URL('..', import.meta.url));
+const source = fs.readFileSync(path.join(repo, 'server/src/skills.js'), 'utf8');
+const suite = fs.readFileSync(path.join(repo, 'server/test/skills.test.mjs'), 'utf8');
+const mutations = [
+  ['create overwrite guard', 'if (create && (r || existing !== null))', 'if (false)'],
+  ['normalized collision guard', 'if (other.toLowerCase() === name.toLowerCase() || otherId === id)', 'if (false)'],
+  ['stale revision guard', 'if (snapshot(name, m).revision !== revision)', 'if (false)'],
+  ['external installed-file guard', 'if (actual !== t.hash && actual !== r.pending?.targetHash && actual !== null)', 'if (false)'],
+  ['unowned installation guard', 'if (actual !== null && (!adopt || actual !== expected))', 'if (false)'],
+  ['recursive directory deletion', 'io.unlinkSync(t.path);', 'io.rmSync(path.dirname(t.path), { recursive: true, force: true });'],
+  ['pending deletion protection', /if \(m\.skills\[name\]\?\.pending\?\.kind === 'delete'\)|if \(r\?\.pending\?\.kind === 'delete'\)/g, 'if (false)'],
+  ['temporary exclusive creation', 'fs.constants.O_EXCL | fs.constants.O_NOFOLLOW', 'fs.constants.O_TRUNC'],
+];
+let failed = 0;
+for (const [name, from, to] of mutations) {
+  if (!(from instanceof RegExp ? from.test(source) : source.includes(from))) throw new Error(`Mutation point missing: ${name}`);
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-skills-mutant-'));
+  try {
+    fs.mkdirSync(path.join(root, 'src')); fs.mkdirSync(path.join(root, 'test'));
+    fs.writeFileSync(path.join(root, 'package.json'), '{"type":"module"}');
+    fs.writeFileSync(path.join(root, 'src/skills.js'), source.replace(from, to));
+    fs.writeFileSync(path.join(root, 'test/skills.test.mjs'), suite);
+    const run = spawnSync(process.execPath, [path.join(root, 'test/skills.test.mjs')], { encoding: 'utf8', timeout: 30000 });
+    const killed = run.status !== 0 && /not ok/.test(run.stdout);
+    console.log(`${killed ? 'KILLED' : 'SURVIVED'} ${name}`);
+    if (!killed) { failed++; console.log((run.stderr || run.stdout).slice(-800)); }
+  } finally { fs.rmSync(root, { recursive: true, force: true }); }
+}
+if (failed) process.exitCode = 1;

--- a/scripts/mutation-check-skills.mjs
+++ b/scripts/mutation-check-skills.mjs
@@ -9,10 +9,16 @@ const source = fs.readFileSync(path.join(repo, 'server/src/skills.js'), 'utf8');
 const suite = fs.readFileSync(path.join(repo, 'server/test/skills.test.mjs'), 'utf8');
 const mutations = [
   ['recreated skill identity', 'instance: nonce()', "instance: 'reused'"],
-  ['generated deletion flag', 'if (load().disabledGenerated.includes(name))', 'if (false)'],
+  ['generated deletion flag', 'if (m.disabledGenerated.includes(name))', 'if (false)'],
+  ['explicit save accepts confirmed source', 'const sourceConfirmed = confirmSource(r, observed);', 'const sourceConfirmed = false;'],
+  ['explicit deletion accepts confirmed source', 'const sourceConfirmed = confirmSource(r, confirmed);', 'const sourceConfirmed = false;'],
+  ['failed create cannot adopt a new source', 'if (r.sourceHash === null && accepted !== r.pending?.sourceHash)', 'if (false)'],
+  ['pending save keeps intended content', /if \(hash\(content\) !== (?:pending|r\.pending)\.sourceHash\)/g, 'if (false)'],
+  ['customized generated source is preserved', 'if (customized && !m.disabledGenerated.includes(name))', 'if (false)'],
+  ['user-created source resists generation', 'if (m.skills[name] && m.skills[name].generated !== true)', 'if (false)'],
   ['create overwrite guard', 'if (create && (r || existing !== null))', 'if (false)'],
   ['normalized collision guard', 'if (other.toLowerCase() === name.toLowerCase() || otherId === id)', 'if (false)'],
-  ['stale revision guard', 'if (snapshot(name, m).revision !== revision)', 'if (false)'],
+  ['stale revision guard', 'if (observed.revision !== revision)', 'if (false)'],
   ['external installed-file guard', 'if (actual !== t.hash && actual !== r.pending?.targetHash && actual !== null)', 'if (false)'],
   ['unowned installation guard', 'if (actual !== null && (!adopt || actual !== expected))', 'if (false)'],
   ['manifest destination identity', "t.path !== path.join(t.root, r.id, 'SKILL.md')", 'false'],

--- a/scripts/mutation-check-skills.mjs
+++ b/scripts/mutation-check-skills.mjs
@@ -15,6 +15,8 @@ const mutations = [
   ['stale revision guard', 'if (snapshot(name, m).revision !== revision)', 'if (false)'],
   ['external installed-file guard', 'if (actual !== t.hash && actual !== r.pending?.targetHash && actual !== null)', 'if (false)'],
   ['unowned installation guard', 'if (actual !== null && (!adopt || actual !== expected))', 'if (false)'],
+  ['manifest destination identity', "t.path !== path.join(t.root, r.id, 'SKILL.md')", 'false'],
+  ['pre-existing directory ownership', 'if (t.dirOwned)', 'if (true)'],
   ['recursive directory deletion', 'io.unlinkSync(t.path);', 'io.rmSync(path.dirname(t.path), { recursive: true, force: true });'],
   ['pending deletion protection', /if \(m\.skills\[name\]\?\.pending\?\.kind === 'delete'\)|if \(r\?\.pending\?\.kind === 'delete'\)/g, 'if (false)'],
   ['temporary exclusive creation', 'fs.constants.O_EXCL | fs.constants.O_NOFOLLOW', 'fs.constants.O_TRUNC'],

--- a/scripts/mutation-check-skills.mjs
+++ b/scripts/mutation-check-skills.mjs
@@ -9,13 +9,14 @@ const source = fs.readFileSync(path.join(repo, 'server/src/skills.js'), 'utf8');
 const suite = fs.readFileSync(path.join(repo, 'server/test/skills.test.mjs'), 'utf8');
 const mutations = [
   ['recreated skill identity', 'instance: nonce()', "instance: 'reused'"],
-  ['generated deletion flag', 'if (m.disabledGenerated.includes(name))', 'if (false)'],
+  ['legacy customization honoured once', 'if (m.disabledGenerated.includes(name)) {', 'if (false) {'],
+  ['generated names are read-only', 'if (readOnly(name, m.skills[name])) throw new SkillError(403, readOnlyMessage(name));', ''],
+  ['newest generation supersedes an interrupted one', 'if (r?.pending) {', 'if (false) {'],
   ['explicit save accepts confirmed source', 'const sourceConfirmed = confirmSource(r, observed);', 'const sourceConfirmed = false;'],
   ['explicit deletion accepts confirmed source', 'const sourceConfirmed = confirmSource(r, confirmed);', 'const sourceConfirmed = false;'],
   ['failed create cannot adopt a new source', 'if (r.sourceHash === null && accepted !== r.pending?.sourceHash)', 'if (false)'],
   ['pending save keeps intended content', /if \(hash\(content\) !== (?:pending|r\.pending)\.sourceHash\)/g, 'if (false)'],
-  ['customized generated source is preserved', 'if (customized && !m.disabledGenerated.includes(name))', 'if (false)'],
-  ['user-created source resists generation', 'if (m.skills[name] && m.skills[name].generated !== true)', 'if (false)'],
+  ['user-created source resists generation', 'if (r && r.generated !== true)', 'if (false)'],
   ['create overwrite guard', 'if (create && (r || existing !== null))', 'if (false)'],
   ['normalized collision guard', 'if (other.toLowerCase() === name.toLowerCase() || otherId === id)', 'if (false)'],
   ['stale revision guard', 'if (observed.revision !== revision)', 'if (false)'],

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,9 +8,10 @@ import crypto from 'node:crypto';
 import express from 'express';
 import { WebSocketServer } from 'ws';
 import {
-  PORT, PUBLIC_DIR, DATA_DIR, WORKSPACES_DIR, SKILLS_DIR,
+  PORT, PUBLIC_DIR, DATA_DIR, WORKSPACES_DIR, SKILLS_DIR, STATE_DIR,
   ensureDirs, cliCatalog, cliById, slugify, workspacePath, refreshVersions, PASSIVE_CLIS, isRemote,
 } from './config.js';
+import { createSkillsService, skillTargetDirs } from './skills.js';
 import * as remote from './remote.js';
 import * as store from './sessions.js';
 import * as groups from './groups.js';
@@ -99,7 +100,16 @@ function ensureWorkspaceFolders() {
   }
 }
 ensureWorkspaceFolders();
-distributeAllSkills(); // re-publish skills to each agent's dir on boot
+const skills = createSkillsService({ sourceRoot: SKILLS_DIR, stateRoot: path.join(STATE_DIR, 'skills'), targetRoots: skillTargetDirs() });
+const reportSkills = (result) => {
+  if (!result.ok) {
+    const failures = (result.results || [result]).filter((r) => !r.ok)
+      .map(({ name, error, source, manifest, targets }) => ({ name, error, source, manifest, targets }));
+    console.error('[skills] degraded distribution', JSON.stringify({ error: result.error, failures }));
+  }
+  return result;
+};
+skills.redistribute().then(reportSkills).catch((e) => console.error('[skills]', e.message));
 
 // Configure a Claude Code statusline hook that captures the official rate_limits
 // payload to disk (for the Usage page), preserving any existing settings.
@@ -1210,7 +1220,7 @@ function loadAmConfig() {
   };
 }
 app.get('/api/config', (_req, res) => res.json({ ...loadAmConfig(), defaultArtifactsSpace: defaultArtifactsSpace() }));
-app.put('/api/config', (req, res) => {
+app.put('/api/config', async (req, res) => {
   const b = req.body || {};
   const cfg = {
     artifacts: {
@@ -1234,8 +1244,8 @@ app.put('/api/config', (req, res) => {
     },
   };
   try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}
-  generateEnvSkill(loadSecretNotes());
-  res.json({ ok: true });
+  const skillDistribution = await generateEnvSkill(loadSecretNotes());
+  res.json({ ok: true, skillDistribution });
 });
 
 // ---------- bucket backup: status + run-now (docs/bucket-backup.md) ----------
@@ -1630,119 +1640,35 @@ from the environment when you need it (e.g. \`$NAME\`); never print secret value
 
 ${envLines}
 `;
-  const p = skillPath('environment.md');
-  if (p) { try { fs.mkdirSync(SKILLS_DIR, { recursive: true }); fs.writeFileSync(p, content); } catch {} }
-  distributeSkill('environment.md', content);
+  return skills.generate('environment.md', content).then(reportSkills)
+    .catch((e) => reportSkills({ ok: false, error: e.message }));
 }
 
 app.get('/api/secrets', (_req, res) => res.json({ detected: injectedEnvKeys(), notes: loadSecretNotes() }));
-app.put('/api/secrets', (req, res) => {
+app.put('/api/secrets', async (req, res) => {
   const notes = (req.body && req.body.notes && typeof req.body.notes === 'object') ? req.body.notes : {};
   try { fs.writeFileSync(SECRET_NOTES_FILE, JSON.stringify(notes, null, 2)); } catch {}
-  generateEnvSkill(notes);
-  res.json({ ok: true });
+  const skillDistribution = await generateEnvSkill(notes);
+  res.json({ ok: true, skillDistribution });
 });
 
 // ---------- skills (markdown/text files in the workspace) ----------
-const SKILL_RE = /^[\w.\- ]{1,80}$/;
-function skillPath(name) {
-  if (!SKILL_RE.test(name) || name.includes('/') || name.includes('..')) return null;
-  return path.join(SKILLS_DIR, name);
-}
-
-// Fan skills out as SKILL.md into the dirs every agent auto-reads, so a saved
-// skill is available to all of them in every new session. Gated to real Space
-// deployments (or explicit opt-in): on a dev laptop these paths are the
-// developer's OWN ~/.claude etc. — local test runs must not write there.
-function skillTargetDirs() {
-  if (!process.env.SPACE_ID && process.env.AM_DISTRIBUTE_SKILLS !== '1') return [];
-  const home = process.env.HOME || os.homedir();
-  const claudeCfg = process.env.CLAUDE_CONFIG_DIR || path.join(home, '.claude');
-  const dirs = [
-    path.join(home, '.agents', 'skills'),   // Codex and opencode
-    path.join(claudeCfg, 'skills'),          // Claude Code
-    path.join(home, '.hermes', 'skills'),    // Hermes
-  ];
-  // GEMINI_CLI_HOME deliberately changes the home Gemini resolves its global
-  // .agents directory against; fan skills into that local/checkpointed home as
-  // well as the ordinary durable HOME.
-  if (process.env.GEMINI_CLI_HOME) dirs.push(path.join(process.env.GEMINI_CLI_HOME, '.agents', 'skills'));
-  // OpenClaw runs with its own HOME (see entrypoint.sh) and reads managed
-  // skills from ~/.agents/skills resolved against THAT home. Recreated on
-  // every boot, so it needs no backup coverage.
-  if (process.env.OPENCLAW_HOME) dirs.push(path.join(process.env.OPENCLAW_HOME, '.agents', 'skills'));
-  return dirs;
-}
-function parseSkillFile(filename, content) {
-  const name = slugify(path.basename(filename).replace(/\.[^.]+$/, '')) || 'skill';
-  let body = content;
-  let desc = '';
-  const fm = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
-  if (fm) {
-    const d = fm[1].match(/^description:\s*(.+)$/m);
-    if (d) desc = d[1].trim().replace(/^["']|["']$/g, '');
-    body = fm[2];
-  }
-  if (!desc) {
-    const h = body.match(/^#+\s*(.+)$/m);
-    desc = (h ? h[1] : (body.split('\n').find((l) => l.trim()) || name)).trim();
-  }
-  desc = desc.replace(/\s+/g, ' ').slice(0, 300).replace(/"/g, '\\"');
-  return { name, description: desc, body: body.trim() };
-}
-function distributeSkill(filename, content) {
-  const { name, description, body } = parseSkillFile(filename, content);
-  const md = `---\nname: ${name}\ndescription: "${description}"\n---\n\n${body}\n`;
-  for (const base of skillTargetDirs()) {
-    try { fs.mkdirSync(path.join(base, name), { recursive: true }); fs.writeFileSync(path.join(base, name, 'SKILL.md'), md); } catch {}
-  }
-}
-function undistributeSkill(filename) {
-  const name = slugify(path.basename(filename).replace(/\.[^.]+$/, ''));
-  for (const base of skillTargetDirs()) {
-    try { fs.rmSync(path.join(base, name), { recursive: true, force: true }); } catch {}
-  }
-}
-function distributeAllSkills() {
-  let files = [];
-  try { files = fs.readdirSync(SKILLS_DIR).filter((f) => { try { return fs.statSync(path.join(SKILLS_DIR, f)).isFile(); } catch { return false; } }); } catch {}
-  for (const f of files) {
-    try { distributeSkill(f, fs.readFileSync(path.join(SKILLS_DIR, f), 'utf8')); } catch {}
-  }
-}
-
-app.get('/api/skills', (_req, res) => {
-  fs.mkdirSync(SKILLS_DIR, { recursive: true });
-  const files = fs.readdirSync(SKILLS_DIR, { withFileTypes: true })
-    .filter((e) => e.isFile())
-    .map((e) => ({ name: e.name, size: fs.statSync(path.join(SKILLS_DIR, e.name)).size }));
-  files.sort((a, b) => a.name.localeCompare(b.name));
-  res.json(files);
-});
-
-app.get('/api/skills/:name', (req, res) => {
-  const p = skillPath(req.params.name);
-  if (!p || !fs.existsSync(p)) return res.status(404).json({ error: 'not found' });
-  res.json({ name: req.params.name, content: fs.readFileSync(p, 'utf8') });
-});
-
-app.put('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }), (req, res) => {
-  const p = skillPath(req.params.name);
-  if (!p) return res.status(400).json({ error: 'bad name' });
-  fs.mkdirSync(SKILLS_DIR, { recursive: true });
-  const content = typeof req.body === 'string' ? req.body : '';
-  fs.writeFileSync(p, content);
-  distributeSkill(req.params.name, content); // push to every agent
-  res.json({ ok: true });
-});
-
-app.delete('/api/skills/:name', (req, res) => {
-  const p = skillPath(req.params.name);
-  if (!p) return res.status(400).json({ error: 'bad name' });
-  try { fs.unlinkSync(p); } catch {}
-  undistributeSkill(req.params.name);
-  res.json({ ok: true });
-});
+// POST is create-only; PUT and DELETE require the revision returned by GET.
+// A partial result is a successful HTTP exchange, not a claim of full mutation.
+const skillRoute = (run) => async (req, res) => {
+  try {
+    const result = await run(req);
+    res.status(result?.ok === false ? 207 : 200).json(result);
+  } catch (e) { res.status(e.status || 503).json({ error: e.message }); }
+};
+app.get('/api/skills', skillRoute(() => skills.list()));
+app.get('/api/skills/:name', skillRoute((req) => skills.get(req.params.name)));
+const skillText = (req) => req.get('content-length') === '0' ? '' : req.body;
+app.post('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }),
+  skillRoute((req) => skills.create(req.params.name, skillText(req))));
+app.put('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }),
+  skillRoute((req) => skills.update(req.params.name, skillText(req), req.get('If-Match'))));
+app.delete('/api/skills/:name', skillRoute((req) => skills.remove(req.params.name, req.get('If-Match'))));
 
 // ---------- file browser (for the Files agent) ----------
 function folderPathOf(session) {

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -100,7 +100,9 @@ function ensureWorkspaceFolders() {
   }
 }
 ensureWorkspaceFolders();
-const skills = createSkillsService({ sourceRoot: SKILLS_DIR, stateRoot: path.join(STATE_DIR, 'skills'), targetRoots: skillTargetDirs() });
+// environment.md is derived from the Space configuration (generateEnvSkill), so it
+// is read-only in the editor and API and the newest generation always wins.
+const skills = createSkillsService({ sourceRoot: SKILLS_DIR, stateRoot: path.join(STATE_DIR, 'skills'), targetRoots: skillTargetDirs(), generated: ['environment.md'] });
 const reportSkills = (result) => {
   if (!result.ok) {
     const failures = (result.results || [result]).filter((r) => !r.ok)
@@ -1568,7 +1570,7 @@ What is different about them:
   which sleeps, drops off wifi, and closes lids. Ask once and move on.
 
 ## Shared skills
-- Reusable skills live in \`/data/workspaces/skills/\`. Create and publish them through the Skills editor or \`/api/skills\`: POST creates only; GET returns the revision required by PUT/DELETE in \`If-Match\`. If you edit a source through Files or on disk, review its current contents in Skills and explicitly Save to publish it. Startup leaves unreviewed source edits and independently modified installations untouched. Read skills for project conventions and recurring tasks.
+- Reusable skills live in \`/data/workspaces/skills/\`. Create and publish them through the Skills editor or \`/api/skills\`: POST creates only; GET returns the revision required by PUT/DELETE in \`If-Match\`. If you edit a source through Files or on disk, review its current contents in Skills and explicitly Save to publish it. Startup leaves unreviewed source edits and independently modified installations untouched. This \`environment.md\` is generated from the Space configuration and read-only; put your own instructions in a separate skill. Read skills for project conventions and recurring tasks.
 
 ## Tooling
 - A full Linux shell with \`git\`, \`ripgrep\` (\`rg\`), \`node\`, and \`python3\`, plus build tools. Reach for \`rg\` for fast search.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1568,7 +1568,7 @@ What is different about them:
   which sleeps, drops off wifi, and closes lids. Ask once and move on.
 
 ## Shared skills
-- Reusable skills (like this one) live in \`/data/workspaces/skills/\` and are published into every agent's skills directory automatically. Read them for project conventions and recurring tasks.
+- Reusable skills live in \`/data/workspaces/skills/\`. Create and publish them through the Skills editor or \`/api/skills\`: POST creates only; GET returns the revision required by PUT/DELETE in \`If-Match\`. If you edit a source through Files or on disk, review its current contents in Skills and explicitly Save to publish it. Startup leaves unreviewed source edits and independently modified installations untouched. Read skills for project conventions and recurring tasks.
 
 ## Tooling
 - A full Linux shell with \`git\`, \`ripgrep\` (\`rg\`), \`node\`, and \`python3\`, plus build tools. Reach for \`rg\` for fast search.

--- a/server/src/skills.js
+++ b/server/src/skills.js
@@ -205,19 +205,36 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
       if (record) verified(record, name, { deleting: record.pending?.kind === 'delete' });
       else problem = 'Ownership is not established. Resolve the name or installation conflict and restart distribution; existing installations are untouched.';
     } catch (e) { problem = e.message; }
+    if (!problem && record?.generated) problem = m.disabledGenerated.includes(name)
+      ? 'Automatic regeneration is paused to preserve your edits. Explicit saves still publish this skill.'
+      : 'This skill is generated. Saving changes preserves your edits and pauses automatic regeneration.';
     return { name, content: content ?? '', sourceExists: content !== null, revision, ...(problem ? { problem } : {}),
       managed: !!record, pending: record?.pending?.kind || null,
       installations: installed.map(({ path, hash, error }) => ({ path, exists: hash !== null && hash !== undefined, ...(error ? { error } : {}) })) };
   }
   function match(name, m, revision) {
     if (!revision) throw new SkillError(428, 'A current skill revision is required');
-    if (snapshot(name, m).revision !== revision) conflict('Skill or installations changed; refresh before saving or confirming deletion');
+    const observed = snapshot(name, m);
+    if (observed.revision !== revision) conflict('Skill or installations changed; refresh before saving or confirming deletion');
+    return observed;
+  }
+  function confirmSource(r, observed) {
+    // Accept only source bytes covered by an explicit matching revision.
+    // Installed-file hashes, pending targets and intended save content stay fixed.
+    if (!r || !observed) return false;
+    const accepted = observed.sourceExists ? hash(observed.content) : null;
+    // A failed first create may never have owned a source at all. Only its
+    // already-published intended bytes establish ownership in that case.
+    if (r.sourceHash === null && accepted !== r.pending?.sourceHash) return false;
+    if (r.sourceHash === accepted) return false;
+    r.sourceHash = accepted;
+    return true;
   }
   function verified(r, name, { deleting = false } = {}) {
     const { source } = config();
     targetsValid(r);
     const src = current(source, path.join(source, name));
-    if (src !== r.sourceHash && src !== r.pending?.sourceHash && !(deleting && src === null)) conflict('Source was modified outside the manager');
+    if (src !== r.sourceHash && src !== r.pending?.sourceHash && !(deleting && src === null)) conflict('Source was modified outside the Skills editor; review the current source before saving or confirming deletion');
     for (const t of r.targets) {
       const actual = current(t.root, t.path);
       if (actual !== t.hash && actual !== r.pending?.targetHash && actual !== null) conflict(`Installed file was modified outside the manager: ${t.path}`);
@@ -275,9 +292,18 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     const existing = read(source, path.join(source, name));
     let r = m.skills[name];
     if (create && (r || existing !== null)) conflict('Skill already exists; choose a different name or open the existing skill');
-    if (!create && !boot) match(name, m, revision);
+    const observed = !create && !boot ? match(name, m, revision) : null;
     if (r?.pending?.kind === 'delete') conflict('Deletion is pending; retry deletion before creating this skill again');
-    if (r?.pending?.kind === 'write') return finishWrite(name, content, m);
+    const customized = !!(observed && r?.generated && hash(content) !== r.sourceHash);
+    const sourceConfirmed = confirmSource(r, observed);
+    if (r?.pending?.kind === 'write') {
+      if (sourceConfirmed) {
+        if (hash(content) !== r.pending.sourceHash) conflict('An incomplete save must be retried with the same content');
+        verified(r, name);
+        persist(m); // persist the reviewed source before retrying the fixed intent
+      }
+      return finishWrite(name, content, m);
+    }
     if (r) verified(r, name);
     else {
       if (!create && !boot) conflict('Skill is not managed; refresh after startup adoption or resolve its installation conflict');
@@ -289,18 +315,19 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     r.generated = r.generated || generated || m.disabledGenerated.includes(name);
     r.pending = { kind: 'write', id: nonce(), sourceHash: hash(content), targetHash: hash(generatedSkill(name, content)) };
     m.skills[name] = r;
-    if (create) m.disabledGenerated = m.disabledGenerated.filter((n) => n !== name);
+    if (customized && !m.disabledGenerated.includes(name)) m.disabledGenerated.push(name);
     persist(m); // intent first; a failure here must change no skill bytes
     return finishWrite(name, content, m);
   }
   function remove(name, revision) {
-    const m = load(); identity(name, m); match(name, m, revision);
+    const m = load(); identity(name, m); const confirmed = match(name, m, revision);
     const r = m.skills[name];
     if (!r) throw new SkillError(404, 'No ownership record; no installed files were removed');
     if (r.pending?.kind === 'write') conflict('A save is incomplete; retry it before deleting');
+    const sourceConfirmed = confirmSource(r, confirmed);
     verified(r, name, { deleting: true });
-    if (!r.pending) {
-      r.pending = { kind: 'delete', id: nonce() };
+    if (!r.pending || sourceConfirmed) {
+      if (!r.pending) r.pending = { kind: 'delete', id: nonce() };
       persist(m); // exact frozen target set; boot must never republish this source
     }
     const results = [];
@@ -361,7 +388,9 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     redistribute: serial(redistribute),
     generate: serial((name, content) => {
       skillId(name);
-      if (load().disabledGenerated.includes(name)) return { ok: true, status: 'complete', source: 'generation-disabled', targets: [], manifest: 'persisted', skill: null };
+      const m = load();
+      if (m.disabledGenerated.includes(name)) return { ok: true, status: 'complete', source: 'generation-disabled', targets: [], manifest: 'persisted', skill: null };
+      if (m.skills[name] && m.skills[name].generated !== true) conflict('A user-managed skill already uses this name; automatic generation cannot replace it');
       return write(name, content, { boot: true, generated: true });
     }),
   };

--- a/server/src/skills.js
+++ b/server/src/skills.js
@@ -1,0 +1,361 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+
+export class SkillError extends Error {
+  constructor(status, message) { super(message); this.status = status; }
+}
+const conflict = (message) => { throw new SkillError(409, message); };
+const hash = (content) => createHash('sha256').update(content).digest('hex');
+const digest = (value) => value === null || (typeof value === 'string' && /^[a-f0-9]{64}$/.test(value));
+const below = (root, file) => file.startsWith(root + path.sep);
+
+// Keep the old filename -> slug mapping, but never substitute an empty fallback.
+export function skillId(filename) {
+  if (typeof filename !== 'string' || !/^[\w.\- ]{1,80}$/.test(filename)
+      || filename.includes('..')) throw new SkillError(400, 'Invalid skill filename');
+  const id = filename.replace(/\.[^.]+$/, '').toLowerCase().replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '').slice(0, 40);
+  if (!id) throw new SkillError(400, 'Skill filename must contain a letter or number');
+  return id;
+}
+
+export function generatedSkill(filename, content) {
+  const id = skillId(filename);
+  let body = content, desc = '';
+  const fm = content.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (fm) {
+    const d = fm[1].match(/^description:\s*(.+)$/m);
+    if (d) desc = d[1].trim().replace(/^["']|["']$/g, '');
+    body = fm[2];
+  }
+  if (!desc) desc = (body.match(/^#+\s*(.+)$/m)?.[1] || body.split('\n').find((l) => l.trim()) || id).trim();
+  desc = desc.replace(/\s+/g, ' ').slice(0, 300).replace(/"/g, '\\"');
+  return `---\nname: ${id}\ndescription: "${desc}"\n---\n\n${body.trim()}\n`;
+}
+
+export function skillTargetDirs(env = process.env) {
+  if (!env.SPACE_ID && env.AM_DISTRIBUTE_SKILLS !== '1') return [];
+  const home = env.HOME || os.homedir();
+  const dirs = [path.join(home, '.agents', 'skills'), path.join(env.CLAUDE_CONFIG_DIR || path.join(home, '.claude'), 'skills'), path.join(home, '.hermes', 'skills')];
+  for (const home of [env.GEMINI_CLI_HOME, env.OPENCLAW_HOME]) if (home) dirs.push(path.join(home, '.agents', 'skills'));
+  return dirs;
+}
+
+// One instance per manager. Every caller (including reads and boot) goes through
+// its queue. Injectable sync IO keeps fault tests deterministic; no awaited gap
+// exists between preflight and publication within a process.
+export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], io = fs, nonce = randomUUID }) {
+  let queue = Promise.resolve();
+  const serial = (fn) => (...args) => {
+    const result = queue.then(() => fn(...args));
+    queue = result.catch(() => {});
+    return result;
+  };
+  const stat = (p) => { try { return io.lstatSync(p); } catch (e) { if (e.code === 'ENOENT') return null; throw e; } };
+  // Resolve configured aliases, including a not-yet-created suffix, without
+  // creating anything. Dangling configured symlinks are errors, not missing dirs.
+  function canonical(p) {
+    p = path.resolve(p);
+    if (stat(p)) return io.realpathSync(p);
+    const parent = path.dirname(p);
+    if (parent === p) throw new Error('Cannot resolve skills root');
+    return path.join(canonical(parent), path.basename(p));
+  }
+  // Lazy resolution lets a bad skill root degrade skills, not server startup.
+  let roots;
+  function config() {
+    if (!roots) {
+      const source = canonical(sourceRoot), state = canonical(stateRoot);
+      const targets = [...new Set(targetRoots.map(canonical))].sort();
+      const all = [source, state, ...targets];
+      if (all.some((a, i) => all.some((b, j) => i !== j && (a === b || below(a, b))))) {
+        throw new SkillError(409, 'Skills source, state and destination roots must not overlap');
+      }
+      roots = { source, state, targets };
+    }
+    return roots;
+  }
+  function checkRoot(root) {
+    if (canonical(root) !== root) conflict('Skills root changed; restore its configured location');
+    const s = stat(root);
+    if (s && !s.isDirectory()) conflict('Skills root is not a directory');
+  }
+  function entry(root, file) {
+    checkRoot(root);
+    if (!below(root, file)) conflict('Invalid managed file path');
+    const parts = path.relative(root, file).split(path.sep);
+    let p = root;
+    for (const [i, part] of parts.entries()) {
+      p = path.join(p, part);
+      const s = stat(p);
+      if (s?.isSymbolicLink()) conflict('Symlink at managed skill entry');
+      if (s && i < parts.length - 1 && !s.isDirectory()) conflict('Managed skill parent is not a directory');
+      if (s && i === parts.length - 1 && !s.isFile()) conflict('Managed skill entry is not a regular file');
+    }
+    return stat(file);
+  }
+  function read(root, file) { return entry(root, file) ? io.readFileSync(file, 'utf8') : null; }
+  function current(root, file) { return entry(root, file) ? hash(io.readFileSync(file)) : null; }
+  function mkdir(root, dir = root) {
+    checkRoot(root);
+    io.mkdirSync(root, { recursive: true });
+    if (dir !== root) {
+      if (!below(root, dir) || path.dirname(dir) !== root) conflict('Invalid skill directory');
+      const s = stat(dir);
+      if (s && (s.isSymbolicLink() || !s.isDirectory())) conflict('Invalid skill directory');
+      if (!s) io.mkdirSync(dir);
+    }
+  }
+  function atomic(root, file, content, expected) {
+    entry(root, file);
+    mkdir(root, path.dirname(file));
+    const temp = path.join(path.dirname(file), `.am-skill-${nonce()}.tmp`);
+    let fd, owned = false, inode;
+    try {
+      fd = io.openSync(temp, fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_NOFOLLOW, 0o600);
+      owned = true;
+      inode = io.fstatSync(fd).ino;
+      io.writeFileSync(fd, content, 'utf8');
+      io.fsyncSync(fd);
+      io.closeSync(fd); fd = undefined;
+      if (current(root, file) !== expected) conflict('Skill file changed before publication');
+      const ts = stat(temp);
+      if (!ts?.isFile() || ts.isSymbolicLink() || ts.ino !== inode) conflict('Skill temporary file changed');
+      // Bucket-backed roots need rename (hard links are not generally supported).
+      // The queue + immediate revision check protect manager operations; this
+      // is not a renameat2/OS sandbox against hostile same-user races.
+      io.renameSync(temp, file); owned = false;
+    } finally {
+      if (fd !== undefined) io.closeSync(fd);
+      // Never clean a pre-existing or substituted temp entry.
+      const s = owned ? stat(temp) : null;
+      if (s?.isFile() && !s.isSymbolicLink() && s.ino === inode) io.unlinkSync(temp);
+    }
+  }
+  const manifestPath = () => path.join(config().state, 'skills-v1.json');
+  function load() {
+    const { state } = config();
+    const bytes = read(state, manifestPath());
+    if (bytes === null) return { version: 1, sourceRoot: config().source, skills: Object.create(null) };
+    try {
+      const m = JSON.parse(bytes);
+      if (m.version !== 1 || m.sourceRoot !== config().source || !m.skills || Array.isArray(m.skills) || typeof m.skills !== 'object') throw new Error();
+      const ids = new Set();
+      for (const [name, r] of Object.entries(m.skills)) {
+        if (r.id !== skillId(name) || ids.has(r.id) || !digest(r.sourceHash) || !Array.isArray(r.targets)) throw new Error();
+        ids.add(r.id);
+        const seen = new Set();
+        for (const t of r.targets) {
+          if (typeof t.root !== 'string' || t.path !== path.join(t.root, r.id, 'SKILL.md')
+              || !path.isAbsolute(t.root) || !digest(t.hash) || typeof t.dirOwned !== 'boolean' || seen.has(t.root)) throw new Error();
+          seen.add(t.root);
+        }
+        if (r.pending && (!['write', 'delete'].includes(r.pending.kind) || typeof r.pending.id !== 'string'
+            || (r.pending.kind === 'write' && (!r.pending.sourceHash || !digest(r.pending.sourceHash) || !r.pending.targetHash || !digest(r.pending.targetHash))))) throw new Error();
+      }
+      Object.setPrototypeOf(m.skills, null);
+      return m;
+    } catch { throw new SkillError(503, 'Invalid ownership manifest; skills mutations are disabled until it is repaired'); }
+  }
+  function persist(m) {
+    const { state } = config();
+    atomic(state, manifestPath(), JSON.stringify(m, null, 2) + '\n', current(state, manifestPath()));
+  }
+  function names(m) {
+    const { source } = config(); checkRoot(source);
+    return [...new Set([...(stat(source) ? io.readdirSync(source).filter((n) => !n.startsWith('.am-skill-')) : []), ...Object.keys(m.skills)])];
+  }
+  function identity(name, m) {
+    const id = skillId(name);
+    for (const other of names(m)) {
+      if (other === name) continue;
+      let otherId; try { otherId = skillId(other); } catch { continue; }
+      if (other.toLowerCase() === name.toLowerCase() || otherId === id) conflict(`Skill name conflicts with ${other}; choose a different name or open the existing skill`);
+    }
+    return id;
+  }
+  function targetsValid(r) {
+    const allowed = config().targets;
+    for (const t of r.targets) {
+      if (!allowed.includes(t.root) || canonical(t.root) !== t.root) conflict('Recorded destination is no longer configured; restore the target configuration before retrying');
+      entry(t.root, t.path);
+    }
+  }
+  function snapshot(name, m) {
+    const { source, targets } = config();
+    skillId(name);
+    const content = read(source, path.join(source, name));
+    const record = m.skills[name];
+    if (content === null && !record) throw new SkillError(404, 'Skill not found; no owned installation was removed');
+    const installed = (record?.targets || []).map((t) => {
+      let observed, error;
+      try {
+        if (!targets.includes(t.root)) conflict('Destination is no longer configured');
+        observed = current(t.root, t.path);
+      } catch (e) { error = e.message; }
+      return { path: t.path, hash: observed, ...(error ? { error } : {}) };
+    });
+    const revision = hash(JSON.stringify({ name, contentHash: content === null ? null : hash(content), record, installed, targets }));
+    let problem;
+    try {
+      identity(name, m);
+      if (record) verified(record, name, { deleting: record.pending?.kind === 'delete' });
+      else problem = 'Ownership is not established. Resolve the name or installation conflict and restart distribution; existing installations are untouched.';
+    } catch (e) { problem = e.message; }
+    return { name, content: content ?? '', sourceExists: content !== null, revision, ...(problem ? { problem } : {}),
+      managed: !!record, pending: record?.pending?.kind || null,
+      installations: installed.map(({ path, hash, error }) => ({ path, exists: hash !== null && hash !== undefined, ...(error ? { error } : {}) })) };
+  }
+  function match(name, m, revision) {
+    if (!revision) throw new SkillError(428, 'A current skill revision is required');
+    if (snapshot(name, m).revision !== revision) conflict('Skill or installations changed; refresh before saving or confirming deletion');
+  }
+  function verified(r, name, { deleting = false } = {}) {
+    const { source } = config();
+    targetsValid(r);
+    const src = current(source, path.join(source, name));
+    if (src !== r.sourceHash && src !== r.pending?.sourceHash && !(deleting && src === null)) conflict('Source was modified outside the manager');
+    for (const t of r.targets) {
+      const actual = current(t.root, t.path);
+      if (actual !== t.hash && actual !== r.pending?.targetHash && actual !== null) conflict(`Installed file was modified outside the manager: ${t.path}`);
+      // A file that was never owned cannot be claimed simply because it appeared.
+      if (t.hash === null && actual !== null && actual !== r.pending?.targetHash) conflict(`Unowned installation: ${t.path}`);
+    }
+  }
+  function targetPlan(r, id, expected, adopt) {
+    targetsValid(r);
+    const result = [...r.targets];
+    for (const root of config().targets) {
+      if (result.some((t) => t.root === root)) continue;
+      const file = path.join(root, id, 'SKILL.md');
+      const actual = current(root, file);
+      if (actual !== null && (!adopt || actual !== expected)) conflict(`Unowned installation at ${file}; choose another name or resolve it outside the manager`);
+      result.push({ root, path: file, hash: actual, dirOwned: !stat(path.dirname(file)) });
+    }
+    return result;
+  }
+  function outcome(name, source, targets, manifest, error) {
+    let skill;
+    try { skill = snapshot(name, load()); } catch { /* missing or inaccessible */ }
+    const ok = !error && manifest === 'persisted' && targets.every((t) => !t.error);
+    return { ok, status: ok ? 'complete' : 'partial', source, targets, manifest, ...(error ? { error } : {}), skill: skill || null };
+  }
+  function finishWrite(name, content, m) {
+    const { source } = config(), r = m.skills[name], pending = r.pending;
+    if (hash(content) !== pending.sourceHash) conflict('An incomplete save must be retried with the same content');
+    verified(r, name);
+    const file = path.join(source, name), results = [];
+    let sourceStatus = 'unchanged';
+    try {
+      const actual = current(source, file);
+      if (actual !== pending.sourceHash) atomic(source, file, content, actual);
+      sourceStatus = 'persisted';
+    } catch (e) { return outcome(name, 'failed', r.targets.map((t) => ({ path: t.path, status: 'not-attempted' })), 'persisted', e.message); }
+    const generated = generatedSkill(name, content);
+    for (const t of r.targets) {
+      try {
+        const actual = current(t.root, t.path);
+        if (actual !== pending.targetHash) atomic(t.root, t.path, generated, actual);
+        results.push({ path: t.path, status: 'installed' });
+      } catch (e) { results.push({ path: t.path, status: 'failed', error: e.message }); }
+    }
+    if (results.some((t) => t.error)) return outcome(name, sourceStatus, results, 'persisted', 'Some installations failed; retry this save');
+    r.sourceHash = pending.sourceHash;
+    for (const t of r.targets) t.hash = pending.targetHash;
+    delete r.pending;
+    try { persist(m); } catch (e) { return outcome(name, sourceStatus, results, 'failed', e.message); }
+    return outcome(name, sourceStatus, results, 'persisted');
+  }
+  function write(name, content, { create = false, revision, boot = false, generated = false } = {}) {
+    if (typeof content !== 'string') throw new SkillError(400, 'Skill content must be text');
+    const m = load(), id = identity(name, m), { source } = config();
+    const existing = read(source, path.join(source, name));
+    let r = m.skills[name];
+    if (create && (r || existing !== null)) conflict('Skill already exists; choose a different name or open the existing skill');
+    if (!create && !boot) match(name, m, revision);
+    if (r?.pending?.kind === 'delete') conflict('Deletion is pending; retry deletion before creating this skill again');
+    if (r?.pending?.kind === 'write') return finishWrite(name, content, m);
+    if (r) verified(r, name);
+    else {
+      if (!create && !boot) conflict('Skill is not managed; refresh after startup adoption or resolve its installation conflict');
+      r = { id, sourceHash: existing === null ? null : hash(existing), targets: [] };
+    }
+    // Legacy adoption is checked against the CURRENT source, including for the
+    // generated environment skill, before any newly generated text is written.
+    r.targets = targetPlan(r, id, hash(generatedSkill(name, existing ?? content)), boot && existing !== null);
+    r.generated = r.generated || generated;
+    r.pending = { kind: 'write', id: nonce(), sourceHash: hash(content), targetHash: hash(generatedSkill(name, content)) };
+    m.skills[name] = r;
+    persist(m); // intent first; a failure here must change no skill bytes
+    return finishWrite(name, content, m);
+  }
+  function remove(name, revision) {
+    const m = load(); identity(name, m); match(name, m, revision);
+    const r = m.skills[name];
+    if (!r) throw new SkillError(404, 'No ownership record; no installed files were removed');
+    if (r.pending?.kind === 'write') conflict('A save is incomplete; retry it before deleting');
+    verified(r, name, { deleting: true });
+    if (!r.pending) {
+      r.pending = { kind: 'delete', id: nonce() };
+      persist(m); // exact frozen target set; boot must never republish this source
+    }
+    const results = [];
+    for (const t of r.targets) {
+      try {
+        const actual = current(t.root, t.path);
+        if (actual !== null) {
+          if (actual !== t.hash) conflict('Installed file changed during deletion');
+          io.unlinkSync(t.path);
+        }
+        results.push({ path: t.path, status: actual === null ? 'absent' : 'removed' });
+        // Only directories we created, only when empty. Extra files always stay.
+        if (t.dirOwned) {
+          const dir = path.dirname(t.path);
+          try { io.rmdirSync(dir); } catch (e) { if (!['ENOENT', 'ENOTEMPTY', 'EEXIST'].includes(e.code)) results[results.length - 1].directoryError = e.message; }
+        }
+      } catch (e) { results.push({ path: t.path, status: 'failed', error: e.message }); }
+    }
+    if (results.some((t) => t.error)) return outcome(name, 'retained', results, 'persisted', 'Deletion is incomplete; only the remaining confirmed installations will be retried');
+    const { source } = config(), file = path.join(source, name);
+    try {
+      const actual = current(source, file);
+      if (actual !== null) {
+        if (actual !== r.sourceHash) conflict('Source changed during deletion');
+        io.unlinkSync(file);
+      }
+    } catch (e) { return outcome(name, 'failed', results, 'persisted', e.message); }
+    delete m.skills[name];
+    try { persist(m); } catch (e) { return outcome(name, 'removed', results, 'failed', e.message); }
+    return outcome(name, 'removed', results, 'persisted');
+  }
+  function redistribute() {
+    const results = [];
+    let m;
+    try { m = load(); } catch (e) { return { ok: false, error: e.message, results }; }
+    let all;
+    try { all = names(m); } catch (e) { return { ok: false, error: e.message, results }; }
+    for (const name of all) {
+      try {
+        if (m.skills[name]?.pending?.kind === 'delete') { results.push({ name, ok: false, error: 'Deletion pending; explicit retry required' }); continue; }
+        const content = read(config().source, path.join(config().source, name));
+        if (content === null) throw new SkillError(409, 'Source missing; existing installations were retained');
+        results.push({ name, ...write(name, content, { boot: true }) });
+      } catch (e) { results.push({ name, ok: false, error: e.message }); }
+    }
+    return { ok: results.every((r) => r.ok), results };
+  }
+  return {
+    list: serial(() => { const m = load(); return names(m).map((name) => {
+      try { const s = snapshot(name, m); return { name, size: Buffer.byteLength(s.content), pending: s.pending }; }
+      catch (e) { return { name, size: 0, error: e.message }; }
+    }).sort((a, b) => a.name.localeCompare(b.name)); }),
+    get: serial((name) => snapshot(name, load())),
+    create: serial((name, content) => write(name, content, { create: true })),
+    update: serial((name, content, revision) => write(name, content, { revision })),
+    remove: serial(remove),
+    redistribute: serial(redistribute),
+    generate: serial((name, content) => write(name, content, { boot: true, generated: true })),
+  };
+}

--- a/server/src/skills.js
+++ b/server/src/skills.js
@@ -138,13 +138,14 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
   function load() {
     const { state } = config();
     const bytes = read(state, manifestPath());
-    if (bytes === null) return { version: 1, sourceRoot: config().source, skills: Object.create(null) };
+    if (bytes === null) return { version: 1, sourceRoot: config().source, disabledGenerated: [], skills: Object.create(null) };
     try {
       const m = JSON.parse(bytes);
       if (m.version !== 1 || m.sourceRoot !== config().source || !m.skills || Array.isArray(m.skills) || typeof m.skills !== 'object') throw new Error();
+      if (!Array.isArray(m.disabledGenerated) || m.disabledGenerated.some((name) => { try { skillId(name); return false; } catch { return true; } })) throw new Error();
       const ids = new Set();
       for (const [name, r] of Object.entries(m.skills)) {
-        if (r.id !== skillId(name) || ids.has(r.id) || !digest(r.sourceHash) || !Array.isArray(r.targets)) throw new Error();
+        if (typeof r.instance !== 'string' || !r.instance || r.id !== skillId(name) || ids.has(r.id) || !digest(r.sourceHash) || !Array.isArray(r.targets)) throw new Error();
         ids.add(r.id);
         const seen = new Set();
         for (const t of r.targets) {
@@ -280,7 +281,7 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     if (r) verified(r, name);
     else {
       if (!create && !boot) conflict('Skill is not managed; refresh after startup adoption or resolve its installation conflict');
-      r = { id, sourceHash: existing === null ? null : hash(existing), targets: [] };
+      r = { id, instance: nonce(), sourceHash: existing === null ? null : hash(existing), targets: [] };
     }
     // Legacy adoption is checked against the CURRENT source, including for the
     // generated environment skill, before any newly generated text is written.
@@ -288,6 +289,7 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     r.generated = r.generated || generated;
     r.pending = { kind: 'write', id: nonce(), sourceHash: hash(content), targetHash: hash(generatedSkill(name, content)) };
     m.skills[name] = r;
+    if (create) m.disabledGenerated = m.disabledGenerated.filter((n) => n !== name);
     persist(m); // intent first; a failure here must change no skill bytes
     return finishWrite(name, content, m);
   }
@@ -327,6 +329,7 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
       }
     } catch (e) { return outcome(name, 'failed', results, 'persisted', e.message); }
     delete m.skills[name];
+    if (r.generated && !m.disabledGenerated.includes(name)) m.disabledGenerated.push(name);
     try { persist(m); } catch (e) { return outcome(name, 'removed', results, 'failed', e.message); }
     return outcome(name, 'removed', results, 'persisted');
   }
@@ -356,6 +359,10 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     update: serial((name, content, revision) => write(name, content, { revision })),
     remove: serial(remove),
     redistribute: serial(redistribute),
-    generate: serial((name, content) => write(name, content, { boot: true, generated: true })),
+    generate: serial((name, content) => {
+      skillId(name);
+      if (load().disabledGenerated.includes(name)) return { ok: true, status: 'complete', source: 'generation-disabled', targets: [], manifest: 'persisted', skill: null };
+      return write(name, content, { boot: true, generated: true });
+    }),
   };
 }

--- a/server/src/skills.js
+++ b/server/src/skills.js
@@ -7,6 +7,11 @@ export class SkillError extends Error {
   constructor(status, message) { super(message); this.status = status; }
 }
 const conflict = (message) => { throw new SkillError(409, message); };
+const readOnlyMessage = (name) => `${name} is generated from this Space's configuration and is read-only: it is rebuilt on every start and whenever secret descriptions change. Keep your own instructions in a separate skill.`;
+const LEGACY_NOTICE = {
+  kept: 'Your earlier edits to this generated skill are still in place, but it is now read-only and will be replaced by the generated content the next time the environment is rebuilt (a restart, or a change to secret descriptions). Copy anything you want to keep into another skill now.',
+  replaced: 'Your earlier edits to this generated skill were replaced by the generated content; it is read-only. Keep your own instructions in a separate skill.',
+};
 const hash = (content) => createHash('sha256').update(content).digest('hex');
 const digest = (value) => value === null || (typeof value === 'string' && /^[a-f0-9]{64}$/.test(value));
 const below = (root, file) => file.startsWith(root + path.sep);
@@ -46,7 +51,13 @@ export function skillTargetDirs(env = process.env) {
 // One instance per manager. Every caller (including reads and boot) goes through
 // its queue. Injectable sync IO keeps fault tests deterministic; no awaited gap
 // exists between preflight and publication within a process.
-export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], io = fs, nonce = randomUUID }) {
+//
+// `generated` names the skills the manager rebuilds from its own inputs (the
+// environment skill). Their content is derived, not authored, so they are
+// read-only through create/update/remove, and the newest generated content is
+// always authoritative: an interrupted earlier generation can never hold the
+// next one hostage, because nobody can reproduce the old bytes on purpose.
+export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], generated = [], io = fs, nonce = randomUUID }) {
   let queue = Promise.resolve();
   const serial = (fn) => (...args) => {
     const result = queue.then(() => fn(...args));
@@ -155,6 +166,7 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
         }
         if (r.pending && (!['write', 'delete'].includes(r.pending.kind) || typeof r.pending.id !== 'string'
             || (r.pending.kind === 'write' && (!r.pending.sourceHash || !digest(r.pending.sourceHash) || !r.pending.targetHash || !digest(r.pending.targetHash))))) throw new Error();
+        if (r.legacyEdit !== undefined && !Object.hasOwn(LEGACY_NOTICE, r.legacyEdit)) throw new Error();
       }
       Object.setPrototypeOf(m.skills, null);
       return m;
@@ -163,6 +175,12 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
   function persist(m) {
     const { state } = config();
     atomic(state, manifestPath(), JSON.stringify(m, null, 2) + '\n', current(state, manifestPath()));
+  }
+  // Generated names are read-only whether or not a record exists yet: a user
+  // must not be able to create the file the manager is about to regenerate.
+  const readOnly = (name, r) => generated.includes(name) || r?.generated === true;
+  function refuseIfReadOnly(name, m) {
+    if (readOnly(name, m.skills[name])) throw new SkillError(403, readOnlyMessage(name));
   }
   function names(m) {
     const { source } = config(); checkRoot(source);
@@ -205,11 +223,10 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
       if (record) verified(record, name, { deleting: record.pending?.kind === 'delete' });
       else problem = 'Ownership is not established. Resolve the name or installation conflict and restart distribution; existing installations are untouched.';
     } catch (e) { problem = e.message; }
-    if (!problem && record?.generated) problem = m.disabledGenerated.includes(name)
-      ? 'Automatic regeneration is paused to preserve your edits. Explicit saves still publish this skill.'
-      : 'This skill is generated. Saving changes preserves your edits and pauses automatic regeneration.';
+    const locked = readOnly(name, record);
+    if (!problem && locked) problem = record?.legacyEdit ? LEGACY_NOTICE[record.legacyEdit] : readOnlyMessage(name);
     return { name, content: content ?? '', sourceExists: content !== null, revision, ...(problem ? { problem } : {}),
-      managed: !!record, pending: record?.pending?.kind || null,
+      managed: !!record, readOnly: locked, pending: record?.pending?.kind || null,
       installations: installed.map(({ path, hash, error }) => ({ path, exists: hash !== null && hash !== undefined, ...(error ? { error } : {}) })) };
   }
   function match(name, m, revision) {
@@ -294,7 +311,6 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     if (create && (r || existing !== null)) conflict('Skill already exists; choose a different name or open the existing skill');
     const observed = !create && !boot ? match(name, m, revision) : null;
     if (r?.pending?.kind === 'delete') conflict('Deletion is pending; retry deletion before creating this skill again');
-    const customized = !!(observed && r?.generated && hash(content) !== r.sourceHash);
     const sourceConfirmed = confirmSource(r, observed);
     if (r?.pending?.kind === 'write') {
       if (sourceConfirmed) {
@@ -312,10 +328,9 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     // Legacy adoption is checked against the CURRENT source, including for the
     // generated environment skill, before any newly generated text is written.
     r.targets = targetPlan(r, id, hash(generatedSkill(name, existing ?? content)), boot && existing !== null);
-    r.generated = r.generated || generated || m.disabledGenerated.includes(name);
+    r.generated = r.generated || generated;
     r.pending = { kind: 'write', id: nonce(), sourceHash: hash(content), targetHash: hash(generatedSkill(name, content)) };
     m.skills[name] = r;
-    if (customized && !m.disabledGenerated.includes(name)) m.disabledGenerated.push(name);
     persist(m); // intent first; a failure here must change no skill bytes
     return finishWrite(name, content, m);
   }
@@ -356,7 +371,6 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
       }
     } catch (e) { return outcome(name, 'failed', results, 'persisted', e.message); }
     delete m.skills[name];
-    if (r.generated && !m.disabledGenerated.includes(name)) m.disabledGenerated.push(name);
     try { persist(m); } catch (e) { return outcome(name, 'removed', results, 'failed', e.message); }
     return outcome(name, 'removed', results, 'persisted');
   }
@@ -382,15 +396,45 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
       catch (e) { return { name, size: 0, error: e.message }; }
     }).sort((a, b) => a.name.localeCompare(b.name)); }),
     get: serial((name) => snapshot(name, load())),
-    create: serial((name, content) => write(name, content, { create: true })),
-    update: serial((name, content, revision) => write(name, content, { revision })),
-    remove: serial(remove),
+    create: serial((name, content) => { skillId(name); refuseIfReadOnly(name, load()); return write(name, content, { create: true }); }),
+    update: serial((name, content, revision) => { skillId(name); refuseIfReadOnly(name, load()); return write(name, content, { revision }); }),
+    remove: serial((name, revision) => { skillId(name); refuseIfReadOnly(name, load()); return remove(name, revision); }),
     redistribute: serial(redistribute),
     generate: serial((name, content) => {
       skillId(name);
       const m = load();
-      if (m.disabledGenerated.includes(name)) return { ok: true, status: 'complete', source: 'generation-disabled', targets: [], manifest: 'persisted', skill: null };
-      if (m.skills[name] && m.skills[name].generated !== true) conflict('A user-managed skill already uses this name; automatic generation cannot replace it');
+      const r = m.skills[name];
+      if (r && r.generated !== true) conflict('A user-managed skill already uses this name; automatic generation cannot replace it');
+      let changed = false;
+      // Legacy: an edit or deletion made while generated skills were still
+      // editable left a `disabledGenerated` flag. An edit is honoured for one
+      // more cycle — the editor says so — and replaced on the next; a deletion
+      // has nothing to keep, so regeneration simply resumes.
+      if (m.disabledGenerated.includes(name)) {
+        m.disabledGenerated = m.disabledGenerated.filter((other) => other !== name);
+        if (r) {
+          r.legacyEdit = 'kept';
+          persist(m);
+          return { ok: true, status: 'complete', source: 'legacy-edit-kept', targets: [], manifest: 'persisted', skill: snapshot(name, m) };
+        }
+        changed = true;
+      } else if (r?.legacyEdit === 'kept') { r.legacyEdit = 'replaced'; changed = true; }
+      else if (r?.legacyEdit === 'replaced') { delete r.legacyEdit; changed = true; }
+      // An interrupted earlier generation left an intent whose bytes only the
+      // old inputs could reproduce. The files that carry those intended bytes
+      // were written by this manager — adopt them as owned, drop the intent,
+      // and let the newest content through. Externally modified files are
+      // still refused by the ordinary ownership checks in write().
+      if (r?.pending) {
+        const { source } = config();
+        if (r.pending.kind === 'write') {
+          if (current(source, path.join(source, name)) === r.pending.sourceHash) r.sourceHash = r.pending.sourceHash;
+          for (const t of r.targets) if (current(t.root, t.path) === r.pending.targetHash) t.hash = r.pending.targetHash;
+        }
+        delete r.pending;
+        changed = true;
+      }
+      if (changed) persist(m);
       return write(name, content, { boot: true, generated: true });
     }),
   };

--- a/server/src/skills.js
+++ b/server/src/skills.js
@@ -286,7 +286,7 @@ export function createSkillsService({ sourceRoot, stateRoot, targetRoots = [], i
     // Legacy adoption is checked against the CURRENT source, including for the
     // generated environment skill, before any newly generated text is written.
     r.targets = targetPlan(r, id, hash(generatedSkill(name, existing ?? content)), boot && existing !== null);
-    r.generated = r.generated || generated;
+    r.generated = r.generated || generated || m.disabledGenerated.includes(name);
     r.pending = { kind: 'write', id: nonce(), sourceHash: hash(content), targetHash: hash(generatedSkill(name, content)) };
     m.skills[name] = r;
     if (create) m.disabledGenerated = m.disabledGenerated.filter((n) => n !== name);

--- a/server/test/fixtures/skills-faults.mjs
+++ b/server/test/fixtures/skills-faults.mjs
@@ -1,0 +1,17 @@
+// Test-only preload: fail one named fixture path, never production IO.
+import fs from 'node:fs';
+import path from 'node:path';
+const file = process.env.AM_SKILLS_TEST_FAULT;
+const originalRead = fs.readFileSync;
+const fault = () => { try { return JSON.parse(originalRead(file, 'utf8')); } catch { return {}; } };
+for (const method of ['unlinkSync', 'renameSync']) {
+  const original = fs[method];
+  fs[method] = (...args) => {
+    const f = fault();
+    const destination = method === 'renameSync' ? args[1] : args[0];
+    if (f.method === method && f.path === destination && destination.startsWith(path.dirname(process.env.HOME) + '/')) {
+      throw Object.assign(new Error('Fixture storage failure'), { code: 'EIO' });
+    }
+    return original(...args);
+  };
+}

--- a/server/test/fixtures/skills-server.mjs
+++ b/server/test/fixtures/skills-server.mjs
@@ -1,0 +1,62 @@
+// Disposable real-server fixture. No inherited credentials, Space ID, harness
+// homes, or PATH entries containing the operator's CLIs reach the child.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { skillTargetDirs } from '../../src/skills.js';
+const serverDir = fileURLToPath(new URL('../..', import.meta.url));
+const delay = (ms) => new Promise((r) => setTimeout(r, ms));
+export async function skillsServer() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-skills-api-'));
+  const bin = path.join(root, 'bin'); fs.mkdirSync(bin);
+  fs.symlinkSync(process.execPath, path.join(bin, 'node'));
+  const env = { PATH: `${bin}:/usr/bin:/bin`, LANG: 'C.UTF-8',
+    DATA_DIR: path.join(root, 'data'), HOME: path.join(root, 'home'),
+    CLAUDE_CONFIG_DIR: path.join(root, 'claude'), CODEX_HOME: path.join(root, 'codex'),
+    GEMINI_CLI_HOME: path.join(root, 'gemini'), OPENCLAW_HOME: path.join(root, 'openclaw'),
+    XDG_CONFIG_HOME: path.join(root, 'config'), XDG_DATA_HOME: path.join(root, 'xdg'),
+    OPENCODE_CONFIG_DIR: path.join(root, 'opencode'), AM_REPIN_DIR: path.join(root, 'repin'),
+    AM_BASHRC: path.join(root, 'no-bashrc'), PUBLIC_DIR: path.join(root, 'public'),
+    AM_SKILLS_TEST_FAULT: path.join(root, 'fault.json'),
+  };
+  const targetRoots = skillTargetDirs({ ...env, AM_DISTRIBUTE_SKILLS: '1' }).sort();
+  if (targetRoots.length !== 5 || targetRoots.some((p) => !p.startsWith(root + '/'))) throw new Error('Unsafe skills test roots');
+  // Opt in only after validating every destination.
+  env.AM_DISTRIBUTE_SKILLS = '1';
+  let child, log = '', url;
+  async function stop() {
+    if (!child || child.exitCode !== null) return;
+    const exit = new Promise((r) => child.once('exit', r));
+    child.kill('SIGTERM'); await exit; child = null;
+  }
+  async function start({ distribute = true } = {}) {
+    const probe = net.createServer();
+    await new Promise((r) => probe.listen(0, '127.0.0.1', r));
+    const port = probe.address().port; await new Promise((r) => probe.close(r));
+    url = `http://127.0.0.1:${port}`; log = '';
+    child = spawn(process.execPath, ['--import', fileURLToPath(new URL('./skills-faults.mjs', import.meta.url)), 'src/index.js'], {
+      cwd: serverDir, env: { ...env, AM_DISTRIBUTE_SKILLS: distribute ? '1' : '', PORT: String(port) }, stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    child.stdout.on('data', (s) => { log += s; }); child.stderr.on('data', (s) => { log += s; });
+    for (let i = 0; i < 100; i++) {
+      if (child.exitCode !== null) throw new Error(`Fixture server exited: ${log}`);
+      if (log.includes(`Agent Manager :${port}`) && await fetch(`${url}/api/health`).then((r) => r.ok).catch(() => false)) return;
+      await delay(50);
+    }
+    throw new Error(`Fixture server timeout: ${log}`);
+  }
+  return { root, env, targetRoots, get url() { return url; }, get log() { return log; }, start, stop,
+    source: (name) => path.join(env.DATA_DIR, 'workspaces', 'skills', name),
+    target: (i, id) => path.join(targetRoots[i], id, 'SKILL.md'),
+    fault: (value) => fs.writeFileSync(env.AM_SKILLS_TEST_FAULT, JSON.stringify(value)),
+    async api(name = '', method = 'GET', content, revision) {
+      const r = await fetch(`${url}/api/skills${name ? '/' + encodeURIComponent(name) : ''}`, { method,
+        headers: { 'content-type': 'text/plain', 'x-am-origin': 'operator', ...(revision ? { 'If-Match': revision } : {}) }, body: content });
+      return { status: r.status, body: await r.json() };
+    },
+    async cleanup() { await stop(); fs.rmSync(root, { recursive: true, force: true }); },
+  };
+}

--- a/server/test/skills-api.test.mjs
+++ b/server/test/skills-api.test.mjs
@@ -51,6 +51,12 @@ test('real routes, startup and generated caller share ownership and revisions', 
   const res = await fetch(`${f.url}/api/secrets`, { method: 'PUT', headers: { 'content-type': 'application/json', 'x-am-origin': 'operator' }, body: JSON.stringify({ notes: {} }) });
   assert.equal((await res.json()).skillDistribution.ok, false);
   assert.equal(fs.readFileSync(f.target(0, 'environment'), 'utf8'), 'user environment');
+  const envSource = (await get('environment.md')).content;
+  fs.writeFileSync(f.target(0, 'environment'), generatedSkill('environment.md', envSource));
+  assert.equal((await f.api('environment.md', 'DELETE', undefined, (await get('environment.md')).revision)).body.ok, true);
+  await f.stop(); await f.start();
+  assert.equal((await f.api('environment.md')).status, 404);
+  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'environment')), false);
   assert.equal((await fetch(`${f.url}/api/health`)).status, 200);
 });
 

--- a/server/test/skills-api.test.mjs
+++ b/server/test/skills-api.test.mjs
@@ -53,10 +53,17 @@ test('real routes, startup and generated caller share ownership and revisions', 
   assert.equal(fs.readFileSync(f.target(0, 'environment'), 'utf8'), 'user environment');
   const envSource = (await get('environment.md')).content;
   fs.writeFileSync(f.target(0, 'environment'), generatedSkill('environment.md', envSource));
-  assert.equal((await f.api('environment.md', 'DELETE', undefined, (await get('environment.md')).revision)).body.ok, true);
-  await f.stop(); await f.start();
-  assert.equal((await f.api('environment.md')).status, 404);
-  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'environment')), false);
+  // The generated skill is read-only through the API, whatever revision is presented.
+  const env = await get('environment.md');
+  assert.equal(env.readOnly, true); assert.match(env.problem, /read-only/);
+  assert.equal((await f.api('environment.md', 'PUT', '# My environment', env.revision)).status, 403);
+  assert.equal((await f.api('environment.md', 'DELETE', undefined, env.revision)).status, 403);
+  assert.equal((await f.api('environment.md', 'POST', '# My environment')).status, 403);
+  assert.equal((await get('environment.md')).content, envSource);
+  await f.stop(); await f.start(); // a new port: the generated text legitimately changes
+  const regenerated = await get('environment.md');
+  assert.equal(regenerated.readOnly, true); assert.equal(regenerated.pending, null);
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'environment'), 'utf8'), generatedSkill('environment.md', regenerated.content));
   assert.equal((await fetch(`${f.url}/api/health`)).status, 200);
 });
 
@@ -103,22 +110,34 @@ test('real routes allow reviewed external source edits after restart while rejec
   for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'demo')), false);
 });
 
-for (const action of ['recreate', 'save']) {
-  test(`Settings and startup preserve a generated skill's explicit ${action}`, async (t) => {
-    const f = await skillsServer(); t.after(() => f.cleanup()); await f.start();
-    const current = (await f.api('environment.md')).body;
-    if (action === 'recreate') {
-      assert.equal((await f.api('environment.md', 'DELETE', undefined, current.revision)).body.ok, true);
-      assert.equal((await f.api('environment.md', 'POST', '# My environment')).body.ok, true);
-    } else {
-      assert.equal((await f.api('environment.md', 'PUT', '# My environment', current.revision)).body.ok, true);
-    }
-    for (const route of ['/api/config', '/api/secrets']) {
-      const res = await fetch(f.url + route, { method: 'PUT', headers: { 'content-type': 'application/json', 'x-am-origin': 'operator' }, body: '{}' });
-      assert.equal((await res.json()).skillDistribution.source, 'generation-disabled');
-    }
-    await f.stop(); await f.start();
-    assert.equal((await f.api('environment.md')).body.content, '# My environment');
-    for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'environment'), 'utf8'), generatedSkill('environment.md', '# My environment'));
-  });
-}
+test('the environment skill regenerates after an interrupted generation, through Settings and on startup', async (t) => {
+  const f = await skillsServer(); t.after(() => f.cleanup()); await f.start();
+  // The generated text embeds the jobs cost limit, so a Settings save with a
+  // new limit is a generation with genuinely different content.
+  const settings = (askAboveUsd) => fetch(`${f.url}/api/config`, { method: 'PUT', headers: { 'content-type': 'application/json', 'x-am-origin': 'operator' }, body: JSON.stringify({ jobs: { askAboveUsd } }) }).then((r) => r.json());
+  const before = (await f.api('environment.md')).body;
+  // Boot N: the regeneration triggered by a Settings save fails on one target.
+  f.fault({ method: 'renameSync', path: f.target(2, 'environment') });
+  const broken = await settings(11);
+  assert.equal(broken.skillDistribution.ok, false);
+  assert.equal((await f.api('environment.md')).body.pending, 'write');
+  // The inputs change again; the old intended bytes can no longer be produced.
+  f.fault({});
+  const recovered = await settings(22);
+  assert.equal(recovered.skillDistribution.ok, true, JSON.stringify(recovered.skillDistribution));
+  const after = (await f.api('environment.md')).body;
+  assert.equal(after.pending, null);
+  assert.notEqual(after.content, before.content);
+  assert.match(after.content, /\$22\b/);
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'environment'), 'utf8'), generatedSkill('environment.md', after.content));
+  // Boot N+1 with an interrupted generation left over from boot N.
+  f.fault({ method: 'renameSync', path: f.target(0, 'environment') });
+  assert.equal((await settings(33)).skillDistribution.ok, false);
+  f.fault({});
+  await f.stop(); await f.start();
+  const booted = (await f.api('environment.md')).body;
+  assert.equal(booted.pending, null); assert.equal(booted.readOnly, true);
+  assert.match(booted.content, /\$33\b/);
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'environment'), 'utf8'), generatedSkill('environment.md', booted.content));
+  assert.doesNotMatch(f.log, /An incomplete save must be retried/);
+});

--- a/server/test/skills-api.test.mjs
+++ b/server/test/skills-api.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { skillsServer } from './fixtures/skills-server.mjs';
+import { generatedSkill } from '../src/skills.js';
+
+test('real routes, startup and generated caller share ownership and revisions', async (t) => {
+  const f = await skillsServer(); t.after(() => f.cleanup()); await f.start();
+  const get = async (name = 'demo.md') => (await f.api(name)).body;
+  const environment = await get('environment.md');
+  assert.equal(environment.managed, true); assert.equal(environment.installations.length, 5);
+  assert.equal((await f.api('demo.md', 'PUT', 'implicit overwrite')).status, 428);
+  const created = await f.api('demo.md', 'POST', '# first');
+  assert.equal(created.status, 200); assert.equal(created.body.ok, true);
+  assert.equal((await f.api('demo.md', 'POST', '# upload')).status, 409);
+  assert.equal((await f.api('Demo.txt', 'POST', '# collision')).status, 409);
+  assert.equal((await f.api('empty.md', 'POST', '')).body.ok, true);
+  assert.equal((await get('empty.md')).content, '');
+  const initial = await get();
+  const simultaneous = await Promise.all(['# saved', '# other'].map((text) => f.api('demo.md', 'PUT', text, initial.revision)));
+  assert.deepEqual(simultaneous.map((r) => r.status).sort(), [200, 409]);
+  assert.equal((await f.api('demo.md', 'DELETE', undefined, initial.revision)).status, 409);
+  const saved = await get();
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'demo'), 'utf8'), generatedSkill('demo.md', saved.content));
+  await f.stop(); await f.start();
+  assert.equal((await get()).content, saved.content);
+  assert.equal((await get()).revision, saved.revision); // idempotent unchanged boot
+  const beforeExternal = await get();
+  fs.writeFileSync(f.target(2, 'demo'), 'user-installed copy');
+  assert.equal((await f.api('demo.md', 'PUT', '# replace', beforeExternal.revision)).status, 409);
+  assert.equal((await f.api('demo.md', 'DELETE', undefined, (await get()).revision)).status, 409);
+  assert.equal(fs.readFileSync(f.source('demo.md'), 'utf8'), saved.content);
+  fs.writeFileSync(f.target(2, 'demo'), generatedSkill('demo.md', saved.content));
+  fs.writeFileSync(path.join(path.dirname(f.target(1, 'demo')), 'support.txt'), 'extra');
+  f.fault({ method: 'unlinkSync', path: f.target(2, 'demo') });
+  const partial = await f.api('demo.md', 'DELETE', undefined, (await get()).revision);
+  assert.equal(partial.status, 207); assert.equal(partial.body.ok, false);
+  assert.deepEqual(partial.body.targets.map((r) => r.status), ['removed', 'removed', 'failed', 'removed', 'removed']);
+  await f.stop(); await f.start();
+  assert.equal((await get()).pending, 'delete');
+  assert.equal(fs.existsSync(f.target(0, 'demo')), false);
+  assert.equal((await f.api('demo.md', 'POST', 'retry wrong route')).status, 409);
+  f.fault({});
+  assert.equal((await f.api('demo.md', 'DELETE', undefined, (await get()).revision)).body.ok, true);
+  assert.equal((await f.api('demo.md', 'DELETE', undefined, 'old')).status, 404);
+  assert.equal(fs.readFileSync(path.join(path.dirname(f.target(1, 'demo')), 'support.txt'), 'utf8'), 'extra');
+  assert.equal(fs.existsSync(f.source('demo.md')), false);
+  // The actual generated caller must refuse an externally edited installation.
+  fs.writeFileSync(f.target(0, 'environment'), 'user environment');
+  const res = await fetch(`${f.url}/api/secrets`, { method: 'PUT', headers: { 'content-type': 'application/json', 'x-am-origin': 'operator' }, body: JSON.stringify({ notes: {} }) });
+  assert.equal((await res.json()).skillDistribution.ok, false);
+  assert.equal(fs.readFileSync(f.target(0, 'environment'), 'utf8'), 'user environment');
+  assert.equal((await fetch(`${f.url}/api/health`)).status, 200);
+});
+
+test('local server defaults never install skills in any harness home', async (t) => {
+  const f = await skillsServer(); t.after(() => f.cleanup()); await f.start({ distribute: false });
+  assert.equal((await f.api('local.md', 'POST', 'local')).body.ok, true);
+  assert.equal((await f.api('environment.md')).body.installations.length, 0);
+  for (const root of f.targetRoots) assert.equal(fs.existsSync(root), false);
+});
+
+test('corrupt manifest degrades skills while the actual server stays available', async (t) => {
+  const f = await skillsServer(); t.after(() => f.cleanup());
+  const state = path.join(f.env.DATA_DIR, 'state', 'skills'); fs.mkdirSync(state, { recursive: true });
+  fs.writeFileSync(path.join(state, 'skills-v1.json'), '{bad');
+  await f.start();
+  assert.equal((await f.api('demo.md', 'POST', 'new')).status, 503);
+  assert.equal(fs.existsSync(f.source('environment.md')), false);
+  for (const root of f.targetRoots) assert.equal(fs.existsSync(root), false);
+  assert.equal((await fetch(`${f.url}/api/health`)).status, 200);
+  assert.match(f.log, /degraded distribution/);
+});

--- a/server/test/skills-api.test.mjs
+++ b/server/test/skills-api.test.mjs
@@ -78,3 +78,47 @@ test('corrupt manifest degrades skills while the actual server stays available',
   assert.equal((await fetch(`${f.url}/api/health`)).status, 200);
   assert.match(f.log, /degraded distribution/);
 });
+
+test('real routes allow reviewed external source edits after restart while rejecting stale revisions', async (t) => {
+  const f = await skillsServer(); t.after(() => f.cleanup()); await f.start();
+  await f.api('demo.md', 'POST', '# Original');
+  const stale = (await f.api('demo.md')).body.revision;
+  fs.writeFileSync(f.source('demo.md'), '# Edited in Files or by an agent');
+  assert.equal((await f.api('demo.md', 'PUT', '# Stale save', stale)).status, 409);
+  assert.equal((await f.api('demo.md', 'DELETE', undefined, stale)).status, 409);
+  await f.stop(); await f.start();
+  const reviewed = (await f.api('demo.md')).body;
+  assert.equal(reviewed.content, '# Edited in Files or by an agent');
+  assert.match(reviewed.problem, /Source was modified/);
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'demo'), 'utf8'), generatedSkill('demo.md', '# Original'));
+  const saved = await f.api('demo.md', 'PUT', '# Reviewed and published', reviewed.revision);
+  assert.equal(saved.status, 200); assert.equal(saved.body.ok, true);
+  await f.stop(); await f.start();
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'demo'), 'utf8'), generatedSkill('demo.md', '# Reviewed and published'));
+  fs.writeFileSync(f.source('demo.md'), '# Another external edit');
+  const confirmed = (await f.api('demo.md')).body;
+  const deleted = await f.api('demo.md', 'DELETE', undefined, confirmed.revision);
+  assert.equal(deleted.status, 200); assert.equal(deleted.body.ok, true);
+  assert.equal(fs.existsSync(f.source('demo.md')), false);
+  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'demo')), false);
+});
+
+for (const action of ['recreate', 'save']) {
+  test(`Settings and startup preserve a generated skill's explicit ${action}`, async (t) => {
+    const f = await skillsServer(); t.after(() => f.cleanup()); await f.start();
+    const current = (await f.api('environment.md')).body;
+    if (action === 'recreate') {
+      assert.equal((await f.api('environment.md', 'DELETE', undefined, current.revision)).body.ok, true);
+      assert.equal((await f.api('environment.md', 'POST', '# My environment')).body.ok, true);
+    } else {
+      assert.equal((await f.api('environment.md', 'PUT', '# My environment', current.revision)).body.ok, true);
+    }
+    for (const route of ['/api/config', '/api/secrets']) {
+      const res = await fetch(f.url + route, { method: 'PUT', headers: { 'content-type': 'application/json', 'x-am-origin': 'operator' }, body: '{}' });
+      assert.equal((await res.json()).skillDistribution.source, 'generation-disabled');
+    }
+    await f.stop(); await f.start();
+    assert.equal((await f.api('environment.md')).body.content, '# My environment');
+    for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'environment'), 'utf8'), generatedSkill('environment.md', '# My environment'));
+  });
+}

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -89,6 +89,56 @@ test('stale tabs, missing tags, source and installed edits preserve bytes', asyn
   assert.equal(read(f.target(2)), 'external installation');
 });
 
+for (const action of ['save', 'delete']) {
+  test(`a fresh revision permits ${action} of an externally edited source without claiming edited installations`, async (t) => {
+    const f = fixture(t); await f.service.create('demo.md', 'first');
+    const mutate = (s, rev) => action === 'save' ? s.update('demo.md', 'published', rev) : s.remove('demo.md', rev);
+    const stale = await revision(f.service);
+    f.seed(f.source(), 'edited outside Skills');
+    await rejects(mutate(f.service, stale));
+    const restart = createSkillsService(f.options);
+    assert.equal((await restart.redistribute()).ok, false);
+    assert.equal(read(f.source()), 'edited outside Skills');
+    for (let i = 0; i < 5; i++) assert.equal(read(f.target(i)), generatedSkill('demo.md', 'first'));
+
+    f.seed(f.target(2), 'independent installed edit');
+    await rejects(mutate(restart, await revision(restart)));
+    assert.equal(read(f.source()), 'edited outside Skills');
+    assert.equal(read(f.target(2)), 'independent installed edit');
+    f.seed(f.target(2), generatedSkill('demo.md', 'first'));
+    assert.equal((await mutate(restart, await revision(restart))).ok, true);
+    if (action === 'save') {
+      assert.equal(read(f.source()), 'published');
+      for (let i = 0; i < 5; i++) assert.equal(read(f.target(i)), generatedSkill('demo.md', 'published'));
+    } else {
+      assert.equal(fs.existsSync(f.source()), false);
+      for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i)), false);
+    }
+  });
+
+  test(`${action} persists the confirmed external source before a failure and keeps retries scoped`, async (t) => {
+    const f = fixture(t); await f.service.create('demo.md', 'first');
+    f.seed(f.source(), 'confirmed external edit');
+    const mutate = (s, rev) => action === 'save' ? s.update('demo.md', 'published', rev) : s.remove('demo.md', rev);
+    const s = createSkillsService({ ...f.options, io: { ...fs,
+      renameSync(a, b) { if (action === 'save' && b === f.source()) throw fail('source rename'); return fs.renameSync(a, b); },
+      unlinkSync(p) { if (action === 'delete' && p === f.target(2)) throw fail('target unlink'); return fs.unlinkSync(p); },
+    } });
+    assert.equal((await mutate(s, await revision(s))).ok, false);
+    assert.equal(read(f.source()), 'confirmed external edit');
+    const restart = createSkillsService(f.options);
+    assert.equal((await restart.redistribute()).ok, false);
+    const stale = await revision(restart);
+    f.seed(f.source(), 'another external edit');
+    await rejects(mutate(restart, stale));
+    assert.equal(read(f.source()), 'another external edit');
+    // Reviewing the new source can authorize it, but cannot change the pending
+    // save's intended content or add any installation to its original targets.
+    if (action === 'save') await rejects(restart.update('demo.md', 'different intent', await revision(restart)));
+    assert.equal((await mutate(restart, await revision(restart))).ok, true);
+  });
+}
+
 test('unowned installations block create and legacy adoption unless byte identical', async (t) => {
   const f = fixture(t);
   f.seed(f.target(), generatedSkill('demo.md', 'first'));
@@ -370,6 +420,22 @@ test('an incomplete create retries with the original content and cannot become a
   assert.equal(read(f.source('independent.md')), 'untouched');
 });
 
+test('a fresh revision cannot claim an unrelated source after its initial creation failed', async (t) => {
+  const f = fixture(t);
+  const s = createSkillsService({ ...f.options, io: { ...fs, writeFileSync(fd, content, ...args) {
+    if (content === 'intended') throw fail('initial source write');
+    return fs.writeFileSync(fd, content, ...args);
+  } } });
+  assert.equal((await s.create('demo.md', 'intended')).source, 'failed');
+  const manifest = read(f.manifest);
+  f.seed(f.source(), 'independent source');
+  const restart = createSkillsService(f.options);
+  await rejects(restart.update('demo.md', 'intended', await revision(restart)));
+  assert.equal(read(f.source()), 'independent source');
+  assert.equal(read(f.manifest), manifest);
+  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i)), false);
+});
+
 test('a changed configured target set invalidates prepared deletion without broadening it', async (t) => {
   const f = fixture(t); await f.service.create('demo.md', 'first');
   const confirmed = await revision(f.service);
@@ -443,6 +509,24 @@ test('permanently deleted generated skills stay absent on restart until explicit
   await restart.remove('environment.md', await revision(restart, 'environment.md'));
   assert.equal((await restart.generate('environment.md', 'must stay deleted')).source, 'generation-disabled');
   await restart.create('environment.md', 'explicit recreation');
-  assert.equal((await restart.generate('environment.md', 'new generation')).ok, true);
-  assert.equal(read(f.source('environment.md')), 'new generation');
+  assert.equal((await restart.generate('environment.md', 'new generation')).source, 'generation-disabled');
+  assert.equal(read(f.source('environment.md')), 'explicit recreation');
+});
+
+test('an explicit edit to a generated skill pauses regeneration without preventing ordinary publication', async (t) => {
+  const f = fixture(t); await f.service.generate('environment.md', 'generated');
+  await f.service.update('environment.md', 'operator customization', await revision(f.service, 'environment.md'));
+  const restart = createSkillsService(f.options);
+  assert.equal((await restart.generate('environment.md', 'new generation')).source, 'generation-disabled');
+  assert.equal((await restart.redistribute()).ok, true);
+  assert.equal(read(f.source('environment.md')), 'operator customization');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'operator customization'));
+  assert.match((await restart.get('environment.md')).problem, /regeneration is paused/);
+});
+
+test('automatic generation cannot take over a user-created managed skill', async (t) => {
+  const f = fixture(t); await f.service.create('environment.md', 'user-created');
+  await rejects(f.service.generate('environment.md', 'generated'));
+  assert.equal(read(f.source('environment.md')), 'user-created');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'user-created'));
 });

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -3,7 +3,9 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
+import { createHash } from 'node:crypto';
 import { createSkillsService, generatedSkill, skillId, skillTargetDirs } from '../src/skills.js';
+const sha = (text) => createHash('sha256').update(text).digest('hex');
 
 function fixture(t, count = 5) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-skills-'));
@@ -496,32 +498,121 @@ test('deleting and recreating identical bytes cannot revive an old confirmation'
   assert.equal(read(f.source()), 'first');
 });
 
-test('permanently deleted generated skills stay absent on restart until explicitly recreated', async (t) => {
-  const f = fixture(t); await f.service.generate('environment.md', 'generated');
-  await f.service.remove('environment.md', await revision(f.service, 'environment.md'));
-  const restart = createSkillsService(f.options);
-  assert.equal((await restart.redistribute()).ok, true);
-  const r = await restart.generate('environment.md', 'new generation');
-  assert.equal(r.source, 'generation-disabled');
+test('generated skills are read-only: create, update and remove are refused and regeneration continues', async (t) => {
+  const f = fixture(t);
+  const s = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  // Before the first generation the name is already reserved.
+  await rejects(s.create('environment.md', 'user-created'), 403);
   assert.equal(fs.existsSync(f.source('environment.md')), false);
-  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'environment')), false);
-  await restart.create('environment.md', 'explicit recreation');
-  await restart.remove('environment.md', await revision(restart, 'environment.md'));
-  assert.equal((await restart.generate('environment.md', 'must stay deleted')).source, 'generation-disabled');
-  await restart.create('environment.md', 'explicit recreation');
-  assert.equal((await restart.generate('environment.md', 'new generation')).source, 'generation-disabled');
-  assert.equal(read(f.source('environment.md')), 'explicit recreation');
+  assert.equal((await s.generate('environment.md', 'generated')).ok, true);
+  const snap = await s.get('environment.md');
+  assert.equal(snap.readOnly, true); assert.match(snap.problem, /read-only/);
+  await rejects(s.update('environment.md', 'operator customization', snap.revision), 403);
+  await rejects(s.remove('environment.md', snap.revision), 403);
+  await rejects(s.create('environment.md', 'again'), 403);
+  assert.equal(read(f.source('environment.md')), 'generated');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'generated'));
+  // The list without a configured name still refuses a record that was generated.
+  const restart = createSkillsService(f.options);
+  await rejects(restart.update('environment.md', 'edit', await revision(restart, 'environment.md')), 403);
+  await rejects(restart.remove('environment.md', await revision(restart, 'environment.md')), 403);
+  assert.equal((await restart.generate('environment.md', 'new generation')).ok, true);
+  assert.equal(read(f.source('environment.md')), 'new generation');
+  // Ordinary skills are untouched by the rule.
+  assert.equal((await s.create('demo.md', 'first')).ok, true);
+  assert.equal((await s.update('demo.md', 'second', await revision(s))).ok, true);
+  assert.equal((await s.get('demo.md')).readOnly, false);
 });
 
-test('an explicit edit to a generated skill pauses regeneration without preventing ordinary publication', async (t) => {
-  const f = fixture(t); await f.service.generate('environment.md', 'generated');
-  await f.service.update('environment.md', 'operator customization', await revision(f.service, 'environment.md'));
-  const restart = createSkillsService(f.options);
-  assert.equal((await restart.generate('environment.md', 'new generation')).source, 'generation-disabled');
+test('the newest generation wins over an interrupted earlier one, whatever its content', async (t) => {
+  const f = fixture(t);
+  // Boot N: generating "second" fails part-way (one target write). The intent
+  // for "second" is recorded. Boot N+1 generates "third" — the inputs changed
+  // and nobody can reproduce "second" any more.
+  let fired = false;
+  const flaky = createSkillsService({ ...f.options, generated: ['environment.md'], io: { ...fs, writeFileSync(fd, content, ...args) {
+    if (!fired && content === generatedSkill('environment.md', 'second') && args[0] === 'utf8' && typeof fd === 'number') { fired = true; throw fail('target write'); }
+    return fs.writeFileSync(fd, content, ...args);
+  } } });
+  assert.equal((await flaky.generate('environment.md', 'first')).ok, true);
+  const interrupted = await flaky.generate('environment.md', 'second');
+  assert.equal(interrupted.ok, false); assert.equal(interrupted.skill.pending, 'write');
+  assert.equal(read(f.source('environment.md')), 'second');
+  const restart = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  // Startup redistribution cannot finish that intent with other content — and does not need to.
+  const third = await restart.generate('environment.md', 'third');
+  assert.equal(third.ok, true, JSON.stringify(third));
+  assert.equal(read(f.source('environment.md')), 'third');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'third'));
+  const m = JSON.parse(read(f.manifest));
+  assert.equal(m.skills['environment.md'].pending, undefined);
   assert.equal((await restart.redistribute()).ok, true);
-  assert.equal(read(f.source('environment.md')), 'operator customization');
-  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'operator customization'));
-  assert.match((await restart.get('environment.md')).problem, /regeneration is paused/);
+  // An externally modified installation is still a conflict, not something regeneration overwrites.
+  f.seed(f.target(1, 'environment'), 'user copy');
+  await rejects(restart.generate('environment.md', 'fourth'));
+  assert.equal(read(f.target(1, 'environment')), 'user copy');
+  assert.equal(read(f.source('environment.md')), 'third');
+});
+
+test('an interrupted generation whose source write failed is also superseded', async (t) => {
+  const f = fixture(t);
+  const flaky = createSkillsService({ ...f.options, generated: ['environment.md'], io: { ...fs, writeFileSync(fd, content, ...args) {
+    if (content === 'second') throw fail('source write');
+    return fs.writeFileSync(fd, content, ...args);
+  } } });
+  assert.equal((await flaky.generate('environment.md', 'first')).ok, true);
+  assert.equal((await flaky.generate('environment.md', 'second')).source, 'failed');
+  assert.equal(read(f.source('environment.md')), 'first');
+  const restart = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  assert.equal((await restart.generate('environment.md', 'third')).ok, true);
+  assert.equal(read(f.source('environment.md')), 'third');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'third'));
+});
+
+test('a legacy customization is honoured for one cycle, then replaced, and the editor is told both times', async (t) => {
+  const f = fixture(t);
+  const s = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  assert.equal((await s.generate('environment.md', 'generated')).ok, true);
+  // What the previous contract left behind: a customized source, its installed
+  // rendering, and a paused-regeneration flag in the manifest.
+  const custom = 'operator customization';
+  f.seed(f.source('environment.md'), custom);
+  for (let i = 0; i < 5; i++) f.seed(f.target(i, 'environment'), generatedSkill('environment.md', custom));
+  const m = JSON.parse(read(f.manifest));
+  m.disabledGenerated = ['environment.md'];
+  m.skills['environment.md'].sourceHash = sha(custom);
+  for (const target of m.skills['environment.md'].targets) target.hash = sha(generatedSkill('environment.md', custom));
+  fs.writeFileSync(f.manifest, JSON.stringify(m, null, 2) + '\n');
+  const upgraded = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  // Cycle 1: kept, with a warning that names what will happen.
+  const kept = await upgraded.generate('environment.md', 'new generation');
+  assert.equal(kept.ok, true); assert.equal(kept.source, 'legacy-edit-kept');
+  assert.equal(read(f.source('environment.md')), custom);
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', custom));
+  const warned = await upgraded.get('environment.md');
+  assert.equal(warned.readOnly, true); assert.match(warned.problem, /still in place.*will be replaced/);
+  await rejects(upgraded.update('environment.md', 'more edits', warned.revision), 403);
+  assert.deepEqual(JSON.parse(read(f.manifest)).disabledGenerated, []);
+  // Cycle 2: replaced, and the editor says so.
+  assert.equal((await upgraded.generate('environment.md', 'newer generation')).ok, true);
+  assert.equal(read(f.source('environment.md')), 'newer generation');
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i, 'environment')), generatedSkill('environment.md', 'newer generation'));
+  assert.match((await upgraded.get('environment.md')).problem, /were replaced/);
+  // Cycle 3: back to the plain read-only explanation.
+  assert.equal((await upgraded.generate('environment.md', 'newest')).ok, true);
+  assert.match((await upgraded.get('environment.md')).problem, /read-only/);
+  assert.doesNotMatch((await upgraded.get('environment.md')).problem, /replaced/);
+  assert.equal(JSON.parse(read(f.manifest)).skills['environment.md'].legacyEdit, undefined);
+});
+
+test('a legacy deletion of a generated skill no longer keeps it deleted', async (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(f.options.stateRoot, { recursive: true });
+  fs.writeFileSync(f.manifest, JSON.stringify({ version: 1, sourceRoot: f.options.sourceRoot, disabledGenerated: ['environment.md'], skills: {} }, null, 2) + '\n');
+  const s = createSkillsService({ ...f.options, generated: ['environment.md'] });
+  assert.equal((await s.generate('environment.md', 'generated again')).ok, true);
+  assert.equal(read(f.source('environment.md')), 'generated again');
+  assert.deepEqual(JSON.parse(read(f.manifest)).disabledGenerated, []);
 });
 
 test('automatic generation cannot take over a user-created managed skill', async (t) => {

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -1,0 +1,378 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import test from 'node:test';
+import { createSkillsService, generatedSkill, skillId, skillTargetDirs } from '../src/skills.js';
+
+function fixture(t, count = 5) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-skills-'));
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  const sourceRoot = path.join(root, 'source'), stateRoot = path.join(root, 'state');
+  const targetRoots = Array.from({ length: count }, (_, i) => path.join(root, `harness-${i}`));
+  const options = { sourceRoot, stateRoot, targetRoots };
+  const source = (name = 'demo.md') => path.join(sourceRoot, name);
+  const target = (i = 0, id = 'demo') => path.join(targetRoots[i], id, 'SKILL.md');
+  const seed = (p, text) => { fs.mkdirSync(path.dirname(p), { recursive: true }); fs.writeFileSync(p, text); };
+  const manifest = path.join(stateRoot, 'skills-v1.json');
+  return { root, options, source, target, seed, manifest, service: createSkillsService(options) };
+}
+const read = (p) => fs.readFileSync(p, 'utf8');
+const revision = async (s, name = 'demo.md') => (await s.get(name)).revision;
+const fail = (message) => Object.assign(new Error(message), { code: 'EIO' });
+const rejects = (promise, status = 409) => assert.rejects(promise, (e) => e.status === status);
+
+for (const name of ['', '.', '..', '...', '../demo.md', 'folder/demo.md', 'a\\b.md', '---.md', '__.txt', ' .md']) {
+  test(`invalid identity ${JSON.stringify(name)} makes no writes`, async (t) => {
+    const f = fixture(t);
+    await rejects(f.service.create(name, 'new'), 400);
+    assert.deepEqual(fs.readdirSync(f.root), []);
+  });
+}
+
+test('valid mapping remains compatible and collisions never replace bytes', async (t) => {
+  const f = fixture(t);
+  assert.equal(skillId('My_skill.v2.md'), 'my-skill-v2');
+  assert.equal(skillId('.hidden.md'), 'hidden');
+  assert.equal(skillId('a'.repeat(70) + '.md'), 'a'.repeat(40));
+  for (const [name, collision] of [['Demo.md', 'demo.MD'], ['hello.md', 'hello.txt'], ['My skill.md', 'My_skill.md'], ['a'.repeat(50) + '.md', 'a'.repeat(51) + '.txt']]) {
+    assert.equal((await f.service.create(name, 'original')).ok, true);
+    await rejects(f.service.create(collision, 'replacement'));
+    await rejects(f.service.create(name, 'replacement'));
+    assert.equal(read(f.source(name)), 'original');
+  }
+});
+
+test('owned lifecycle, restart, all targets, support files and permanent deletion', async (t) => {
+  const f = fixture(t);
+  for (let i = 0; i < 5; i++) f.seed(path.join(f.options.targetRoots[i], 'independent', 'SKILL.md'), `unrelated ${i}`);
+  assert.equal((await f.service.create('demo.md', '# First')).ok, true);
+  for (let i = 0; i < 5; i++) f.seed(path.join(path.dirname(f.target(i)), 'support.txt'), `support ${i}`);
+  assert.equal((await f.service.update('demo.md', '# Second', await revision(f.service))).ok, true);
+  const restart = createSkillsService(f.options);
+  assert.equal((await restart.redistribute()).ok, true);
+  const record = JSON.parse(read(f.manifest)).skills['demo.md'];
+  assert.equal(record.id, 'demo'); assert.equal(record.targets.length, 5); assert.equal(record.pending, undefined);
+  for (let i = 0; i < 5; i++) assert.equal(read(f.target(i)), generatedSkill('demo.md', '# Second'));
+  assert.equal((await restart.remove('demo.md', await revision(restart))).ok, true);
+  await rejects(restart.remove('demo.md', 'old-tag'), 404);
+  assert.equal(fs.existsSync(f.source()), false);
+  for (let i = 0; i < 5; i++) {
+    assert.equal(fs.existsSync(f.target(i)), false);
+    assert.equal(read(path.join(path.dirname(f.target(i)), 'support.txt')), `support ${i}`);
+    assert.equal(read(path.join(f.options.targetRoots[i], 'independent', 'SKILL.md')), `unrelated ${i}`);
+    assert.ok(fs.statSync(f.options.targetRoots[i]).isDirectory());
+  }
+  assert.deepEqual(JSON.parse(read(f.manifest)), { version: 1, sourceRoot: f.options.sourceRoot, skills: {} });
+  assert.deepEqual(fs.readdirSync(f.options.stateRoot), ['skills-v1.json']);
+  assert.deepEqual(fs.readdirSync(f.options.sourceRoot), []);
+});
+
+test('stale tabs, missing tags, source and installed edits preserve bytes', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const tab = await revision(f.service);
+  await rejects(f.service.update('demo.md', 'second'), 428);
+  await f.service.update('demo.md', 'second', tab);
+  await rejects(f.service.update('demo.md', 'stale', tab));
+  await rejects(f.service.remove('demo.md', tab));
+  const second = await revision(f.service);
+  f.seed(f.source(), 'external source');
+  await rejects(f.service.update('demo.md', 'third', second));
+  await rejects(f.service.remove('demo.md', second));
+  assert.equal((await f.service.redistribute()).ok, false);
+  assert.equal(read(f.source()), 'external source');
+  f.seed(f.source(), 'second');
+  f.seed(f.target(2), 'external installation');
+  await rejects(f.service.update('demo.md', 'third', await revision(f.service)));
+  await rejects(f.service.remove('demo.md', await revision(f.service)));
+  assert.equal(read(f.target(0)), generatedSkill('demo.md', 'second'));
+  assert.equal(read(f.target(2)), 'external installation');
+});
+
+test('unowned installations block create and legacy adoption unless byte identical', async (t) => {
+  const f = fixture(t);
+  f.seed(f.target(), generatedSkill('demo.md', 'first'));
+  await rejects(f.service.create('demo.md', 'first'));
+  assert.equal(fs.existsSync(f.source()), false);
+  f.seed(f.source(), 'different');
+  assert.equal((await f.service.redistribute()).ok, false);
+  assert.equal(fs.existsSync(f.manifest), false);
+  f.seed(f.source(), 'first');
+  f.seed(path.join(path.dirname(f.target()), 'helper.py'), 'user-owned');
+  assert.equal((await f.service.redistribute()).ok, true);
+  assert.equal(JSON.parse(read(f.manifest)).skills['demo.md'].targets[0].dirOwned, false);
+  await f.service.remove('demo.md', await revision(f.service));
+  assert.equal(read(path.join(path.dirname(f.target()), 'helper.py')), 'user-owned');
+});
+
+test('ambiguous legacy identities adopt neither and unrelated source still distributes', async (t) => {
+  const f = fixture(t);
+  f.seed(f.source('Demo.md'), 'first'); f.seed(f.source(), 'first');
+  f.seed(f.source('unrelated.md'), 'okay');
+  f.seed(f.target(), generatedSkill('demo.md', 'first'));
+  const boot = await f.service.redistribute();
+  assert.equal(boot.ok, false);
+  assert.equal(boot.results.filter((r) => r.ok).length, 1);
+  assert.deepEqual(Object.keys(JSON.parse(read(f.manifest)).skills), ['unrelated.md']);
+  assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+});
+
+test('missing sources never trigger inferred deletion, valid records permit explicit cleanup', async (t) => {
+  const f = fixture(t);
+  f.seed(f.target(), 'independent');
+  await rejects(f.service.remove('demo.md', 'unknown'), 404);
+  assert.equal(read(f.target()), 'independent');
+  fs.unlinkSync(f.target());
+  await f.service.create('demo.md', 'first'); fs.unlinkSync(f.source());
+  assert.equal((await createSkillsService(f.options).redistribute()).ok, false);
+  assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+  await f.service.remove('demo.md', await revision(f.service));
+  assert.equal(fs.existsSync(f.target()), false);
+});
+
+for (const kind of ['source', 'target', 'dangling-source', 'dangling-target', 'parent']) {
+  test(`${kind} symlink is rejected without changing independent data`, async (t) => {
+    const f = fixture(t); f.seed(path.join(f.root, 'independent'), 'safe');
+    const isSource = kind.includes('source');
+    const p = kind === 'parent' ? path.dirname(f.target()) : isSource ? f.source() : f.target();
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.symlinkSync(path.join(f.root, kind.startsWith('dangling') ? 'absent' : 'independent'), p);
+    await rejects(f.service.create('demo.md', 'new'));
+    assert.equal(read(path.join(f.root, 'independent')), 'safe');
+    assert.ok(fs.lstatSync(p).isSymbolicLink());
+  });
+}
+
+test('temporary symlinks are neither followed nor cleaned up', async (t) => {
+  const f = fixture(t); f.seed(path.join(f.root, 'independent'), 'safe');
+  fs.mkdirSync(f.options.stateRoot);
+  const tmp = path.join(f.options.stateRoot, '.am-skill-fixed.tmp');
+  fs.symlinkSync(path.join(f.root, 'independent'), tmp);
+  const s = createSkillsService({ ...f.options, nonce: () => 'fixed' });
+  await assert.rejects(s.create('demo.md', 'new'), /EEXIST/);
+  assert.equal(read(path.join(f.root, 'independent')), 'safe');
+  assert.ok(fs.lstatSync(tmp).isSymbolicLink());
+  assert.equal(fs.existsSync(f.source()), false);
+});
+
+test('configured aliases deduplicate and later root redirection is rejected', async (t) => {
+  const f = fixture(t, 1);
+  fs.mkdirSync(f.options.targetRoots[0]);
+  const alias = path.join(f.root, 'alias'); fs.symlinkSync(f.options.targetRoots[0], alias);
+  const options = { ...f.options, targetRoots: [alias, f.options.targetRoots[0], alias] };
+  const s = createSkillsService(options);
+  await s.create('demo.md', 'first');
+  assert.equal((await s.get('demo.md')).installations.length, 1);
+  fs.renameSync(f.options.targetRoots[0], path.join(f.root, 'moved'));
+  fs.symlinkSync(path.join(f.root, 'moved'), f.options.targetRoots[0]);
+  await rejects(s.remove('demo.md', await revision(s)));
+  assert.equal(read(path.join(f.root, 'moved', 'demo', 'SKILL.md')), generatedSkill('demo.md', 'first'));
+});
+
+for (const state of ['corrupt', 'unreadable', 'unwritable', 'outside-path', 'outside-root']) {
+  test(`${state} manifest cannot authorize any mutations`, async (t) => {
+    const f = fixture(t); await f.service.create('demo.md', 'first');
+    const m = JSON.parse(read(f.manifest));
+    let io = fs;
+    if (state === 'corrupt') f.seed(f.manifest, '{broken');
+    if (state === 'outside-path') { m.skills['demo.md'].targets[0].path = path.join(f.root, 'independent'); f.seed(f.manifest, JSON.stringify(m)); }
+    if (state === 'outside-root') { m.skills['demo.md'].targets[0].root = f.root; m.skills['demo.md'].targets[0].path = path.join(f.root, 'demo', 'SKILL.md'); f.seed(f.manifest, JSON.stringify(m)); }
+    if (state === 'unreadable') io = { ...fs, readFileSync(p, ...args) { if (p === f.manifest) throw fail('manifest read'); return fs.readFileSync(p, ...args); } };
+    if (state === 'unwritable') io = { ...fs, renameSync(a, b) { if (b === f.manifest) throw fail('manifest write'); return fs.renameSync(a, b); } };
+    const s = createSkillsService({ ...f.options, io });
+    await assert.rejects(async () => s.remove('demo.md', await revision(s)));
+    assert.equal(read(f.source()), 'first');
+    assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+  });
+}
+
+test('loss of a manifest allows only verified legacy adoption, never removal', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  fs.unlinkSync(f.manifest);
+  await rejects(f.service.remove('demo.md', await revision(f.service)), 404);
+  f.seed(f.target(1), 'independent change');
+  assert.equal((await f.service.redistribute()).ok, false);
+  assert.equal(read(f.target(1)), 'independent change');
+});
+
+for (const stage of ['source-write', 'target-write', 'target-rename', 'manifest-intent', 'manifest-final']) {
+  test(`${stage} failure is truthful and retryable without historical content`, async (t) => {
+    const f = fixture(t); await f.service.create('demo.md', 'first');
+    let fired = false, manifestRenames = 0;
+    const io = { ...fs,
+      writeFileSync(fd, content, ...args) {
+        if (!fired && ((stage === 'source-write' && content === 'second') || (stage === 'target-write' && content === generatedSkill('demo.md', 'second')))) { fired = true; throw fail(stage); }
+        return fs.writeFileSync(fd, content, ...args);
+      },
+      renameSync(a, b) {
+        if (b === f.manifest) manifestRenames++;
+        if (!fired && ((stage === 'target-rename' && b === f.target(2)) || (stage === 'manifest-intent' && b === f.manifest) || (stage === 'manifest-final' && b === f.manifest && manifestRenames === 2))) { fired = true; throw fail(stage); }
+        return fs.renameSync(a, b);
+      },
+    };
+    const s = createSkillsService({ ...f.options, io });
+    if (stage === 'manifest-intent') {
+      await assert.rejects(s.update('demo.md', 'second', await revision(s)), /manifest-intent/);
+      assert.equal(read(f.source()), 'first');
+      assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+    } else {
+      const r = await s.update('demo.md', 'second', await revision(s));
+      assert.equal(r.ok, false); assert.equal(r.status, 'partial');
+      assert.equal(r.manifest, stage === 'manifest-final' ? 'failed' : 'persisted');
+      if (stage === 'source-write') assert.equal(read(f.source()), 'first');
+      if (stage === 'target-write') assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+      if (stage === 'target-rename') assert.equal(read(f.target(2)), generatedSkill('demo.md', 'first'));
+    }
+    const restart = createSkillsService(f.options);
+    assert.equal((await restart.update('demo.md', 'second', await revision(restart))).ok, true);
+    for (let i = 0; i < 5; i++) assert.equal(read(f.target(i)), generatedSkill('demo.md', 'second'));
+    assert.deepEqual(fs.readdirSync(f.options.stateRoot), ['skills-v1.json']);
+    assert.deepEqual(fs.readdirSync(f.options.sourceRoot), ['demo.md']);
+  });
+}
+
+test('partial deletion retains source, skips boot publication, freezes targets and protects external edits on retry', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const s = createSkillsService({ ...f.options, io: { ...fs, unlinkSync(p) { if (p === f.target(2)) throw fail('target unlink'); return fs.unlinkSync(p); } } });
+  const r = await s.remove('demo.md', await revision(s));
+  assert.equal(r.ok, false); assert.equal(r.source, 'retained');
+  assert.deepEqual(r.targets.map((t) => t.status), ['removed', 'removed', 'failed', 'removed', 'removed']);
+  assert.equal(read(f.source()), 'first');
+  const extra = path.join(f.root, 'new-target');
+  const restart = createSkillsService({ ...f.options, targetRoots: [...f.options.targetRoots, extra] });
+  assert.equal((await restart.redistribute()).ok, false);
+  assert.equal(fs.existsSync(f.target()), false);
+  assert.equal(fs.existsSync(extra), false);
+  f.seed(f.target(2), 'user replacement');
+  await rejects(restart.remove('demo.md', await revision(restart)));
+  assert.equal(read(f.target(2)), 'user replacement');
+  f.seed(f.target(2), generatedSkill('demo.md', 'first'));
+  assert.equal((await restart.remove('demo.md', await revision(restart))).ok, true);
+  assert.equal(fs.existsSync(extra), false);
+});
+
+for (const stage of ['source-unlink', 'manifest-final']) {
+  test(`delete ${stage} can restart and finish only the recorded operation`, async (t) => {
+    const f = fixture(t); await f.service.create('demo.md', 'first');
+    let commits = 0;
+    const s = createSkillsService({ ...f.options, io: { ...fs,
+      unlinkSync(p) { if (stage === 'source-unlink' && p === f.source()) throw fail(stage); return fs.unlinkSync(p); },
+      renameSync(a, b) { if (b === f.manifest && ++commits === 2 && stage === 'manifest-final') throw fail(stage); return fs.renameSync(a, b); },
+    } });
+    const r = await s.remove('demo.md', await revision(s)); assert.equal(r.ok, false);
+    assert.equal(r.source, stage === 'source-unlink' ? 'failed' : 'removed');
+    const restart = createSkillsService(f.options);
+    assert.equal((await restart.redistribute()).ok, false);
+    assert.equal((await restart.remove('demo.md', await revision(restart))).ok, true);
+  });
+}
+
+test('concurrent operations and boot share serialization without losing updates', async (t) => {
+  const f = fixture(t);
+  const creates = await Promise.allSettled([f.service.create('demo.md', 'first'), f.service.create('Demo.txt', 'other')]);
+  assert.equal(creates.filter((r) => r.status === 'fulfilled').length, 1);
+  const rev = await revision(f.service);
+  const updates = await Promise.allSettled([f.service.update('demo.md', 'second', rev), f.service.update('demo.md', 'third', rev)]);
+  assert.equal(updates.filter((r) => r.status === 'fulfilled').length, 1);
+  const bootRev = await revision(f.service);
+  await Promise.allSettled([f.service.redistribute(), f.service.update('demo.md', 'after boot', bootRev)]);
+  assert.equal(read(f.source()), 'after boot');
+  await Promise.all([f.service.update('demo.md', 'before boot', await revision(f.service)), f.service.redistribute()]);
+  assert.equal(read(f.source()), 'before boot');
+  assert.equal(read(f.target()), generatedSkill('demo.md', 'before boot'));
+  const deleteRev = await revision(f.service);
+  const deletes = await Promise.allSettled([f.service.remove('demo.md', deleteRev), f.service.remove('demo.md', deleteRev)]);
+  assert.equal(deletes.filter((r) => r.status === 'fulfilled').length, 1);
+  assert.equal(fs.existsSync(f.source()), false);
+});
+
+test('generated skills obey ordinary ownership, collisions and pending deletion', async (t) => {
+  const f = fixture(t);
+  assert.equal((await f.service.generate('environment.md', 'first')).ok, true);
+  assert.equal((await f.service.generate('environment.md', 'second')).ok, true);
+  f.seed(f.target(0, 'environment'), 'user copy');
+  await rejects(f.service.generate('environment.md', 'third'));
+  assert.equal(read(f.source('environment.md')), 'second');
+  f.seed(f.source('ENVIRONMENT.txt'), 'collision');
+  await rejects(f.service.generate('environment.md', 'third'));
+});
+
+test('development guard keeps all real target homes out of distribution', async (t) => {
+  const f = fixture(t);
+  const env = { HOME: path.join(f.root, 'home'), CLAUDE_CONFIG_DIR: path.join(f.root, 'claude'), GEMINI_CLI_HOME: path.join(f.root, 'gemini'), OPENCLAW_HOME: path.join(f.root, 'openclaw') };
+  assert.deepEqual(skillTargetDirs(env), []);
+  const targets = skillTargetDirs({ ...env, AM_DISTRIBUTE_SKILLS: '1' });
+  assert.equal(targets.length, 5); assert.ok(targets.every((p) => p.startsWith(f.root + '/')));
+  assert.deepEqual(skillTargetDirs({ ...env, SPACE_ID: 'fixture/space' }), targets);
+  const s = createSkillsService({ ...f.options, targetRoots: [] });
+  assert.equal((await s.create('demo.md', 'first')).targets.length, 0);
+  assert.equal(fs.existsSync(env.HOME), false);
+});
+
+test('an incomplete create retries with the original content and cannot become an overwrite', async (t) => {
+  const f = fixture(t);
+  const s = createSkillsService({ ...f.options, io: { ...fs, writeFileSync(fd, content, ...args) {
+    if (content === 'first') throw fail('source create');
+    return fs.writeFileSync(fd, content, ...args);
+  } } });
+  const r = await s.create('demo.md', 'first');
+  assert.equal(r.ok, false); assert.equal(r.source, 'failed');
+  assert.equal(r.skill.sourceExists, false); assert.equal(r.skill.pending, 'write');
+  const restart = createSkillsService(f.options);
+  assert.equal((await restart.redistribute()).ok, false);
+  await rejects(restart.create('demo.md', 'new'));
+  await rejects(restart.update('demo.md', 'new', await revision(restart)));
+  assert.equal((await restart.create('independent.md', 'untouched')).ok, true);
+  assert.equal((await restart.update('demo.md', 'first', await revision(restart))).ok, true);
+  assert.equal(read(f.source('independent.md')), 'untouched');
+});
+
+test('a changed configured target set invalidates prepared deletion without broadening it', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const confirmed = await revision(f.service);
+  const extra = path.join(f.root, 'new-destination');
+  const restart = createSkillsService({ ...f.options, targetRoots: [...f.options.targetRoots, extra] });
+  await rejects(restart.remove('demo.md', confirmed));
+  assert.equal(read(f.source()), 'first');
+  assert.equal((await restart.remove('demo.md', await revision(restart))).ok, true);
+  assert.equal(fs.existsSync(extra), false);
+});
+
+test('source and state aliases work, and overlapping ownership roots are refused', async (t) => {
+  const f = fixture(t);
+  fs.mkdirSync(f.options.sourceRoot); fs.mkdirSync(f.options.stateRoot);
+  const sourceAlias = path.join(f.root, 'source-alias'), stateAlias = path.join(f.root, 'state-alias');
+  fs.symlinkSync(f.options.sourceRoot, sourceAlias); fs.symlinkSync(f.options.stateRoot, stateAlias);
+  const s = createSkillsService({ ...f.options, sourceRoot: sourceAlias, stateRoot: stateAlias });
+  assert.equal((await s.create('demo.md', 'first')).ok, true);
+  const overlapping = createSkillsService({ ...f.options, targetRoots: [f.options.sourceRoot] });
+  await rejects(overlapping.create('other.md', 'second'));
+  assert.equal(read(f.source()), 'first');
+});
+
+test('update versus delete with one revision commits only the first intent', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const rev = await revision(f.service);
+  const results = await Promise.allSettled([f.service.update('demo.md', 'saved', rev), f.service.remove('demo.md', rev)]);
+  assert.equal(results[0].status, 'fulfilled'); assert.equal(results[1].status, 'rejected');
+  assert.equal(read(f.source()), 'saved');
+  const m = JSON.parse(read(f.manifest)); assert.equal(m.skills['demo.md'].pending, undefined);
+});
+
+test('ownership cannot move to another source root by reusing its manifest', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const otherRoot = path.join(f.root, 'other-source'); f.seed(path.join(otherRoot, 'demo.md'), 'first');
+  const moved = createSkillsService({ ...f.options, sourceRoot: otherRoot });
+  await rejects(moved.remove('demo.md', await revision(f.service)), 503);
+  assert.equal(read(path.join(otherRoot, 'demo.md')), 'first');
+  assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
+});
+
+test('atomic publication works on roots without hard-link support', async (t) => {
+  const f = fixture(t);
+  const s = createSkillsService({ ...f.options, io: { ...fs, linkSync() { throw Object.assign(new Error('Hard links unsupported'), { code: 'ENOTSUP' }); } } });
+  assert.equal((await s.create('demo.md', 'first')).ok, true);
+  assert.equal((await s.update('demo.md', 'second', await revision(s))).ok, true);
+  assert.equal(read(f.source()), 'second');
+  assert.equal(read(f.target()), generatedSkill('demo.md', 'second'));
+});

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -397,6 +397,9 @@ test('permanently deleted generated skills stay absent on restart until explicit
   assert.equal(fs.existsSync(f.source('environment.md')), false);
   for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'environment')), false);
   await restart.create('environment.md', 'explicit recreation');
+  await restart.remove('environment.md', await revision(restart, 'environment.md'));
+  assert.equal((await restart.generate('environment.md', 'must stay deleted')).source, 'generation-disabled');
+  await restart.create('environment.md', 'explicit recreation');
   assert.equal((await restart.generate('environment.md', 'new generation')).ok, true);
   assert.equal(read(f.source('environment.md')), 'new generation');
 });

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -105,6 +105,26 @@ test('unowned installations block create and legacy adoption unless byte identic
   assert.equal(read(path.join(path.dirname(f.target()), 'helper.py')), 'user-owned');
 });
 
+test('deletion preserves a pre-existing directory even when removing the skill leaves it empty', async (t) => {
+  const f = fixture(t);
+  const preexisting = path.dirname(f.target());
+  fs.mkdirSync(preexisting, { recursive: true });
+  assert.equal((await f.service.create('demo.md', 'first')).ok, true);
+  const record = JSON.parse(read(f.manifest)).skills['demo.md'];
+  assert.deepEqual(record.targets.map((target) => target.dirOwned), [false, true, true, true, true]);
+
+  const restart = createSkillsService(f.options);
+  assert.equal((await restart.remove('demo.md', await revision(restart))).ok, true);
+  assert.equal(fs.existsSync(f.source()), false);
+  assert.ok(fs.statSync(preexisting).isDirectory());
+  assert.deepEqual(fs.readdirSync(preexisting), []);
+  for (let i = 0; i < 5; i++) {
+    assert.equal(fs.existsSync(f.target(i)), false);
+    assert.ok(fs.statSync(f.options.targetRoots[i]).isDirectory());
+    if (i > 0) assert.equal(fs.existsSync(path.dirname(f.target(i))), false);
+  }
+});
+
 test('ambiguous legacy identities adopt neither and unrelated source still distributes', async (t) => {
   const f = fixture(t);
   f.seed(f.source('Demo.md'), 'first'); f.seed(f.source(), 'first');
@@ -185,6 +205,29 @@ for (const state of ['corrupt', 'unreadable', 'unwritable', 'outside-path', 'out
     assert.equal(read(f.target()), generatedSkill('demo.md', 'first'));
   });
 }
+
+test('a manifest cannot redirect deletion to another skill inside an allowed target root', async (t) => {
+  const f = fixture(t);
+  await f.service.create('demo.md', 'first');
+  await f.service.create('other.md', 'independent');
+  const m = JSON.parse(read(f.manifest));
+  const sibling = m.skills['other.md'].targets[0];
+  // Keep the allowed root and copy the sibling's real hash: neither root
+  // containment nor external-edit checks should mask the wrong skill identity.
+  Object.assign(m.skills['demo.md'].targets[0], { path: sibling.path, hash: sibling.hash });
+  const tampered = JSON.stringify(m);
+  f.seed(f.manifest, tampered);
+
+  const restart = createSkillsService(f.options);
+  await rejects(async () => restart.remove('demo.md', await revision(restart)), 503);
+  assert.equal(read(f.manifest), tampered);
+  assert.equal(read(f.source()), 'first');
+  assert.equal(read(f.source('other.md')), 'independent');
+  for (let i = 0; i < 5; i++) {
+    assert.equal(read(f.target(i)), generatedSkill('demo.md', 'first'));
+    assert.equal(read(f.target(i, 'other')), generatedSkill('other.md', 'independent'));
+  }
+});
 
 test('loss of a manifest allows only verified legacy adoption, never removal', async (t) => {
   const f = fixture(t); await f.service.create('demo.md', 'first');

--- a/server/test/skills.test.mjs
+++ b/server/test/skills.test.mjs
@@ -63,7 +63,7 @@ test('owned lifecycle, restart, all targets, support files and permanent deletio
     assert.equal(read(path.join(f.options.targetRoots[i], 'independent', 'SKILL.md')), `unrelated ${i}`);
     assert.ok(fs.statSync(f.options.targetRoots[i]).isDirectory());
   }
-  assert.deepEqual(JSON.parse(read(f.manifest)), { version: 1, sourceRoot: f.options.sourceRoot, skills: {} });
+  assert.deepEqual(JSON.parse(read(f.manifest)), { version: 1, sourceRoot: f.options.sourceRoot, disabledGenerated: [], skills: {} });
   assert.deepEqual(fs.readdirSync(f.options.stateRoot), ['skills-v1.json']);
   assert.deepEqual(fs.readdirSync(f.options.sourceRoot), []);
 });
@@ -375,4 +375,28 @@ test('atomic publication works on roots without hard-link support', async (t) =>
   assert.equal((await s.update('demo.md', 'second', await revision(s))).ok, true);
   assert.equal(read(f.source()), 'second');
   assert.equal(read(f.target()), generatedSkill('demo.md', 'second'));
+});
+
+test('deleting and recreating identical bytes cannot revive an old confirmation', async (t) => {
+  const f = fixture(t); await f.service.create('demo.md', 'first');
+  const oldConfirmation = await revision(f.service);
+  await f.service.remove('demo.md', oldConfirmation);
+  await f.service.create('demo.md', 'first');
+  await rejects(f.service.remove('demo.md', oldConfirmation));
+  await rejects(f.service.update('demo.md', 'stale edit', oldConfirmation));
+  assert.equal(read(f.source()), 'first');
+});
+
+test('permanently deleted generated skills stay absent on restart until explicitly recreated', async (t) => {
+  const f = fixture(t); await f.service.generate('environment.md', 'generated');
+  await f.service.remove('environment.md', await revision(f.service, 'environment.md'));
+  const restart = createSkillsService(f.options);
+  assert.equal((await restart.redistribute()).ok, true);
+  const r = await restart.generate('environment.md', 'new generation');
+  assert.equal(r.source, 'generation-disabled');
+  assert.equal(fs.existsSync(f.source('environment.md')), false);
+  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'environment')), false);
+  await restart.create('environment.md', 'explicit recreation');
+  assert.equal((await restart.generate('environment.md', 'new generation')).ok, true);
+  assert.equal(read(f.source('environment.md')), 'new generation');
 });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -738,7 +738,7 @@ export const setTraceSource = (id: string, kind: 'session' | 'bundle', ref: stri
 // ---- skills ----
 export interface SkillFile { name: string; size: number; pending?: 'write' | 'delete' | null; error?: string; }
 export interface SkillSnapshot {
-  name: string; content: string; revision: string; managed: boolean; sourceExists: boolean; problem?: string;
+  name: string; content: string; revision: string; managed: boolean; sourceExists: boolean; problem?: string; readOnly?: boolean;
   pending: 'write' | 'delete' | null;
   installations: { path: string; exists: boolean; error?: string }[];
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -736,14 +736,26 @@ export const setTraceSource = (id: string, kind: 'session' | 'bundle', ref: stri
   fetch(`/api/trace/${id}/source`, { method: 'PUT', headers: HEADERS, body: JSON.stringify({ kind, ref }) }).then(json);
 
 // ---- skills ----
-export interface SkillFile { name: string; size: number; }
-export const listSkills = (): Promise<SkillFile[]> => fetch('/api/skills').then(json);
-export const getSkill = (name: string): Promise<{ name: string; content: string }> =>
-  fetch(`/api/skills/${encodeURIComponent(name)}`).then(json);
-export const saveSkill = (name: string, content: string) =>
-  fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'PUT', headers: { 'content-type': 'text/plain' }, body: content }).then(json);
-export const deleteSkill = (name: string) =>
-  fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'DELETE' }).then(json);
+export interface SkillFile { name: string; size: number; pending?: 'write' | 'delete' | null; error?: string; }
+export interface SkillSnapshot {
+  name: string; content: string; revision: string; managed: boolean; sourceExists: boolean; problem?: string;
+  pending: 'write' | 'delete' | null;
+  installations: { path: string; exists: boolean; error?: string }[];
+}
+export interface SkillResult {
+  ok: boolean; status: 'complete' | 'partial'; source: string; manifest: string; error?: string;
+  targets: { path: string; status: string; error?: string; directoryError?: string }[];
+  skill: SkillSnapshot | null;
+}
+export const listSkills = (): Promise<SkillFile[]> => fetch('/api/skills').then(jsonOrError);
+export const getSkill = (name: string): Promise<SkillSnapshot> =>
+  fetch(`/api/skills/${encodeURIComponent(name)}`).then(jsonOrError);
+export const createSkill = (name: string, content: string): Promise<SkillResult> =>
+  fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'POST', headers: { 'content-type': 'text/plain' }, body: content }).then(jsonOrError);
+export const saveSkill = (name: string, content: string, revision: string): Promise<SkillResult> =>
+  fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'PUT', headers: { 'content-type': 'text/plain', 'If-Match': revision }, body: content }).then(jsonOrError);
+export const deleteSkill = (name: string, revision: string): Promise<SkillResult> =>
+  fetch(`/api/skills/${encodeURIComponent(name)}`, { method: 'DELETE', headers: { 'If-Match': revision } }).then(jsonOrError);
 
 // ---- the API log (Settings → API log) ----
 // Written by operationMiddleware: every mutating call, plus the one read that is

--- a/web/src/components/SkillsEditor.tsx
+++ b/web/src/components/SkillsEditor.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as api from '../api';
-import type { SkillFile } from '../api';
+import type { SkillFile, SkillSnapshot, SkillResult } from '../api';
 import { renderMarkdown } from '../lib/markdown';
 import { TrashGlyph } from './icons';
 
@@ -18,82 +18,131 @@ function parseFront(md: string): { meta: Record<string, string> | null; body: st
 
 export default function SkillsEditor() {
   const [skills, setSkills] = useState<SkillFile[]>([]);
-  const [selected, setSelected] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState<SkillSnapshot | null>(null);
+  const selected = loaded?.name;
   const [content, setContent] = useState('');
   const [mode, setMode] = useState<'view' | 'edit'>('view');
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState('');
-  const [confirmDel, setConfirmDel] = useState(false);
-
-  const refresh = () => api.listSkills().then(setSkills).catch(() => {});
-  useEffect(() => { refresh(); }, []);
-
-  const open = async (name: string) => {
-    const r = await api.getSkill(name);
-    setSelected(name);
-    setContent(r.content);
-    setMode('view');
-    setConfirmDel(false);
+  const [uploadText, setUploadText] = useState<string | null>(null);
+  const [confirmDel, setConfirmDel] = useState<SkillSnapshot | null>(null);
+  const [staleConfirmation, setStaleConfirmation] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const working = useRef(false);
+  const [error, setError] = useState('');
+  const [result, setResult] = useState<SkillResult | null>(null);
+  const [latest, setLatest] = useState<SkillSnapshot | null>(null);
+  const dialog = useRef<HTMLDialogElement>(null);
+  const dirty = !!loaded && content !== loaded.content;
+  const refresh = async () => setSkills(await api.listSkills());
+  const run = async (action: () => Promise<void>) => {
+    if (working.current) return;
+    working.current = true; setBusy(true);
+    try { await action(); } catch (e) { setError(e instanceof Error ? e.message : String(e)); }
+    finally { working.current = false; setBusy(false); }
   };
+  useEffect(() => { run(refresh); }, []);
+  useEffect(() => {
+    if (confirmDel && !dialog.current?.open) dialog.current?.showModal();
+    if (!confirmDel && dialog.current?.open) dialog.current.close();
+  }, [confirmDel]);
 
-  const create = async () => {
+  const open = (name: string) => run(async () => {
+    const skill = await api.getSkill(name);
+    setLatest(null); setLoaded(skill); setContent(skill.content); setMode('view'); setConfirmDel(null);
+  });
+  const showResult = (r: SkillResult) => {
+    setResult(r);
+    setError(r.ok ? '' : r.error || 'Operation incomplete. Review the remaining state and retry.');
+  };
+  const create = () => run(async () => {
     let name = newName.trim();
     if (!name) return;
     if (!name.includes('.')) name += '.md';
-    await api.saveSkill(name, `# ${name.replace(/\.[^.]+$/, '')}\n\n`);
-    setCreating(false);
-    setNewName('');
+    const text = uploadText ?? `# ${name.replace(/\.[^.]+$/, '')}\n\n`;
+    const r = await api.createSkill(name, text);
+    showResult(r);
+    if (r.skill) { setLoaded(r.skill); setContent(text); setMode('edit'); }
+    // A partial create is now a managed pending save; retry via Save, not POST.
+    if (r.skill) { setCreating(false); setNewName(''); setUploadText(null); }
     await refresh();
-    await open(name);
-    setMode('edit');
-  };
-
-  const upload = async (file: File) => {
+  });
+  const upload = (file: File) => run(async () => {
     const text = await file.text();
-    await api.saveSkill(file.name, text);
+    setUploadText(text); setNewName(file.name); setCreating(true);
+    const r = await api.createSkill(file.name, text);
+    showResult(r);
+    if (r.skill) {
+      setLoaded(r.skill); setContent(text); setMode(r.ok ? 'view' : 'edit');
+      setCreating(false); setUploadText(null); setNewName('');
+    }
     await refresh();
-    await open(file.name);
-  };
-
-  const save = async () => {
-    if (!selected) return;
-    await api.saveSkill(selected, content);
-    refresh();
-    setMode('view');
-  };
-
-  const remove = async () => {
-    if (!selected) return;
-    await api.deleteSkill(selected);
-    setSelected(null);
-    setContent('');
-    setConfirmDel(false);
-    refresh();
-  };
+  });
+  const save = () => run(async () => {
+    if (!loaded) return;
+    const r = await api.saveSkill(loaded.name, content, loaded.revision);
+    showResult(r);
+    if (r.skill) setLoaded(r.skill);
+    if (r.ok) { setMode('view'); setLatest(null); }
+    await refresh();
+  });
+  const prepareDelete = () => run(async () => {
+    if (!loaded) return;
+    setConfirmDel(await api.getSkill(loaded.name)); setStaleConfirmation(false);
+  });
+  const remove = () => run(async () => {
+    if (!confirmDel || staleConfirmation) return;
+    try {
+      const r = await api.deleteSkill(confirmDel.name, confirmDel.revision);
+      showResult(r);
+      if (r.ok) { setLoaded(null); setContent(''); setConfirmDel(null); }
+      else {
+        setConfirmDel(r.skill); setLoaded(r.skill);
+        if (!r.skill) setStaleConfirmation(true);
+      }
+      await refresh();
+    } catch (e) { setStaleConfirmation(true); throw e; }
+  });
 
   return (
     <div className="skills">
       <div className="skills-list">
         <div className="skills-actions">
-          <button className="btn-ghost" onClick={() => setCreating((c) => !c)}>+ New</button>
-          <label className="btn-ghost upload-btn">Upload<input type="file" hidden accept=".md,.markdown,.txt,text/*" onChange={(e) => { if (e.target.files?.[0]) upload(e.target.files[0]); e.target.value = ''; }} /></label>
+          <button className="btn-ghost" disabled={busy || dirty} onClick={() => { setCreating((c) => !c); setUploadText(null); }}>+ New</button>
+          <label className="btn-ghost upload-btn">Upload<input type="file" disabled={busy || dirty} hidden accept=".md,.markdown,.txt,text/*" onChange={(e) => { if (e.target.files?.[0]) upload(e.target.files[0]); e.target.value = ''; }} /></label>
         </div>
         {creating && (
           <div className="widget" style={{ margin: '0 0 8px' }}>
-            <input autoFocus placeholder="name.md" value={newName}
+            <label>{uploadText !== null ? 'Upload as' : 'New skill name'}<input autoFocus disabled={busy} placeholder="name.md" value={newName}
               onChange={(e) => setNewName(e.target.value)}
-              onKeyDown={(e) => { if (e.key === 'Enter') create(); if (e.key === 'Escape') setCreating(false); }} />
+              onKeyDown={(e) => { if (e.key === 'Enter') create(); if (e.key === 'Escape') setCreating(false); }} /></label>
+            <button className="btn-primary" disabled={busy || !newName.trim()} onClick={create}>Create</button>
+            <button className="btn-ghost" disabled={busy} onClick={() => { setCreating(false); setUploadText(null); }}>Cancel</button>
           </div>
         )}
         {skills.length === 0 && <div className="s-help" style={{ padding: '8px 4px' }}>No skills yet. Create one or upload a markdown file.</div>}
         {skills.map((s) => (
-          <button key={s.name} className={`skill-item${selected === s.name ? ' active' : ''}`} onClick={() => open(s.name)}>
-            <span className="name">{s.name}</span>
+          <button key={s.name} className={`skill-item${selected === s.name ? ' active' : ''}`} disabled={busy || dirty} onClick={() => open(s.name)}>
+            <span className="name">{s.name}{s.pending ? ` (${s.pending} pending)` : ''}</span>
           </button>
         ))}
       </div>
 
       <div className="skills-editor">
+        {loaded?.problem && <div className="skill-outcome" role="alert">{loaded.problem}</div>}
+        {(error || result?.status === 'partial') && <div className="skill-outcome" role="alert">
+          <p>{error}</p>
+          {result?.status === 'partial' && <>
+            <p>Source: {result.source}. Ownership record: {result.manifest}.</p>
+            <ul>{result.targets.map((t) => <li key={t.path}><code>{t.path}</code>: {t.status}{t.error ? ` — ${t.error}` : ''}</li>)}</ul>
+          </>}
+          {loaded && <button className="btn-ghost" disabled={busy} onClick={() => run(async () => {
+            const skill = await api.getSkill(loaded.name);
+            setLoaded(skill); setLatest(skill);
+          })}>Refresh revision (keep entered text)</button>}
+          <button className="btn-ghost" onClick={() => { setError(''); setResult(null); }}>Dismiss</button>
+        </div>}
+        {latest && <details className="skill-outcome" open><summary>Current saved source — compare before saving your entered text</summary><pre>{latest.content}</pre></details>}
         {!selected ? (
           <div className="files-empty">Select a skill to view, or create a new one.</div>
         ) : (
@@ -102,19 +151,12 @@ export default function SkillsEditor() {
               <span className="mono skill-title">{selected}</span>
               <span className="spacer" />
               <div className="seg">
-                <button className={mode === 'view' ? 'on' : ''} onClick={() => setMode('view')}>View</button>
-                <button className={mode === 'edit' ? 'on' : ''} onClick={() => setMode('edit')}>Edit</button>
+                <button className={mode === 'view' ? 'on' : ''} disabled={busy} onClick={() => setMode('view')}>View</button>
+                <button className={mode === 'edit' ? 'on' : ''} disabled={busy || loaded?.pending === 'delete'} onClick={() => setMode('edit')}>Edit</button>
               </div>
-              {mode === 'edit' && <button className="btn-primary" onClick={save}>Save</button>}
-              {confirmDel ? (
-                <span className="confirm-del">
-                  <span className="s-muted">Delete from all agents?</span>
-                  <button className="btn-danger" onClick={remove}>Delete</button>
-                  <button className="btn-ghost" onClick={() => setConfirmDel(false)}>Cancel</button>
-                </span>
-              ) : (
-                <button className="btn-ghost danger" title="Delete skill" onClick={() => setConfirmDel(true)}><TrashGlyph /> Delete</button>
-              )}
+              {mode === 'edit' && <button className="btn-primary" disabled={busy || loaded?.pending === 'delete'} onClick={save}>{loaded?.pending === 'write' ? 'Retry save' : 'Save'}</button>}
+              {dirty && <button className="btn-ghost" disabled={busy} onClick={() => setContent(loaded?.content || '')}>Discard edits</button>}
+              <button className="btn-ghost danger" title="Delete skill" disabled={busy || loaded?.pending === 'write' || !loaded?.managed} onClick={prepareDelete}><TrashGlyph /> Delete</button>
             </div>
             {mode === 'view' ? (() => {
               const { meta, body } = parseFront(content);
@@ -140,11 +182,28 @@ export default function SkillsEditor() {
                 </div>
               );
             })() : (
-              <textarea className="skill-text" value={content} onChange={(e) => setContent(e.target.value)} spellCheck={false} />
+              <textarea aria-label="Skill content" disabled={busy} className="skill-text" value={content} onChange={(e) => setContent(e.target.value)} spellCheck={false} />
             )}
           </>
         )}
       </div>
+      <dialog ref={dialog} className="skill-delete-dialog" aria-labelledby="skill-delete-title"
+        onCancel={(e) => { e.preventDefault(); if (!working.current) setConfirmDel(null); }}>
+        {confirmDel && <>
+          <h2 id="skill-delete-title">Permanently delete {confirmDel.name}?</h2>
+          <p>This permanently deletes the source and the managed files listed below. It cannot be undone.</p>
+          <ul>{confirmDel.installations.map((t) => <li key={t.path}><code>{t.path}</code>{!t.exists ? ' (already absent)' : ''}{t.error ? ` — ${t.error}` : ''}</li>)}</ul>
+          {!confirmDel.installations.length && <p>No managed installations. Only the source will be deleted.</p>}
+          {error && <p role="alert">{error}</p>}
+          {result?.status === 'partial' && <p>Source: {result.source}. Ownership record: {result.manifest}. Remaining installations are listed above.</p>}
+          <div className="skill-delete-actions">
+            <button autoFocus className="btn-ghost" disabled={busy} onClick={() => setConfirmDel(null)}>Cancel</button>
+            {staleConfirmation
+              ? <button className="btn-ghost" disabled={busy} onClick={prepareDelete}>Refresh confirmation</button>
+              : <button className="btn-danger" disabled={busy} onClick={remove}>{busy ? 'Deleting…' : confirmDel.pending === 'delete' ? 'Retry permanent deletion' : 'Permanently delete'}</button>}
+          </div>
+        </>}
+      </dialog>
     </div>
   );
 }

--- a/web/src/components/SkillsEditor.tsx
+++ b/web/src/components/SkillsEditor.tsx
@@ -152,11 +152,13 @@ export default function SkillsEditor() {
               <span className="spacer" />
               <div className="seg">
                 <button className={mode === 'view' ? 'on' : ''} disabled={busy} onClick={() => setMode('view')}>View</button>
-                <button className={mode === 'edit' ? 'on' : ''} disabled={busy || loaded?.pending === 'delete'} onClick={() => setMode('edit')}>Edit</button>
+                {/* Generated skills are derived from the Space configuration: the
+                    server refuses edits and deletion, and the alert above says why. */}
+                <button className={mode === 'edit' ? 'on' : ''} disabled={busy || loaded?.pending === 'delete' || loaded?.readOnly} title={loaded?.readOnly ? 'Generated skill — read-only' : undefined} onClick={() => setMode('edit')}>Edit</button>
               </div>
-              {mode === 'edit' && <button className="btn-primary" disabled={busy || loaded?.pending === 'delete'} onClick={save}>{loaded?.pending === 'write' ? 'Retry save' : 'Save'}</button>}
+              {mode === 'edit' && !loaded?.readOnly && <button className="btn-primary" disabled={busy || loaded?.pending === 'delete'} onClick={save}>{loaded?.pending === 'write' ? 'Retry save' : 'Save'}</button>}
               {dirty && <button className="btn-ghost" disabled={busy} onClick={() => setContent(loaded?.content || '')}>Discard edits</button>}
-              <button className="btn-ghost danger" title="Delete skill" disabled={busy || loaded?.pending === 'write' || !loaded?.managed} onClick={prepareDelete}><TrashGlyph /> Delete</button>
+              {!loaded?.readOnly && <button className="btn-ghost danger" title="Delete skill" disabled={busy || loaded?.pending === 'write' || !loaded?.managed} onClick={prepareDelete}><TrashGlyph /> Delete</button>}
             </div>
             {mode === 'view' ? (() => {
               const { meta, body } = parseFront(content);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -2102,3 +2102,14 @@ a.btn-ghost { text-decoration: none; }
 .skiphead { display: flex; align-items: flex-start; gap: 12px; }
 .skiphead > span { flex: 1; min-width: 0; }
 .skiprestore { flex: none; font-size: 11.5px; padding: 3px 8px; white-space: nowrap; }
+
+/* Skills mutation feedback stays beside the buffer until explicitly dismissed. */
+.skill-outcome { padding: 12px; margin: 8px; border: 1px solid var(--border); border-left: 3px solid var(--danger, #b64b47); border-radius: 5px; font-size: 12px; }
+.skill-outcome p { margin: 0 0 8px; }
+.skill-outcome code, .skill-delete-dialog code { overflow-wrap: anywhere; }
+.skill-outcome ul, .skill-delete-dialog ul { padding-left: 20px; }
+.skill-delete-dialog { width: min(580px, calc(100% - 40px)); max-height: 80vh; overflow: auto; padding: 24px; border: 1px solid var(--border); border-radius: 8px; background: var(--panel); color: var(--text); font: inherit; }
+.skill-delete-dialog::backdrop { background: rgb(0 0 0 / 55%); }
+.skill-delete-dialog h2 { font-size: 17px; margin: 0 0 12px; }
+.skill-delete-dialog p, .skill-delete-dialog li { font-size: 13px; line-height: 1.6; }
+.skill-delete-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 20px; }

--- a/web/test/skills.browser.test.mjs
+++ b/web/test/skills.browser.test.mjs
@@ -1,0 +1,142 @@
+// Focused browser coverage runs through normal suite discovery. Real component,
+// API helpers, routes and disposable server; only a held response is intercepted.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
+import { skillsServer } from '../../server/test/fixtures/skills-server.mjs';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+const web = fileURLToPath(new URL('..', import.meta.url));
+const f = await skillsServer();
+let browser, releaseDelete;
+const shots = process.env.AM_SKILLS_SCREENSHOTS;
+async function screenshot(page, name) {
+  if (shots) { fs.mkdirSync(shots, { recursive: true }); await page.screenshot({ path: path.join(shots, `${name}.png`), fullPage: true }); }
+}
+try {
+  fs.mkdirSync(f.env.PUBLIC_DIR);
+  fs.copyFileSync(path.join(web, 'src/styles.css'), path.join(f.env.PUBLIC_DIR, 'styles.css'));
+  fs.writeFileSync(path.join(f.env.PUBLIC_DIR, 'index.html'), '<!doctype html><html><head><link rel="stylesheet" href="/styles.css"></head><body><div id="root" style="height:100vh;padding:24px"></div><script src="/skills.js"></script></body></html>');
+  await build({ stdin: { contents: `import React from 'react'; import {createRoot} from 'react-dom/client'; import SkillsEditor from './src/components/SkillsEditor'; createRoot(document.getElementById('root')).render(<SkillsEditor/>);`, resolveDir: web, loader: 'tsx' },
+    bundle: true, outfile: path.join(f.env.PUBLIC_DIR, 'skills.js'), jsx: 'automatic', define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent' });
+  await f.start();
+  await f.api('demo.md', 'POST', '# Original\n\nKeep this source.');
+  await f.api('other.md', 'POST', '# Other');
+  browser = await chromium.launch(chromiumLaunchOptions());
+  const context = await browser.newContext({ viewport: { width: 1100, height: 800 } });
+  context.setDefaultTimeout(10000);
+  const page = await context.newPage();
+  let deletes = 0;
+  page.on('request', (req) => { if (req.method() === 'DELETE') deletes++; });
+  await page.goto(f.url);
+  await page.getByRole('button', { name: 'demo.md', exact: true }).click();
+  await page.getByText('Keep this source.').waitFor();
+  // Same-name upload preserves the existing skill and offers another filename.
+  await page.locator('input[type=file]').setInputFiles({ name: 'demo.md', mimeType: 'text/plain', buffer: Buffer.from('# Uploaded replacement') });
+  await page.getByRole('alert').filter({ hasText: 'already exists' }).waitFor();
+  assert.equal(fs.readFileSync(f.source('demo.md'), 'utf8'), '# Original\n\nKeep this source.');
+  assert.equal(await page.getByLabel('Upload as').inputValue(), 'demo.md');
+  await screenshot(page, 'skills-upload-conflict');
+  await page.getByRole('button', { name: 'Cancel', exact: true }).click();
+  await page.getByRole('button', { name: 'Dismiss', exact: true }).click();
+  console.log('PASS upload collision preserves original and offers a different name');
+
+  // A second browser tab saves first. The failed save must retain text + target.
+  const second = await context.newPage(); await second.goto(f.url);
+  await second.getByRole('button', { name: 'demo.md', exact: true }).click();
+  await page.getByRole('button', { name: 'Edit', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Skill content' }).fill('# My unsaved buffer');
+  await second.getByRole('button', { name: 'Edit', exact: true }).click();
+  await second.getByRole('textbox', { name: 'Skill content' }).fill('# Saved by other tab');
+  await second.getByRole('button', { name: 'Save', exact: true }).click();
+  await second.getByRole('heading', { name: 'Saved by other tab' }).waitFor();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.getByRole('alert').filter({ hasText: 'changed' }).waitFor();
+  assert.equal(await page.getByRole('textbox', { name: 'Skill content' }).inputValue(), '# My unsaved buffer');
+  assert.equal(await page.locator('.skill-title').innerText(), 'demo.md');
+  assert.equal(fs.readFileSync(f.source('demo.md'), 'utf8'), '# Saved by other tab');
+  await screenshot(page, 'skills-stale-save');
+  await page.getByRole('button', { name: 'Refresh revision (keep entered text)' }).click();
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.getByRole('heading', { name: 'My unsaved buffer' }).waitFor();
+  console.log('PASS two-tab conflict preserves buffer; explicit save after refresh succeeds');
+
+  // A real source rename failure also keeps the buffer and exposes a safe retry.
+  await page.getByRole('button', { name: 'Edit', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Skill content' }).fill('# Storage retry buffer');
+  f.fault({ method: 'renameSync', path: f.source('demo.md') });
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.getByRole('button', { name: 'Retry save', exact: true }).waitFor();
+  assert.equal(await page.getByRole('textbox', { name: 'Skill content' }).inputValue(), '# Storage retry buffer');
+  assert.equal(fs.readFileSync(f.source('demo.md'), 'utf8'), '# My unsaved buffer');
+  assert.match(await page.getByRole('alert').innerText(), /Source: failed/);
+  f.fault({});
+  await page.getByRole('button', { name: 'Retry save', exact: true }).click();
+  await page.getByRole('heading', { name: 'Storage retry buffer' }).waitFor();
+  console.log('PASS storage failure preserves old source and entered buffer; retry save completes');
+
+  // Opening/cancelling/Escape are read-only. Cancel owns default focus.
+  const dialog = page.getByRole('dialog');
+  await page.getByTitle('Delete skill', { exact: true }).click();
+  await dialog.waitFor();
+  assert.equal(deletes, 0);
+  assert.match(await dialog.innerText(), /Permanently delete demo.md/);
+  assert.match(await dialog.innerText(), /cannot be undone/);
+  assert.equal(await dialog.locator('li').count(), 5);
+  assert.equal(await page.evaluate(() => document.activeElement?.textContent), 'Cancel');
+  await screenshot(page, 'skills-delete-confirmation');
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+  assert.equal(deletes, 0);
+  await page.getByTitle('Delete skill', { exact: true }).click();
+  await dialog.waitFor(); await page.keyboard.press('Escape');
+  await dialog.waitFor({ state: 'hidden' }); assert.equal(deletes, 0);
+  // A new selection needs its own confirmation; the old dialog cannot retarget.
+  await page.getByRole('button', { name: 'other.md', exact: true }).click();
+  await page.getByTitle('Delete skill', { exact: true }).click();
+  await dialog.waitFor(); assert.match(await dialog.innerText(), /Permanently delete other.md/);
+  await dialog.getByRole('button', { name: 'Cancel', exact: true }).click();
+  assert.equal(deletes, 0);
+  await page.getByRole('button', { name: 'demo.md', exact: true }).click();
+  console.log('PASS opening, Cancel and Escape never delete; selection cannot retarget a dialog');
+
+  // Revision changes after opening require a fresh confirmation.
+  await page.getByTitle('Delete skill', { exact: true }).click(); await dialog.waitFor();
+  const current = (await f.api('demo.md')).body;
+  await f.api('demo.md', 'PUT', '# Changed after confirmation', current.revision);
+  await dialog.getByRole('button', { name: 'Permanently delete', exact: true }).click();
+  await dialog.getByRole('button', { name: 'Refresh confirmation' }).waitFor();
+  assert.equal(deletes, 1); assert.ok(fs.existsSync(f.source('demo.md')));
+  await dialog.getByRole('button', { name: 'Refresh confirmation' }).click();
+  await dialog.getByRole('button', { name: 'Permanently delete', exact: true }).waitFor();
+
+  // Hold the actual response so duplicate DOM clicks exercise the immediate ref
+  // guard, even before React commits disabled=true. The server fails one unlink.
+  f.fault({ method: 'unlinkSync', path: f.target(2, 'demo') });
+  const gate = new Promise((r) => { releaseDelete = r; });
+  await page.route('**/api/skills/demo.md', async (route) => {
+    if (route.request().method() !== 'DELETE') return route.continue();
+    const response = await route.fetch(); await gate; await route.fulfill({ response });
+  });
+  await dialog.getByRole('button', { name: 'Permanently delete', exact: true }).evaluate((button) => { button.click(); button.click(); });
+  await dialog.getByRole('button', { name: 'Deleting…', exact: true }).waitFor();
+  assert.equal(deletes, 2);
+  assert.equal(await dialog.getByRole('button', { name: 'Deleting…', exact: true }).isDisabled(), true);
+  releaseDelete();
+  await dialog.getByRole('button', { name: 'Retry permanent deletion' }).waitFor();
+  assert.match(await dialog.innerText(), /Deletion is incomplete/);
+  assert.equal((await dialog.locator('li').allTextContents()).filter((s) => s.includes('already absent')).length, 4);
+  assert.ok(fs.existsSync(f.source('demo.md')));
+  assert.equal(fs.existsSync(f.target(0, 'demo')), false);
+  await screenshot(page, 'skills-partial-deletion');
+  f.fault({}); await page.unroute('**/api/skills/demo.md');
+  await dialog.getByRole('button', { name: 'Retry permanent deletion' }).click();
+  await dialog.waitFor({ state: 'hidden' });
+  assert.equal(deletes, 3); assert.equal(fs.existsSync(f.source('demo.md')), false);
+  assert.equal(fs.readFileSync(f.source('other.md'), 'utf8'), '# Other');
+  console.log('PASS stale confirmation refresh, duplicate submission guard, persistent partial state and scoped retry');
+} finally {
+  releaseDelete?.();
+  await browser?.close(); await f.cleanup();
+}

--- a/web/test/skills.browser.test.mjs
+++ b/web/test/skills.browser.test.mjs
@@ -156,6 +156,17 @@ try {
   assert.equal(deletes, 4); assert.equal(fs.existsSync(f.source('other.md')), false);
   for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'other')), false);
   console.log('PASS reviewed external source edits can be saved and explicitly confirmed for deletion');
+
+  // The generated environment skill is read-only: the editor says why, offers
+  // no Save or Delete, and Edit is disabled.
+  await page.getByRole('button', { name: 'environment.md', exact: true }).click();
+  await page.getByRole('alert').filter({ hasText: 'read-only' }).waitFor();
+  assert.equal(await page.getByRole('button', { name: 'Edit', exact: true }).isDisabled(), true);
+  assert.equal(await page.getByRole('button', { name: 'Save', exact: true }).count(), 0);
+  assert.equal(await page.getByTitle('Delete skill', { exact: true }).count(), 0);
+  assert.equal((await f.api('environment.md', 'PUT', '# edit', (await f.api('environment.md')).body.revision)).status, 403);
+  await screenshot(page, 'skills-generated-read-only');
+  console.log('PASS the generated environment skill is read-only in the editor and the API');
 } finally {
   releaseDelete?.();
   await browser?.close(); await f.cleanup();

--- a/web/test/skills.browser.test.mjs
+++ b/web/test/skills.browser.test.mjs
@@ -7,6 +7,7 @@ import { build } from 'esbuild';
 import { chromium } from 'playwright';
 import { fileURLToPath } from 'node:url';
 import { skillsServer } from '../../server/test/fixtures/skills-server.mjs';
+import { generatedSkill } from '../../server/src/skills.js';
 import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
 const web = fileURLToPath(new URL('..', import.meta.url));
 const f = await skillsServer();
@@ -136,6 +137,25 @@ try {
   assert.equal(deletes, 3); assert.equal(fs.existsSync(f.source('demo.md')), false);
   assert.equal(fs.readFileSync(f.source('other.md'), 'utf8'), '# Other');
   console.log('PASS stale confirmation refresh, duplicate submission guard, persistent partial state and scoped retry');
+
+  // Files and agents can edit sources too. Reviewing the current source in the
+  // real editor must permit an explicit save and a newly confirmed deletion.
+  fs.writeFileSync(f.source('other.md'), '# Written outside Skills');
+  await page.getByRole('button', { name: 'other.md', exact: true }).click();
+  await page.getByRole('heading', { name: 'Written outside Skills' }).waitFor();
+  await page.getByRole('button', { name: 'Edit', exact: true }).click();
+  await page.getByRole('textbox', { name: 'Skill content' }).fill('# Reviewed external edit');
+  await page.getByRole('button', { name: 'Save', exact: true }).click();
+  await page.getByRole('heading', { name: 'Reviewed external edit' }).waitFor();
+  for (let i = 0; i < 5; i++) assert.equal(fs.readFileSync(f.target(i, 'other'), 'utf8'), generatedSkill('other.md', '# Reviewed external edit'));
+  fs.writeFileSync(f.source('other.md'), '# Changed before confirmation');
+  await page.getByTitle('Delete skill', { exact: true }).click(); await dialog.waitFor();
+  assert.equal(deletes, 3); assert.ok(fs.existsSync(f.source('other.md')));
+  await dialog.getByRole('button', { name: 'Permanently delete', exact: true }).click();
+  await dialog.waitFor({ state: 'hidden' });
+  assert.equal(deletes, 4); assert.equal(fs.existsSync(f.source('other.md')), false);
+  for (let i = 0; i < 5; i++) assert.equal(fs.existsSync(f.target(i, 'other')), false);
+  console.log('PASS reviewed external source edits can be saved and explicitly confirmed for deletion');
 } finally {
   releaseDelete?.();
   await browser?.close(); await f.cleanup();


### PR DESCRIPTION
Closes #121

Managed skill operations now share one ownership-aware lifecycle service. Create/upload is create-only; explicit saves and permanent deletion require a current revision. The atomic versioned manifest binds source root, filename, installation ID, unique creation identity and exact generated files. Unrelated installations and support files remain untouched.

The service serializes API, startup and generated-environment callers, validates content revisions and symlink redirection, and adopts legacy installations only when their generated file is unambiguous and byte-identical. Pending intents retain hashes and a fixed target set for incomplete operations. Deletion removes the source last and blocks startup republication. Deleting or customizing a generated skill pauses automatic regeneration; explicit recreation publishes the user's content while keeping that pause. Recreating identical content gets a new identity, invalidating old confirmations.

The editor preserves failed-save buffers, exposes conflicts and per-target partial outcomes, and supports safe retries. Its separate permanent-deletion dialog shows the exact name and installations, focuses Cancel, captures identity/revision, and prevents duplicate submission.

[Ownership, migration and API contract](docs/managed-skills.md) · [Screenshots: upload conflict, stale save, deletion confirmation and partial deletion](https://lvwerra-agent-artifacts.static.hf.space/managed-skills-121.html)

Deliberately excluded: trash, backups, snapshots, restore, undo, version history, marketplace changes, frontmatter redesign, global slug changes, a file-manager rewrite and a reusable draft/autosave controller. The existing general API audit-log policy and bucket-backup system are unchanged; no skills-specific content history was introduced. No new distribution destination, merge or production deployment. A fresh revision lets an operator review and explicitly save or delete an externally edited managed source. The accepted source hash is persisted before mutation, including scoped retries. A failed initial create cannot claim an unrelated source that subsequently appears. Externally modified installed copies and legacy ownership conflicts still require deliberate resolution outside this API; there is no force-adopt/overwrite endpoint. Generation cannot take over a user-created skill or overwrite a customized generated skill; the editor explains the generation pause.

Validation on `a8aed2d`, based on freshly fetched `ef08e843`:

- `npm test --prefix server -- skills` — passes: 57 service tests and 6 real API/startup tests, through normal discovery, plus the package's queued-prompt prelude. Includes sibling-file redirection within an allowed root and preservation of pre-existing empty installation directories; both precise guard mutations fail their regression tests. Also covers reviewed external source saves/deletions and pending retries, plus Settings/startup preservation of customized or recreated generated content.
- `node scripts/mutation-check-skills.mjs` — all 18 service mutations caught.
- Reverting the service to `0ec41e1` in a disposable copy makes exactly the three new API regression tests fail; the other three still pass.
- `node scripts/mutation-check-skills-ui.mjs` — all 3 browser mutations caught.
- `npm test --prefix web` — all 24 discovered suites pass, including the focused browser suite and real editor Save/Delete of externally edited sources.
- `npm run build --prefix web` — production TypeScript check and Vite build pass; existing chunk-size advisory remains.
- `npm test --prefix server` — stops at the **known baseline failure** in `server/test/crons.test.mjs` #4 after six discovered suites pass; later suites are not started by the default runner. Separately reproduced with `node server/test/crons.test.mjs` in an unchanged `ef08e843` worktree: it observes both `schedule` and `restart`, instead of only `restart`. No cron changes included. The 21 other suites pass separately. Migration and resize also pass in disposable test copies with unused ports (only the test port constants changed; application code is this commit), after a prior migration run encountered `EADDRINUSE` on 7893. Overall, 29/30 default server suites pass; only the known cron case fails.

API/browser fixtures clear inherited Space settings, credentials and harness-home overrides, verify all five disposable targets before opting into distribution, and launch no real harnesses. Full-suite runs also used disposable HOME/config roots with inherited Space settings removed. Publication uses temporary-file rename, compatible with roots lacking hard links. Path checks prevent accidental redirection; they do not claim isolation from hostile same-user filesystem races or multiple managers sharing one state root.


