### PR TITLE
Overview: an Unread section with durable read tracking

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,6 +17,8 @@ import * as groups from './groups.js';
 import * as order from './order.js';
 import * as demo from './demo.js';
 import * as hidden from './hidden.js';
+import * as readMarks from './read-marks.js';
+import { sourceKey } from './output-id.js';
 import * as crons from './crons.js';
 import { ensureClaudeDialogDefaults, trustWorkspacesRoot } from './first-run.js';
 import {
@@ -61,6 +63,7 @@ groups.init();
 order.init();
 demo.init();
 hidden.init();
+readMarks.init();
 // Lifecycle adapters report conversation resets (e.g. /clear) with the exact
 // id, so re-pin watchers can follow them even in shared folders where storage
 // discovery must refuse to guess. Both installers are non-fatal; the existing
@@ -317,11 +320,33 @@ app.post('/api/notify', async (req, res) => {
 // Overview cards: every agent's state + what it did since your last prompt.
 // Targeted digest for one session — lets the Overview fill tiles one by one
 // while the bulk build (below) is still chewing through the bucket.
+/**
+ * The newest human-facing reply this session has produced, as an identity the
+ * Overview can compare against what the operator has read. `null` when there is
+ * nothing readable yet, or when the digest could not be built — which is not
+ * the same as "all read", and the client is careful to treat it that way.
+ */
+const outputOf = (session, digest) => {
+  const src = sourceKey(session);
+  if (!src || !digest || !digest.outSeq) return null;
+  return { src, seq: digest.outSeq, hash: digest.outHash || '' };
+};
+// `outFresh` is parser bookkeeping — how the next reply knows a prompt came
+// between it and the last one. Not something a client should see or store.
+const stripInternal = (digest) => {
+  if (!digest) return digest;
+  const { outFresh, ...rest } = digest;
+  return rest;
+};
+
 app.get('/api/meta/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const digest = await digestFor(s);
-  res.json({ id: s.id, digest });
+  // The same output/read pair the bulk pass publishes: a tile filled by this
+  // targeted route has to be able to say whether it is unread too, or it would
+  // read as "all caught up" purely because it loaded down a different path.
+  res.json({ id: s.id, digest: stripInternal(digest), output: outputOf(s, digest), read: readMarks.get(s.id) });
 });
 
 app.get('/api/meta', async (_req, res) => {
@@ -333,12 +358,60 @@ app.get('/api/meta', async (_req, res) => {
     .map((s) => {
       // A remote agent's digest comes from its message folder, not the bulk
       // transcript pass — which never sees it.
-      if (isRemote(s.cli)) return { ...s, digest: remote.remoteDigest(s), remote: remote.remoteInfo(s) };
-      const d = digests.get(s.id);
-      if (d) { const { _ts, ...digest } = d; return { ...s, digest }; }
-      return { ...s, digest: null };
+      const digest = isRemote(s.cli) ? remote.remoteDigest(s) : (() => {
+        const d = digests.get(s.id);
+        if (!d) return null;
+        const { _ts, ...rest } = d;
+        return rest;
+      })();
+      const base = isRemote(s.cli)
+        ? { ...s, digest: stripInternal(digest), remote: remote.remoteInfo(s) }
+        : { ...s, digest: stripInternal(digest) };
+      return { ...base, output: outputOf(s, digest), read: readMarks.get(s.id) };
     });
+  // The one-time rollout baseline. Taken from the versions actually observed in
+  // this pass, not a timestamp, so a reply landing while it is being written is
+  // newer than anything captured here and stays eligible for Unread. Skipped
+  // entirely until at least one session has readable output, so a first poll
+  // that arrives before any transcript is parsed cannot burn the baseline on an
+  // empty fleet and leave the real history unread.
+  if (!readMarks.initialized()) {
+    const observed = sessions.filter((s) => s.output).map((s) => [s.id, s.output]);
+    if (observed.length) {
+      readMarks.baseline(new Map(observed));
+      for (const s of sessions) if (s.output) s.read = readMarks.get(s.id);
+    }
+  }
+  readMarks.retain(new Set(store.list().map((s) => s.id)));
   res.json({ sessions, generatedAt: new Date().toISOString() });
+});
+
+/**
+ * "I was shown this reply." One route for both paths — a conversation scrolled
+ * to a visible latest answer, and the Unread section's Mark all read — because
+ * they make exactly the same claim and must be applied by exactly the same
+ * rules. A batch so the bulk action is one request rather than one per card.
+ *
+ * Every entry is answered individually. The client needs to know which of its
+ * marks landed: a rejected one is not a failure to retry, it means the reply it
+ * described is no longer the newest and something unseen has taken its place.
+ */
+app.post('/api/read', express.json({ limit: '64kb' }), async (req, res) => {
+  const marks = Array.isArray(req.body?.marks) ? req.body.marks.slice(0, 200) : null;
+  if (!marks) return res.status(400).json({ error: 'expected { marks: [{ id, src, seq, hash }] }' });
+  const digests = await traceDigests();
+  const results = {};
+  for (const m of marks) {
+    const s = store.get(String(m?.id || ''));
+    if (!s) { results[String(m?.id)] = 'unknown'; continue; }
+    const digest = isRemote(s.cli) ? remote.remoteDigest(s) : (digests.get(s.id) || null);
+    results[s.id] = readMarks.acknowledge(
+      s.id,
+      { src: String(m.src || ''), seq: Number(m.seq), hash: String(m.hash || '') },
+      outputOf(s, digest),
+    );
+  }
+  res.json({ results, marks: readMarks.all() });
 });
 
 // Whose turn a `user` message is attributed to in a remote log. The Space owner

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -335,7 +335,7 @@ const outputOf = (session, digest) => {
 // between it and the last one. Not something a client should see or store.
 const stripInternal = (digest) => {
   if (!digest) return digest;
-  const { outFresh, ...rest } = digest;
+  const { outFresh, outKey, ...rest } = digest;
   return rest;
 };
 
@@ -371,16 +371,20 @@ app.get('/api/meta', async (_req, res) => {
     });
   // The one-time rollout baseline. Taken from the versions actually observed in
   // this pass, not a timestamp, so a reply landing while it is being written is
-  // newer than anything captured here and stays eligible for Unread. Skipped
-  // entirely until at least one session has readable output, so a first poll
-  // that arrives before any transcript is parsed cannot burn the baseline on an
-  // empty fleet and leave the real history unread.
+  // newer than anything captured here and stays eligible for Unread.
+  //
+  // It runs on the first pass that could observe anything at all, including one
+  // where nothing has spoken yet. Waiting for the first session WITH output
+  // looked safer and was the opposite: on a fresh install the baseline would sit
+  // untaken until some agent's first reply arrived, and then take that reply as
+  // history the operator had already read.
+  //
+  // `traceDigests()` has resolved by this point, so a session reporting no
+  // output here genuinely has none rather than not being parsed yet. It gets no
+  // mark, which is what leaves its first reply unread.
   if (!readMarks.initialized()) {
-    const observed = sessions.filter((s) => s.output).map((s) => [s.id, s.output]);
-    if (observed.length) {
-      readMarks.baseline(new Map(observed));
-      for (const s of sessions) if (s.output) s.read = readMarks.get(s.id);
-    }
+    readMarks.baseline(new Map(sessions.filter((s) => s.output).map((s) => [s.id, s.output])));
+    for (const s of sessions) s.read = readMarks.get(s.id);
   }
   readMarks.retain(new Set(store.list().map((s) => s.id)));
   res.json({ sessions, generatedAt: new Date().toISOString() });
@@ -397,8 +401,12 @@ app.get('/api/meta', async (_req, res) => {
  * described is no longer the newest and something unseen has taken its place.
  */
 app.post('/api/read', express.json({ limit: '64kb' }), async (req, res) => {
-  const marks = Array.isArray(req.body?.marks) ? req.body.marks.slice(0, 200) : null;
+  const marks = Array.isArray(req.body?.marks) ? req.body.marks : null;
   if (!marks) return res.status(400).json({ error: 'expected { marks: [{ id, src, seq, hash }] }' });
+  // Refused rather than truncated. Silently dropping the tail of a batch and
+  // answering 200 for the part that fit is how a session stays unread while the
+  // client reports success; the client sends bounded chunks instead.
+  if (marks.length > 200) return res.status(413).json({ error: 'too many marks in one request; send at most 200' });
   const digests = await traceDigests();
   const results = {};
   for (const m of marks) {

--- a/server/src/output-id.js
+++ b/server/src/output-id.js
@@ -1,0 +1,48 @@
+// Which reply is this?
+//
+// The Overview's unread section has to ask "has the operator seen THIS answer?"
+// rather than "is there something newer than a timestamp?", so every surface
+// that produces human-facing assistant output names it the same way: a sequence
+// number and a hash of the full text.
+//
+// Both halves are load-bearing. The sequence separates two replies with
+// identical text, or the same timestamp — only a counter can. The hash catches
+// a streaming answer that grew, including past the 280-character card clip,
+// where the visible summary would look unchanged although the operator has been
+// shown something new.
+//
+// Deliberately NOT the trace file's revision, which also moves for tool calls,
+// token counts and status records — none of which are anything to read.
+
+/**
+ * Cheap and stable rather than cryptographic: this only has to separate one
+ * reply from the next within a single transcript. FNV-1a, with the length
+ * appended because a truncated-versus-extended streaming answer is exactly the
+ * pair most likely to collide in a 32-bit space.
+ */
+export function outputHash(text) {
+  const t = String(text ?? '');
+  let h = 0x811c9dc5;
+  for (let i = 0; i < t.length; i++) {
+    h ^= t.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return `${h.toString(36)}${t.length.toString(36)}`;
+}
+
+/**
+ * The generation of a session's transcript: which file/thread the output is
+ * coming from. It changes when a session's trace is replaced — codex repins
+ * `codexRollout` on a new run — and an acknowledgement carrying the old
+ * generation must not be read as covering the new one's output.
+ */
+export function sourceKey(session) {
+  if (!session) return '';
+  const parts = [
+    session.remote?.name ? `r:${session.remote.name}` : '',
+    session.sessionUuid || '',
+    session.codexRollout || '',
+    session.opencodeSessionId || '',
+  ].filter(Boolean);
+  return parts.length ? outputHash(parts.join('|')) : '';
+}

--- a/server/src/read-marks.js
+++ b/server/src/read-marks.js
@@ -1,0 +1,128 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { DATA_DIR } from './config.js';
+
+// What the operator has already read.
+//
+// One mark per session: the exact output version they were last shown. Unread
+// is then a comparison — "is the newest reply the one they have seen?" — rather
+// than a flag anyone has to remember to clear.
+//
+// Server-side because the answer has to be the same on the operator's phone as
+// on their laptop, and has to survive a refresh. A browser can cache it; it
+// cannot be the authority.
+//
+// A mark is {src, seq, hash}:
+//   src  — which transcript generation it belongs to. When a session's trace is
+//          replaced (codex repins a rollout on a new run) the old mark cannot
+//          be read as covering the new file's replies, which start again at 1.
+//   seq  — how far through that transcript's replies the operator has read.
+//          Only ever moves forward, which is what makes a late or duplicated
+//          request harmless.
+//   hash — of the exact text shown. Two acknowledgements at the same seq can
+//          still describe different content when a streaming answer grew, and
+//          the newer one has not been read.
+
+const FILE = path.join(DATA_DIR, 'read-marks.json');
+let state = { initialized: false, marks: {} };
+
+function persist() {
+  const tmp = `${FILE}.tmp`;
+  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  fs.renameSync(tmp, FILE);
+}
+
+export function init() {
+  try {
+    const parsed = JSON.parse(fs.readFileSync(FILE, 'utf8'));
+    state = {
+      initialized: !!parsed.initialized,
+      marks: parsed.marks && typeof parsed.marks === 'object' ? parsed.marks : {},
+    };
+  } catch {
+    state = { initialized: false, marks: {} };
+  }
+}
+
+/** Has the one-time rollout baseline been taken? */
+export function initialized() { return state.initialized; }
+
+export function get(id) { return state.marks[id] || null; }
+
+export function all() { return { ...state.marks }; }
+
+const validMark = (m) => !!m
+  && typeof m.src === 'string'
+  && Number.isInteger(m.seq) && m.seq >= 0
+  && typeof m.hash === 'string' && m.hash.length <= 64;
+
+/**
+ * Record that `mark` was shown for this session, against the output the server
+ * currently believes is newest (`latest`).
+ *
+ * Returns the outcome rather than throwing, because a rejection here is an
+ * ordinary answer — "that is not what is on screen any more" — and the caller
+ * has to be able to tell it apart from a write that failed.
+ *
+ *   'ok'       — recorded (or already covered, which is the same outcome)
+ *   'stale'    — describes output older than what is already acknowledged, or a
+ *                generation that is no longer current. Progress never moves back.
+ *   'future'   — claims to have seen further than the newest output that
+ *                exists. A client cannot acknowledge what the server has not
+ *                produced.
+ *   'mismatch' — the right position but not the right content: a streaming
+ *                answer moved on between rendering and acknowledging. The
+ *                operator saw the old one, so the new one stays unread.
+ */
+export function acknowledge(id, mark, latest) {
+  if (!validMark(mark)) return 'invalid';
+  if (!latest || !latest.src) return 'unknown';
+  // A mark from a previous run of the transcript says nothing about this one.
+  if (mark.src !== latest.src) return 'stale';
+  if (mark.seq > latest.seq) return 'future';
+  if (mark.seq === latest.seq && mark.hash !== latest.hash) return 'mismatch';
+
+  const cur = state.marks[id];
+  if (cur && cur.src === mark.src) {
+    // Monotonic within a generation: a late or reordered request cannot undo
+    // reading the operator has already done.
+    if (cur.seq > mark.seq) return 'stale';
+    if (cur.seq === mark.seq && cur.hash === mark.hash) return 'ok'; // already there
+  }
+  state.marks[id] = { src: mark.src, seq: mark.seq, hash: mark.hash, at: new Date().toISOString() };
+  persist();
+  return 'ok';
+}
+
+/**
+ * The one-time rollout baseline: everything that exists right now counts as
+ * read, so turning this on does not declare the operator's whole history
+ * unread.
+ *
+ * Takes exact observed versions, not a wall-clock cutoff — a reply landing
+ * while this is being written is newer than the versions captured here, so it
+ * stays eligible for Unread instead of being swallowed by a timestamp.
+ *
+ * Runs once ever. A session with no readable output yet is skipped rather than
+ * marked read at seq 0, so its first reply is unread rather than presumed seen.
+ */
+export function baseline(latestById) {
+  if (state.initialized) return false;
+  for (const [id, latest] of latestById) {
+    if (!latest || !latest.src || !latest.seq) continue;
+    state.marks[id] = { src: latest.src, seq: latest.seq, hash: latest.hash, at: new Date().toISOString() };
+  }
+  state.initialized = true;
+  persist();
+  return true;
+}
+
+/** Drop marks for sessions that no longer exist. Renaming or moving a session
+ *  keeps its id, and so keeps its mark. */
+export function retain(validIds) {
+  let changed = false;
+  for (const id of Object.keys(state.marks)) {
+    if (!validIds.has(id)) { delete state.marks[id]; changed = true; }
+  }
+  if (changed) persist();
+}

--- a/server/src/read-marks.js
+++ b/server/src/read-marks.js
@@ -26,10 +26,15 @@ import { DATA_DIR } from './config.js';
 const FILE = path.join(DATA_DIR, 'read-marks.json');
 let state = { initialized: false, marks: {} };
 
-function persist() {
+// Write first, adopt second. The in-memory copy is what /api/meta answers from,
+// so promoting it before the file lands would publish a reply as read that a
+// restart brings back unread — and the caller would have been told it failed.
+// Nothing here mutates `state` unless the bytes are on disk.
+function commit(next) {
   const tmp = `${FILE}.tmp`;
-  fs.writeFileSync(tmp, JSON.stringify(state, null, 2));
+  fs.writeFileSync(tmp, JSON.stringify(next, null, 2));
   fs.renameSync(tmp, FILE);
+  state = next;
 }
 
 export function init() {
@@ -81,16 +86,24 @@ export function acknowledge(id, mark, latest) {
   if (mark.src !== latest.src) return 'stale';
   if (mark.seq > latest.seq) return 'future';
   if (mark.seq === latest.seq && mark.hash !== latest.hash) return 'mismatch';
+  // Does this mark name exactly what is newest right now? That claim is always
+  // recordable, even when the stored cursor carries a HIGHER number: a rotated
+  // or replaced transcript restarts its sequence, and refusing the new, lower
+  // one as "stale" would leave real new output permanently unacknowledgeable.
+  const exact = mark.seq === latest.seq && mark.hash === latest.hash;
 
   const cur = state.marks[id];
-  if (cur && cur.src === mark.src) {
+  if (cur && cur.src === mark.src && !exact) {
     // Monotonic within a generation: a late or reordered request cannot undo
     // reading the operator has already done.
     if (cur.seq > mark.seq) return 'stale';
-    if (cur.seq === mark.seq && cur.hash === mark.hash) return 'ok'; // already there
   }
-  state.marks[id] = { src: mark.src, seq: mark.seq, hash: mark.hash, at: new Date().toISOString() };
-  persist();
+  if (cur && cur.src === mark.src && cur.seq === mark.seq && cur.hash === mark.hash) {
+    // Already recorded AND already on disk — `state` is only ever adopted from a
+    // completed write, so this shortcut cannot stand in for one that failed.
+    return 'ok';
+  }
+  commit({ ...state, marks: { ...state.marks, [id]: { src: mark.src, seq: mark.seq, hash: mark.hash, at: new Date().toISOString() } } });
   return 'ok';
 }
 
@@ -108,21 +121,26 @@ export function acknowledge(id, mark, latest) {
  */
 export function baseline(latestById) {
   if (state.initialized) return false;
+  const marks = { ...state.marks }, at = new Date().toISOString();
   for (const [id, latest] of latestById) {
     if (!latest || !latest.src || !latest.seq) continue;
-    state.marks[id] = { src: latest.src, seq: latest.seq, hash: latest.hash, at: new Date().toISOString() };
+    marks[id] = { src: latest.src, seq: latest.seq, hash: latest.hash, at };
   }
-  state.initialized = true;
-  persist();
+  // Same rule as acknowledge: the flag and the marks become true together, and
+  // only once the file holds them. A failed write leaves the baseline untaken,
+  // so the next poll retries it rather than starting to track from a moment
+  // nothing recorded.
+  commit({ ...state, initialized: true, marks });
   return true;
 }
 
 /** Drop marks for sessions that no longer exist. Renaming or moving a session
  *  keeps its id, and so keeps its mark. */
 export function retain(validIds) {
+  const marks = {};
   let changed = false;
-  for (const id of Object.keys(state.marks)) {
-    if (!validIds.has(id)) { delete state.marks[id]; changed = true; }
+  for (const [id, mark] of Object.entries(state.marks)) {
+    if (validIds.has(id)) marks[id] = mark; else changed = true;
   }
-  if (changed) persist();
+  if (changed) commit({ ...state, marks });
 }

--- a/server/src/remote.js
+++ b/server/src/remote.js
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import { outputHash } from './output-id.js';
 import path from 'node:path';
 import { WORKSPACES_DIR } from './config.js';
 import { update } from './sessions.js';
@@ -410,6 +411,13 @@ export function remoteDigest(session) {
     running: isListening(name) && !session.remote.paused,
     turnsLog: sinceTurns.slice(0, -1).reverse()
       .map((m) => ({ answer: clip(m.text), answerMd: clipRaw(m.text), ts: Date.parse(m.at || '') || 0 })),
+    // A remote log already numbers its messages, so the unread cursor uses that
+    // rather than deriving one: it is authoritative, monotonic, and survives a
+    // reconnect. The hash still comes from the full text, so an agent that
+    // edits and resends the same message is a new thing to read.
+    outSeq: answer ? answer.seq : 0,
+    outHash: answer ? outputHash(answer.text) : '',
+    outClipped: answer ? clipRaw(answer.text).length < String(answer.text || '').trim().length : false,
   };
 }
 

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -52,7 +52,7 @@ function mergeInto(a, b) {
 // Built in the same parse pass: every real user prompt resets the segment, so
 // whatever accumulated by EOF is the activity since the last thing you said.
 function emptyDigest() {
-  return { lastPromptText: '', lastPromptRaw: '', lastPromptTs: 0, lastAssistantText: '', lastAssistantMd: '', lastAssistantTs: 0, sinceTurns: 0, sinceToolCalls: 0, sinceTools: {}, sinceFiles: [], sinceTokens: 0, running: false, turnsLog: [], outSeq: 0, outHash: '', outClipped: false, outFresh: false };
+  return { lastPromptText: '', lastPromptRaw: '', lastPromptTs: 0, lastAssistantText: '', lastAssistantMd: '', lastAssistantTs: 0, sinceTurns: 0, sinceToolCalls: 0, sinceTools: {}, sinceFiles: [], sinceTokens: 0, running: false, turnsLog: [], outSeq: 0, outHash: '', outClipped: false, outFresh: false, outKey: null };
 }
 
 // ---------- which reply is this? (the Overview's unread cursor) ----------
@@ -96,7 +96,13 @@ function digestPrompt(d, text, ts) {
   // way to tell "ask again, get the same answer" apart from a record repeated.
   d.outFresh = true;
 }
-function digestAssistant(d, text, ts) {
+// `key` is the harness's own identity for this assistant message, where it has
+// one. Claude does (`message.id`), and it is the only thing that can tell two
+// replies apart when they say the same words — the case the text comparison
+// below gets wrong. Harnesses that mirror one message across several record
+// types with no shared id (codex writes agent_message and task_complete) pass
+// none, and fall back to that comparison.
+function digestAssistant(d, text, ts, key) {
   const clipped = clip(text);
   // Same text again (codex mirrors agent_message/response_item/task_complete):
   // refresh metadata only, don't log a phantom turn.
@@ -111,16 +117,26 @@ function digestAssistant(d, text, ts) {
   // which compares clipped text and so cannot tell a grown streaming answer
   // from the same one twice.
   const hash = outputHash(text);
-  // A prompt in between makes this a new reply whatever it says; otherwise only
-  // changed text does.
+  // A different message is a different reply, whatever it says. With an id from
+  // the harness that is a fact, not an inference — two `msg-1: "Done."` and
+  // `msg-3: "Done."` records are two replies, and the operator who read the
+  // first has not read the second.
   //
-  // The one thing this cannot separate is an agent repeating itself verbatim
-  // with no prompt in between — that is indistinguishable from the mirrored
-  // records every harness writes (codex emits agent_message and task_complete
-  // with the same words), and counting those would mark a session unread every
-  // time it finished a turn. Collapsing them is the safe direction: the
-  // operator has already been shown those words.
-  if (hash !== d.outHash || d.outFresh) { d.outSeq += 1; d.outHash = hash; }
+  // Without an id, the fallback: a prompt in between makes this new, and
+  // otherwise only changed text does. That still cannot separate an agent
+  // repeating itself verbatim mid-turn from the mirrored records such harnesses
+  // write, and collapsing those stays the safe direction — the alternative
+  // marks a session unread every time it finishes a turn. The limitation is now
+  // confined to harnesses that give us nothing to tell the two apart.
+  const fresh = key !== undefined && key !== null
+    ? key !== d.outKey
+    : (hash !== d.outHash || d.outFresh);
+  if (fresh) d.outSeq += 1;
+  // A revision of the SAME message (a second text block, a streaming answer
+  // that grew) keeps its sequence and changes its hash, which is a new version
+  // to be seen without being a new reply.
+  d.outHash = hash;
+  if (key !== undefined && key !== null) d.outKey = key;
   d.outFresh = false;
   // Whether the card's copy of this answer is the whole answer. A reply longer
   // than clipRaw's cap is shown with its tail cut off, and the Overview must
@@ -179,7 +195,7 @@ function parseClaude(txt) {
             const file = /^(Edit|Write|MultiEdit|NotebookEdit)$/.test(name) && c.input && c.input.file_path;
             digestTool(dg, name, file || null);
           } else if (c.type === 'text' && c.text && c.text.trim()) {
-            digestAssistant(dg, c.text, j.timestamp);
+            digestAssistant(dg, c.text, j.timestamp, id);
           }
         }
       }

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -10,6 +10,7 @@ import { mark, tracked, PHASE } from './watchdog.js';
 // resolver sharing uses. share.js does not import traces.js, so no cycle.
 import { findTrace, HARNESS_LABEL } from './share.js';
 import { cachedTrace, traceRevision } from './trace-revision.js';
+import { outputHash } from './output-id.js';
 
 // Workspace-wide trace analytics: parse every Claude transcript and Codex
 // rollout on the Space into per-conversation stats (turns, tool calls, web
@@ -51,8 +52,27 @@ function mergeInto(a, b) {
 // Built in the same parse pass: every real user prompt resets the segment, so
 // whatever accumulated by EOF is the activity since the last thing you said.
 function emptyDigest() {
-  return { lastPromptText: '', lastPromptRaw: '', lastPromptTs: 0, lastAssistantText: '', lastAssistantMd: '', lastAssistantTs: 0, sinceTurns: 0, sinceToolCalls: 0, sinceTools: {}, sinceFiles: [], sinceTokens: 0, running: false, turnsLog: [] };
+  return { lastPromptText: '', lastPromptRaw: '', lastPromptTs: 0, lastAssistantText: '', lastAssistantMd: '', lastAssistantTs: 0, sinceTurns: 0, sinceToolCalls: 0, sinceTools: {}, sinceFiles: [], sinceTokens: 0, running: false, turnsLog: [], outSeq: 0, outHash: '', outClipped: false, outFresh: false };
 }
+
+// ---------- which reply is this? (the Overview's unread cursor) ----------
+//
+// `outSeq`/`outHash` name the newest piece of human-facing assistant output, so
+// the Overview can ask "has the operator seen THIS?" instead of "is there
+// something newer than a timestamp?".
+//
+// Both halves are load-bearing:
+//
+//   seq  — how many distinct outputs this transcript has produced. Two replies
+//          with identical text, or the same timestamp, are still different
+//          replies, and only a counter separates them.
+//   hash — of the FULL text, not the 280-char card clip. A streaming answer
+//          that grows past the clip would otherwise look unchanged, and the
+//          operator has been shown something new.
+//
+// Deliberately NOT the file's revision: that moves for tool calls, token
+// counts and status records, none of which are anything to read.
+//
 const clip = (s, n = 280) => { const t = (s || '').replace(/\s+/g, ' ').trim(); return t.length > n ? `${t.slice(0, n - 1)}…` : t; };
 // Markdown-preserving variant (keeps newlines) for the expandable card view.
 const clipRaw = (s, n = 6000) => { const t = (s || '').trim(); return t.length > n ? `${t.slice(0, n - 1)}…` : t; };
@@ -66,6 +86,15 @@ function digestPrompt(d, text, ts) {
   d.turnsLog = []; // arrows only walk the current request's turns
   // The previous answer belongs to the previous prompt — never show it as "LAST".
   d.lastAssistantText = ''; d.lastAssistantMd = ''; d.lastAssistantTs = 0;
+  // outSeq/outHash are NOT cleared here. They name the newest reply this
+  // transcript has produced, and typing at an agent is not reading what it
+  // last said — clearing them would quietly mark an unseen answer as seen the
+  // moment the operator sent the next prompt.
+  //
+  // What a prompt DOES do is end the current reply. Whatever the agent says
+  // next is a new one even if it says exactly the same words, which is the only
+  // way to tell "ask again, get the same answer" apart from a record repeated.
+  d.outFresh = true;
 }
 function digestAssistant(d, text, ts) {
   const clipped = clip(text);
@@ -78,6 +107,26 @@ function digestAssistant(d, text, ts) {
     }
     d.lastAssistantText = clipped;
   }
+  // Off the FULL text, before any clipping, and before the mirror check above —
+  // which compares clipped text and so cannot tell a grown streaming answer
+  // from the same one twice.
+  const hash = outputHash(text);
+  // A prompt in between makes this a new reply whatever it says; otherwise only
+  // changed text does.
+  //
+  // The one thing this cannot separate is an agent repeating itself verbatim
+  // with no prompt in between — that is indistinguishable from the mirrored
+  // records every harness writes (codex emits agent_message and task_complete
+  // with the same words), and counting those would mark a session unread every
+  // time it finished a turn. Collapsing them is the safe direction: the
+  // operator has already been shown those words.
+  if (hash !== d.outHash || d.outFresh) { d.outSeq += 1; d.outHash = hash; }
+  d.outFresh = false;
+  // Whether the card's copy of this answer is the whole answer. A reply longer
+  // than clipRaw's cap is shown with its tail cut off, and the Overview must
+  // not record the omitted part as read — the reader, which serves the trace
+  // itself, is where that reply can actually be finished.
+  d.outClipped = clipRaw(text).length < String(text || '').trim().length;
   d.lastAssistantMd = clipRaw(text);
   d.lastAssistantTs = Date.parse(ts) || d.lastAssistantTs;
 }
@@ -772,6 +821,10 @@ function memoized() {
   }
   return resultMemo.val || building;
 }
+
+// Exposed for tests: the unread cursor's rules live in the parser, and a
+// hand-built digest object would exercise none of them.
+export const __parseClaudeForTest = parseClaude;
 
 export async function buildTraces() {
   const { perSession, totals, sessions } = await memoized();

--- a/server/test/unread.test.mjs
+++ b/server/test/unread.test.mjs
@@ -1,0 +1,232 @@
+// Unread, end to end: which reply the transcript produced, what an
+// acknowledgement is allowed to cover, and what survives a restart.
+//
+// The output identity half runs against the real transcript parsers with
+// fixture files, because the interesting failures are all about what the parser
+// calls "a new reply" — a mirrored record, a streaming answer that grew, two
+// answers with the same words. A hand-made digest object would test none of it.
+//
+// Run with:  node test/unread.test.mjs
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const PORT = 7889;
+const API = `http://localhost:${PORT}`;
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'unread-srv-'));
+const CLAUDE_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'unread-claude-'));
+
+let pass = 0; let fail = 0;
+const check = (name, ok, detail = '') => {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${name}${detail ? `  ${detail}` : ''}`);
+  ok ? pass++ : fail++;
+};
+
+// ---------- output identity, straight through the real parser ----------
+const { parseClaudeForTest } = await import('../src/traces.js').then((m) => ({
+  parseClaudeForTest: m.__parseClaudeForTest,
+}));
+
+const line = (o) => `${JSON.stringify(o)}\n`;
+const assistant = (text, ts, id) => line({
+  type: 'assistant', timestamp: ts, uuid: id,
+  message: { id, content: [{ type: 'text', text }] },
+});
+const userMsg = (text, ts) => line({ type: 'user', timestamp: ts, message: { content: text } });
+const toolUse = (ts, id) => line({
+  type: 'assistant', timestamp: ts, uuid: `t${id}`,
+  message: { id: `t${id}`, content: [{ type: 'tool_use', id, name: 'Read', input: { file_path: '/x' } }] },
+});
+
+const digestOf = (txt) => parseClaudeForTest(txt).digest;
+const idOf = (txt) => { const d = digestOf(txt); return `${d.outSeq}:${d.outHash}`; };
+
+console.log('\nwhich reply is this?');
+{
+  const one = assistant('First answer.', '2026-01-01T00:00:00Z', 'm1');
+  check('one reply is seq 1', digestOf(one).outSeq === 1, `seq ${digestOf(one).outSeq}`);
+
+  const two = one + assistant('Second answer.', '2026-01-01T00:01:00Z', 'm2');
+  check('a second reply advances the sequence', digestOf(two).outSeq === 2, `seq ${digestOf(two).outSeq}`);
+  check('and is a different identity', idOf(one) !== idOf(two));
+
+  // The mirror case: codex writes agent_message and task_complete with the same
+  // words; Claude repeats a block. Same text must not invent a reply.
+  const mirrored = one + assistant('First answer.', '2026-01-01T00:00:05Z', 'm1b');
+  check('the same words again is NOT a new reply', digestOf(mirrored).outSeq === 1, `seq ${digestOf(mirrored).outSeq}`);
+  check('and not a new identity either', idOf(mirrored) === idOf(one));
+
+  // Two genuinely separate replies that happen to say the same thing.
+  const sameText = one + userMsg('again please', '2026-01-01T00:00:30Z') + assistant('First answer.', '2026-01-01T00:01:00Z', 'm3');
+  check('the same words after a prompt IS a new reply', digestOf(sameText).outSeq === 2, `seq ${digestOf(sameText).outSeq}`);
+
+  // A streaming answer growing past the 280-char card clip: the visible summary
+  // is unchanged, the reply is not.
+  const long = 'x'.repeat(400);
+  const partial = assistant(long, '2026-01-01T00:00:00Z', 'm1');
+  const grown = assistant(`${long} and one more sentence.`, '2026-01-01T00:00:01Z', 'm1');
+  const a = digestOf(partial); const b = digestOf(grown);
+  check('a grown streaming answer is a new identity', `${a.outSeq}:${a.outHash}` !== `${b.outSeq}:${b.outHash}`);
+  check('even though the clipped card text is identical', a.lastAssistantText === b.lastAssistantText);
+  check('and the card says its copy is incomplete', b.outClipped === false && a.outClipped === false,
+    'clipRaw caps at 6000, so 400 chars is whole');
+
+  const huge = 'y'.repeat(7000);
+  check('a reply longer than the card can hold is flagged clipped', digestOf(assistant(huge, '2026-01-01T00:00:00Z', 'mh')).outClipped === true);
+
+  // Same timestamp, different replies.
+  const tie = assistant('A', '2026-01-01T00:00:00Z', 'm1') + assistant('B', '2026-01-01T00:00:00Z', 'm2');
+  check('two replies at the same timestamp are still two', digestOf(tie).outSeq === 2, `seq ${digestOf(tie).outSeq}`);
+}
+
+console.log('\nnoise that must not look like something to read');
+{
+  const base = assistant('The answer.', '2026-01-01T00:00:00Z', 'm1');
+  const before = idOf(base);
+  check('tool calls do not create a reply', idOf(base + toolUse('2026-01-01T00:00:10Z', 'tu1')) === before);
+  check('a user prompt does not create a reply', idOf(base + userMsg('next', '2026-01-01T00:00:20Z')) === before);
+  // The one that used to be a real bug: the digest clears its assistant fields
+  // on a new prompt, which would have erased the unread cursor with them.
+  const afterPrompt = digestOf(base + userMsg('next', '2026-01-01T00:00:20Z'));
+  check('a prompt clears the card text but NOT the unread cursor',
+    afterPrompt.lastAssistantText === '' && afterPrompt.outSeq === 1,
+    `text=${JSON.stringify(afterPrompt.lastAssistantText)} seq=${afterPrompt.outSeq}`);
+}
+
+// ---------- the durable half ----------
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...BASE_ENV } = process.env;
+const boot = () => spawn('node', ['src/index.js'], {
+  env: {
+    ...BASE_ENV, PORT: String(PORT), DATA_DIR, AM_BASHRC: '/nonexistent',
+    AM_ALLOW_MISSING_ORIGIN: '1', CLAUDE_CONFIG_DIR: CLAUDE_DIR,
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let srv = boot();
+let log = '';
+srv.stdout.on('data', (d) => { log += d; });
+srv.stderr.on('data', (d) => { log += d; });
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const api = async (route, init = {}) => {
+  const sep = route.includes('?') ? '&' : '?';
+  const r = await fetch(`${API}${route}${sep}from=operator`, { headers: { 'content-type': 'application/json' }, ...init });
+  let body = null; try { body = await r.json(); } catch { /* empty */ }
+  return { status: r.status, body };
+};
+const waitUp = async () => {
+  for (let i = 0; i < 120; i++) {
+    if (await fetch(`${API}/api/health`).then((r) => r.ok).catch(() => false)) return;
+    await sleep(250);
+  }
+};
+const mkRemote = async (name) =>
+  (await api('/api/sessions', { method: 'POST', body: JSON.stringify({ cli: 'remote', name, path: name }) })).body;
+const say = (name, text) => fetch(`${API}/api/remote/${name}/messages?from=agent`, {
+  method: 'POST', headers: { 'content-type': 'text/plain' }, body: text,
+});
+const metaFor = async (id) => (await api('/api/meta')).body.sessions.find((s) => s.id === id);
+const unread = (s) => {
+  const o = s?.output; const r = s?.read;
+  if (!o || !o.seq) return false;
+  if (!r) return true;
+  return r.src !== o.src || r.seq < o.seq || (r.seq === o.seq && r.hash !== o.hash);
+};
+
+try {
+  await waitUp();
+
+  console.log('\nthe rollout baseline: today is read, tomorrow is not');
+  const a = await mkRemote('alpha');
+  await say('alpha', 'An answer from before the feature existed.');
+  const first = await metaFor(a.id);
+  check('an existing reply starts read', !unread(first), JSON.stringify(first.read));
+  await say('alpha', 'A reply that arrived afterwards.');
+  check('the next reply is unread', unread(await metaFor(a.id)));
+
+  const b = await mkRemote('beta');
+  const bMeta = await metaFor(b.id);
+  check('a session with nothing to read is not "read" — it has no mark at all', !bMeta.output && !bMeta.read);
+  await say('beta', 'Its very first answer.');
+  check('so its FIRST reply is unread, not presumed seen', unread(await metaFor(b.id)));
+
+  console.log('\nacknowledging');
+  const cur = await metaFor(a.id);
+  const ack = (marks) => api('/api/read', { method: 'POST', body: JSON.stringify({ marks }) });
+  const okMark = { id: a.id, ...cur.output };
+  check('acknowledging what is on screen is recorded', (await ack([okMark])).body.results[a.id] === 'ok');
+  check('and the session is read', !unread(await metaFor(a.id)));
+  check('replaying the same acknowledgement is harmless', (await ack([okMark])).body.results[a.id] === 'ok');
+
+  await say('alpha', 'Something new, after the acknowledgement.');
+  check('new output is unread again', unread(await metaFor(a.id)));
+  check('and the OLD acknowledgement replayed does not cover it',
+    (await ack([okMark])).body.results[a.id] === 'ok' && unread(await metaFor(a.id)));
+
+  // Out-of-order delivery: the reader acknowledged reply 2, then a duplicate of
+  // the reply-1 acknowledgement arrives late. It is honest progress, so it is
+  // accepted — but it must not drag the recorded position back to 1, or the
+  // operator would be shown reply 2 as unread again after reading it.
+  {
+    const cur2 = (await metaFor(a.id)).output;
+    await ack([{ id: a.id, ...cur2 }]);
+    const high = (await metaFor(a.id)).read.seq;
+    await ack([okMark]); // the older one, arriving late
+    const after = (await metaFor(a.id)).read;
+    check('a late acknowledgement for an older reply cannot move progress back',
+      after.seq === high, `${high} -> ${after.seq}`);
+    check('and the session it had caught up on stays read', !unread(await metaFor(a.id)));
+    // Put it back where the rest of the suite expects it.
+    await say('alpha', 'And one more, so the refusal cases have something to refuse.');
+  }
+
+  const latest = (await metaFor(a.id)).output;
+  check('a mark claiming to have read further than exists is refused',
+    (await ack([{ id: a.id, ...latest, seq: latest.seq + 50 }])).body.results[a.id] === 'future');
+  check('a mark from another transcript generation is refused',
+    (await ack([{ id: a.id, ...latest, src: 'someothergeneration' }])).body.results[a.id] === 'stale');
+  check('the right position with the wrong content is refused',
+    (await ack([{ id: a.id, ...latest, hash: 'notwhatwasshown' }])).body.results[a.id] === 'mismatch');
+  check('after all those refusals it is still unread', unread(await metaFor(a.id)));
+  check('an unknown session is refused, not invented', (await ack([{ id: 'ghost', src: 'x', seq: 1, hash: 'h' }])).body.results.ghost === 'unknown');
+
+  console.log('\nbulk acknowledgement (Mark all read)');
+  const both = [a.id, b.id];
+  const marks = [];
+  for (const id of both) { const m = await metaFor(id); if (m.output) marks.push({ id, ...m.output }); }
+  const bulk = await ack(marks);
+  check('one request covers the whole section', both.every((id) => bulk.body.results[id] === 'ok'));
+  check('and both are read', !unread(await metaFor(a.id)) && !unread(await metaFor(b.id)));
+  // A reply arriving during the request is not in the captured batch.
+  await say('alpha', 'Arrived while the batch was in flight.');
+  check('a reply that arrived mid-batch is NOT covered by it',
+    (await ack(marks)).body.results[a.id] === 'ok' && unread(await metaFor(a.id)));
+
+  console.log('\nit survives a restart');
+  const beforeRestart = (await metaFor(b.id)).read;
+  srv.kill(); await sleep(700);
+  srv = boot();
+  srv.stdout.on('data', (d) => { log += d; });
+  srv.stderr.on('data', (d) => { log += d; });
+  await waitUp();
+  const afterRestart = (await metaFor(b.id)).read;
+  check('the mark is still there', !!afterRestart && afterRestart.seq === beforeRestart.seq,
+    `${JSON.stringify(beforeRestart)} -> ${JSON.stringify(afterRestart)}`);
+  check('and the baseline is not taken a second time', unread(await metaFor(a.id)),
+    'alpha had unread output before the restart and must still have it');
+
+  console.log('\nrenaming keeps the read state');
+  await api(`/api/sessions/${b.id}`, { method: 'PUT', body: JSON.stringify({ name: 'beta-renamed' }) });
+  const renamed = await metaFor(b.id);
+  check('a renamed session keeps its mark', !!renamed.read && !unread(renamed));
+} catch (e) {
+  check(`suite threw: ${e && e.message}`, false, log.slice(-700));
+} finally {
+  srv.kill();
+  try { fs.rmSync(DATA_DIR, { recursive: true, force: true }); } catch { /* tmp */ }
+  try { fs.rmSync(CLAUDE_DIR, { recursive: true, force: true }); } catch { /* tmp */ }
+}
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/server/test/unread.test.mjs
+++ b/server/test/unread.test.mjs
@@ -51,11 +51,36 @@ console.log('\nwhich reply is this?');
   check('a second reply advances the sequence', digestOf(two).outSeq === 2, `seq ${digestOf(two).outSeq}`);
   check('and is a different identity', idOf(one) !== idOf(two));
 
-  // The mirror case: codex writes agent_message and task_complete with the same
-  // words; Claude repeats a block. Same text must not invent a reply.
-  const mirrored = one + assistant('First answer.', '2026-01-01T00:00:05Z', 'm1b');
-  check('the same words again is NOT a new reply', digestOf(mirrored).outSeq === 1, `seq ${digestOf(mirrored).outSeq}`);
+  // A real Claude mirror repeats the SAME message id — a re-emitted record, or
+  // a second block of one message. That must not invent a reply.
+  const mirrored = one + assistant('First answer.', '2026-01-01T00:00:05Z', 'm1');
+  check('the same message id again is NOT a new reply', digestOf(mirrored).outSeq === 1, `seq ${digestOf(mirrored).outSeq}`);
   check('and not a new identity either', idOf(mirrored) === idOf(one));
+
+  // A DIFFERENT message that happens to say the same words is a different
+  // reply, and the operator who read the first has not read the second. Claude
+  // gives us the message id, so this is a fact rather than a guess.
+  const twice = assistant('Done.', '2026-01-01T00:00:00Z', 'msg-1')
+    + toolUse('2026-01-01T00:00:10Z', 'tu9')
+    + assistant('Done.', '2026-01-01T00:00:20Z', 'msg-3');
+  check('two distinct messages with identical text are two replies',
+    digestOf(twice).outSeq === 2, `seq ${digestOf(twice).outSeq}`);
+  check('so reading the first leaves the second unread',
+    idOf(twice) !== idOf(assistant('Done.', '2026-01-01T00:00:00Z', 'msg-1')));
+
+  // A second text block of ONE message is more of the same reply: same
+  // sequence, new content to be seen.
+  const twoBlocks = `${JSON.stringify({
+    type: 'assistant', timestamp: '2026-01-01T00:00:00Z', uuid: 'mb',
+    message: { id: 'mb', content: [{ type: 'text', text: 'part one' }, { type: 'text', text: 'part two' }] },
+  })}\n`;
+  const mb = digestOf(twoBlocks);
+  check('two blocks of one message are one reply', mb.outSeq === 1, `seq ${mb.outSeq}`);
+  check('but the later block changes the version to be seen',
+    mb.outHash !== digestOf(`${JSON.stringify({
+      type: 'assistant', timestamp: '2026-01-01T00:00:00Z', uuid: 'mb',
+      message: { id: 'mb', content: [{ type: 'text', text: 'part one' }] },
+    })}\n`).outHash);
 
   // Two genuinely separate replies that happen to say the same thing.
   const sameText = one + userMsg('again please', '2026-01-01T00:00:30Z') + assistant('First answer.', '2026-01-01T00:01:00Z', 'm3');
@@ -127,15 +152,21 @@ const say = (name, text) => fetch(`${API}/api/remote/${name}/messages?from=agent
   method: 'POST', headers: { 'content-type': 'text/plain' }, body: text,
 });
 const metaFor = async (id) => (await api('/api/meta')).body.sessions.find((s) => s.id === id);
+// The same rule the Overview applies, kept deliberately in one line so it
+// cannot drift into a friendlier version of itself: read means the mark names
+// EXACTLY the newest output. web/src/lib/unread.ts is the implementation the
+// app uses and web/test/unread.test.mjs pins its cases; this mirrors it so the
+// server suite is asserting what the operator would actually see.
 const unread = (s) => {
   const o = s?.output; const r = s?.read;
   if (!o || !o.seq) return false;
-  if (!r) return true;
-  return r.src !== o.src || r.seq < o.seq || (r.seq === o.seq && r.hash !== o.hash);
+  return !r || r.src !== o.src || r.seq !== o.seq || r.hash !== o.hash;
 };
 
 try {
   await waitUp();
+
+  const ack = (marks) => api('/api/read', { method: 'POST', body: JSON.stringify({ marks }) });
 
   console.log('\nthe rollout baseline: today is read, tomorrow is not');
   const a = await mkRemote('alpha');
@@ -151,9 +182,16 @@ try {
   await say('beta', 'Its very first answer.');
   check('so its FIRST reply is unread, not presumed seen', unread(await metaFor(b.id)));
 
+  console.log('\nan oversized batch is refused, not silently trimmed');
+  {
+    const big = Array.from({ length: 201 }, (_, i) => ({ id: `x${i}`, src: 's', seq: 1, hash: 'h' }));
+    const r = await ack(big);
+    check('over the cap is a 413, not a partial 200', r.status === 413, `status ${r.status}`);
+    check('and nothing is reported as done', !r.body?.results);
+  }
+
   console.log('\nacknowledging');
   const cur = await metaFor(a.id);
-  const ack = (marks) => api('/api/read', { method: 'POST', body: JSON.stringify({ marks }) });
   const okMark = { id: a.id, ...cur.output };
   check('acknowledging what is on screen is recorded', (await ack([okMark])).body.results[a.id] === 'ok');
   check('and the session is read', !unread(await metaFor(a.id)));
@@ -203,6 +241,57 @@ try {
   check('a reply that arrived mid-batch is NOT covered by it',
     (await ack(marks)).body.results[a.id] === 'ok' && unread(await metaFor(a.id)));
 
+  console.log('\na write that fails is not published as read');
+  {
+    // The reviewer's reproduction: make the marker file unwritable by putting a
+    // directory where its temp file goes. The acknowledgement must fail AND the
+    // reply must still read as unread — publishing it from memory while the
+    // bytes never landed is the failure this whole feature exists to avoid.
+    const c = await mkRemote('gamma');
+    await say('gamma', 'first');
+    await metaFor(c.id);                 // baseline covers it
+    await say('gamma', 'second, unread');
+    const before = await metaFor(c.id);
+    check('unread to begin with', unread(before));
+    const blocker = path.join(DATA_DIR, 'read-marks.json.tmp');
+    fs.mkdirSync(blocker, { recursive: true });
+    let failed = false;
+    try {
+      const r = await ack([{ id: c.id, ...before.output }]);
+      failed = r.status >= 400 || r.body?.results?.[c.id] !== 'ok';
+    } catch { failed = true; }
+    check('the acknowledgement does not report success', failed);
+    check('and the reply is STILL unread', unread(await metaFor(c.id)),
+      'a failed write must not be published from memory');
+    fs.rmSync(blocker, { recursive: true, force: true });
+    // The retry must actually write, not take an "already there" shortcut off
+    // the in-memory copy the failed attempt left behind.
+    const again = await metaFor(c.id);
+    check('the retry is accepted', (await ack([{ id: c.id, ...again.output }])).body.results[c.id] === 'ok');
+    check('and it is now read', !unread(await metaFor(c.id)));
+    const onDisk = JSON.parse(fs.readFileSync(path.join(DATA_DIR, 'read-marks.json'), 'utf8'));
+    check('the mark reached the file, not just memory', !!onDisk.marks[c.id],
+      JSON.stringify(onDisk.marks[c.id] || null));
+  }
+
+  console.log('\na replaced transcript does not inherit the old cursor');
+  {
+    // A rotated transcript restarts its sequence. The pane record cannot always
+    // tell one run from the next — OpenClaw merges several session files into
+    // one pane — so a mark numerically AHEAD of the current output must not be
+    // read as "already seen".
+    const d = await mkRemote('delta');
+    await say('delta', 'one'); await say('delta', 'two'); await say('delta', 'three');
+    const cur = await metaFor(d.id);
+    await ack([{ id: d.id, ...cur.output }]);
+    check('read after acknowledging', !unread(await metaFor(d.id)));
+    // Simulate the replacement: the same generation key, a LOWER sequence.
+    const lower = { ...cur.output, seq: 1, hash: 'freshstart' };
+    check('a lower sequence under the same generation reads as unread',
+      unread({ output: lower, read: (await metaFor(d.id)).read }),
+      'a cursor from a transcript that is gone must not cover new output');
+  }
+
   console.log('\nit survives a restart');
   const beforeRestart = (await metaFor(b.id)).read;
   srv.kill(); await sleep(700);
@@ -220,6 +309,45 @@ try {
   await api(`/api/sessions/${b.id}`, { method: 'PUT', body: JSON.stringify({ name: 'beta-renamed' }) });
   const renamed = await metaFor(b.id);
   check('a renamed session keeps its mark', !!renamed.read && !unread(renamed));
+  // ---- a fresh install whose fleet has not spoken yet ----
+  //
+  // Its own store, because the point is the FIRST pass ever taken. Waiting for
+  // some session to have output before baselining looked safer and was the
+  // opposite: on an empty fleet the baseline sat untaken until the first reply
+  // arrived, and then took that reply as history already read.
+  console.log('\na fresh install does not baseline away its first reply');
+  {
+    const fresh = fs.mkdtempSync(path.join(os.tmpdir(), 'unread-fresh-'));
+    const port = PORT + 1;
+    const child = spawn('node', ['src/index.js'], {
+      env: { ...BASE_ENV, PORT: String(port), DATA_DIR: fresh, AM_BASHRC: '/nonexistent', AM_ALLOW_MISSING_ORIGIN: '1', CLAUDE_CONFIG_DIR: CLAUDE_DIR },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    const base = `http://localhost:${port}`;
+    const call = async (route, init = {}) => {
+      const sep = route.includes('?') ? '&' : '?';
+      const r = await fetch(`${base}${route}${sep}from=operator`, { headers: { 'content-type': 'application/json' }, ...init });
+      return { status: r.status, body: await r.json().catch(() => null) };
+    };
+    try {
+      for (let i = 0; i < 120; i++) {
+        if (await fetch(`${base}/api/health`).then((r) => r.ok).catch(() => false)) break;
+        await sleep(250);
+      }
+      const only = (await call('/api/sessions', { method: 'POST', body: JSON.stringify({ cli: 'remote', name: 'solo', path: 'solo' }) })).body;
+      const seen = (await call('/api/meta')).body.sessions.find((x) => x.id === only.id);
+      check('the first poll finds nothing to read, and records nothing', !seen.output && !seen.read);
+      await fetch(`${base}/api/remote/solo/messages?from=agent`, { method: 'POST', headers: { 'content-type': 'text/plain' }, body: 'THE VERY FIRST REPLY' });
+      const after = (await call('/api/meta')).body.sessions.find((x) => x.id === only.id);
+      check('so its very first reply is UNREAD, not baselined away', unread(after),
+        JSON.stringify({ output: after.output, read: after.read }));
+      check('and the baseline was taken on that first pass, once',
+        JSON.parse(fs.readFileSync(path.join(fresh, 'read-marks.json'), 'utf8')).initialized === true);
+    } finally {
+      child.kill();
+      try { fs.rmSync(fresh, { recursive: true, force: true }); } catch { /* tmp */ }
+    }
+  }
 } catch (e) {
   check(`suite threw: ${e && e.message}`, false, log.slice(-700));
 } finally {

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,7 @@
     "build": "tsc --noEmit && vite build",
     "typecheck": "tsc --noEmit",
     "test": "node ../scripts/run-suites.mjs",
-    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs && node test/remotePaneState.render.test.mjs",
+    "test:render": "node test/statusMark.render.test.mjs && node test/stateLogo.render.test.mjs && node test/promptBand.render.test.mjs && node test/remotePaneState.render.test.mjs && node test/seenLatest.render.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,6 +16,7 @@ import BackupBanner from './components/BackupBanner';
 import OverviewSearchBox from './components/OverviewSearchBox';
 import Welcome from './components/Welcome';
 import * as api from './api';
+import { applyAck, furtherMark, type ReadMark } from './lib/unread';
 import type { Cli, GridSpec, MoveTarget, OverviewChip, OverviewSort, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
 import { hiddenSessionIds } from './lib/overviewHidden';
@@ -462,6 +463,49 @@ export default function App() {
     t = setTimeout(tick, 1500);
     return () => { alive = false; clearTimeout(t); };
   }, []);
+
+  // ---- what the operator has read ----
+  //
+  // The server owns this; these are the acknowledgements sent since the last
+  // poll answered, held so a card does not flash back to unread while the
+  // request is in flight. Merged with the server's copy by taking whichever has
+  // read further, so a poll that overtook an acknowledgement cannot regress it.
+  const [readLocal, setReadLocal] = useState<Record<string, ReadMark>>({});
+  // Marks already in flight or already landed, so a reader that keeps observing
+  // the same visible reply sends one request rather than one per frame. Keyed
+  // by the exact version, so genuinely new output is never coalesced away.
+  const ackSent = useRef<Set<string>>(new Set());
+  const markSeen = useCallback((marks: (api.OutputVersion & { id: string })[]) => {
+    const fresh = marks.filter((m) => !ackSent.current.has(`${m.id}:${m.src}:${m.seq}:${m.hash}`));
+    if (!fresh.length) return Promise.resolve(true);
+    for (const m of fresh) ackSent.current.add(`${m.id}:${m.src}:${m.seq}:${m.hash}`);
+    // Bounded: this only exists to stop repeat sends, so old entries are not
+    // worth keeping once it has grown past a fleet's worth of replies.
+    if (ackSent.current.size > 500) ackSent.current = new Set(fresh.map((m) => `${m.id}:${m.src}:${m.seq}:${m.hash}`));
+    return api.markRead(fresh)
+      .then((r) => {
+        setReadLocal((prev) => applyAck(prev, fresh, r.results));
+        // A rejected mark can be retried later against whatever is newest then;
+        // forgetting it here is what makes that possible.
+        for (const m of fresh) if (r.results[m.id] !== 'ok') ackSent.current.delete(`${m.id}:${m.src}:${m.seq}:${m.hash}`);
+        return Object.values(r.results).every((v) => v === 'ok');
+      })
+      .catch(() => {
+        // Nothing was written, so nothing is read. Drop the coalescing entries
+        // or a failed acknowledgement would never be attempted again.
+        for (const m of fresh) ackSent.current.delete(`${m.id}:${m.src}:${m.seq}:${m.hash}`);
+        return false;
+      });
+  }, []);
+  // What the Overview and the reader actually compare against.
+  const metaRead = useMemo(() => {
+    const out: Record<string, api.MetaSession> = {};
+    for (const [id, m] of Object.entries(meta)) {
+      const merged = furtherMark(m.read, readLocal[id]);
+      out[id] = merged === m.read ? m : { ...m, read: merged };
+    }
+    return out;
+  }, [meta, readLocal]);
 
   // Archive threshold from the operator config; refresh when settings closes
   // (that's where it's edited).
@@ -934,6 +978,14 @@ export default function App() {
                 focused={shown && sessions.length > 1 && s.id === focusedId}
                 visible={shown && deckVisible}
                 active={shown && deckVisible && s.id === focusedId}
+                // Only the active pane in a visible deck can acknowledge a
+                // reply: one sitting behind another is rendered but obscured,
+                // and rendering is not reading.
+                seen={shown && deckVisible && s.id === focusedId ? {
+                  version: metaRead[s.id]?.output ? { id: s.id, ...metaRead[s.id].output! } : null,
+                  clip: metaRead[s.id]?.digest?.lastAssistantText || '',
+                  onSeen: markSeen,
+                } : undefined}
                 dragId={shown && canDrag ? `p:${s.id}` : undefined}
                 isMobile={isMobile}
                 onBack={ownsBack ? () => setMobileStage(false) : undefined}
@@ -1144,8 +1196,9 @@ export default function App() {
               archived={archivedIds}
               showArchived={showArchived}
               showHidden={showHidden}
-              meta={meta}
+              meta={metaRead}
               metaReady={metaReady}
+              onSeen={markSeen}
               isMobile={isMobile}
               onOpen={(sid) => {
                 const g = tree.groups.find((x) => x.sessionIds.includes(sid));

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -16,7 +16,9 @@ import BackupBanner from './components/BackupBanner';
 import OverviewSearchBox from './components/OverviewSearchBox';
 import Welcome from './components/Welcome';
 import * as api from './api';
-import { applyAck, furtherMark, type ReadMark } from './lib/unread';
+import { applyAck, furtherMark, retireLocal, type ReadMark } from './lib/unread';
+// Matches the server's per-request cap; the client splits rather than being cut.
+const ACK_CHUNK = 100;
 import type { Cli, GridSpec, MoveTarget, OverviewChip, OverviewSort, Session, Tree } from './types';
 import { onPaneMode, readPaneMode, writePaneMode } from './lib/paneMode';
 import { hiddenSessionIds } from './lib/overviewHidden';
@@ -482,13 +484,21 @@ export default function App() {
     // Bounded: this only exists to stop repeat sends, so old entries are not
     // worth keeping once it has grown past a fleet's worth of replies.
     if (ackSent.current.size > 500) ackSent.current = new Set(fresh.map((m) => `${m.id}:${m.src}:${m.seq}:${m.hash}`));
-    return api.markRead(fresh)
-      .then((r) => {
-        setReadLocal((prev) => applyAck(prev, fresh, r.results));
+    // Sent in bounded chunks rather than one request the server would have to
+    // cap: a section larger than the cap must be acknowledged in full or report
+    // which targets were left, never silently truncated to the first N.
+    const chunks: (api.OutputVersion & { id: string })[][] = [];
+    for (let i = 0; i < fresh.length; i += ACK_CHUNK) chunks.push(fresh.slice(i, i + ACK_CHUNK));
+    return Promise.all(chunks.map((c) => api.markRead(c).then((r) => r.results)))
+      .then((all) => {
+        const results: Record<string, string> = Object.assign({}, ...all);
+        setReadLocal((prev) => applyAck(prev, fresh, results));
         // A rejected mark can be retried later against whatever is newest then;
         // forgetting it here is what makes that possible.
-        for (const m of fresh) if (r.results[m.id] !== 'ok') ackSent.current.delete(`${m.id}:${m.src}:${m.seq}:${m.hash}`);
-        return Object.values(r.results).every((v) => v === 'ok');
+        for (const m of fresh) if (results[m.id] !== 'ok') ackSent.current.delete(`${m.id}:${m.src}:${m.seq}:${m.hash}`);
+        // Every mark must come back named. A session missing from the answer is
+        // not a success, and reporting it as one is how a target gets dropped.
+        return fresh.every((m) => results[m.id] === 'ok');
       })
       .catch(() => {
         // Nothing was written, so nothing is read. Drop the coalescing entries
@@ -501,11 +511,18 @@ export default function App() {
   const metaRead = useMemo(() => {
     const out: Record<string, api.MetaSession> = {};
     for (const [id, m] of Object.entries(meta)) {
-      const merged = furtherMark(m.read, readLocal[id]);
+      const merged = furtherMark(m.read, readLocal[id], m.output);
       out[id] = merged === m.read ? m : { ...m, read: merged };
     }
     return out;
   }, [meta, readLocal]);
+  // Once the server's own copy has caught up, the local acknowledgement has
+  // nothing left to add — and a local mark for a generation that is gone would
+  // otherwise keep overriding the truth forever. Retiring them is what lets
+  // polling converge across devices.
+  useEffect(() => {
+    setReadLocal((prev) => retireLocal(prev, Object.values(meta)));
+  }, [meta]);
 
   // Archive threshold from the operator config; refresh when settings closes
   // (that's where it's edited).
@@ -983,7 +1000,7 @@ export default function App() {
                 // and rendering is not reading.
                 seen={shown && deckVisible && s.id === focusedId ? {
                   version: metaRead[s.id]?.output ? { id: s.id, ...metaRead[s.id].output! } : null,
-                  clip: metaRead[s.id]?.digest?.lastAssistantText || '',
+                  
                   onSeen: markSeen,
                 } : undefined}
                 dragId={shown && canDrag ? `p:${s.id}` : undefined}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -215,14 +215,38 @@ export interface MetaDigest {
   sinceTurns: number; sinceToolCalls: number; sinceTools: Record<string, number>; sinceFiles: string[];
   sinceTokens: number;
   running?: boolean;        // task in flight (codex task_started/task_complete)
+  // The unread cursor: which reply this is, and whether the copy above is the
+  // whole of it. See server/src/output-id.js.
+  outSeq?: number; outHash?: string; outClipped?: boolean;
   turnsLog?: TurnEntry[];   // newest-first history of completed exchanges
 }
-export interface MetaSession extends Session { digest: MetaDigest | null }
+// Which reply is newest, and which one the operator has been shown. The pair is
+// the whole unread feature: see lib/unread.ts for the comparison, and
+// server/src/output-id.js for how a reply gets its identity.
+export interface OutputVersion { src: string; seq: number; hash: string }
+export interface MetaSession extends Session {
+  digest: MetaDigest | null;
+  output?: OutputVersion | null;
+  read?: (OutputVersion & { at?: string }) | null;
+}
 export const getMeta = (): Promise<{ sessions: MetaSession[]; generatedAt: string }> =>
   fetch('/api/meta').then(json);
+
+/**
+ * "These replies were shown to the operator." Used by both read paths — a
+ * conversation scrolled to a visible latest answer, and the Unread section's
+ * Mark all read — because they make the same claim and must be judged by the
+ * same rules.
+ *
+ * Each mark is answered separately: 'ok' means recorded, anything else means
+ * the reply it described is no longer the newest, and the session stays unread.
+ */
+export const markRead = (marks: (OutputVersion & { id: string })[]): Promise<{
+  results: Record<string, string>;
+}> => fetch('/api/read', { method: 'POST', headers: HEADERS, body: JSON.stringify({ marks }) }).then(jsonOrError);
 // Targeted digest for one session (progressive tile fill); digest is null when
 // this CLI only resolves through the bulk pass.
-export const getMetaOne = (id: string): Promise<{ id: string; digest: MetaDigest | null }> =>
+export const getMetaOne = (id: string): Promise<{ id: string; digest: MetaDigest | null; output?: OutputVersion | null; read?: (OutputVersion & { at?: string }) | null }> =>
   fetch(`/api/meta/${id}`).then(json);
 // ---------- remote agents ----------
 // The pane polls this at the app's usual 2 s cadence. since=0 returns the tail;

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -6,7 +6,7 @@ import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionS
 import { chipBuckets, isPassive, isRemote, STATE_LABEL, REMOTE_STATE_LABEL } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
-import { isUnread, markFor } from '../lib/unread';
+import { answerMatches, isUnread, markFor } from '../lib/unread';
 import { useSeenLatest } from './useSeenLatest';
 import { matchesOverviewSearch } from '../lib/overviewSearch';
 import { hiddenSessionIds } from '../lib/overviewHidden';
@@ -316,7 +316,24 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose, onSe
   // The version acknowledged is `s.output`, which came from the same digest as
   // the text above it — so the identity always describes the words on screen
   // rather than whatever the server happens to have parsed since.
-  const canSee = !!(windowed && onSeen && !entry && showAnswer && !d?.outClipped && s.output);
+  // Two branches can draw the reply, and each has its own way of not being the
+  // newest one in full:
+  //
+  //   transcript branch — the reader-grade view. It shows the whole answer, so
+  //     the card's clip limit does not apply; it must not be paged back
+  //     (`back > 0` prepends earlier exchanges but `latestX` stays newest, so
+  //     what matters is that the rendered answer IS the version we would claim).
+  //   digest branch     — a summary. It must be the live latest (`!entry`), it
+  //     must actually be rendered, and it must not be the truncated copy of a
+  //     reply longer than the card can hold.
+  const transcriptShown = !!latestX;
+  const answerTexts = transcriptShown
+    ? (latestX.answer || []).flatMap((t) => t.blocks || [])
+      .filter((b) => b.type === 'text').map((b) => (b as { text: string }).text || '')
+    : [];
+  const canSee = !!(windowed && onSeen && s.output && (transcriptShown
+    ? answerMatches(answerTexts, s.output.hash)
+    : (!entry && showAnswer && !d?.outClipped)));
   const seenRef = useSeenLatest({
     version: canSee && s.output ? { id: s.id, ...s.output } : null,
     eligible: canSee,
@@ -362,6 +379,11 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose, onSe
                 open={openWork}
                 onToggle={() => setOpenWork((o) => !o)}
                 running={running && !justSent}
+                // The expanded conversation acknowledges from whichever branch
+                // is actually drawing the reply. Once a real transcript loads,
+                // this is it — the digest fallback below is no longer on screen,
+                // and an observer left only there would stop clearing anything.
+                answerRef={windowed ? (node) => { seenRef.current = node; } : undefined}
               />
             </div>
             {/* Optimistic echo: the digest round-trip can take seconds, and a
@@ -702,8 +724,14 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
     // flight. Its unread state is untouched, so it arrives here the moment it
     // stops. Carving rather than copying is what keeps a session in exactly one
     // block — the sort's own order survives inside each.
-    const unread = [...ranked.dated, ...ranked.undated].filter((r) => isUnread(r.m));
-    const keep = (rows: typeof ranked.dated) => rows.filter((r) => !isUnread(r.m));
+    // `atWork`, not the ranking pin: when the chip has already narrowed the feed
+    // to working agents the pin is deliberately switched off (it would empty the
+    // sorted block), and reading that flag here would sweep every running agent
+    // into Unread — where Mark all read would then clear them, against both the
+    // section's rule and the button's own promise.
+    const stillWorking = (r: { m: MetaSession }) => atWork(r.m);
+    const unread = [...ranked.dated, ...ranked.undated].filter((r) => !stillWorking(r) && isUnread(r.m));
+    const keep = (rows: typeof ranked.dated) => rows.filter((r) => stillWorking(r) || !isUnread(r.m));
     return { running: ranked.running, dated: keep(ranked.dated), undated: keep(ranked.undated), unread };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived, hiddenIds, showHidden, groupNameOf, query]);

--- a/web/src/components/Overview.tsx
+++ b/web/src/components/Overview.tsx
@@ -1,11 +1,13 @@
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import type { CSSProperties, ReactNode } from 'react';
 import * as api from '../api';
-import type { MetaSession, TraceTurn } from '../api';
+import type { MetaSession, OutputVersion, TraceTurn } from '../api';
 import type { Cli, OverviewChip, OverviewFilter, OverviewSort, Session, SessionState, Tree } from '../types';
 import { chipBuckets, isPassive, isRemote, STATE_LABEL, REMOTE_STATE_LABEL } from '../types';
 import { renderMarkdown } from '../lib/markdown';
 import { rankSessions, sortLabel } from '../lib/overviewSort';
+import { isUnread, markFor } from '../lib/unread';
+import { useSeenLatest } from './useSeenLatest';
 import { matchesOverviewSearch } from '../lib/overviewSearch';
 import { hiddenSessionIds } from '../lib/overviewHidden';
 import type { Rankable } from '../lib/overviewSort';
@@ -134,7 +136,7 @@ const Caret = () => (
  * two, and history grows one turn at a time instead of a stepper that replaced
  * the answer with an older one.
  */
-export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
+export function Card({ s, color, group, pending, isMobile, onOpen, onClose, onSeen }: {
   s: MetaSession;
   color?: string;
   // The group this agent belongs to, when the feed is not already drawing one
@@ -144,6 +146,8 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   isMobile?: boolean;
   onOpen: (sid: string) => void;
   onClose?: () => void; // present when the card lives in the conversation window
+  // Present only where the whole reply is on screen: the expanded window.
+  onSeen?: (marks: (OutputVersion & { id: string })[]) => Promise<boolean> | void;
 }) {
   const d = s.digest;
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -298,6 +302,27 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
   const showAnswer = entry ? !!answerText : (!!answerText && (answerFresh || !running));
   const answerHtml = showAnswer ? renderMarkdown(answerMd || answerText) : '';
 
+  // Reading the expanded conversation is one of the two surfaces that can
+  // acknowledge a reply. Every condition below is a way this card could be
+  // showing something that is NOT the newest reply in full:
+  //
+  //   windowed    — a compact tile or card preview is a summary, not the reply.
+  //   onSeen      — only the expanded window is given the callback at all.
+  //   !entry      — the operator has paged back to an earlier turn.
+  //   showAnswer  — nothing is rendered yet (running, or a just-sent prompt).
+  //   !outClipped — the answer is longer than the card's copy of it, so the
+  //                 tail was never shown. That one is finished in the reader.
+  //
+  // The version acknowledged is `s.output`, which came from the same digest as
+  // the text above it — so the identity always describes the words on screen
+  // rather than whatever the server happens to have parsed since.
+  const canSee = !!(windowed && onSeen && !entry && showAnswer && !d?.outClipped && s.output);
+  const seenRef = useSeenLatest({
+    version: canSee && s.output ? { id: s.id, ...s.output } : null,
+    eligible: canSee,
+    onSeen: onSeen || (() => {}),
+  });
+
   return (
     <div className={`ov-card${windowed ? '' : ' ov-compact'}`}>
       <div className="ov-id" onClick={() => onOpen(s.id)} title="Open pane">
@@ -374,7 +399,7 @@ export function Card({ s, color, group, pending, isMobile, onOpen, onClose }: {
               </div>
             )}
             {answerHtml && (
-              <div className="ov-answer-wrap">
+              <div className="ov-answer-wrap" ref={seenRef}>
                 <div className="markdown ov-md" dangerouslySetInnerHTML={{ __html: answerHtml }} />
               </div>
             )}
@@ -538,7 +563,7 @@ export function Tile({ s, color, group, dim, pending, onOpen }: { s: MetaSession
 /** Mission control: one reading column — group capsules with their agents as
  *  slabs, loose agents as standalone panels. Unless a sort is on, in which case
  *  it is one flat ranked column instead (see §"sorted feed" below). */
-export default function Overview({ clis, tree, chip, sort, query, view, archived, showArchived, showHidden, meta, metaReady, isMobile, onOpen }: {
+export default function Overview({ clis, tree, chip, sort, query, view, archived, showArchived, showHidden, meta, metaReady, onSeen, isMobile, onOpen }: {
   clis: Cli[];
   tree: Tree;
   chip: OverviewChip;     // controlled by the bottom bar in App
@@ -553,12 +578,40 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
   showHidden: boolean;
   meta: Record<string, MetaSession>; // continuously polled in App; instant on open
   metaReady: boolean;                // false until the first poll lands
+  // "These replies were shown." Resolves false when nothing was durably
+  // recorded, which is what Mark all read reports as a retryable failure.
+  onSeen: (marks: (OutputVersion & { id: string })[]) => Promise<boolean>;
   isMobile: boolean;
   onOpen: (sid: string) => void;
 }) {
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [durs, setDurs] = useState<Record<string, number>>({});
   const [openId, setOpenId] = useState<string | null>(null); // conversation window
+  // Mark all read: one batch at a time, with the versions captured when it was
+  // clicked. A reply arriving mid-request is not in that batch, so the server
+  // rejects the mark that would have covered it and the card stays unread —
+  // which is the point. Retry deliberately reuses the ORIGINAL capture rather
+  // than rescanning, so a slow request cannot quietly widen what it clears.
+  const [marking, setMarking] = useState(false);
+  const [markFailed, setMarkFailed] = useState<(OutputVersion & { id: string })[] | null>(null);
+  const markAllRead = async (rows: MetaSession[]) => {
+    if (marking) return;
+    const batch = rows.map(markFor).filter(Boolean) as (OutputVersion & { id: string })[];
+    if (!batch.length) return;
+    setMarking(true); setMarkFailed(null);
+    const ok = await onSeen(batch);
+    setMarking(false);
+    // Truthful: nothing is claimed read unless the server said so. On failure
+    // the section stays exactly as it was, with one compact way to try again.
+    if (!ok) setMarkFailed(batch);
+  };
+  const retryMarkRead = async () => {
+    if (marking || !markFailed) return;
+    setMarking(true);
+    const ok = await onSeen(markFailed);
+    setMarking(false);
+    if (ok) setMarkFailed(null);
+  };
   useEffect(() => {
     if (!openId) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpenId(null); };
@@ -642,8 +695,16 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
     // Until the first /api/meta lands every digest is null, which would file the
     // whole fleet under "nothing sent yet" — a labelled claim about agents we
     // know nothing about yet. One unlabelled block until we do.
-    if (!metaReady) return { running: [], dated: items, undated: [] };
-    return rankSessions(items, sort);
+    if (!metaReady) return { running: [], dated: items, undated: [], unread: [] };
+    const ranked = rankSessions(items, sort);
+    // Unread is carved out of the ranked tail, never out of `running`: an agent
+    // still working stays in the block the operator watches while work is in
+    // flight. Its unread state is untouched, so it arrives here the moment it
+    // stops. Carving rather than copying is what keeps a session in exactly one
+    // block — the sort's own order survives inside each.
+    const unread = [...ranked.dated, ...ranked.undated].filter((r) => isUnread(r.m));
+    const keep = (rows: typeof ranked.dated) => rows.filter((r) => !isUnread(r.m));
+    return { running: ranked.running, dated: keep(ranked.dated), undated: keep(ranked.undated), unread };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [sorted, sort, tree.order, sessById, groupById, meta, metaReady, chip, archived, showArchived, hiddenIds, showHidden, groupNameOf, query]);
 
@@ -721,6 +782,7 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
     type Row = { id: string; m: MetaSession };
     const blocks = [
       { key: 'running', label: 'running now', rows: sections.running },
+      { key: 'unread', label: 'unread', rows: sections.unread },
       // No label before the first poll answers: `sections` is unranked then.
       { key: 'dated', label: metaReady ? sortLabel(sort) : '', rows: sections.dated },
       { key: 'undated', label: sort === 'prompt' ? 'nothing sent yet' : 'no reply yet', rows: sections.undated },
@@ -739,6 +801,22 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
       if (b.label) out.push(
         <div className="ov-sortlbl mono" key={`lbl:${b.key}`}>
           <span>{b.label}</span><span className="ov-sortrule" /><span className="ov-sortn">{b.rows.length}</span>
+          {b.key === 'unread' && markFailed && (
+            <button className="ov-markread ov-markerr" onClick={() => void retryMarkRead()} disabled={marking}>
+              couldn’t save · retry
+            </button>
+          )}
+          {b.key === 'unread' && !markFailed && (
+            <button
+              className="ov-markread"
+              disabled={marking}
+              // Says what it will and will not touch: this section as it stands,
+              // which is the filtered set on screen — not the running agents
+              // above it, and not anything a filter is currently hiding.
+              title={`Mark the ${b.rows.length} unread ${b.rows.length === 1 ? 'reply' : 'replies'} in this section as read. Running agents and anything the current filters hide are left alone.`}
+              onClick={() => void markAllRead(b.rows.map((r) => r.m))}
+            >{marking ? 'marking…' : 'Mark all read'}</button>
+          )}
         </div>,
       );
       for (const { m } of b.rows as Row[]) {
@@ -761,7 +839,8 @@ export default function Overview({ clis, tree, chip, sort, query, view, archived
         {/* The window shows ONE agent on its own — no capsule around it, sorted
             or not — so it names its group the way a pane header does. */}
         <Card s={dataFor(openSess)} color={colorOf[openSess.cli]} group={groupNameOf[openSess.id]}
-          pending={pending(openSess.id)} isMobile={isMobile} onOpen={onOpen} onClose={() => setOpenId(null)} />
+          pending={pending(openSess.id)} isMobile={isMobile} onOpen={onOpen} onClose={() => setOpenId(null)}
+          onSeen={onSeen} />
       </div>
     </div>
   );

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -10,6 +10,7 @@ import { STATE_LABEL, isRemote } from '../types';
 import StateLogo from './StateLogo';
 import TraceInfo from './TraceInfo';
 import ConversationView from './conversation/ConversationView';
+import type { ConversationSeen } from './conversation/ConversationView';
 import { isPassive } from '../types';
 import type { PaneMode } from '../lib/paneMode';
 import { groupLabel, sessionTitle } from '../lib/sessionTitle';
@@ -191,10 +192,14 @@ if (typeof window !== 'undefined') {
 export default function TerminalPane({
   session, cli, theme, focused, visible, active, zoom = 100, mode = 'terminal',
   dragId, isMobile, groupName, onBack, onDragActive, onFocus, onRename, onClose,
-  onShare,
+  onShare, seen,
 }: {
   session: Session;
   cli?: Cli;
+  // The unread cursor, passed straight to the reader. Only supplied while this
+  // pane is the active one, so a pane sitting behind another in a deck cannot
+  // acknowledge a reply nobody is looking at.
+  seen?: ConversationSeen;
   theme: 'light' | 'dark';
   groupName?: string | null; // the group this pane belongs to, if any
   focused?: boolean;
@@ -1219,6 +1224,7 @@ export default function TerminalPane({
               onCloseSearch={() => setSearchOpen(false)}
               onAttachPicker={setReaderAttach}
               onHead={(head) => { setReaderFacts(head); setReaderLoaded(head?.loaded); }}
+              seen={seen}
             />
           </div>
         )}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -2,19 +2,17 @@ import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, use
 import * as api from '../../api';
 import type { OutputVersion, SubAgentEntry } from '../../api';
 import { useSeenLatest } from '../useSeenLatest';
+import { answerMatches } from '../../lib/unread';
 
 /**
  * The unread cursor for one session, as the reader needs it.
  *
- * `clip` is the Overview digest's copy of the same reply, used only to check
- * that both surfaces are describing the same one — the identity itself is
- * `version`, which the server produced. Without that check a reader still
- * showing turn N could acknowledge an N+1 the poll had already learned about
- * and the operator had never seen.
+ * The reader proves it is showing this exact reply by hashing what it rendered
+ * and comparing against `version.hash`, so a reader still displaying turn N
+ * cannot acknowledge an N+1 the poll had already learned about.
  */
 export interface ConversationSeen {
   version: (OutputVersion & { id: string }) | null;
-  clip: string;
   onSeen: (marks: (OutputVersion & { id: string })[]) => Promise<boolean> | void;
 }
 import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib/traceWindows';
@@ -239,24 +237,22 @@ export default function ConversationView({
   //     scrolled far out of view is not in the DOM and cannot be observed at all
   //   no search — a query shows matching older turns; the newest may not be
   //     among them, and a match is not the latest reply
-  //   the answer agrees with the Overview's copy of it — the two surfaces parse
-  //     the transcript separately, so this is what proves the reader has caught
-  //     up with the version being acknowledged rather than lagging a poll behind
-  // Only `text` blocks: thinking, tool calls and their results are not what the
-  // Overview's copy of the reply contains, and are not what the operator reads
-  // as the answer.
-  const lastAnswer = exchanges.length
+  //   the rendered answer hashes to the version being acknowledged — the two
+  //     surfaces parse the transcript separately, so this is what proves the
+  //     reader has caught up rather than lagging a poll behind. It is an exact
+  //     content identity, not a prefix: two replies routinely share their first
+  //     few hundred characters, and a growing streaming answer differs only in
+  //     the tail, which is precisely what a prefix cannot see.
+  //
+  // Only `text` blocks: thinking, tool calls and their results are not the
+  // reply, and are not what the server hashed.
+  const answerTexts = exchanges.length
     ? (exchanges[exchanges.length - 1].answer || [])
       .flatMap((t) => t.blocks || [])
       .filter((b) => b.type === 'text')
       .map((b) => (b as { text: string }).text || '')
-      .join(' ')
-    : '';
-  const norm = (t: string) => t.replace(/\s+/g, ' ').trim();
-  const clip = norm(seen?.clip || '');
-  // The digest's copy is clipped to 280 characters with an ellipsis, so the
-  // reader's full text starts with it rather than equalling it.
-  const agrees = !!clip && norm(lastAnswer).startsWith(clip.replace(/…$/, ''));
+    : [];
+  const agrees = !!seen?.version && answerMatches(answerTexts, seen.version.hash);
   const canSee = !!(seen?.version && !q && agrees && exchanges.length);
   const seenRef = useSeenLatest({
     version: canSee && seen?.version ? seen.version : null,
@@ -300,16 +296,14 @@ export default function ConversationView({
         {q && <div className="cxv-msg mono">{shown.length} of {exchanges.length} loaded turns match{atStart ? '' : ' · Earlier history has not been searched'}</div>}
         <div ref={virtual.container}>
           <div aria-hidden="true" style={{ height: virtual.before }} />
-          {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => {
-            virtual.measure(x.key, node);
-            // Only the newest exchange carries the read observer. Being in this
-            // slice at all means it is rendered; the observer then decides
-            // whether it is actually on screen.
-            if (n === exchanges.length - 1) seenRef.current = node;
-          }}>
+          {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => virtual.measure(x.key, node)}>
             <ExchangeView x={x} n={n + 1} total={exchanges.length} q={q || undefined} baseModel={head?.model || undefined}
               open={q ? undefined : openWork.get(x.key) || false} onToggle={() => setOpenWork((map) => new Map(map).set(x.key, !map.get(x.key)))}
-              running={live && n === exchanges.length - 1 && !sent} turns={turns} sessionId={session.id} live={!!session.running && !paused} roster={roster} />
+              running={live && n === exchanges.length - 1 && !sent} turns={turns} sessionId={session.id} live={!!session.running && !paused} roster={roster}
+              // The observer rides the newest exchange's ANSWER. Watching the
+              // whole exchange would let a visible prompt, with its answer
+              // thousands of pixels below the fold, clear the unread mark.
+              answerRef={n === exchanges.length - 1 ? (node) => { seenRef.current = node; } : undefined} />
           </div>)}
           <div aria-hidden="true" style={{ height: virtual.after }} />
         </div>

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -1,6 +1,22 @@
 import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../../api';
-import type { SubAgentEntry } from '../../api';
+import type { OutputVersion, SubAgentEntry } from '../../api';
+import { useSeenLatest } from '../useSeenLatest';
+
+/**
+ * The unread cursor for one session, as the reader needs it.
+ *
+ * `clip` is the Overview digest's copy of the same reply, used only to check
+ * that both surfaces are describing the same one — the identity itself is
+ * `version`, which the server produced. Without that check a reader still
+ * showing turn N could acknowledge an N+1 the poll had already learned about
+ * and the operator had never seen.
+ */
+export interface ConversationSeen {
+  version: (OutputVersion & { id: string }) | null;
+  clip: string;
+  onSeen: (marks: (OutputVersion & { id: string })[]) => Promise<boolean> | void;
+}
 import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib/traceWindows';
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
@@ -24,7 +40,7 @@ import { writePaneMode } from '../../lib/paneMode';
 /** The reader owns presentation and draft state. The store owns the transcript;
  * the virtual list owns measurement. Neither requires a terminal attachment. */
 export default function ConversationView({
-  session, paused, isMobile, readOnly, onHandover, searchOpen, onCloseSearch, onAttachPicker, onHead,
+  session, paused, isMobile, readOnly, onHandover, searchOpen, onCloseSearch, onAttachPicker, onHead, seen,
 }: {
   session: Session;
   paused?: boolean;
@@ -35,6 +51,18 @@ export default function ConversationView({
   onCloseSearch?: () => void;
   onAttachPicker?: (picker: { open: () => void; disabled: boolean; reason?: string } | null) => void;
   onHead?: (head: TraceHeadInfo | null) => void;
+  /**
+   * The unread cursor for this session, when the app is tracking one. The
+   * reader is the surface that shows a reply in full, so it is where a long
+   * answer the Overview had to clip can actually be acknowledged.
+   *
+   * `clip` is the Overview digest's copy of the same reply, used only to check
+   * the two surfaces are talking about the same one — the identity itself is
+   * `version`, which the server produced. Without that check a reader still
+   * showing turn N could acknowledge an N+1 the poll had already learned about
+   * and the operator had never seen.
+   */
+  seen?: ConversationSeen;
 }) {
   const scroller = useRef<HTMLDivElement>(null);
   const following = useRef(true);
@@ -204,6 +232,38 @@ export default function ConversationView({
   useEffect(() => { reportHead.current?.(head); }, [head]);
   useEffect(() => () => reportHead.current?.(null), []);
 
+  // Acknowledging a reply from the reader needs the reader to be showing that
+  // exact reply, not merely to be open on this session.
+  //
+  //   the last exchange is rendered — the list is virtual, so an exchange
+  //     scrolled far out of view is not in the DOM and cannot be observed at all
+  //   no search — a query shows matching older turns; the newest may not be
+  //     among them, and a match is not the latest reply
+  //   the answer agrees with the Overview's copy of it — the two surfaces parse
+  //     the transcript separately, so this is what proves the reader has caught
+  //     up with the version being acknowledged rather than lagging a poll behind
+  // Only `text` blocks: thinking, tool calls and their results are not what the
+  // Overview's copy of the reply contains, and are not what the operator reads
+  // as the answer.
+  const lastAnswer = exchanges.length
+    ? (exchanges[exchanges.length - 1].answer || [])
+      .flatMap((t) => t.blocks || [])
+      .filter((b) => b.type === 'text')
+      .map((b) => (b as { text: string }).text || '')
+      .join(' ')
+    : '';
+  const norm = (t: string) => t.replace(/\s+/g, ' ').trim();
+  const clip = norm(seen?.clip || '');
+  // The digest's copy is clipped to 280 characters with an ellipsis, so the
+  // reader's full text starts with it rather than equalling it.
+  const agrees = !!clip && norm(lastAnswer).startsWith(clip.replace(/…$/, ''));
+  const canSee = !!(seen?.version && !q && agrees && exchanges.length);
+  const seenRef = useSeenLatest({
+    version: canSee && seen?.version ? seen.version : null,
+    eligible: canSee,
+    onSeen: seen?.onSeen || (() => {}),
+  });
+
   return <div className="cxv">
     <div className="cxv-bar cxv-status mono">
       <span>{head ? `${exchanges.length.toLocaleString()} turns loaded` : phase === 'loading' ? 'Reading transcript…' : 'Conversation'}</span>
@@ -240,7 +300,13 @@ export default function ConversationView({
         {q && <div className="cxv-msg mono">{shown.length} of {exchanges.length} loaded turns match{atStart ? '' : ' · Earlier history has not been searched'}</div>}
         <div ref={virtual.container}>
           <div aria-hidden="true" style={{ height: virtual.before }} />
-          {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => virtual.measure(x.key, node)}>
+          {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => {
+            virtual.measure(x.key, node);
+            // Only the newest exchange carries the read observer. Being in this
+            // slice at all means it is rendered; the observer then decides
+            // whether it is actually on screen.
+            if (n === exchanges.length - 1) seenRef.current = node;
+          }}>
             <ExchangeView x={x} n={n + 1} total={exchanges.length} q={q || undefined} baseModel={head?.model || undefined}
               open={q ? undefined : openWork.get(x.key) || false} onToggle={() => setOpenWork((map) => new Map(map).set(x.key, !map.get(x.key)))}
               running={live && n === exchanges.length - 1 && !sent} turns={turns} sessionId={session.id} live={!!session.running && !paused} roster={roster} />

--- a/web/src/components/conversation/Exchange.tsx
+++ b/web/src/components/conversation/Exchange.tsx
@@ -425,9 +425,13 @@ function LiveAgents({ rows, sessionId, live, rosterKnown, roster, ancestors }: {
 }
 
 export function ExchangeView({
-  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live, roster, ancestors,
+  x, n, total, open, onToggle, running, dim, q, baseModel, turns, sessionId, live, roster, ancestors, answerRef,
 }: {
   x: Exchange;
+  /** Attached to the ANSWER, not the exchange: the unread cursor is cleared by
+   *  seeing the reply, and a visible prompt above a long run of work is not
+   *  that. See useSeenLatest. */
+  answerRef?: (node: HTMLDivElement | null) => void;
   n?: number;            // 1-based position — the viewer numbers turns, a card does not
   total?: number;
   open?: boolean;        // controlled fold of the work
@@ -599,7 +603,7 @@ export function ExchangeView({
           when the agent answered and then kept going, `answerAt` puts it back
           between the two runs of steps instead of under work it predates. */}
       {answerHtml ? (
-        <div className="cx-answer">
+        <div className="cx-answer" ref={answerRef}>
           <div className="markdown cx-md" dangerouslySetInnerHTML={{ __html: answerHtml }} />
           {!!answerMore && <div className="cx-note mono">…{moreLabel(answerMore)}</div>}
         </div>

--- a/web/src/components/useSeenLatest.ts
+++ b/web/src/components/useSeenLatest.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import type { OutputVersion } from '../api';
+
+/**
+ * Acknowledge a reply only once it has actually been put in front of the
+ * operator.
+ *
+ * The bar is deliberately higher than "the component rendered". Mounting a
+ * conversation, selecting a route, a fetch resolving, or the reader's `At
+ * latest` flag all say something about the program, not about what the operator
+ * can see. So this asks the browser instead: is the element carrying the latest
+ * reply intersecting the viewport, in a foreground tab, on a surface the caller
+ * says is the active one?
+ *
+ * `eligible` is the caller's own honesty check — that what is on screen really
+ * is the newest reply and really is complete. A card paged back to an older
+ * turn, a clipped answer, a reader scrolled up: all of those render an element
+ * that is perfectly visible and are not the thing we would be acknowledging.
+ *
+ * Fires once per version. A newer reply is a new version, so it needs its own
+ * observation; nothing here ever says "mark whatever is latest read".
+ */
+export function useSeenLatest({ version, eligible, onSeen }: {
+  /** The exact output being displayed, or null when there is nothing to claim. */
+  version: (OutputVersion & { id: string }) | null;
+  /** Caller's guard: is this element really showing that version, in full? */
+  eligible: boolean;
+  onSeen: (marks: (OutputVersion & { id: string })[]) => Promise<boolean> | void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const done = useRef<string>('');
+  const cb = useRef(onSeen);
+  cb.current = onSeen;
+
+  const key = version ? `${version.id}:${version.src}:${version.seq}:${version.hash}` : '';
+  useEffect(() => {
+    const el = ref.current;
+    if (!el || !version || !eligible || done.current === key) return undefined;
+
+    let cancelled = false;
+    const fire = () => {
+      if (cancelled || done.current === key) return;
+      // A background tab renders and reports intersection perfectly well. The
+      // operator is not looking at it.
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
+      done.current = key;
+      void cb.current([version]);
+    };
+
+    // No IntersectionObserver (jsdom, very old browsers): do nothing rather
+    // than fall back to "it exists, so it was seen" — the whole point is that
+    // presence is not evidence.
+    if (typeof IntersectionObserver === 'undefined') return undefined;
+    // A slice of the answer is enough: a long reply may not fit the viewport at
+    // any scroll position, and demanding all of it would never acknowledge one.
+    const io = new IntersectionObserver((entries) => {
+      for (const e of entries) if (e.isIntersecting) fire();
+    }, { threshold: 0.15 });
+    io.observe(el);
+    // Coming back to the tab with the reply already on screen counts; the
+    // observer will not re-fire on its own for an element that never moved.
+    const onVis = () => {
+      if (document.visibilityState !== 'visible') return;
+      const r = el.getBoundingClientRect();
+      const h = window.innerHeight || 0;
+      if (r.bottom > 0 && r.top < h) fire();
+    };
+    document.addEventListener('visibilitychange', onVis);
+    return () => { cancelled = true; io.disconnect(); document.removeEventListener('visibilitychange', onVis); };
+  }, [key, eligible, version]);
+
+  return ref;
+}

--- a/web/src/components/useSeenLatest.ts
+++ b/web/src/components/useSeenLatest.ts
@@ -25,10 +25,14 @@ export function useSeenLatest({ version, eligible, onSeen }: {
   version: (OutputVersion & { id: string }) | null;
   /** Caller's guard: is this element really showing that version, in full? */
   eligible: boolean;
+  /** Resolves false when nothing was durably stored, which schedules a retry. */
   onSeen: (marks: (OutputVersion & { id: string })[]) => Promise<boolean> | void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
   const done = useRef<string>('');
+  // One attempt at a time for a given version, so a burst of intersection
+  // callbacks is one request rather than a queue of identical ones.
+  const inFlight = useRef<string>('');
   const cb = useRef(onSeen);
   cb.current = onSeen;
 
@@ -39,12 +43,21 @@ export function useSeenLatest({ version, eligible, onSeen }: {
 
     let cancelled = false;
     const fire = () => {
-      if (cancelled || done.current === key) return;
+      if (cancelled || done.current === key || inFlight.current === key) return;
       // A background tab renders and reports intersection perfectly well. The
       // operator is not looking at it.
       if (typeof document !== 'undefined' && document.visibilityState !== 'visible') return;
-      done.current = key;
-      void cb.current([version]);
+      // Claimed, not finished. Marking it done here would retire the version on
+      // a request that never stored anything: the reply stays unread on the
+      // server and this observer refuses to try again for as long as it lives.
+      // It becomes done only when the write is confirmed.
+      inFlight.current = key;
+      Promise.resolve(cb.current([version])).then((ok) => {
+        inFlight.current = '';
+        // `undefined` means the caller does not report an outcome; treat that as
+        // done rather than retrying forever against a caller that cannot answer.
+        if (ok !== false) done.current = key;
+      }).catch(() => { inFlight.current = ''; });
     };
 
     // No IntersectionObserver (jsdom, very old browsers): do nothing rather
@@ -56,6 +69,9 @@ export function useSeenLatest({ version, eligible, onSeen }: {
     const io = new IntersectionObserver((entries) => {
       for (const e of entries) if (e.isIntersecting) fire();
     }, { threshold: 0.15 });
+    // Scrolling away and back is a fresh chance for a version whose write
+    // failed: the observer fires again on re-entry, and `done` was never set.
+
     io.observe(el);
     // Coming back to the tab with the reply already on screen counts; the
     // observer will not re-fire on its own for an element that never moved.

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -40,10 +40,16 @@ export function isUnread(s: Readable): boolean {
   const o = s.output;
   if (!o || !o.seq) return false;
   const r = s.read;
-  if (!r) return true;
-  if (r.src !== o.src) return true;
-  if (r.seq < o.seq) return true;
-  return r.seq === o.seq && r.hash !== o.hash;
+  // Read means the mark names EXACTLY what is newest. Anything else is unread.
+  //
+  // The strictness earns its keep on the "mark is further along" case, which is
+  // not the impossibility it looks like: a rotated or replaced transcript
+  // restarts its sequence at 1, and a harness whose runs cannot be told apart
+  // from the pane record alone — OpenClaw merges several session files into one
+  // pane — will present that new reply under the same generation key. Reading
+  // `mark.seq >= output.seq` as "seen it" hides genuinely new output behind a
+  // cursor from a transcript that no longer exists.
+  return !r || r.src !== o.src || r.seq !== o.seq || r.hash !== o.hash;
 }
 
 /**
@@ -84,13 +90,53 @@ export function markFor(s: Readable): (OutputVersion & { id: string }) | null {
  * mark from a different generation is not comparable at all — the newer
  * generation wins, because the older one describes a transcript that is gone.
  */
-export function furtherMark(a: ReadMark | null | undefined, b: ReadMark | null | undefined): ReadMark | null {
-  if (!a) return b || null;
-  if (!b) return a;
-  if (a.src !== b.src) return b; // b is the one the caller just learned about
-  if (b.seq > a.seq) return b;
-  if (b.seq === a.seq && b.hash !== a.hash) return b;
-  return a;
+export function furtherMark(
+  server: ReadMark | null | undefined,
+  local: ReadMark | null | undefined,
+  output?: OutputVersion | null,
+): ReadMark | null {
+  if (!local) return server || null;
+  if (!server) return local;
+  // Different generations are not comparable by number, so neither "further"
+  // nor "newer argument" decides it — the current output does. Whichever mark
+  // belongs to the transcript in front of us is the only one that can describe
+  // it; a local mark left over from the previous generation must not shout down
+  // a server mark another device just wrote for this one.
+  if (server.src !== local.src) {
+    if (output?.src === server.src) return server;
+    if (output?.src === local.src) return local;
+    return server; // unknowable: the server is the authority
+  }
+  if (local.seq > server.seq) return local;
+  // Same position, different content: the local one was observed against text
+  // the server had not published yet, so it is the later observation.
+  if (local.seq === server.seq && local.hash !== server.hash && server.hash !== output?.hash) return local;
+  return server;
+}
+
+/**
+ * Local acknowledgements the server has caught up with, and can stop being
+ * remembered. Without this the local map only ever grows, and a mark from a
+ * generation that is gone stays in it forever.
+ */
+export function retireLocal(
+  local: Record<string, ReadMark>,
+  sessions: Readable[],
+): Record<string, ReadMark> {
+  const keep: Record<string, ReadMark> = {};
+  let dropped = false;
+  const byId = new Map(sessions.map((s) => [s.id, s]));
+  for (const [id, mark] of Object.entries(local)) {
+    const s = byId.get(id);
+    const server = s?.read;
+    const covered = !s // the session is gone
+      || (server && server.src === mark.src && (server.seq > mark.seq
+        || (server.seq === mark.seq && server.hash === mark.hash)))
+      // A mark for a generation that is no longer the current one says nothing.
+      || (s.output && s.output.src !== mark.src);
+    if (covered) dropped = true; else keep[id] = mark;
+  }
+  return dropped ? keep : local;
 }
 
 /**
@@ -117,4 +163,43 @@ export function applyAck(
     changed = true;
   }
   return changed ? next : prev;
+}
+
+/**
+ * The server's output hash, recomputed in the browser.
+ *
+ * Duplicated from server/src/output-id.js on purpose: the reader has to be able
+ * to say "the reply I am showing IS the one this version names", and the only
+ * way to say that exactly is to hash the same bytes the server hashed. A
+ * prefix comparison cannot — two different replies routinely share their first
+ * few hundred characters, and a streaming answer's tail is exactly what a
+ * prefix ignores. web/test/unread.test.mjs pins the two implementations to the
+ * same vectors so they cannot drift apart silently.
+ */
+export function outputHash(text: string): string {
+  const t = String(text ?? '');
+  let h = 0x811c9dc5;
+  for (let i = 0; i < t.length; i++) {
+    h ^= t.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return `${h.toString(36)}${t.length.toString(36)}`;
+}
+
+/**
+ * Is the rendered answer the reply this version names?
+ *
+ * The harnesses hand their assistant text to the digest in slightly different
+ * shapes — Claude one text block at a time, the others a whole message — so the
+ * candidates are the last text block and the blocks joined. A match on either is
+ * an exact content identity. No match means the reader is showing something
+ * else (an older turn, a stale window, a differently assembled message), and
+ * the caller must leave the reply unread rather than guess.
+ */
+export function answerMatches(texts: string[], hash: string): boolean {
+  if (!hash || !texts.length) return false;
+  const last = texts[texts.length - 1];
+  return outputHash(last) === hash
+    || outputHash(texts.join('\n')) === hash
+    || outputHash(texts.join('')) === hash;
 }

--- a/web/src/lib/unread.ts
+++ b/web/src/lib/unread.ts
@@ -1,0 +1,120 @@
+// Has the operator read this agent's latest reply?
+//
+// The whole feature is one comparison — the newest output the server has seen
+// against the newest the operator has been shown — so the comparison lives in
+// one place, in the open, rather than being spelled out slightly differently in
+// the Overview, the reader and the bulk action.
+
+export interface OutputVersion { src: string; seq: number; hash: string }
+export interface ReadMark extends OutputVersion { at?: string }
+
+/** What a session carries once /api/meta has answered for it. */
+export interface Readable {
+  id: string;
+  output?: OutputVersion | null;
+  read?: ReadMark | null;
+}
+
+/**
+ * Unread means: there is human-facing output, and the mark does not describe
+ * it.
+ *
+ * The three ways a mark can fail to describe it are all real cases, not
+ * defensive padding:
+ *
+ *   no mark          — nothing has ever been read here. Note this is only
+ *                      reachable for output that appeared AFTER the rollout
+ *                      baseline; the baseline gave every existing reply a mark.
+ *   older generation — the transcript was replaced (a new run repins it), so a
+ *                      mark against the old file says nothing about this one.
+ *                      A stale acknowledgement must never cover new output.
+ *   behind, or the same position with different content — a streaming answer
+ *                      that grew is something else to read, even at the same
+ *                      sequence number.
+ *
+ * No output at all is NOT unread: an agent that has never spoken has nothing to
+ * show. Missing metadata is likewise not unread — but it is not "read" either,
+ * and nothing here writes a mark for it, so the first real reply still counts.
+ */
+export function isUnread(s: Readable): boolean {
+  const o = s.output;
+  if (!o || !o.seq) return false;
+  const r = s.read;
+  if (!r) return true;
+  if (r.src !== o.src) return true;
+  if (r.seq < o.seq) return true;
+  return r.seq === o.seq && r.hash !== o.hash;
+}
+
+/**
+ * Which of the three Overview blocks a session belongs in.
+ *
+ * A running agent stays in Running even when it has unread output: what it is
+ * saying now is not finished, and moving it would take it out from under the
+ * one block the operator watches while work is in flight. Its unread state is
+ * untouched, so it lands in Unread as soon as it stops.
+ */
+export type Section = 'running' | 'unread' | 'rest';
+export function sectionOf(s: Readable, running: boolean): Section {
+  if (running) return 'running';
+  return isUnread(s) ? 'unread' : 'rest';
+}
+
+/**
+ * The acknowledgement a surface should send for what it just displayed.
+ *
+ * Deliberately the version the client already holds rather than "whatever is
+ * newest on the server": the server rejects anything that no longer matches, so
+ * a reply that arrived between rendering and acknowledging stays unread instead
+ * of being swept up by a mark it was never part of.
+ */
+export function markFor(s: Readable): (OutputVersion & { id: string }) | null {
+  const o = s.output;
+  if (!o || !o.seq) return null;
+  return { id: s.id, src: o.src, seq: o.seq, hash: o.hash };
+}
+
+/**
+ * Of two marks for the same session, the one that has read further.
+ *
+ * The client holds two: what the last /api/meta said, and what it has
+ * acknowledged since. A poll in flight during an acknowledgement carries the
+ * older of the two, and taking it at face value would flash the card back to
+ * unread and then forward again. Taking the further one cannot regress, and a
+ * mark from a different generation is not comparable at all — the newer
+ * generation wins, because the older one describes a transcript that is gone.
+ */
+export function furtherMark(a: ReadMark | null | undefined, b: ReadMark | null | undefined): ReadMark | null {
+  if (!a) return b || null;
+  if (!b) return a;
+  if (a.src !== b.src) return b; // b is the one the caller just learned about
+  if (b.seq > a.seq) return b;
+  if (b.seq === a.seq && b.hash !== a.hash) return b;
+  return a;
+}
+
+/**
+ * Fold a server answer back into the local view.
+ *
+ * Only 'ok' advances anything. A rejection is an ordinary answer — the reply
+ * that was displayed is no longer the newest — so the session stays unread and
+ * the operator sees the thing they have not read, which is the truthful
+ * outcome. Nothing here can move a mark backwards: the caller keeps whichever
+ * of the two is further on.
+ */
+export function applyAck(
+  prev: Record<string, ReadMark>,
+  sent: (OutputVersion & { id: string })[],
+  results: Record<string, string>,
+): Record<string, ReadMark> {
+  let changed = false;
+  const next = { ...prev };
+  for (const m of sent) {
+    if (results[m.id] !== 'ok') continue;
+    const cur = next[m.id];
+    if (cur && cur.src === m.src && (cur.seq > m.seq || (cur.seq === m.seq && cur.hash === m.hash))) continue;
+    next[m.id] = { src: m.src, seq: m.seq, hash: m.hash };
+    changed = true;
+  }
+  return changed ? next : prev;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -347,6 +347,21 @@ body {
 /* --border-strong is a BORDER token: as text on the page background it lands at
    ~1.4:1 in either theme, i.e. a count nobody can read. */
 .ov-sortn { color: var(--muted); }
+/* Mark all read: a text button on the Unread heading, in the heading's own
+   voice rather than a control bolted beside it. Compact by treatment, not by
+   shrinking the hit area — the padding keeps a comfortable target on touch
+   while the type stays the same size as the label it sits on. */
+.ov-markread {
+  flex: none; background: none; border: none; padding: 4px 6px; margin: -4px -2px -4px 0;
+  font: inherit; font-size: 10.5px; font-weight: 600; letter-spacing: 0.08em;
+  color: var(--accent); cursor: pointer; border-radius: var(--r-sm);
+}
+.ov-markread:hover:not(:disabled) { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.ov-markread:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.ov-markread:disabled { color: var(--muted); cursor: default; }
+/* A batch that did not save says so where it was triggered, and stays until it
+   is retried — there is no toast, because a read receipt is not news. */
+.ov-markerr { color: var(--danger); }
 /* The group an agent is in, when the feed is flat and no capsule says it. Both
    surfaces put it on the name's row, and on both the prefix is context while the
    name is the thing you are looking for — so the group is what gives way.

--- a/web/test/fixtures/seenWiring.tsx
+++ b/web/test/fixtures/seenWiring.tsx
@@ -1,0 +1,42 @@
+// The real ExchangeView, wired to the real hook through the real `answerRef`.
+//
+// Loaded by seenLatest.render.test.mjs. Kept as its own file rather than an
+// inline string so the component and hook are imported the way the app imports
+// them, and so this stays type-checked with everything else.
+import { createElement as h } from 'react';
+import { createRoot } from 'react-dom/client';
+import { ExchangeView } from '../../src/components/conversation/Exchange';
+import { useSeenLatest } from '../../src/components/useSeenLatest';
+
+const version = { id: 's1', src: 'gen1', seq: 1, hash: 'h1' };
+declare global { interface Window { acks: string[][]; mountWired: () => void } }
+window.acks = [];
+
+// A prompt long enough to fill the viewport on its own, with the answer below.
+const long = Array.from({ length: 60 }, (_, i) => `prompt line ${i}`).join('\n');
+const x = {
+  key: 'x1',
+  at: 0,
+  prompt: { role: 'user' as const, blocks: [{ type: 'text' as const, text: long }], harness: 'claude' },
+  steps: [],
+  answer: [{ role: 'assistant' as const, blocks: [{ type: 'text' as const, text: 'THE ANSWER' }], harness: 'claude' }],
+  startTs: 0,
+  endTs: 0,
+  tokens: 0,
+  toolCalls: 0,
+};
+
+function Wired() {
+  const ref = useSeenLatest({
+    version,
+    eligible: true,
+    onSeen: (marks) => { window.acks.push(marks.map((m) => m.hash)); },
+  });
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return h('div', null, h(ExchangeView as any, { x, answerRef: (n: HTMLDivElement | null) => { ref.current = n; } }));
+}
+
+window.mountWired = () => {
+  window.acks = [];
+  createRoot(document.getElementById('root')!).render(h(Wired));
+};

--- a/web/test/seenLatest.render.test.mjs
+++ b/web/test/seenLatest.render.test.mjs
@@ -29,12 +29,17 @@ import { useSeenLatest } from ${JSON.stringify(path.join(HERE, '../src/component
 
 const version = { id: 's1', src: 'gen1', seq: 3, hash: 'h3' };
 (window as any).acks = [];
+// Set by a test to make the acknowledgement report a failed write.
+(window as any).failNext = false;
 
 function Harness({ eligible }: { eligible: boolean }) {
   const ref = useSeenLatest({
     version,
     eligible,
-    onSeen: (marks) => { (window as any).acks.push(marks.map((m) => m.hash)); },
+    onSeen: (marks) => {
+      (window as any).acks.push(marks.map((m) => m.hash));
+      return Promise.resolve(!(window as any).failNext);
+    },
   });
   return h('div', null,
     h('div', { style: { height: '2000px' }, id: 'filler' }, 'earlier history'),
@@ -135,6 +140,37 @@ await page.waitForTimeout(200);
   check('returning to the tab with it on screen does acknowledge', () => assert.deepEqual(got, ['h3']));
 }
 
+console.log('\na write that failed is tried again');
+await load();
+await page.evaluate(() => { window.failNext = true; });
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(250);
+{
+  const got = await acks();
+  check('the first attempt happens', () => assert.deepEqual(got, ['h3']));
+}
+// Scroll away and back, the way an operator reading a long conversation does.
+await page.evaluate(() => window.scrollTo(0, 0));
+await page.waitForTimeout(150);
+await page.evaluate(() => { window.failNext = false; });
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(250);
+{
+  const got = await acks();
+  check('a version whose write failed is attempted again, not written off', () => {
+    assert.equal(got.length, 2, `attempts: ${JSON.stringify(got)}`);
+  });
+}
+// Now that one succeeded, it must stop.
+await page.evaluate(() => window.scrollTo(0, 0));
+await page.waitForTimeout(150);
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(250);
+{
+  const got = await acks();
+  check('and once it succeeds it stops being retried', () => assert.equal(got.length, 2));
+}
+
 console.log('\nthe caller can veto');
 await load(false); // eligible: false — e.g. paged back to an older turn
 await page.evaluate(() => document.getElementById('answer').scrollIntoView());
@@ -142,6 +178,43 @@ await page.waitForTimeout(200);
 {
   const got = await acks();
   check('a visible answer the caller says is not the latest is not acknowledged', () => assert.deepEqual(got, []));
+}
+
+// ---- the wiring, not just the hook ----
+//
+// The hook is only as good as what it is pointed at. This mounts the real
+// ExchangeView with a long prompt and its answer far below, wires the real hook
+// to the real `answerRef`, and checks that seeing the PROMPT is not seeing the
+// reply. Watching the exchange wrapper instead would pass every assertion above
+// and still clear the mark from a viewport showing none of the answer.
+{
+  const out2 = path.join(dir, 'wiring.js');
+  await build({
+    entryPoints: [path.join(HERE, 'fixtures/seenWiring.tsx')], outfile: out2, bundle: true, format: 'iife', logLevel: 'error', jsx: 'automatic',
+    nodePaths: [path.join(HERE, '../node_modules')],
+    loader: { '.css': 'empty' },
+  });
+  await page.setContent('<body style="margin:0"><div id="root"></div></body>');
+  await page.addScriptTag({ content: fs.readFileSync(out2, 'utf8') });
+  await page.evaluate(() => window.mountWired());
+  await page.waitForTimeout(250);
+  const geom = await page.evaluate(() => {
+    const a = document.querySelector('.cx-answer');
+    return a ? { top: Math.round(a.getBoundingClientRect().top), viewport: window.innerHeight, acks: window.acks.flat() } : null;
+  });
+  check('the observer is on the answer, and the answer really is below the fold', () => {
+    assert.ok(geom, 'ExchangeView rendered no .cx-answer');
+    assert.ok(geom.top > geom.viewport, `answer at y=${geom.top}, viewport ${geom.viewport}`);
+  });
+  check('a visible prompt does NOT acknowledge the answer below it', () => {
+    assert.deepEqual(geom.acks, []);
+  });
+  await page.evaluate(() => document.querySelector('.cx-answer').scrollIntoView());
+  await page.waitForTimeout(250);
+  {
+    const got = await page.evaluate(() => window.acks.flat());
+    check('scrolling to the answer itself does acknowledge it', () => assert.deepEqual(got, ['h1']));
+  }
 }
 
 await browser.close();

--- a/web/test/seenLatest.render.test.mjs
+++ b/web/test/seenLatest.render.test.mjs
@@ -1,0 +1,149 @@
+// When is a reply "shown to the operator"?
+//
+// This drives the real hook in a real browser with a real IntersectionObserver,
+// because every interesting case here is one where the component rendered
+// perfectly well and the operator still saw nothing: the answer is below the
+// fold, or the tab is in the background. A test that called the acknowledgement
+// path directly would agree with itself and prove none of it.
+//
+// am-test: manual — needs Chromium; run with `npm run test:render`.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'seen-'));
+const entry = path.join(dir, 'entry.tsx');
+
+// A page that is deliberately taller than the viewport, with the observed
+// answer at the bottom — the shape of a conversation you have to scroll.
+fs.writeFileSync(entry, `
+import { createElement as h, StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { useSeenLatest } from ${JSON.stringify(path.join(HERE, '../src/components/useSeenLatest'))};
+
+const version = { id: 's1', src: 'gen1', seq: 3, hash: 'h3' };
+(window as any).acks = [];
+
+function Harness({ eligible }: { eligible: boolean }) {
+  const ref = useSeenLatest({
+    version,
+    eligible,
+    onSeen: (marks) => { (window as any).acks.push(marks.map((m) => m.hash)); },
+  });
+  return h('div', null,
+    h('div', { style: { height: '2000px' }, id: 'filler' }, 'earlier history'),
+    h('div', { ref, id: 'answer', style: { height: '200px', background: '#eee' } }, 'the latest reply'),
+  );
+}
+
+(window as any).mount = (eligible: boolean) => {
+  (window as any).acks = [];
+  const el = document.getElementById('root');
+  createRoot(el).render(h(StrictMode, null, h(Harness, { eligible })));
+};
+`);
+
+const outfile = path.join(dir, 'bundle.js');
+await build({
+  entryPoints: [entry], outfile, bundle: true, format: 'iife', logLevel: 'error', jsx: 'automatic',
+  // The entry lives in a temp dir, so point the resolver at this package's
+  // modules rather than the temp dir's (empty) neighbourhood.
+  nodePaths: [path.join(HERE, '../node_modules')],
+});
+const bundle = fs.readFileSync(outfile, 'utf8');
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const ctx = await browser.newContext({ viewport: { width: 700, height: 500 } });
+const page = await ctx.newPage();
+const load = async (eligible = true) => {
+  await page.setContent('<body style="margin:0"><div id="root"></div></body>');
+  await page.addScriptTag({ content: bundle });
+  await page.evaluate((e) => window.mount(e), eligible);
+  await page.waitForTimeout(120);
+};
+const acks = () => page.evaluate(() => window.acks.flat());
+
+console.log('\nrendering is not reading');
+await load();
+{
+  const rendered = await page.locator('#answer').count();
+  const got = await acks();
+  check('an answer below the fold is in the DOM and is NOT acknowledged', () => {
+    assert.equal(rendered, 1, 'it really is rendered');
+    assert.deepEqual(got, []);
+  });
+}
+
+console.log('\nscrolling it into view is');
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(200);
+{
+  const got = await acks();
+  check('the reply is acknowledged once it is actually on screen', () => assert.deepEqual(got, ['h3']));
+}
+await page.evaluate(() => window.scrollTo(0, 0));
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(200);
+{
+  const got = await acks();
+  check('and only once, however many times it comes back into view', () => assert.equal(got.length, 1));
+}
+
+console.log('\na background tab sees nothing');
+await load();
+// A real hidden document: the observer still fires, which is exactly why the
+// hook cannot trust it alone.
+await page.evaluate(() => {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' });
+  document.dispatchEvent(new Event('visibilitychange'));
+});
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(200);
+{
+  const got = await acks();
+  check('an on-screen reply in a hidden tab is not acknowledged', () => assert.deepEqual(got, []));
+}
+{
+  const intersecting = await page.evaluate(() => new Promise((res) => {
+    const io = new IntersectionObserver((es) => { res(es.some((e) => e.isIntersecting)); io.disconnect(); });
+    io.observe(document.getElementById('answer'));
+  }));
+  check('(the element was intersecting all along)', () => assert.equal(intersecting, true));
+}
+// Coming back to the tab with the reply still on screen counts.
+await page.evaluate(() => {
+  Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+  document.dispatchEvent(new Event('visibilitychange'));
+});
+await page.waitForTimeout(200);
+{
+  const got = await acks();
+  check('returning to the tab with it on screen does acknowledge', () => assert.deepEqual(got, ['h3']));
+}
+
+console.log('\nthe caller can veto');
+await load(false); // eligible: false — e.g. paged back to an older turn
+await page.evaluate(() => document.getElementById('answer').scrollIntoView());
+await page.waitForTimeout(200);
+{
+  const got = await acks();
+  check('a visible answer the caller says is not the latest is not acknowledged', () => assert.deepEqual(got, []));
+}
+
+await browser.close();
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/unread.test.mjs
+++ b/web/test/unread.test.mjs
@@ -18,7 +18,8 @@ await build({
   entryPoints: [path.join(HERE, '../src/lib/unread.ts')],
   outfile: out, format: 'esm', bundle: true, logLevel: 'error',
 });
-const { isUnread, sectionOf, markFor, furtherMark, applyAck } = await import(pathToFileURL(out).href);
+const { isUnread, sectionOf, markFor, furtherMark, retireLocal, applyAck, outputHash, answerMatches } = await import(pathToFileURL(out).href);
+const { outputHash: serverHash } = await import(pathToFileURL(path.join(HERE, '../../server/src/output-id.js')).href);
 
 let failed = 0;
 const check = (what, fn) => {
@@ -57,9 +58,13 @@ check('a mark from a replaced transcript does not cover the new one', () => {
   // swallow the new file's first nine replies.
   assert.equal(isUnread(S(v(1, 'h1', 'gen2'), v(9, 'h9', 'gen1'))), true);
 });
-check('a mark that has read further than the newest output is not unread', () => {
-  // Can only happen from a stale poll; it must not flicker the card.
-  assert.equal(isUnread(S(v(3), v(5))), false);
+check('a mark that has read FURTHER than the newest output is unread', () => {
+  // Not the impossibility it looks like: a rotated or replaced transcript
+  // restarts its sequence at 1, and a harness whose runs cannot be told apart
+  // from the pane record alone presents that new reply under the same key.
+  // Reading "seq 5 >= seq 1, so seen it" hides genuinely new output behind a
+  // cursor from a transcript that no longer exists.
+  assert.equal(isUnread(S(v(1, 'freshstart'), v(5))), true);
 });
 
 console.log('\nwhich block a session belongs in');
@@ -103,12 +108,76 @@ check('a poll that overtook an acknowledgement does not flash the card', () => {
   assert.deepEqual(furtherMark({ src: 'g', seq: 2, hash: 'b' }, { src: 'g', seq: 5, hash: 'e' }), { src: 'g', seq: 5, hash: 'e' });
   assert.deepEqual(furtherMark({ src: 'g', seq: 5, hash: 'e' }, { src: 'g', seq: 2, hash: 'b' }), { src: 'g', seq: 5, hash: 'e' });
 });
-check('a mark for a new generation replaces one for the old, whatever its number', () => {
-  assert.deepEqual(furtherMark({ src: 'old', seq: 99, hash: 'x' }, { src: 'new', seq: 1, hash: 'y' }), { src: 'new', seq: 1, hash: 'y' });
+check('the generation in front of us decides, not which argument came second', () => {
+  // This used to return whichever mark was passed second, on the assumption it
+  // was the newly learned one. App passes its RETAINED local mark there, so a
+  // stale local generation was overriding fresh server state forever.
+  const oldMark = { src: 'old', seq: 99, hash: 'x' };
+  const newMark = { src: 'new', seq: 1, hash: 'y' };
+  assert.deepEqual(furtherMark(oldMark, newMark, { src: 'new', seq: 1, hash: 'y' }), newMark);
+  assert.deepEqual(furtherMark(newMark, oldMark, { src: 'new', seq: 1, hash: 'y' }), newMark);
 });
 check('the same version twice is the same mark', () => {
   const a = { src: 'g', seq: 3, hash: 'h' };
   assert.equal(furtherMark(a, { src: 'g', seq: 3, hash: 'h' }), a);
+});
+
+console.log('\nthe two copies of the read state, and which one wins');
+check('a local mark from a dead generation cannot shout down the server\'s current one', () => {
+  // Tab A acknowledged g1; the transcript rolled to g2; tab B read g2. Every
+  // poll in A must converge on g2, not keep restoring its own stale g1.
+  const server = { src: 'g2', seq: 1, hash: 'b' };
+  const local = { src: 'g1', seq: 9, hash: 'a' };
+  assert.deepEqual(furtherMark(server, local, { src: 'g2', seq: 1, hash: 'b' }), server);
+});
+check('a local mark for the CURRENT generation still wins over an older server copy', () => {
+  const server = { src: 'g2', seq: 1, hash: 'a' };
+  const local = { src: 'g2', seq: 3, hash: 'c' };
+  assert.deepEqual(furtherMark(server, local, { src: 'g2', seq: 3, hash: 'c' }), local);
+});
+check('with no output to arbitrate, the server is the authority', () => {
+  assert.deepEqual(furtherMark({ src: 'g2', seq: 1, hash: 'b' }, { src: 'g1', seq: 9, hash: 'a' }, null),
+    { src: 'g2', seq: 1, hash: 'b' });
+});
+check('a local mark is retired once the server has caught up', () => {
+  const local = { s1: { src: 'g', seq: 3, hash: 'c' } };
+  const after = retireLocal(local, [{ id: 's1', output: v(3, 'c'), read: { src: 'g', seq: 3, hash: 'c' } }]);
+  assert.deepEqual(after, {});
+});
+check('…and when its generation is gone, so polling can converge', () => {
+  const local = { s1: { src: 'g1', seq: 9, hash: 'a' } };
+  assert.deepEqual(retireLocal(local, [{ id: 's1', output: v(1, 'b', 'g2'), read: null }]), {});
+});
+check('but one the server has not seen yet is kept', () => {
+  const local = { s1: { src: 'gen1', seq: 3, hash: 'h3' } };
+  assert.equal(retireLocal(local, [{ id: 's1', output: v(3), read: null }]), local,
+    'same object, so holding it costs no re-render');
+});
+
+console.log('\nnaming the reply that was actually rendered');
+check('the browser hash agrees with the server\'s, byte for byte', () => {
+  for (const t of ['', 'Done.', 'a'.repeat(500), 'unicode ✓ ⠋ é', '# Heading\n\nbody\n', JSON.stringify({ a: 1 })]) {
+    assert.equal(outputHash(t), serverHash(t), `diverged on ${JSON.stringify(t.slice(0, 20))}`);
+  }
+});
+check('a rendered answer matching the version is accepted', () => {
+  assert.equal(answerMatches(['the whole reply'], serverHash('the whole reply')), true);
+});
+check('two replies sharing a long prefix are NOT confused', () => {
+  // The bug this replaced: a 279-character prefix comparison called these the
+  // same reply, so the Reader displaying A acknowledged B.
+  const a = `${'x'.repeat(400)} TAIL A`;
+  const b = `${'x'.repeat(400)} TAIL B`;
+  assert.equal(answerMatches([a], serverHash(b)), false, 'displaying A must not acknowledge B');
+  assert.equal(answerMatches([b], serverHash(b)), true);
+});
+check('a multi-block answer matches on its last block or its join', () => {
+  assert.equal(answerMatches(['one', 'two'], serverHash('two')), true);
+  assert.equal(answerMatches(['one', 'two'], serverHash('one\ntwo')), true);
+});
+check('nothing rendered matches nothing', () => {
+  assert.equal(answerMatches([], serverHash('anything')), false);
+  assert.equal(answerMatches(['x'], ''), false);
 });
 
 console.log('\nthe race the whole design exists for');
@@ -119,7 +188,7 @@ check('B lands while the acknowledgement for A is in flight — B stays unread',
   const sent = [markFor(s)];
   s = S(v(2, 'B'), null);                       // B arrives
   const local = applyAck({}, sent, { s1: 'ok' }); // A's acknowledgement lands
-  s = { ...s, read: furtherMark(s.read, local.s1) };
+  s = { ...s, read: furtherMark(s.read, local.s1, s.output) };
   assert.equal(isUnread(s), true, 'B has not been shown to anyone');
   assert.equal(s.read.seq, 1, 'and A is correctly recorded as read');
 });

--- a/web/test/unread.test.mjs
+++ b/web/test/unread.test.mjs
@@ -1,0 +1,128 @@
+// What counts as unread, and what an acknowledgement is allowed to cover.
+//
+// Every case here is a way the feature could quietly lie to the operator —
+// either by hiding a reply they have not read, or by claiming they read one
+// they never saw. The second is the worse failure and most of these guard it.
+//
+// Run with:  node test/unread.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'unread-')), 'unread.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/unread.ts')],
+  outfile: out, format: 'esm', bundle: true, logLevel: 'error',
+});
+const { isUnread, sectionOf, markFor, furtherMark, applyAck } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+const S = (output, read) => ({ id: 's1', output, read });
+const v = (seq, hash = `h${seq}`, src = 'gen1') => ({ src, seq, hash });
+
+console.log('\nwhat makes a session unread');
+check('output the mark already describes is read', () => {
+  assert.equal(isUnread(S(v(3), v(3))), false);
+});
+check('a newer reply is unread', () => {
+  assert.equal(isUnread(S(v(4), v(3))), true);
+});
+check('never having read anything here is unread', () => {
+  assert.equal(isUnread(S(v(1), null)), true);
+});
+check('an agent that has never spoken is NOT unread', () => {
+  assert.equal(isUnread(S(null, null)), false);
+  assert.equal(isUnread(S({ src: 'gen1', seq: 0, hash: '' }, null)), false);
+});
+check('a streaming answer that grew is unread again at the same position', () => {
+  // Same reply, more text: the operator was shown less than there is now.
+  assert.equal(isUnread(S(v(3, 'grown'), v(3, 'short'))), true);
+});
+check('two replies with identical text are still two replies', () => {
+  // Only the sequence separates them; the hash is the same by construction.
+  assert.equal(isUnread(S(v(4, 'same'), v(3, 'same'))), true);
+});
+check('a mark from a replaced transcript does not cover the new one', () => {
+  // A new run repins the rollout: seq restarts, and an old seq 9 must not
+  // swallow the new file's first nine replies.
+  assert.equal(isUnread(S(v(1, 'h1', 'gen2'), v(9, 'h9', 'gen1'))), true);
+});
+check('a mark that has read further than the newest output is not unread', () => {
+  // Can only happen from a stale poll; it must not flicker the card.
+  assert.equal(isUnread(S(v(3), v(5))), false);
+});
+
+console.log('\nwhich block a session belongs in');
+check('running wins over unread, and keeps the unread state', () => {
+  const s = S(v(4), v(3));
+  assert.equal(sectionOf(s, true), 'running');
+  assert.equal(isUnread(s), true, 'still unread underneath');
+  assert.equal(sectionOf(s, false), 'unread', 'and lands in Unread when it stops');
+});
+check('read and idle is the remainder', () => {
+  assert.equal(sectionOf(S(v(3), v(3)), false), 'rest');
+});
+
+console.log('\nwhat an acknowledgement claims');
+check('it names the version on screen, not "whatever is newest"', () => {
+  assert.deepEqual(markFor(S(v(7, 'seven'))), { id: 's1', src: 'gen1', seq: 7, hash: 'seven' });
+});
+check('there is nothing to acknowledge without output', () => {
+  assert.equal(markFor(S(null)), null);
+});
+
+console.log('\nreconciling the server, the local view and a poll in flight');
+check('a rejected acknowledgement changes nothing — the reply stays unread', () => {
+  const prev = {};
+  const sent = [{ id: 's1', src: 'gen1', seq: 3, hash: 'h3' }];
+  assert.equal(applyAck(prev, sent, { s1: 'mismatch' }), prev, 'same object: no re-render');
+  assert.equal(applyAck(prev, sent, { s1: 'stale' }), prev);
+  assert.equal(applyAck(prev, sent, { s1: 'future' }), prev);
+});
+check('an accepted one advances the local view', () => {
+  const next = applyAck({}, [{ id: 's1', src: 'gen1', seq: 3, hash: 'h3' }], { s1: 'ok' });
+  assert.deepEqual(next.s1, { src: 'gen1', seq: 3, hash: 'h3' });
+});
+check('an accepted OLDER acknowledgement cannot pull progress back', () => {
+  const prev = { s1: { src: 'gen1', seq: 5, hash: 'h5' } };
+  const next = applyAck(prev, [{ id: 's1', src: 'gen1', seq: 2, hash: 'h2' }], { s1: 'ok' });
+  assert.equal(next.s1.seq, 5);
+});
+check('a poll that overtook an acknowledgement does not flash the card', () => {
+  // Server copy is behind the local one; the further of the two survives.
+  assert.deepEqual(furtherMark({ src: 'g', seq: 2, hash: 'b' }, { src: 'g', seq: 5, hash: 'e' }), { src: 'g', seq: 5, hash: 'e' });
+  assert.deepEqual(furtherMark({ src: 'g', seq: 5, hash: 'e' }, { src: 'g', seq: 2, hash: 'b' }), { src: 'g', seq: 5, hash: 'e' });
+});
+check('a mark for a new generation replaces one for the old, whatever its number', () => {
+  assert.deepEqual(furtherMark({ src: 'old', seq: 99, hash: 'x' }, { src: 'new', seq: 1, hash: 'y' }), { src: 'new', seq: 1, hash: 'y' });
+});
+check('the same version twice is the same mark', () => {
+  const a = { src: 'g', seq: 3, hash: 'h' };
+  assert.equal(furtherMark(a, { src: 'g', seq: 3, hash: 'h' }), a);
+});
+
+console.log('\nthe race the whole design exists for');
+check('B lands while the acknowledgement for A is in flight — B stays unread', () => {
+  // A was displayed and acknowledged; B arrived before the answer came back.
+  let s = S(v(1, 'A'), null);
+  assert.equal(isUnread(s), true);
+  const sent = [markFor(s)];
+  s = S(v(2, 'B'), null);                       // B arrives
+  const local = applyAck({}, sent, { s1: 'ok' }); // A's acknowledgement lands
+  s = { ...s, read: furtherMark(s.read, local.s1) };
+  assert.equal(isUnread(s), true, 'B has not been shown to anyone');
+  assert.equal(s.read.seq, 1, 'and A is correctly recorded as read');
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #128

Running → Unread → Remaining, reusing the existing cards and tiles with no duplicates. New human-facing assistant output makes a session unread; tool traffic and status changes do not. A reply counts as read only once it has actually been put in front of the operator.

**Screens and evidence:** https://lvwerra-agent-artifacts.static.hf.space/overview-unread.html

## Implemented

**Output identity (§1).** Every surface that produces assistant output now names it the same way: `{src, seq, hash}` — transcript generation, how many distinct replies it has produced, and a hash of the **full** text of the newest. The sequence separates two replies with identical words or the same timestamp; the hash catches a streaming answer that grew, including past the 280-character card clip where the visible summary is unchanged. Deliberately **not** the file's revision, which also moves for tool calls, token counts and status records. Remote agents reuse their log's own message `seq`, which is already authoritative and monotonic.

> **The trap this had to avoid:** the digest clears its assistant fields on every new prompt. Had the cursor lived in those fields, typing at an agent would have silently marked its unseen answer read. It survives `digestPrompt` on purpose, and a prompt instead makes the *next* reply a new one whatever it says — the only way to tell "ask again, get the same answer" from a record repeated. There is a test that fails if either half regresses.

**Read conditions (§2).** Mounting, route selection, a resolved fetch and the reader's `At latest` flag all describe the program rather than what the operator can see, so none of them acknowledge anything. A real `IntersectionObserver` gates it, plus foreground tab and active surface. Not acknowledged: an answer below the fold, a background tab, a card/tile preview, a pane behind another in a deck, a page back to an earlier turn, a search showing older matches, and a reply longer than the card's copy of it (that one is finished in the Reader, which serves the whole thing). Supported automatic surfaces are the **Reader** and the **expanded Overview conversation**, as the issue specifies.

**Durable, race-safe state (§3).** `server/src/read-marks.js`, a small scoped store beside the existing ones. An acknowledgement names the exact version displayed, never "whatever is newest", and the server accepts it only if that is still newest:

| Request | Answer |
|---|---|
| Exactly what is on screen | `ok` |
| The same one again | `ok` — replays are harmless |
| An older reply, arriving late | `ok`, but recorded progress does not move back |
| A different transcript generation | `stale` |
| Further than any reply that exists | `future` |
| Right position, wrong content (streaming answer moved on) | `mismatch` |
| Unknown session | `unknown` |

A rejection is an ordinary answer — the reply it described is no longer newest — so the card correctly stays unread. Client-side, a poll that overtakes an acknowledgement cannot regress it (the further of the two wins), acknowledgements are coalesced by exact version, and the pending set is bounded.

**Sections (§4)** and **Mark all read (§5).** Both views, correct counts, empty section omitted, existing filters respected, one text button on the heading in the heading's own voice. Scope is the section as captured on click — a reply arriving mid-request stays unread even for a targeted session, and Retry reuses the original capture rather than rescanning. Keyboard-activated in the browser test.

**Rollout baseline.** Existing replies start read, once ever, from versions actually observed rather than a wall-clock cutoff. A session with nothing readable yet is skipped rather than marked read at zero, so its *first* reply is unread rather than presumed seen. Tested across a restart.

## Deliberately left, and why

**Manual (grouped) mode does not get the sections.** The three blocks live in the ranked feed, the layout that already draws every card under **one parent** so a card changing section is a reorder rather than a remount. Manual mode draws each group as its own capsule; hoisting a session out of one changes its parent, and React remounts on a changed parent however stable the key — destroying the reply draft, unfolded work and scroll position of a card that became unread from a background poll. That is precisely the failure the ranked feed's stable-parent comment exists to prevent, and §4 forbids it. Giving manual mode the section requires the capsule layout to adopt a single parent first, which is a separate change; I have not made it here rather than doing it quietly. Manual mode is verified unchanged.

**Terminal view does not acknowledge.** §2 permits this explicitly: opening a socket or painting a cached screen cannot be mapped to a particular reply version, so unread is preserved there.

**An agent repeating itself verbatim with no prompt between** is counted as one reply. It is indistinguishable from the mirrored records every harness writes (codex emits `agent_message` and `task_complete` with the same words), and counting those would mark a session unread every time it finished a turn. Collapsing is the safe direction — the operator has already been shown those words — and it is documented where it happens.

Not bundled, as directed: toolbar relocation, full-history search, general polling changes, #127's mode-switch fix.

## Tests

- `web/test/unread.test.mjs` — the comparison rules, including the race the design exists for (B lands while A's acknowledgement is in flight).
- `server/test/unread.test.mjs` — output identity through the **real Claude parser** with fixture transcripts (mirrors, streaming growth, identical text, timestamp ties, tool/prompt noise), plus the durable half over HTTP: baseline, acknowledgement outcomes, bulk, restart, rename.
- `web/test/seenLatest.render.test.mjs` — the presentation gate in Chromium against a real `IntersectionObserver`. It also asserts the observer *would* have fired in the hidden-tab case, so it is the guard that stops it rather than an accident of layout.

Mutation-checked: a prompt no longer starting a new reply, a prompt clearing the cursor, hashing the clipped card text, backwards acknowledgements, accepting an old generation, accepting non-existent output, and each of the hook's three guards. All caught.

## Results

Typecheck ✅ · web build ✅ · web suites 24/24 ✅ · all four+one `test:render` suites ✅ (0 failures) · all server suites ✅ **except** `server/test/crons.test.mjs` #4, which is red on clean `main` and is not from this branch.

Not merged, not deployed.