### PR TITLE
Files: safe replacements and dozens of reader attachments

### DIFF
--- a/docs/screenshot-input.md
+++ b/docs/screenshot-input.md
@@ -122,7 +122,8 @@ same paste/drop behavior:
 - A files-only submission uses `Please inspect the attached file.` (or `files`
   for several) as its text. Image-only server delivery retains the more specific
   `screenshot` wording.
-- At most five files may be attached to one prompt.
+- There is no per-prompt file-count limit. The separate server safeguards remain
+  100 MiB per file, 500 MiB and 200 stored attachment files per session.
 - Choosing, pasting, or dropping a file starts its upload immediately. Each
   chip shows transferred bytes, percentage, and server-confirmed success.
 - The send button is disabled until every upload has succeeded.
@@ -137,6 +138,19 @@ Pending files remain browser `File` objects for retry even after the server has
 stored them. `URL.createObjectURL()` supplies local previews and is revoked when
 a chip is removed or the component unmounts. Successful files are session-owned
 and follow that session's existing deletion/pruning lifecycle.
+
+The browser runs at most three attachment transfers for one session at once;
+overlapping picker, paste and drop additions join the same FIFO. Another session
+has its own queue. The server serializes publication/quota checks within a
+session, so concurrent requests cannot each pass a stale 500 MiB/200-file check.
+There is no automatic retry and no 20-per-minute rejection: transient failures
+stay beside their file with Retry, while size/storage/validation failures keep
+their reason and require removal rather than repeating the same invalid request.
+A lost response can leave one stored file whose id the browser never learned;
+the lifetime byte/file quotas
+bound those orphans, session removal clears them, and the seven-day orphan-store
+pruner handles sessions that disappeared after a crash. This is deliberately not
+an exactly-once transport claim.
 
 ### 5.2 Rendered terminal reader
 
@@ -338,12 +352,11 @@ Errors:
 | `404` | unknown session/attachment |
 | `413` | empty, larger than 100 MiB, or over the session quota |
 | `415` | a claimed PNG/JPEG/GIF/WebP is malformed |
-| `429` | per-session upload backstop exceeded |
 | `500` | durable write failed |
 
-Use a small backstop such as 20 uploads/minute/session. This is not the security
-boundary—the private Space is—but protects the terminal process from accidental
-paste/drop loops.
+The per-session stream lock, browser's three-transfer queue, and byte/file quotas
+are the load bounds. The old 20-uploads-per-minute counter rejected legitimate
+small-file batches at file 21 without limiting active work, so it was removed.
 
 ### 7.2 Preview
 
@@ -510,10 +523,11 @@ Add a small module, `web/src/lib/attachments.ts`, containing:
 - `transferMayContainFile(DataTransfer)`;
 - duplicate suppression across `items` and `files`;
 - local preview creation/revocation; and
-- sequential upload helpers that report progress and preserve per-file errors.
+- bounded per-session upload helpers that report progress and preserve per-file errors.
 
-Use sequential uploads initially. Five files is the maximum, bucket writes are
-the bottleneck, and simpler ordering makes chip status deterministic.
+The browser starts no more than three uploads for one session; the server streams
+and publishes them one at a time under its session quota lock. Selection order is
+kept independently of completion order.
 
 Add a reusable `Attachments` chip row used by Sidebar and Overview. The
 terminal imports only the transfer/upload helpers.

--- a/docs/workspace-file-uploads.md
+++ b/docs/workspace-file-uploads.md
@@ -1,0 +1,57 @@
+# Workspace file uploads
+
+Workspace uploads are create-only unless the operator confirms one exact
+replacement. This is intentionally different from reader attachments: reader
+files always receive unique server ids, so equal display names remain separate.
+
+## Collision and replacement API
+
+`POST /api/files/:id/upload?path=<folder>&name=<name>` streams bytes. With no
+replacement header it creates a new file. If that destination exists, the server
+does not consume it as authorization and returns `409`:
+
+```json
+{
+  "error": "\"report.txt\" already exists",
+  "code": "file-exists",
+  "name": "report.txt",
+  "path": "reports/report.txt",
+  "revision": "sha256:<bytes>:<digest>",
+  "replaceToken": "<opaque token>"
+}
+```
+
+The Files pane shows the exact name and workspace-relative destination. Replace
+is a separate action in a dialog whose focused/default action is Cancel. Escape
+and backdrop dismissal also cancel. There is no Replace All path.
+
+After confirmation the browser repeats the upload with
+`X-AM-Replace-Token`. The token authenticates the resolved destination and a
+streamed SHA-256 identity of the existing content; it is not an mtime check and
+does not buffer the existing file. Tokens are process-local, so a server restart
+requires a fresh collision/decision. If the file or destination folder changed,
+the server returns `409 replacement-stale` with a fresh identity/token and the
+old choice cannot publish.
+
+## Publication and failure scope
+
+Every body first streams to a random, exclusive `.part` file beside the resolved
+destination. The parent/root relationship and replacement identity are checked
+again after streaming. Only then is the temporary published. Aborts, validation
+errors and failed replacement renames remove that operation's temporary and
+leave existing destination bytes alone. Final-entry symlinks are refused;
+parent aliases must resolve inside the same workspace root and must not retarget
+during the request.
+
+Manager-originated writes to one resolved destination are serialized. Create-only
+publication uses a hard link for atomic no-replace semantics. On storage adapters
+without hard links it falls back to `COPYFILE_EXCL`: a competing creator is still
+never overwritten, but the adapter cannot promise that a brand-new file is
+invisible until the exclusive copy finishes. Replacement uses same-directory
+rename after revalidation. An external agent can still write in the small gap
+between the final content check and the filesystem rename; that cross-process,
+storage-adapter race is not presented as a transaction or exactly-once guarantee.
+
+The text editor keeps its existing content-tag API and UI state. It only shares
+the unique temporary-file and per-destination publication primitive; autosave and
+save-state redesign remain outside this work.

--- a/server/screenshot-input.test.mjs
+++ b/server/screenshot-input.test.mjs
@@ -324,6 +324,7 @@ try {
   await readerPicker.setInputFiles({
     name: 'interrupted.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(256 * 1024),
   });
+  await readerReply.fill('keep this draft while the file fails');
   const interruptedChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'interrupted.bin' });
   await interruptedChip.filter({ has: page.locator('.image-chip-retry') }).waitFor({ state: 'visible' });
   const interruptedText = await interruptedChip.locator('.image-chip-meta').textContent();
@@ -331,6 +332,9 @@ try {
     !!interruptedText?.includes('connection was interrupted')
       && await interruptedChip.locator('.image-chip-retry').isVisible(),
     JSON.stringify({ interruptedText }));
+  check('an unresolved file blocks partial Send without losing the draft',
+    await readerReply.inputValue() === 'keep this draft while the file fails'
+      && await page.locator('.pane-reader .ov-send').count() === 0);
   await interruptedChip.locator('.image-chip-retry').click();
   await interruptedChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
   const attachmentDir = path.join(DATA_DIR, 'state', 'attachments', id);
@@ -340,6 +344,32 @@ try {
   const interruptedRemoved = await waitFor(() => !fs.existsSync(attachmentDir)
     || !fs.readdirSync(attachmentDir).some((name) => name.endsWith('-interrupted.bin')));
   check('removing a successful unsent chip deletes its stored file', interruptedStored && interruptedRemoved);
+  await readerReply.fill('');
+
+  await page.evaluate(() => Object.defineProperty(navigator, 'onLine', { configurable: true, value: false }));
+  await page.route(`**/api/sessions/${id}/attachments`, (route) => route.abort('internetdisconnected'), { times: 1 });
+  await readerPicker.setInputFiles({
+    name: 'offline.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(1024),
+  });
+  const offlineChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'offline.bin' });
+  await offlineChip.filter({ has: page.locator('.image-chip-retry') }).waitFor();
+  check('offline failure is distinguished and remains retryable',
+    (await offlineChip.locator('.image-chip-meta').textContent())?.includes('device is offline'));
+  await offlineChip.getByRole('button', { name: 'Remove offline.bin' }).click();
+  await page.evaluate(() => { delete navigator.onLine; });
+
+  await page.route(`**/api/sessions/${id}/attachments`, (route) => route.fulfill({
+    status: 413, contentType: 'application/json',
+    body: JSON.stringify({ error: 'session attachment storage is full (500 MB max)' }),
+  }), { times: 1 });
+  await readerPicker.setInputFiles({
+    name: 'quota.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(1024),
+  });
+  const quotaChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'quota.bin' });
+  await quotaChip.filter({ has: page.locator('.image-chip-meta', { hasText: '500 MB max' }) }).waitFor();
+  check('storage quota failure stays visible and does not offer a futile retry',
+    await quotaChip.locator('.image-chip-retry').count() === 0);
+  await quotaChip.getByRole('button', { name: 'Remove quota.bin' }).click();
 
   // Hugging Face's ingress may answer before Express with an HTML error page.
   // Preserve the status as a useful diagnosis instead of reducing it to "413".
@@ -350,10 +380,11 @@ try {
     name: 'proxy-limit.bin', mimeType: 'application/octet-stream', buffer: Buffer.alloc(1024),
   });
   const proxyChip = page.locator('.pane-reader .cxv-composer .image-chip', { hasText: 'proxy-limit.bin' });
-  await proxyChip.filter({ has: page.locator('.image-chip-retry') }).waitFor();
+  await proxyChip.filter({ has: page.locator('.image-chip-meta', { hasText: 'HTTP 413' }) }).waitFor();
   const proxyText = await proxyChip.locator('.image-chip-meta').textContent();
   check('a non-JSON proxy rejection keeps an actionable HTTP reason',
-    !!proxyText?.includes('proxy rejected this file as too large') && proxyText.includes('HTTP 413'),
+    !!proxyText?.includes('proxy rejected this file as too large') && proxyText.includes('HTTP 413')
+      && await proxyChip.locator('.image-chip-retry').count() === 0,
     JSON.stringify({ proxyText }));
   await proxyChip.getByRole('button', { name: 'Remove proxy-limit.bin' }).click();
 
@@ -412,6 +443,91 @@ try {
   check('reader sends an image-only structured turn',
     readerInput?.text === '' && readerInput?.attachmentIds?.length === 1,
     JSON.stringify(readerInput));
+
+  // Reader input supports all three browser entry points. Exercise paste and
+  // drop on the real reader before the large picker batch; remove each stored
+  // file again so the following count proves only its own fifty selections.
+  await readerReply.evaluate((element) => {
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(['pasted'], 'reader-paste.txt', { type: 'text/plain' }));
+    element.dispatchEvent(new ClipboardEvent('paste', {
+      bubbles: true, cancelable: true, clipboardData: transfer,
+    }));
+  });
+  const pasted = page.locator('.pane-reader .image-chip', { hasText: 'reader-paste.txt' });
+  await pasted.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  check('reader paste keeps an eligible file', await pasted.count() === 1);
+  await pasted.getByRole('button', { name: 'Remove reader-paste.txt' }).click();
+
+  await page.locator('.pane-reader .cxv').evaluate((element) => {
+    const transfer = new DataTransfer();
+    transfer.items.add(new File(['dropped'], 'reader-drop.txt', { type: 'text/plain' }));
+    for (const type of ['dragenter', 'dragover', 'drop']) {
+      element.dispatchEvent(new DragEvent(type, {
+        bubbles: true, cancelable: true, dataTransfer: transfer,
+      }));
+    }
+  });
+  const dropped = page.locator('.pane-reader .image-chip', { hasText: 'reader-drop.txt' });
+  await dropped.filter({ has: page.locator('.image-chip-meta', { hasText: 'uploaded' }) }).waitFor();
+  check('reader drop keeps an eligible file', await dropped.count() === 1);
+  await dropped.getByRole('button', { name: 'Remove reader-drop.txt' }).click();
+
+  // The requested acceptance case: fifty is ordinary, not a new ceiling. Use
+  // the real picker, real XHR uploads and real server store; only intercept the
+  // final input so this test never submits work to the fixture CLI.
+  const batchNames = Array.from({ length: 50 }, (_, index) => index % 10 === 0 ? 'same-name.txt' : `reader-${index}.txt`);
+  await readerPicker.setInputFiles(batchNames.map((name, index) => ({
+    name, mimeType: index % 3 === 0 ? 'text/markdown' : 'text/plain', buffer: Buffer.from(`reader batch ${index}`),
+  })));
+  const fiftyStored = await waitFor(async () =>
+    await page.locator('.pane-reader .image-chip.uploaded').count() === 50, 30_000);
+  const batchGeometry = await page.locator('.pane-reader').evaluate((pane) => {
+    const list = pane.querySelector('.image-attachment-list');
+    const composer = pane.querySelector('.cxv-composer');
+    const p = pane.getBoundingClientRect(); const l = list.getBoundingClientRect(); const c = composer.getBoundingClientRect();
+    return { count: pane.querySelector('.image-attachments-summary')?.textContent, listHeight: l.height,
+      listScrollable: list.scrollHeight > list.clientHeight, composerBottom: c.bottom, paneBottom: p.bottom };
+  });
+  check('reader accepts all 50 files and keeps the detail list bounded',
+    fiftyStored
+      && batchGeometry.count?.includes('50 files')
+      && batchGeometry.listHeight <= 153
+      && batchGeometry.listScrollable
+      && batchGeometry.composerBottom <= batchGeometry.paneBottom + 1,
+    JSON.stringify(batchGeometry));
+  await page.locator('.pane-deck').evaluate((deck) => {
+    deck.style.width = '390px'; deck.style.gridTemplateColumns = '390px';
+  });
+  const narrowBatch = await page.locator('.pane-reader').evaluate((pane) => ({
+    overflow: pane.scrollWidth > pane.clientWidth,
+    listHeight: pane.querySelector('.image-attachment-list').getBoundingClientRect().height,
+    summary: pane.querySelector('.image-attachments-summary')?.textContent,
+  }));
+  check('the 50-file reader batch stays usable at phone width',
+    !narrowBatch.overflow && narrowBatch.listHeight <= 153 && narrowBatch.summary?.includes('50 files'),
+    JSON.stringify(narrowBatch));
+  if (process.env.ISSUE122_SCREENSHOT) await page.locator('.pane-reader').screenshot({ path: process.env.ISSUE122_SCREENSHOT });
+
+  let batchInput;
+  let sawBatchInput;
+  const batchInputReached = new Promise((resolve) => { sawBatchInput = resolve; });
+  await page.route(`**/api/sessions/${id}/input`, async (route) => {
+    batchInput = route.request().postDataJSON();
+    await route.fulfill({ json: { ok: true } });
+    sawBatchInput();
+  }, { times: 1 });
+  await page.locator('.pane-reader .ov-send').click();
+  await Promise.race([batchInputReached, sleep(10_000).then(() => { throw new Error('50-file reader input did not send'); })]);
+  const storedNames = batchInput.attachmentIds.map((attachmentId) => {
+    const storedName = fs.readdirSync(attachmentDir).find((name) => name.startsWith(`${attachmentId}-`));
+    return storedName?.slice(attachmentId.length + 1);
+  });
+  check('all 50 distinct ids reach Send in selection order, including repeated names',
+    new Set(batchInput.attachmentIds).size === 50
+      && JSON.stringify(storedNames) === JSON.stringify(batchNames),
+    JSON.stringify({ ids: batchInput.attachmentIds.length, names: storedNames }));
+  await page.locator('.pane-deck').evaluate((deck) => { deck.style.width = ''; deck.style.gridTemplateColumns = ''; });
 
   // Overview tiles open a conversation window. It uses the same structured
   // delivery contract even though no terminal pane is mounted in that view.

--- a/server/src/attachments.js
+++ b/server/src/attachments.js
@@ -6,9 +6,8 @@ import { pipeline } from 'node:stream/promises';
 import { STATE_DIR } from './config.js';
 
 export const ATTACHMENT_LIMIT = 100 * 1024 * 1024;
-// A single prompt is capped separately at five files. This lifetime cap keeps
-// a forgotten session from growing without bound while still leaving room for
-// many ordinary attachment turns.
+// Prompt batches have no separate count cap. These lifetime byte/file caps keep
+// a forgotten session bounded while allowing normal batches of dozens.
 export const SESSION_ATTACHMENT_LIMIT = 500 * 1024 * 1024;
 export const SESSION_ATTACHMENT_COUNT_LIMIT = 200;
 export const ATTACHMENT_ID = /^att_[a-f0-9]{24}$/;
@@ -60,7 +59,6 @@ const MIME_BY_EXTENSION = Object.freeze({
   epub: 'application/epub+zip',
 });
 const ATTACHMENT_FILE = /^att_[a-f0-9]{24}(?:[-.]|$)/;
-const uploadWindows = new Map();
 const uploadLocks = new Map();
 
 function httpError(statusCode, message) {
@@ -79,16 +77,12 @@ function sessionDir(sessionId) {
   return path.join(ATTACHMENTS_DIR, sessionId);
 }
 
-function checkUploadRate(sessionId) {
-  const now = Date.now();
-  const recent = (uploadWindows.get(sessionId) || []).filter((at) => now - at < 60_000);
-  if (recent.length >= 20) throw httpError(429, 'too many file uploads — try again in a minute');
-  recent.push(now);
-  uploadWindows.set(sessionId, recent);
-}
-
 // Serialize writes within one session so concurrent uploads cannot each pass a
-// stale quota check. Different sessions still stream in parallel.
+// stale quota check. This is also the server-side active-transfer bound: a
+// fifty-file batch streams one file at a time for its session, while different
+// sessions still make progress independently. The former 20/minute admission
+// counter rejected an ordinary batch at file 21 despite doing no useful load
+// control; the queue and byte/file quotas are the deliberate bounds instead.
 async function withUploadLock(sessionId, task) {
   const previous = uploadLocks.get(sessionId) || Promise.resolve();
   let release;
@@ -238,7 +232,6 @@ export async function receiveAttachment(readable, sessionId, { contentType = '',
   // Other formats are inert files: they are never executed, and the raw route
   // forces them to download rather than rendering browser-active content.
   const originalName = safeFileName(fileName);
-  checkUploadRate(sessionId);
   return withUploadLock(sessionId, async () => {
     const dir = sessionDir(sessionId);
     await fs.promises.mkdir(dir, { recursive: true });
@@ -297,12 +290,9 @@ export async function receiveAttachment(readable, sessionId, { contentType = '',
   });
 }
 
-/** Resolve an untrusted attachment id within exactly one session. */
-export function resolveAttachment(sessionId, attachmentId) {
+function resolveAttachmentFromNames(sessionId, attachmentId, names) {
   if (!ATTACHMENT_ID.test(String(attachmentId))) throw httpError(404, 'attachment not found');
   const dir = sessionDir(sessionId);
-  let names = [];
-  try { names = fs.readdirSync(dir); } catch {}
   for (const name of names) {
     const isCurrent = name.startsWith(`${attachmentId}-`);
     const legacyExtension = name.startsWith(`${attachmentId}.`) ? extensionOf(name) : '';
@@ -318,11 +308,24 @@ export function resolveAttachment(sessionId, attachmentId) {
   throw httpError(404, 'attachment not found');
 }
 
+/** Resolve an untrusted attachment id within exactly one session. */
+export function resolveAttachment(sessionId, attachmentId) {
+  const dir = sessionDir(sessionId);
+  let names = [];
+  try { names = fs.readdirSync(dir); } catch {}
+  return resolveAttachmentFromNames(sessionId, attachmentId, names);
+}
+
 export function resolveAttachments(sessionId, attachmentIds) {
   if (!Array.isArray(attachmentIds)) throw httpError(400, 'attachmentIds must be an array');
-  if (attachmentIds.length > 5) throw httpError(400, 'at most five files may be attached');
   if (new Set(attachmentIds).size !== attachmentIds.length) throw httpError(400, 'duplicate attachment id');
-  return attachmentIds.map((id) => resolveAttachment(sessionId, id));
+  // One directory read for the whole prompt. Re-reading a FUSE-backed session
+  // directory once per id made a legitimate dozens-file Send need dozens of
+  // serial bucket round trips before the harness saw anything.
+  const dir = sessionDir(sessionId);
+  let names = [];
+  try { names = fs.readdirSync(dir); } catch {}
+  return attachmentIds.map((id) => resolveAttachmentFromNames(sessionId, id, names));
 }
 
 /** Remove one unsent attachment without disturbing files the session still uses. */
@@ -335,7 +338,6 @@ export async function removeAttachment(sessionId, attachmentId) {
 }
 
 export async function removeSessionAttachments(sessionId) {
-  uploadWindows.delete(sessionId);
   await withUploadLock(sessionId, () => fs.promises.rm(sessionDir(sessionId), { recursive: true, force: true }));
 }
 

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -46,6 +46,7 @@ import {
 import * as runstate from './runstate.js';
 import { installSlowFsProbe } from './slowfs.js';
 import { operationMiddleware, readOperations } from './operations.js';
+import { fileWriteError, receiveWorkspaceFile, replaceWorkspaceText } from './safe-write.js';
 
 // Before anything else touches the mount: a sync fs call to /data is ~85ms of
 // frozen event loop here, and nothing else in the stack can see it. See slowfs.js.
@@ -1876,7 +1877,7 @@ app.get('/api/files/:id/download', (req, res) => {
 // a stale buffer is worse than making someone reload. Second, only files we could
 // show WHOLE are writable: the preview serves the first 512 KB of a big file, and
 // saving that back would silently truncate the rest.
-app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (req, res) => {
+app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
@@ -1898,15 +1899,21 @@ app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (re
   const text = typeof req.body === 'string' ? req.body : '';
   if (text.length > TEXT_MAX) return res.status(413).json({ error: 'too big to save' });
 
-  // Write beside the target and rename: a crash or a full disk leaves the
-  // original intact rather than a half-written file.
-  const tmp = path.join(path.dirname(f), `.${path.basename(f)}.am-tmp`);
   try {
-    fs.writeFileSync(tmp, text, 'utf8');
-    fs.renameSync(tmp, f);
+    // Recheck under the same destination lock used by uploads. This keeps the
+    // editor's existing content-tag contract while giving both writers unique,
+    // exclusive temporary files and one publication order.
+    await replaceWorkspaceText(f, text, async () => {
+      const current = resolveSafe(folderPathOf(s), req.query.path);
+      if (current !== f || !fs.existsSync(f) || !fs.lstatSync(f).isFile() || fs.lstatSync(f).isSymbolicLink()) {
+        throw fileWriteError(409, 'changed-on-disk', 'changed on disk since you opened it');
+      }
+      if (base && base !== contentTag(f)) {
+        throw fileWriteError(409, 'changed-on-disk', 'changed on disk since you opened it');
+      }
+    });
   } catch (e) {
-    try { fs.unlinkSync(tmp); } catch {}
-    return res.status(500).json({ error: String((e && e.message) || e) });
+    return res.status(e.statusCode || 500).json({ error: String((e && e.message) || e), code: e.code });
   }
   const after = fs.statSync(f);
   res.json({ ok: true, size: after.size, mtime: after.mtimeMs, tag: contentTag(f) });
@@ -1932,9 +1939,14 @@ function contentTag(file) {
 function dependedOnDir(abs) {
   const real = (p) => { try { return fs.realpathSync(p); } catch { return path.resolve(p); } };
   const target = real(abs);
-  if (target === real(SKILLS_DIR)) return 'the shared skills folder';
+  const contains = (parent, child) => child === parent || child.startsWith(parent + path.sep);
+  if (contains(target, real(SKILLS_DIR))) return 'the shared skills folder';
   for (const s of store.list()) {
-    if (s.path && real(workspacePath(s.path)) === target) return `${s.name}'s workspace`;
+    // `path` can be '' (the root) and old records can still omit it until the
+    // boot migration above. Both are real configured dependencies, including
+    // stopped sessions and sessions sharing or nesting a workspace.
+    const workspace = real(workspacePath(s.path ?? s.id));
+    if (contains(target, workspace)) return `${s.name}'s workspace`;
   }
   return null;
 }
@@ -1987,10 +1999,10 @@ app.post('/api/files/:id/rename', (req, res) => {
   if (!from || !name) return res.status(400).json({ error: 'bad name' });
   if (!fs.existsSync(from)) return res.status(404).json({ error: 'not found' });
   if (path.resolve(from) === path.resolve(root)) return res.status(400).json({ error: 'cannot rename the workspace root' });
-  const dep = dependedOnDir(from);
-  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
   const to = path.join(path.dirname(from), name);
   if (path.resolve(to) === path.resolve(from)) return res.json({ ok: true, name }); // no-op
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder contains ${dep}` });
   if (fs.existsSync(to)) return res.status(409).json({ error: `"${name}" already exists here` });
   try {
     fs.renameSync(from, to);
@@ -2011,9 +2023,6 @@ app.post('/api/files/:id/move', (req, res) => {
   const from = resolveSafe(root, b.path);
   if (!from || !fs.existsSync(from)) return res.status(404).json({ error: 'not found' });
   if (path.resolve(from) === path.resolve(root)) return res.status(400).json({ error: 'cannot move the workspace root' });
-  const dep = dependedOnDir(from);
-  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
-
   const destDir = resolveSafe(root, b.to || '');
   if (!destDir || !fs.existsSync(destDir)) return res.status(404).json({ error: 'no such folder' });
   if (!fs.statSync(destDir).isDirectory()) return res.status(400).json({ error: 'not a folder' });
@@ -2030,6 +2039,8 @@ app.post('/api/files/:id/move', (req, res) => {
 
   const to = path.join(destDir, path.basename(from));
   if (path.resolve(to) === path.resolve(from)) return res.json({ ok: true, path: path.relative(root, to) });
+  const dep = dependedOnDir(from);
+  if (dep) return res.status(409).json({ error: `that folder contains ${dep}` });
   if (fs.existsSync(to)) return res.status(409).json({ error: `"${path.basename(from)}" already exists there` });
   try {
     fs.renameSync(from, to);
@@ -2052,7 +2063,7 @@ app.delete('/api/files/:id/entry', (req, res) => {
   // A folder an agent is living in, or the shared skills dir, is not the
   // browser's to remove: the agent's cwd would vanish under a running process.
   const dep = dependedOnDir(target);
-  if (dep) return res.status(409).json({ error: `that folder is ${dep}` });
+  if (dep) return res.status(409).json({ error: `that folder contains ${dep}` });
   try {
     fs.rmSync(target, { recursive: true, force: true });
   } catch (e) {
@@ -2110,25 +2121,56 @@ app.get('/api/files/:id/trace', async (req, res) => {
 
 // Stream uploads straight to disk — a big drag-drop must not be buffered in the
 // RAM of the process that's also pumping every terminal's PTY data.
-app.post('/api/files/:id/upload', (req, res) => {
+app.post('/api/files/:id/upload', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
-  const dir = resolveSafe(folderPathOf(s), req.query.path);
-  const name = String(req.query.name || '');
-  if (!dir || !name || name.includes('/') || name.includes('..')) return res.status(400).json({ error: 'bad path' });
-  const dest = path.join(dir, name);
-  try { fs.mkdirSync(dir, { recursive: true }); } catch (e) { return res.status(500).json({ error: e.message }); }
-  const out = fs.createWriteStream(dest);
-  const fail = (e) => {
-    out.destroy();
-    fs.unlink(dest, () => {}); // don't leave a truncated file behind
-    if (!res.headersSent) res.status(500).json({ error: String(e && e.message || e) });
-  };
-  out.on('error', fail);
-  req.on('error', fail);
-  req.on('aborted', () => fail(new Error('upload aborted')));
-  out.on('finish', () => res.json({ ok: true }));
-  req.pipe(out);
+  const root = folderPathOf(s);
+  const requestedDir = resolveSafe(root, req.query.path);
+  const name = cleanName(req.query.name);
+  if (!requestedDir || !name) return res.status(400).json({ error: 'bad path' });
+  let realRoot; let realDir;
+  try {
+    realRoot = await fs.promises.realpath(root);
+    realDir = await fs.promises.realpath(requestedDir);
+    const stat = await fs.promises.stat(realDir);
+    if (!stat.isDirectory() || (realDir !== realRoot && !realDir.startsWith(realRoot + path.sep))) {
+      return res.status(400).json({ error: 'bad path' });
+    }
+  } catch {
+    return res.status(404).json({ error: 'destination folder no longer exists' });
+  }
+  const destination = path.join(realDir, name);
+  const displayPath = path.relative(root, path.join(requestedDir, name)).split(path.sep).join('/');
+  try {
+    const validate = async () => {
+      let rootNow; let dirNow;
+      try {
+        rootNow = await fs.promises.realpath(root);
+        dirNow = await fs.promises.realpath(requestedDir);
+      } catch {
+        throw fileWriteError(409, 'destination-changed', 'the destination folder changed during upload');
+      }
+      if (rootNow !== realRoot || dirNow !== realDir
+          || (dirNow !== rootNow && !dirNow.startsWith(rootNow + path.sep))) {
+        throw fileWriteError(409, 'destination-changed', 'the destination folder changed during upload');
+      }
+    };
+    const result = await receiveWorkspaceFile(req, destination, {
+      displayPath,
+      replaceToken: req.headers['x-am-replace-token'] || '',
+      validate,
+    });
+    if (!res.destroyed) res.json({ ok: true, path: displayPath, ...result });
+  } catch (e) {
+    if (!res.headersSent && !res.destroyed) res.status(e.statusCode || 500).json({
+      error: String((e && e.message) || e),
+      ...(e.code ? { code: e.code } : {}),
+      ...(e.path !== undefined ? { path: e.path } : {}),
+      ...(e.name !== undefined ? { name: e.name } : {}),
+      ...(e.revision !== undefined ? { revision: e.revision } : {}),
+      ...(e.replaceToken !== undefined ? { replaceToken: e.replaceToken } : {}),
+    });
+  }
 });
 
 // Sanitize a client-supplied workspace-relative path: no '..', no absolute

--- a/server/src/safe-write.js
+++ b/server/src/safe-write.js
@@ -1,0 +1,175 @@
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+
+const destinationLocks = new Map();
+const replacementSecret = crypto.randomBytes(32);
+
+export function fileWriteError(statusCode, code, message, details = {}) {
+  const error = new Error(message);
+  error.statusCode = statusCode;
+  error.code = code;
+  Object.assign(error, details);
+  return error;
+}
+
+/** Serialize only operations that publish to the same resolved destination. */
+export async function withDestinationLock(destination, task) {
+  const key = path.resolve(destination);
+  const previous = destinationLocks.get(key) || Promise.resolve();
+  let release;
+  const hold = new Promise((resolve) => { release = resolve; });
+  const tail = previous.catch(() => {}).then(() => hold);
+  destinationLocks.set(key, tail);
+  await previous.catch(() => {});
+  try {
+    return await task();
+  } finally {
+    release();
+    if (destinationLocks.get(key) === tail) destinationLocks.delete(key);
+  }
+}
+
+const lstatOrNull = async (file) => {
+  try { return await fs.promises.lstat(file); }
+  catch (error) { if (error?.code === 'ENOENT') return null; throw error; }
+};
+
+/** A full content identity, streamed so a large existing file is never buffered. */
+export async function fileRevision(file) {
+  const stat = await lstatOrNull(file);
+  if (!stat) return null;
+  if (stat.isSymbolicLink()) throw fileWriteError(400, 'unsafe-destination', 'the destination is a symbolic link');
+  if (!stat.isFile()) throw fileWriteError(409, 'destination-not-file', 'the destination is not a file');
+  const hash = crypto.createHash('sha256');
+  for await (const chunk of fs.createReadStream(file)) hash.update(chunk);
+  return `sha256:${stat.size}:${hash.digest('hex')}`;
+}
+
+const tokenFor = (destination, revision) => crypto.createHmac('sha256', replacementSecret)
+  .update(path.resolve(destination)).update('\0').update(revision).digest('hex');
+
+const matchesToken = (provided, expected) => {
+  if (!/^[a-f0-9]{64}$/.test(String(provided || ''))) return false;
+  return crypto.timingSafeEqual(Buffer.from(provided, 'hex'), Buffer.from(expected, 'hex'));
+};
+
+const collision = async (destination, displayPath, stale = false) => {
+  const revision = await fileRevision(destination);
+  if (!revision) {
+    throw fileWriteError(409, 'replacement-stale', `"${path.basename(displayPath)}" no longer exists — upload it again`, {
+      path: displayPath, name: path.basename(displayPath), revision: null, replaceToken: null,
+    });
+  }
+  throw fileWriteError(409, stale ? 'replacement-stale' : 'file-exists', stale
+    ? `"${path.basename(displayPath)}" changed after replacement was confirmed`
+    : `"${path.basename(displayPath)}" already exists`, {
+    path: displayPath,
+    name: path.basename(displayPath),
+    revision,
+    replaceToken: tokenFor(destination, revision),
+  });
+};
+
+async function openOwnedTemporary(destination, randomBytes = crypto.randomBytes) {
+  const dir = path.dirname(destination);
+  const base = path.basename(destination).slice(0, 80) || 'upload';
+  for (let attempt = 0; attempt < 8; attempt += 1) {
+    const temporary = path.join(dir, `.${base}.am-upload-${randomBytes(8).toString('hex')}.part`);
+    try {
+      const handle = await fs.promises.open(temporary, 'wx');
+      return { temporary, handle };
+    } catch (error) {
+      if (error?.code !== 'EEXIST') throw error;
+    }
+  }
+  throw fileWriteError(503, 'temporary-collision', 'could not reserve a temporary upload file — retry');
+}
+
+async function stage(readable, destination, options = {}) {
+  const { temporary, handle } = await openOwnedTemporary(destination, options.randomBytes);
+  try {
+    await pipeline(readable, handle.createWriteStream());
+    return temporary;
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await fs.promises.unlink(temporary).catch(() => {});
+    throw error;
+  }
+}
+
+// Hard-link publication gives create-only uploads an atomic no-replace commit.
+// Some storage adapters do not implement links; COPYFILE_EXCL is the bounded
+// fallback. It still refuses a competing creator and Node removes its own
+// partial destination if copying fails, but it cannot promise atomic visibility.
+async function publishCreate(temporary, destination, options = {}) {
+  try {
+    await (options.link || fs.promises.link)(temporary, destination);
+  } catch (error) {
+    if (!['ENOTSUP', 'EOPNOTSUPP', 'EPERM', 'EXDEV'].includes(error?.code)) throw error;
+    await (options.copyFile || fs.promises.copyFile)(temporary, destination, fs.constants.COPYFILE_EXCL);
+  }
+  await fs.promises.unlink(temporary).catch(() => {});
+}
+
+/**
+ * Stream a workspace upload beside its destination, then conditionally publish.
+ * A replacement token is an HMAC over this exact resolved path and the full
+ * current content hash. Tokens die with the server process; after a restart the
+ * safe answer is to ask again.
+ */
+export async function receiveWorkspaceFile(readable, destination, {
+  displayPath = path.basename(destination), replaceToken = '', validate = async () => {},
+  publishReplacement = fs.promises.rename, publishOptions = {}, randomBytes,
+} = {}) {
+  return withDestinationLock(destination, async () => {
+    const before = await fileRevision(destination);
+    if (before) {
+      if (!replaceToken) await collision(destination, displayPath);
+      if (!matchesToken(replaceToken, tokenFor(destination, before))) await collision(destination, displayPath, true);
+    } else if (replaceToken) {
+      await collision(destination, displayPath, true);
+    }
+
+    await validate();
+    let temporary = await stage(readable, destination, { randomBytes });
+    try {
+      await validate();
+      const current = await fileRevision(destination);
+      if (!replaceToken) {
+        if (current) await collision(destination, displayPath);
+        await publishCreate(temporary, destination, publishOptions);
+        temporary = null;
+      } else {
+        if (!current || !matchesToken(replaceToken, tokenFor(destination, current))) {
+          await collision(destination, displayPath, true);
+        }
+        await publishReplacement(temporary, destination);
+        temporary = null;
+      }
+      const after = await fs.promises.stat(destination);
+      return { size: after.size, mtime: after.mtimeMs };
+    } finally {
+      if (temporary) await fs.promises.unlink(temporary).catch(() => {});
+    }
+  });
+}
+
+/** The editor keeps its existing content-tag check but shares owned temp files. */
+export async function replaceWorkspaceText(destination, text, validate = async () => {}, options = {}) {
+  return withDestinationLock(destination, async () => {
+    await validate();
+    let temporary = await stage(Readable.from([Buffer.from(text, 'utf8')]), destination, options);
+    try {
+      await validate();
+      await (options.publishReplacement || fs.promises.rename)(temporary, destination);
+      temporary = null;
+      const after = await fs.promises.stat(destination);
+      return { size: after.size, mtime: after.mtimeMs };
+    } finally {
+      if (temporary) await fs.promises.unlink(temporary).catch(() => {});
+    }
+  });
+}

--- a/server/test/attachments.test.mjs
+++ b/server/test/attachments.test.mjs
@@ -8,7 +8,7 @@ const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-attachments-'));
 process.env.DATA_DIR = root;
 
 const {
-  ATTACHMENT_LIMIT, SESSION_ATTACHMENT_LIMIT, detectImageMime, formatAttachmentDelivery,
+  ATTACHMENT_LIMIT, SESSION_ATTACHMENT_LIMIT, SESSION_ATTACHMENT_COUNT_LIMIT, detectImageMime, formatAttachmentDelivery,
   formatAttachmentPrelude, pruneAttachmentDirs, receiveAttachment, removeAttachment, removeSessionAttachments,
   resolveAttachment, resolveAttachments,
 } = await import('../src/attachments.js');
@@ -56,7 +56,7 @@ try {
 
   assert.throws(() => resolveAttachment('other-123abc', stored.id), /not found/);
   assert.throws(() => resolveAttachment('codex-123abc', '../sessions.json'), /not found/);
-  assert.throws(() => resolveAttachments('codex-123abc', Array(6).fill(stored.id)), /at most five/);
+  assert.throws(() => resolveAttachments('codex-123abc', Array(6).fill(stored.id)), /duplicate attachment id/);
 
   const mislabeled = await receive(png, 'codex-123abc', 'image/jpeg', 'wrong.jpg');
   assert.equal(mislabeled.mime, 'image/png');
@@ -134,6 +134,16 @@ try {
     (error) => error.statusCode === 413 && /500 MB/.test(error.message),
   );
 
+  const countDir = path.join(root, 'state', 'attachments', 'count-quota-123abc');
+  fs.mkdirSync(countDir, { recursive: true });
+  for (let index = 0; index < SESSION_ATTACHMENT_COUNT_LIMIT; index += 1) {
+    fs.writeFileSync(path.join(countDir, `att_${index.toString(16).padStart(24, '0')}-tiny.txt`), 'x');
+  }
+  await assert.rejects(
+    receive(Buffer.from('one more'), 'count-quota-123abc', 'text/plain', 'over.txt'),
+    (error) => error.statusCode === 413 && /200 files/.test(error.message),
+  );
+
   const raceQuotaDir = path.join(root, 'state', 'attachments', 'race-quota-123abc');
   fs.mkdirSync(raceQuotaDir, { recursive: true });
   const raceQuotaFile = path.join(raceQuotaDir, 'existing.bin');
@@ -150,6 +160,51 @@ try {
   const concurrent = await Promise.all(Array.from({ length: 4 }, () =>
     receive(png, 'parallel-123abc', 'application/octet-stream', 'parallel.png')));
   assert.equal(new Set(concurrent.map((image) => image.id)).size, concurrent.length);
+
+  // Fifty is an acceptance case, not a new ceiling. Upload more than that
+  // through the real store and resolver, then prove every requested batch keeps
+  // its order all the way into normal harness delivery.
+  const many = await Promise.all(Array.from({ length: 75 }, (_, index) =>
+    receive(Buffer.from(`batch-${String(index).padStart(2, '0')}`), 'batch-123abc',
+      'text/plain', index % 2 ? 'same-name.txt' : `file-${index}.txt`)));
+  assert.equal(new Set(many.map((file) => file.id)).size, 75, 'same display names remain separate stored files');
+  for (const count of [6, 30, 50, 75]) {
+    const requested = many.slice(0, count);
+    const resolved = resolveAttachments('batch-123abc', requested.map((file) => file.id));
+    assert.deepEqual(resolved.map((file) => file.id), requested.map((file) => file.id));
+    const delivered = formatAttachmentDelivery('codex', `Read ${count}`, resolved);
+    let previous = -1;
+    for (const file of resolved) {
+      const at = delivered.indexOf(JSON.stringify(file.path));
+      assert.ok(at > previous, `${count}-file harness delivery lost or reordered ${file.name}`);
+      previous = at;
+    }
+  }
+
+  let activeTotal = 0; let maxTotal = 0;
+  const activeBySession = new Map(); const maxBySession = new Map();
+  const metered = (sessionId, text) => new Readable({
+    read() {
+      if (this.started) return;
+      this.started = true;
+      const active = (activeBySession.get(sessionId) || 0) + 1;
+      activeBySession.set(sessionId, active);
+      maxBySession.set(sessionId, Math.max(maxBySession.get(sessionId) || 0, active));
+      activeTotal += 1; maxTotal = Math.max(maxTotal, activeTotal);
+      setTimeout(() => {
+        this.push(text); this.push(null);
+        activeBySession.set(sessionId, activeBySession.get(sessionId) - 1);
+        activeTotal -= 1;
+      }, 30);
+    },
+  });
+  await Promise.all([
+    receiveAttachment(metered('meter-a', 'a1'), 'meter-a', { fileName: 'a1.txt' }),
+    receiveAttachment(metered('meter-a', 'a2'), 'meter-a', { fileName: 'a2.txt' }),
+    receiveAttachment(metered('meter-b', 'b1'), 'meter-b', { fileName: 'b1.txt' }),
+  ]);
+  assert.equal(maxBySession.get('meter-a'), 1, 'one session streams one quota-checked file at a time');
+  assert.ok(maxTotal >= 2, 'independent sessions stream without sharing one global lock');
 
   const formatted = formatAttachmentDelivery('codex', 'Compare this', [stored]);
   assert.match(formatted, /Compare this/);

--- a/server/test/files-safety.test.mjs
+++ b/server/test/files-safety.test.mjs
@@ -1,0 +1,228 @@
+// Real file routes in an isolated server: conditional upload publication and
+// configured-folder dependency guards. Never touches the live workspace.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import http from 'node:http';
+import net from 'node:net';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const DATA_DIR = fs.mkdtempSync(path.join(os.tmpdir(), 'am-files-safety-'));
+const WORK = path.join(DATA_DIR, 'workspaces');
+// An old record with no explicit path is migrated to its id at boot. Dependency
+// checks must use that same effective default, even though it is stopped.
+fs.writeFileSync(path.join(DATA_DIR, 'sessions.json'), JSON.stringify([{
+  id: 'legacy-default', name: 'legacy-default-agent', cli: 'shell',
+  createdAt: '2026-09-01T00:00:00.000Z', everStarted: false,
+}]));
+const probe = net.createServer();
+await new Promise((resolve) => probe.listen(0, '127.0.0.1', resolve));
+const PORT = probe.address().port;
+await new Promise((resolve) => probe.close(resolve));
+const API = `http://127.0.0.1:${PORT}`;
+const { SPACE_ID, AM_DISTRIBUTE_SKILLS, DATA_DIR: inheritedData, PORT: inheritedPort,
+  PUBLIC_DIR, ...BASE_ENV } = process.env;
+const server = spawn(process.execPath, ['src/index.js'], {
+  env: {
+    ...BASE_ENV, PORT: String(PORT), DATA_DIR, HOME: path.join(DATA_DIR, 'home'),
+    AM_BASHRC: '/nonexistent', AM_ALLOW_MISSING_ORIGIN: '1',
+  },
+  stdio: ['ignore', 'pipe', 'pipe'],
+});
+let log = '';
+server.stdout.on('data', (chunk) => { log += chunk; });
+server.stderr.on('data', (chunk) => { log += chunk; });
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const api = async (route, init = {}) => {
+  const headers = new Headers(init.headers || {});
+  if (init.method && init.method !== 'GET') headers.set('x-am-origin', 'operator');
+  if (init.body && typeof init.body === 'string' && !headers.has('content-type')) headers.set('content-type', 'application/json');
+  const response = await fetch(`${API}${route}`, { ...init, headers });
+  const responseBody = await response.json().catch(() => null);
+  return { status: response.status, body: responseBody };
+};
+const createSession = async (name, cli, workspace) => (await api('/api/sessions', {
+  method: 'POST', body: JSON.stringify({ name, cli, path: workspace }),
+})).body;
+const upload = (id, folder, name, bytes, token) => api(
+  `/api/files/${id}/upload?path=${encodeURIComponent(folder)}&name=${encodeURIComponent(name)}`,
+  { method: 'POST', headers: {
+    'content-type': 'application/octet-stream',
+    ...(token ? { 'x-am-replace-token': token } : {}),
+  }, body: bytes },
+);
+
+try {
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    if (await fetch(`${API}/api/health`).then((response) => response.ok).catch(() => false)) break;
+    await sleep(100);
+  }
+  assert.ok(log.includes(`:${PORT}`), `server did not start: ${log.slice(-1000)}`);
+
+  const files = await createSession('files', 'files', '.');
+  const nested = await createSession('nested-agent', 'shell', 'team/nested');
+  const sharedOne = await createSession('shared-one', 'shell', 'shared');
+  await createSession('shared-two', 'shell', 'shared');
+  assert.ok(files?.id && nested?.id && sharedOne?.id);
+  fs.writeFileSync(path.join(WORK, 'team', 'nested', 'sentinel.txt'), 'NESTED');
+  fs.writeFileSync(path.join(WORK, 'shared', 'sentinel.txt'), 'SHARED');
+  fs.writeFileSync(path.join(WORK, 'legacy-default', 'sentinel.txt'), 'DEFAULT');
+
+  const renameAncestor = await api(`/api/files/${files.id}/rename`, {
+    method: 'POST', body: JSON.stringify({ path: 'team', name: 'renamed-team' }),
+  });
+  assert.equal(renameAncestor.status, 409);
+  assert.match(renameAncestor.body.error, /nested-agent.*workspace/);
+  assert.equal(fs.readFileSync(path.join(WORK, 'team', 'nested', 'sentinel.txt'), 'utf8'), 'NESTED');
+
+  const deleteAncestor = await api(`/api/files/${files.id}/entry?path=team`, { method: 'DELETE' });
+  assert.equal(deleteAncestor.status, 409);
+  const moveAncestor = await api(`/api/files/${files.id}/move`, {
+    method: 'POST', body: JSON.stringify({ path: 'team', to: '' }),
+  });
+  assert.equal(moveAncestor.status, 200, 'moving a protected folder to its current parent is a safe no-op');
+  const renameNoop = await api(`/api/files/${files.id}/rename`, {
+    method: 'POST', body: JSON.stringify({ path: 'team', name: 'team' }),
+  });
+  assert.equal(renameNoop.status, 200, 'renaming a protected folder to its current name is a safe no-op');
+
+  const exactShared = await api(`/api/files/${files.id}/entry?path=shared`, { method: 'DELETE' });
+  assert.equal(exactShared.status, 409);
+  assert.match(exactShared.body.error, /shared-one.*workspace/);
+  const exactDefault = await api(`/api/files/${files.id}/entry?path=legacy-default`, { method: 'DELETE' });
+  assert.equal(exactDefault.status, 409);
+  assert.match(exactDefault.body.error, /legacy-default-agent.*workspace/);
+  const skills = await api(`/api/files/${files.id}/rename`, {
+    method: 'POST', body: JSON.stringify({ path: 'skills', name: 'skills-away' }),
+  });
+  assert.equal(skills.status, 409);
+  assert.match(skills.body.error, /shared skills/);
+
+  fs.symlinkSync(path.join(WORK, 'team'), path.join(WORK, 'team-alias'));
+  const alias = await api(`/api/files/${files.id}/rename`, {
+    method: 'POST', body: JSON.stringify({ path: 'team-alias', name: 'alias-away' }),
+  });
+  assert.equal(alias.status, 409);
+  assert.match(alias.body.error, /nested-agent.*workspace/);
+
+  fs.mkdirSync(path.join(WORK, 'teamish'));
+  fs.writeFileSync(path.join(WORK, 'teamish', 'unrelated.txt'), 'UNRELATED');
+  const sibling = await api(`/api/files/${files.id}/rename`, {
+    method: 'POST', body: JSON.stringify({ path: 'teamish', name: 'teamish-renamed' }),
+  });
+  assert.equal(sibling.status, 200);
+  assert.equal(fs.readFileSync(path.join(WORK, 'teamish-renamed', 'unrelated.txt'), 'utf8'), 'UNRELATED');
+
+  const sessionsBefore = fs.readFileSync(path.join(DATA_DIR, 'sessions.json'), 'utf8');
+  assert.equal(fs.existsSync(path.join(WORK, 'team', 'nested')), true);
+  assert.equal(fs.readFileSync(path.join(DATA_DIR, 'sessions.json'), 'utf8'), sessionsBefore,
+    'forbidden file operations do not rewrite session configuration');
+
+  const created = await upload(files.id, '', 'report.txt', 'ORIGINAL');
+  assert.equal(created.status, 200);
+  const collision = await upload(files.id, '', 'report.txt', 'SILENT-OVERWRITE');
+  assert.equal(collision.status, 409);
+  assert.deepEqual({ code: collision.body.code, name: collision.body.name, path: collision.body.path },
+    { code: 'file-exists', name: 'report.txt', path: 'report.txt' });
+  assert.match(collision.body.revision, /^sha256:/);
+  assert.match(collision.body.replaceToken, /^[a-f0-9]{64}$/);
+  assert.equal(fs.readFileSync(path.join(WORK, 'report.txt'), 'utf8'), 'ORIGINAL');
+
+  const replaced = await upload(files.id, '', 'report.txt', 'DELIBERATE', collision.body.replaceToken);
+  assert.equal(replaced.status, 200);
+  assert.equal(fs.readFileSync(path.join(WORK, 'report.txt'), 'utf8'), 'DELIBERATE');
+  const staleChoice = await upload(files.id, '', 'report.txt', 'x');
+  fs.writeFileSync(path.join(WORK, 'report.txt'), 'CHANGED-BY-AGENT');
+  const stale = await upload(files.id, '', 'report.txt', 'STALE', staleChoice.body.replaceToken);
+  assert.equal(stale.status, 409);
+  assert.equal(stale.body.code, 'replacement-stale');
+  assert.notEqual(stale.body.replaceToken, staleChoice.body.replaceToken);
+  assert.equal(fs.readFileSync(path.join(WORK, 'report.txt'), 'utf8'), 'CHANGED-BY-AGENT');
+
+  const simultaneous = await Promise.all([
+    upload(files.id, '', 'race.txt', 'RACE-A'),
+    upload(files.id, '', 'race.txt', 'RACE-B'),
+  ]);
+  assert.deepEqual(simultaneous.map((result) => result.status).sort(), [200, 409]);
+  assert.ok(['RACE-A', 'RACE-B'].includes(fs.readFileSync(path.join(WORK, 'race.txt'), 'utf8')));
+
+  fs.writeFileSync(path.join(WORK, 'replace-race.txt'), 'BEFORE');
+  const replaceRaceChoice = await upload(files.id, '', 'replace-race.txt', 'x');
+  const replaceRace = await Promise.all([
+    upload(files.id, '', 'replace-race.txt', 'REPLACE-A', replaceRaceChoice.body.replaceToken),
+    upload(files.id, '', 'replace-race.txt', 'REPLACE-B', replaceRaceChoice.body.replaceToken),
+  ]);
+  assert.deepEqual(replaceRace.map((result) => result.status).sort(), [200, 409]);
+  assert.equal(replaceRace.find((result) => result.status === 409).body.code, 'replacement-stale');
+
+  const outside = path.join(DATA_DIR, 'outside.txt');
+  fs.writeFileSync(outside, 'OUTSIDE');
+  fs.symlinkSync(outside, path.join(WORK, 'outside-link.txt'));
+  const existingLink = await upload(files.id, '', 'outside-link.txt', 'FOLLOW');
+  assert.equal(existingLink.status, 400);
+  assert.equal(fs.readFileSync(outside, 'utf8'), 'OUTSIDE');
+  fs.symlinkSync(path.join(WORK, 'not-there'), path.join(WORK, 'dangling-link.txt'));
+  const danglingLink = await upload(files.id, '', 'dangling-link.txt', 'FOLLOW');
+  assert.equal(danglingLink.status, 400);
+  assert.equal(fs.existsSync(path.join(WORK, 'not-there')), false);
+
+  const outsideDir = path.join(DATA_DIR, 'outside-folder');
+  fs.mkdirSync(outsideDir);
+  fs.symlinkSync(outsideDir, path.join(WORK, 'outside-parent'));
+  const outsideParent = await upload(files.id, 'outside-parent', 'escaped.txt', 'FOLLOW');
+  assert.equal(outsideParent.status, 400);
+  assert.equal(fs.existsSync(path.join(outsideDir, 'escaped.txt')), false);
+
+  fs.mkdirSync(path.join(WORK, 'actual-a'));
+  fs.mkdirSync(path.join(WORK, 'actual-b'));
+  const switcher = path.join(WORK, 'switcher');
+  fs.symlinkSync(path.join(WORK, 'actual-a'), switcher);
+  const switched = await new Promise((resolve, reject) => {
+    const request = http.request(`${API}/api/files/${files.id}/upload?path=switcher&name=switched.txt`, {
+      method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/octet-stream', 'content-length': 16 },
+    }, (response) => {
+      let text = ''; response.on('data', (chunk) => { text += chunk; });
+      response.on('end', () => resolve({ status: response.statusCode, body: JSON.parse(text) }));
+    });
+    request.on('error', reject);
+    request.write('FIRST-HALF');
+    setTimeout(() => {
+      fs.unlinkSync(switcher);
+      fs.symlinkSync(path.join(WORK, 'actual-b'), switcher);
+      request.end('SECOND');
+    }, 50);
+  });
+  assert.equal(switched.status, 409);
+  assert.equal(switched.body.code, 'destination-changed');
+  assert.equal(fs.existsSync(path.join(WORK, 'actual-a', 'switched.txt')), false);
+  assert.equal(fs.existsSync(path.join(WORK, 'actual-b', 'switched.txt')), false);
+
+  fs.writeFileSync(path.join(WORK, 'abort.txt'), 'SURVIVES');
+  const abortChoice = await upload(files.id, '', 'abort.txt', 'x');
+  await new Promise((resolve) => {
+    const request = http.request(`${API}/api/files/${files.id}/upload?path=&name=abort.txt`, {
+      method: 'POST', headers: {
+        'x-am-origin': 'operator', 'x-am-replace-token': abortChoice.body.replaceToken,
+        'content-type': 'application/octet-stream', 'content-length': 100_000,
+      },
+    });
+    request.on('error', () => resolve());
+    request.write(Buffer.alloc(1024, 1));
+    setTimeout(() => { request.destroy(); resolve(); }, 40);
+  });
+  await sleep(120);
+  assert.equal(fs.readFileSync(path.join(WORK, 'abort.txt'), 'utf8'), 'SURVIVES');
+  assert.equal(fs.readdirSync(WORK).some((name) => name.endsWith('.part')), false);
+
+  console.log('file route safety tests passed');
+} catch (error) {
+  console.error(error);
+  console.error(log.slice(-2000));
+  process.exitCode = 1;
+} finally {
+  server.kill('SIGTERM');
+  await Promise.race([new Promise((resolve) => server.once('exit', resolve)), sleep(3000)]);
+  fs.rmSync(DATA_DIR, { recursive: true, force: true });
+}

--- a/server/test/safe-write.test.mjs
+++ b/server/test/safe-write.test.mjs
@@ -1,0 +1,145 @@
+// Workspace upload publication: create-only, explicit conditional replacement,
+// and exact-byte preservation on every failure path.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+import { receiveWorkspaceFile } from '../src/safe-write.js';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-safe-write-'));
+const target = path.join(root, 'report.txt');
+const parts = () => fs.readdirSync(root).filter((name) => name.endsWith('.part'));
+const body = (text) => Readable.from([Buffer.from(text)]);
+
+async function expectCollision(text = 'not written') {
+  try {
+    await receiveWorkspaceFile(body(text), target, { displayPath: 'reports/report.txt' });
+    assert.fail('expected a collision');
+  } catch (error) {
+    assert.equal(error.statusCode, 409);
+    assert.equal(error.code, 'file-exists');
+    assert.equal(error.path, 'reports/report.txt');
+    assert.equal(error.name, 'report.txt');
+    assert.match(error.revision, /^sha256:/);
+    assert.match(error.replaceToken, /^[a-f0-9]{64}$/);
+    return error;
+  }
+}
+
+try {
+  fs.writeFileSync(target, 'ORIGINAL');
+  const first = await expectCollision();
+  assert.equal(fs.readFileSync(target, 'utf8'), 'ORIGINAL', 'create-only collision keeps existing bytes');
+
+  const aborted = new Readable({
+    read() { this.push('PARTIAL'); this.destroy(new Error('connection interrupted')); },
+  });
+  await assert.rejects(receiveWorkspaceFile(aborted, target, {
+    displayPath: 'reports/report.txt', replaceToken: first.replaceToken,
+  }), /connection interrupted/);
+  assert.equal(fs.readFileSync(target, 'utf8'), 'ORIGINAL', 'aborted replacement keeps existing bytes');
+  assert.deepEqual(parts(), [], 'aborted replacement removes only its temporary');
+
+  await receiveWorkspaceFile(body('REPLACED'), target, {
+    displayPath: 'reports/report.txt', replaceToken: first.replaceToken,
+  });
+  assert.equal(fs.readFileSync(target, 'utf8'), 'REPLACED');
+
+  const stale = await expectCollision();
+  fs.writeFileSync(target, 'AGENT-WROTE-THIS');
+  await assert.rejects(receiveWorkspaceFile(body('STALE-CHOICE'), target, {
+    displayPath: 'reports/report.txt', replaceToken: stale.replaceToken,
+  }), (error) => error.statusCode === 409 && error.code === 'replacement-stale'
+    && /^[a-f0-9]{64}$/.test(error.replaceToken));
+  assert.equal(fs.readFileSync(target, 'utf8'), 'AGENT-WROTE-THIS', 'stale confirmation preserves newer bytes');
+
+  const duringUpload = await expectCollision();
+  let continued;
+  const slowReplacement = new Readable({
+    read() {
+      if (continued) return;
+      continued = true;
+      this.push('FIRST-UPLOAD-CHUNK');
+      setTimeout(() => {
+        fs.writeFileSync(target, 'AGENT-WROTE-DURING-UPLOAD');
+        this.push('SECOND-UPLOAD-CHUNK'); this.push(null);
+      }, 20);
+    },
+  });
+  await assert.rejects(receiveWorkspaceFile(slowReplacement, target, {
+    displayPath: 'reports/report.txt', replaceToken: duringUpload.replaceToken,
+  }), (error) => error.statusCode === 409 && error.code === 'replacement-stale');
+  assert.equal(fs.readFileSync(target, 'utf8'), 'AGENT-WROTE-DURING-UPLOAD',
+    'a change during upload wins over the stale replacement stream');
+
+  const beforePublish = await expectCollision();
+  await assert.rejects(receiveWorkspaceFile(body('WILL-NOT-LAND'), target, {
+    displayPath: 'reports/report.txt', replaceToken: beforePublish.replaceToken,
+    publishReplacement: async () => { throw new Error('injected publication failure'); },
+  }), /injected publication failure/);
+  assert.equal(fs.readFileSync(target, 'utf8'), 'AGENT-WROTE-DURING-UPLOAD', 'failed publish preserves existing bytes');
+  assert.deepEqual(parts(), []);
+
+  const createTarget = path.join(root, 'created.txt');
+  const creates = await Promise.allSettled([
+    receiveWorkspaceFile(body('FIRST'), createTarget, { displayPath: 'created.txt' }),
+    receiveWorkspaceFile(body('SECOND'), createTarget, { displayPath: 'created.txt' }),
+  ]);
+  assert.equal(creates.filter((result) => result.status === 'fulfilled').length, 1);
+  assert.equal(creates.filter((result) => result.status === 'rejected'
+    && result.reason.code === 'file-exists').length, 1);
+  assert.ok(['FIRST', 'SECOND'].includes(fs.readFileSync(createTarget, 'utf8')));
+
+  const token = (await (async () => {
+    try { await receiveWorkspaceFile(body('x'), target, { displayPath: 'report.txt' }); }
+    catch (error) { return error.replaceToken; }
+  })());
+  const replacements = await Promise.allSettled([
+    receiveWorkspaceFile(body('REPLACE-A'), target, { displayPath: 'report.txt', replaceToken: token }),
+    receiveWorkspaceFile(body('REPLACE-B'), target, { displayPath: 'report.txt', replaceToken: token }),
+  ]);
+  assert.equal(replacements.filter((result) => result.status === 'fulfilled').length, 1);
+  assert.equal(replacements.filter((result) => result.status === 'rejected'
+    && result.reason.code === 'replacement-stale').length, 1);
+
+  const collisionTempTarget = path.join(root, 'safe.txt');
+  const occupied = path.join(root, '.safe.txt.am-upload-aaaaaaaaaaaaaaaa.part');
+  fs.writeFileSync(occupied, 'UNRELATED-SENTINEL');
+  const random = [Buffer.alloc(8, 0xaa), Buffer.alloc(8, 0xbb)];
+  await receiveWorkspaceFile(body('SAFE'), collisionTempTarget, {
+    displayPath: 'safe.txt', randomBytes: () => random.shift(),
+  });
+  assert.equal(fs.readFileSync(collisionTempTarget, 'utf8'), 'SAFE');
+  assert.equal(fs.readFileSync(occupied, 'utf8'), 'UNRELATED-SENTINEL', 'exclusive temp collision leaves unrelated bytes alone');
+  assert.equal(fs.existsSync(path.join(root, '.safe.txt.am-upload-bbbbbbbbbbbbbbbb.part')), false);
+
+  const tempLinkTarget = path.join(root, 'temp-link-sentinel.txt');
+  const tempLink = path.join(root, '.temp-symlink.txt.am-upload-cccccccccccccccc.part');
+  fs.writeFileSync(tempLinkTarget, 'TEMP-LINK-SENTINEL');
+  fs.symlinkSync(tempLinkTarget, tempLink);
+  const tempRandom = [Buffer.alloc(8, 0xcc), Buffer.alloc(8, 0xdd)];
+  await receiveWorkspaceFile(body('SAFE-PAST-LINK'), path.join(root, 'temp-symlink.txt'), {
+    displayPath: 'temp-symlink.txt', randomBytes: () => tempRandom.shift(),
+  });
+  assert.equal(fs.readFileSync(tempLinkTarget, 'utf8'), 'TEMP-LINK-SENTINEL',
+    'exclusive temporary creation never follows a pre-existing symlink');
+  assert.equal(fs.lstatSync(tempLink).isSymbolicLink(), true, 'cleanup never removes an unowned temporary-path symlink');
+
+  const outside = path.join(root, 'outside.txt');
+  const linked = path.join(root, 'linked.txt');
+  fs.writeFileSync(outside, 'OUTSIDE');
+  fs.symlinkSync(outside, linked);
+  await assert.rejects(receiveWorkspaceFile(body('FOLLOWED'), linked, { displayPath: 'linked.txt' }),
+    (error) => error.code === 'unsafe-destination');
+  assert.equal(fs.readFileSync(outside, 'utf8'), 'OUTSIDE');
+  fs.unlinkSync(linked);
+  fs.symlinkSync(path.join(root, 'missing.txt'), linked);
+  await assert.rejects(receiveWorkspaceFile(body('FOLLOWED'), linked, { displayPath: 'linked.txt' }),
+    (error) => error.code === 'unsafe-destination');
+  assert.equal(fs.existsSync(path.join(root, 'missing.txt')), false);
+
+  console.log('safe workspace write tests passed');
+} finally {
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -263,18 +263,36 @@ export interface AttachmentUploadOptions {
 }
 export const ATTACHMENT_UPLOAD_TIMEOUT_MS = 20 * 60 * 1000;
 
+export class AttachmentUploadError extends Error {
+  status: number;
+  retryable: boolean;
+  constructor(message: string, status: number, retryable = true) {
+    super(message);
+    this.name = 'AttachmentUploadError';
+    this.status = status;
+    this.retryable = retryable;
+  }
+}
+
 const attachmentUploadError = (request: XMLHttpRequest) => {
   let detail = '';
   try {
     const body = JSON.parse(request.responseText || '{}');
     if (typeof body?.error === 'string') detail = body.error;
   } catch { /* An ingress/proxy error can be HTML. Classify it by status below. */ }
-  if (detail) return detail;
-  if (request.status === 413) return 'The server or its proxy rejected this file as too large (HTTP 413). Try a smaller file.';
-  if (request.status === 408 || request.status === 504) return `The upload timed out (HTTP ${request.status}). Check the connection and retry.`;
-  if (request.status === 429) return 'Too many uploads at once (HTTP 429). Wait a minute, then retry.';
-  if (request.status >= 500) return `The upload server failed (HTTP ${request.status}). Retry in a moment.`;
-  return `Upload failed (HTTP ${request.status}${request.statusText ? ` ${request.statusText}` : ''}).`;
+  const message = detail || (request.status === 413
+    ? 'The server or its proxy rejected this file as too large (HTTP 413). Try a smaller file.'
+    : request.status === 408 || request.status === 504
+      ? `The upload timed out (HTTP ${request.status}). Check the connection and retry.`
+      : request.status === 429
+        ? 'Too many uploads at once (HTTP 429). Wait a minute, then retry.'
+        : request.status >= 500
+          ? `The upload server failed (HTTP ${request.status}). Retry in a moment.`
+          : `Upload failed (HTTP ${request.status}${request.statusText ? ` ${request.statusText}` : ''}).`);
+  // Size/storage/validation and missing-session failures cannot become valid by
+  // sending the same bytes again. Network, timeout, throttling and 5xx errors can.
+  return new AttachmentUploadError(message, request.status,
+    ![400, 404, 413, 415].includes(request.status));
 };
 
 /** XMLHttpRequest is intentional: fetch has no browser upload-progress API. */
@@ -311,7 +329,7 @@ export const uploadAttachment = (
   request.upload.onload = () => onProgress?.({ loaded: file.size, total: file.size });
   request.onload = () => {
     if (request.status < 200 || request.status >= 300) {
-      finish(() => reject(new Error(attachmentUploadError(request))));
+      finish(() => reject(attachmentUploadError(request)));
       return;
     }
     try {
@@ -321,10 +339,11 @@ export const uploadAttachment = (
       finish(() => reject(new Error('The upload completed, but the server returned an unreadable response. Retry the file.')));
     }
   };
-  request.onerror = () => finish(() => reject(new Error(
+  request.onerror = () => finish(() => reject(new AttachmentUploadError(
     typeof navigator !== 'undefined' && navigator.onLine === false
       ? 'Upload stopped because this device is offline. Reconnect and retry.'
       : 'Upload connection was interrupted before the server confirmed the file. Check the connection and retry.',
+    request.status,
   )));
   request.onabort = () => finish(() => reject(new Error('Upload was canceled before it completed.')));
   request.ontimeout = () => finish(() => reject(new Error(
@@ -413,10 +432,85 @@ export const getFileTracePage = async (id: string, p: string, offset = 0, limit 
 export const rawUrl = (id: string, p: string) =>
   `/api/files/${id}/raw?path=${encodeURIComponent(p)}`;
 
-export const uploadFile = (id: string, p: string, file: File) =>
-  fetch(`/api/files/${id}/upload?path=${encodeURIComponent(p)}&name=${encodeURIComponent(file.name)}`, {
-    method: 'POST', headers: { 'content-type': 'application/octet-stream' }, body: file,
-  }).then(json);
+export interface WorkspaceFileCollision {
+  code: 'file-exists' | 'replacement-stale';
+  name: string;
+  path: string;
+  revision: string | null;
+  replaceToken: string | null;
+}
+
+export class WorkspaceUploadError extends Error {
+  status: number;
+  collision?: WorkspaceFileCollision;
+  constructor(message: string, status: number, body?: Partial<WorkspaceFileCollision>) {
+    super(message);
+    this.name = 'WorkspaceUploadError';
+    this.status = status;
+    if (body?.code === 'file-exists' || body?.code === 'replacement-stale') {
+      this.collision = {
+        code: body.code,
+        name: String(body.name || ''),
+        path: String(body.path || ''),
+        revision: typeof body.revision === 'string' ? body.revision : null,
+        replaceToken: typeof body.replaceToken === 'string' ? body.replaceToken : null,
+      };
+    }
+  }
+}
+
+export interface WorkspaceUploadOptions extends AttachmentUploadOptions { replaceToken?: string }
+
+/** Workspace uploads use XHR for progress, but replacement remains a separate,
+ * token-bound request after the server reports the exact collision. */
+export const uploadFile = (
+  id: string, p: string, file: File,
+  { replaceToken, onProgress, signal, timeoutMs = ATTACHMENT_UPLOAD_TIMEOUT_MS }: WorkspaceUploadOptions = {},
+): Promise<{ ok: boolean; path: string; size: number; mtime: number }> => new Promise((resolve, reject) => {
+  const request = new XMLHttpRequest();
+  let settled = false;
+  const finish = (task: () => void) => {
+    if (settled) return;
+    settled = true;
+    signal?.removeEventListener('abort', abort);
+    task();
+  };
+  const abort = () => request.abort();
+  if (signal?.aborted) {
+    finish(() => reject(new WorkspaceUploadError('Upload was canceled before it completed.', 0)));
+    return;
+  }
+  request.open('POST', `/api/files/${encodeURIComponent(id)}/upload?path=${encodeURIComponent(p)}&name=${encodeURIComponent(file.name)}`);
+  request.timeout = timeoutMs;
+  request.setRequestHeader('content-type', 'application/octet-stream');
+  request.setRequestHeader('x-am-origin', 'operator');
+  if (replaceToken) request.setRequestHeader('x-am-replace-token', replaceToken);
+  request.upload.onprogress = (event) => onProgress?.({
+    loaded: event.loaded,
+    total: event.lengthComputable && event.total ? event.total : file.size,
+  });
+  request.upload.onload = () => onProgress?.({ loaded: file.size, total: file.size });
+  request.onload = () => {
+    let body: any = {};
+    try { body = JSON.parse(request.responseText || '{}'); } catch {}
+    if (request.status < 200 || request.status >= 300) {
+      finish(() => reject(new WorkspaceUploadError(body.error || `Upload failed (HTTP ${request.status}).`, request.status, body)));
+      return;
+    }
+    finish(() => resolve(body));
+  };
+  request.onerror = () => finish(() => reject(new WorkspaceUploadError(
+    typeof navigator !== 'undefined' && navigator.onLine === false
+      ? 'Upload stopped because this device is offline. Reconnect and retry.'
+      : 'Upload connection was interrupted before the file was published. Retry it.',
+    request.status,
+  )));
+  request.onabort = () => finish(() => reject(new WorkspaceUploadError('Upload was canceled before it completed.', 0)));
+  request.ontimeout = () => finish(() => reject(new WorkspaceUploadError('Upload timed out before the file was published. Retry it.', request.status)));
+  signal?.addEventListener('abort', abort, { once: true });
+  onProgress?.({ loaded: 0, total: file.size });
+  request.send(file);
+});
 
 // Create an empty folder / an empty file inside `parent`. The server refuses a
 // name that already exists rather than overwriting it.

--- a/web/src/components/Attachments.tsx
+++ b/web/src/components/Attachments.tsx
@@ -1,4 +1,4 @@
-import { useId, useRef } from 'react';
+import { useId, useMemo, useRef, useState } from 'react';
 import { attachmentFileError } from '../lib/attachments';
 import type { PendingAttachment } from '../lib/attachments';
 
@@ -21,44 +21,73 @@ export default function Attachments({ attachments, disabled, disabledReason, sho
   onRetry?: (key: string) => void;
 }) {
   const picker = useRef<HTMLInputElement>(null);
+  const [expanded, setExpanded] = useState(true);
   const reasonId = useId();
   const showReason = showPicker && !!disabled && !!disabledReason;
+  const counts = useMemo(() => ({
+    queued: attachments.filter((item) => item.status === 'pending').length,
+    uploading: attachments.filter((item) => item.status === 'uploading').length,
+    uploaded: attachments.filter((item) => item.status === 'uploaded').length,
+    failed: attachments.filter((item) => item.status === 'error').length,
+  }), [attachments]);
+  // A collapsed batch still exposes failures: otherwise the one file preventing
+  // Send would disappear behind an innocent-looking aggregate.
+  const shown = expanded ? attachments : attachments.filter((item) => item.status === 'error');
   if (!showPicker && attachments.length === 0) return null;
   return (
     <div className={`image-attachments${attachments.length ? ' has-images' : ''}${showReason ? ' has-note' : ''}`}>
-      {showPicker && (
-        <>
-          <button
-            type="button"
-            className="image-pick"
-            disabled={disabled}
-            title={disabledReason || 'Attach files'}
-            aria-label="Attach files"
-            aria-describedby={showReason ? reasonId : undefined}
-            onClick={() => picker.current?.click()}
-          >
-            <svg viewBox="0 0 18 18" aria-hidden="true">
-              <path d="M6.2 9.7 10.8 5a2.5 2.5 0 0 1 3.6 3.5l-6.2 6.3a4 4 0 0 1-5.7-5.7l6-6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-            </svg>
-          </button>
-          <input
-            ref={picker}
-            className="image-file-input"
-            type="file"
-            multiple
-            disabled={disabled}
-            onChange={(event) => {
-              onFiles(Array.from(event.currentTarget.files || []));
-              event.currentTarget.value = '';
-            }}
-          />
-        </>
-      )}
-      {showReason && <span id={reasonId} className="image-attachments-note">{disabledReason}</span>}
-      {attachments.map((attachment) => {
+      <div className="image-attachments-head">
+        {showPicker && (
+          <>
+            <button
+              type="button"
+              className="image-pick"
+              disabled={disabled}
+              title={disabledReason || 'Attach files'}
+              aria-label="Attach files"
+              aria-describedby={showReason ? reasonId : undefined}
+              onClick={() => picker.current?.click()}
+            >
+              <svg viewBox="0 0 18 18" aria-hidden="true">
+                <path d="M6.2 9.7 10.8 5a2.5 2.5 0 0 1 3.6 3.5l-6.2 6.3a4 4 0 0 1-5.7-5.7l6-6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </button>
+            <input
+              ref={picker}
+              className="image-file-input"
+              type="file"
+              multiple
+              disabled={disabled}
+              onChange={(event) => {
+                onFiles(Array.from(event.currentTarget.files || []));
+                event.currentTarget.value = '';
+              }}
+            />
+          </>
+        )}
+        {attachments.length > 0 && (
+          <>
+            <span className="image-attachments-summary mono" role="status">
+              {attachments.length} file{attachments.length === 1 ? '' : 's'}
+              {counts.queued ? ` · ${counts.queued} queued` : ''}
+              {counts.uploading ? ` · ${counts.uploading} uploading` : ''}
+              {counts.uploaded ? ` · ${counts.uploaded} uploaded` : ''}
+              {counts.failed ? ` · ${counts.failed} failed` : ''}
+            </span>
+            <button type="button" className="image-details-toggle" aria-expanded={expanded}
+              onClick={() => setExpanded((open) => !open)}>
+              {expanded ? 'hide' : 'details'}
+            </button>
+          </>
+        )}
+        {showReason && <span id={reasonId} className="image-attachments-note">{disabledReason}</span>}
+      </div>
+      {shown.length > 0 && <div className="image-attachment-list">
+      {shown.map((attachment) => {
         const loaded = Math.min(attachment.file.size, attachment.uploadedBytes || 0);
         const progress = attachment.file.size ? Math.round((loaded / attachment.file.size) * 100) : 0;
-        const retryable = attachment.status === 'error' && !attachmentFileError(attachment.file) && !!onRetry;
+        const retryable = attachment.status === 'error' && attachment.retryable !== false
+          && !attachmentFileError(attachment.file) && !!onRetry;
         return (
           <div key={attachment.key} className={`image-chip ${attachment.status}`}>
             {attachment.previewUrl ? (
@@ -72,7 +101,7 @@ export default function Attachments({ attachments, disabled, disabledReason, sho
               <span className="image-chip-name">{attachment.file.name || 'Attachment'}</span>
               <span className="image-chip-meta" aria-live="polite" title={attachment.error}>
                 {attachment.status === 'uploading' ? `${progress}% · ${fmtBytes(loaded)} / ${fmtBytes(attachment.file.size)}`
-                  : attachment.error || (attachment.status === 'uploaded' ? 'uploaded' : fmtBytes(attachment.file.size))}
+                  : attachment.error || (attachment.status === 'uploaded' ? 'uploaded' : `queued · ${fmtBytes(attachment.file.size)}`)}
               </span>
               {attachment.status === 'uploading' && (
                 <span
@@ -94,11 +123,12 @@ export default function Attachments({ attachments, disabled, disabledReason, sho
               type="button"
               onClick={() => onRemove(attachment.key)}
               disabled={disabled}
-              aria-label={`${attachment.status === 'uploading' ? 'Cancel upload' : 'Remove'} ${attachment.file.name || 'file'}`}
+              aria-label={`${attachment.status === 'uploading' || attachment.status === 'pending' ? 'Cancel upload' : 'Remove'} ${attachment.file.name || 'file'}`}
             >×</button>
           </div>
         );
       })}
+      </div>}
     </div>
   );
 }

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -993,7 +993,10 @@ export default function FilesPane({
       setReloadKey((key) => key + 1);
     } catch (error) {
       if (controller.signal.aborted) return;
-      if (error instanceof api.WorkspaceUploadError && error.collision) {
+      // A stale replacement can report that the destination disappeared. With
+      // no fresh token there is nothing left to replace: make the next action a
+      // normal create retry instead of offering a Replace button that cannot run.
+      if (error instanceof api.WorkspaceUploadError && error.collision?.replaceToken) {
         updateWorkspaceUpload(item.key, {
           status: 'collision',
           loaded: 0,

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -3,7 +3,7 @@ import { recall, remember, readWrap, writeWrap } from './filesMemory';
 import type { Session } from '../types';
 import * as api from '../api';
 import { Rails, railPad } from './Rails';
-import type { FileEntry, FileKind, FilePreview } from '../api';
+import type { FileEntry, FileKind, FilePreview, WorkspaceFileCollision } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
 import CodeView from './CodeView';
@@ -202,6 +202,41 @@ function UnsavedDialog({ name, conflict, busy, onSave, onDiscard, onCancel }: {
           <button className="mini-btn primary" autoFocus onClick={onSave} disabled={busy}>
             {busy ? 'Saving…' : conflict ? 'Overwrite and close' : 'Save and close'}
           </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type WorkspaceUploadStatus = 'queued' | 'uploading' | 'uploaded' | 'collision' | 'error' | 'canceled';
+type WorkspaceUpload = {
+  key: string;
+  file: File;
+  folder: string;
+  destination: string;
+  status: WorkspaceUploadStatus;
+  loaded: number;
+  error?: string;
+  collision?: WorkspaceFileCollision;
+};
+
+function ReplaceUploadDialog({ upload, busy, onReplace, onCancel }: {
+  upload: WorkspaceUpload; busy: boolean; onReplace: () => void; onCancel: () => void;
+}) {
+  return (
+    <div className="fv-modal-back" onMouseDown={(event) => { if (event.target === event.currentTarget) onCancel(); }}>
+      <div className="fv-modal" role="dialog" aria-modal="true" aria-label={`Replace ${upload.file.name}?`}
+        onKeyDown={(event) => {
+          event.stopPropagation();
+          if (event.key === 'Escape') { event.preventDefault(); onCancel(); }
+        }}>
+        <div className="fv-modal-title">Replace “{upload.file.name}”?</div>
+        <div className="fv-modal-body">
+          A file already exists at <span className="mono">{upload.destination}</span>. Replace it only if it is still the exact file you reviewed here.
+        </div>
+        <div className="fv-modal-acts">
+          <button className="mini-btn primary" autoFocus disabled={busy} onClick={onCancel}>Cancel</button>
+          <button className="mini-btn danger" disabled={busy} onClick={onReplace}>{busy ? 'Replacing…' : 'Replace'}</button>
         </div>
       </div>
     </div>
@@ -908,6 +943,12 @@ export default function FilesPane({
   const [target, setTarget] = useState<string | null>(kept.target);
   const [acting, setActing] = useState(false);
   const [actErr, setActErr] = useState<string | null>(null);
+  const [workspaceUploads, setWorkspaceUploads] = useState<WorkspaceUpload[]>([]);
+  const workspaceUploadsRef = useRef<WorkspaceUpload[]>([]);
+  const workspaceUploadBusy = useRef(false);
+  const workspaceControllers = useRef(new Map<string, AbortController>());
+  const [pendingReplace, setPendingReplace] = useState<string | null>(null);
+  const [replaceBusy, setReplaceBusy] = useState(false);
   const paneRef = useRef<HTMLDivElement | null>(null);
 
   const dir = useDir(session.id, root, reloadKey);
@@ -931,14 +972,96 @@ export default function FilesPane({
     if (viewing) paneRef.current?.focus({ preventScroll: true });
   }, [viewing]);
 
-  const upload = async (files: FileList | File[]) => {
-    setBusy(true);
-    for (const f of Array.from(files)) {
-      try { await api.uploadFile(session.id, dest, f); } catch { /* skip */ }
-    }
-    setBusy(false);
-    setReloadKey((k) => k + 1);
+  const updateWorkspaceUpload = (key: string, patch: Partial<WorkspaceUpload>) => {
+    const next = workspaceUploadsRef.current.map((item) => item.key === key ? { ...item, ...patch } : item);
+    workspaceUploadsRef.current = next;
+    setWorkspaceUploads(next);
   };
+  const runWorkspaceUpload = async (item: WorkspaceUpload, replaceToken?: string) => {
+    if (workspaceUploadsRef.current.find((current) => current.key === item.key)?.status === 'canceled') return;
+    const controller = new AbortController();
+    workspaceControllers.current.set(item.key, controller);
+    updateWorkspaceUpload(item.key, { status: 'uploading', loaded: 0, error: undefined, collision: undefined });
+    try {
+      await api.uploadFile(session.id, item.folder, item.file, {
+        replaceToken,
+        signal: controller.signal,
+        onProgress: ({ loaded }) => updateWorkspaceUpload(item.key, { loaded }),
+      });
+      if (controller.signal.aborted) return;
+      updateWorkspaceUpload(item.key, { status: 'uploaded', loaded: item.file.size });
+      setReloadKey((key) => key + 1);
+    } catch (error) {
+      if (controller.signal.aborted) return;
+      if (error instanceof api.WorkspaceUploadError && error.collision) {
+        updateWorkspaceUpload(item.key, {
+          status: 'collision',
+          loaded: 0,
+          error: error.message,
+          collision: error.collision,
+          destination: `${rootLabel}/${error.collision.path}`,
+        });
+      } else {
+        updateWorkspaceUpload(item.key, {
+          status: 'error', loaded: 0,
+          error: error instanceof Error ? error.message : 'Upload failed before the file was published.',
+        });
+      }
+    } finally {
+      if (workspaceControllers.current.get(item.key) === controller) workspaceControllers.current.delete(item.key);
+    }
+  };
+
+  const upload = async (files: FileList | File[]) => {
+    if (workspaceUploadBusy.current) {
+      setActErr('Wait for the current upload batch, or cancel a file in it.');
+      return;
+    }
+    const selected = Array.from(files);
+    if (!selected.length) return;
+    const folder = dest;
+    const items = selected.map((file): WorkspaceUpload => ({
+      key: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`,
+      file,
+      folder,
+      destination: `${rootLabel}/${join(folder, file.name)}`,
+      status: 'queued',
+      loaded: 0,
+    }));
+    workspaceUploadsRef.current = [...workspaceUploadsRef.current, ...items];
+    setWorkspaceUploads(workspaceUploadsRef.current);
+    workspaceUploadBusy.current = true;
+    setBusy(true); setActErr(null);
+    for (const item of items) await runWorkspaceUpload(item);
+    workspaceUploadBusy.current = false;
+    setBusy(false);
+  };
+
+  const cancelWorkspaceUpload = (key: string) => {
+    workspaceControllers.current.get(key)?.abort();
+    updateWorkspaceUpload(key, { status: 'canceled', loaded: 0, error: undefined, collision: undefined });
+    if (pendingReplace === key) setPendingReplace(null);
+  };
+  const retryWorkspaceUpload = (key: string) => {
+    if (workspaceUploadBusy.current || replaceBusy) return;
+    const item = workspaceUploadsRef.current.find((candidate) => candidate.key === key);
+    if (item) void runWorkspaceUpload(item);
+  };
+  const confirmWorkspaceReplace = async () => {
+    const item = workspaceUploadsRef.current.find((candidate) => candidate.key === pendingReplace);
+    const token = item?.collision?.replaceToken;
+    if (!item || !token || replaceBusy) return;
+    setReplaceBusy(true);
+    await runWorkspaceUpload(item, token);
+    setReplaceBusy(false); setPendingReplace(null);
+  };
+  const cancelWorkspaceReplace = () => {
+    if (pendingReplace) cancelWorkspaceUpload(pendingReplace);
+    setPendingReplace(null);
+  };
+  useEffect(() => () => {
+    for (const controller of workspaceControllers.current.values()) controller.abort();
+  }, []);
 
   // Nothing is written without being asked for, so leaving a file with an unsaved
   // buffer would drop it silently. Ask in a dialog — the answer is the work.
@@ -1048,6 +1171,15 @@ export default function FilesPane({
     };
   }, [dir.entries]);
 
+  const workspaceUploadCounts = useMemo(() => ({
+    queued: workspaceUploads.filter((item) => item.status === 'queued').length,
+    uploading: workspaceUploads.filter((item) => item.status === 'uploading').length,
+    uploaded: workspaceUploads.filter((item) => item.status === 'uploaded').length,
+    failed: workspaceUploads.filter((item) => item.status === 'error' || item.status === 'collision').length,
+    canceled: workspaceUploads.filter((item) => item.status === 'canceled').length,
+  }), [workspaceUploads]);
+  const replacement = workspaceUploads.find((item) => item.key === pendingReplace) || null;
+
   const meta = info.meta;
   const name = viewing ? viewing.split('/').pop()! : '';
 
@@ -1111,9 +1243,9 @@ export default function FilesPane({
               onClick={() => { setCreating('file'); setNewName(''); setActErr(null); }}
             ><FilePlusGlyph /></button>
             <button className="mini-btn" title="Refresh" onClick={() => setReloadKey((k) => k + 1)}><RefreshGlyph /></button>
-            <label className="mini-btn upload-btn" title="Upload files">
+            <label className={`mini-btn upload-btn${busy ? ' disabled' : ''}`} title={busy ? 'Current upload batch is still running' : 'Upload files'}>
               <UploadGlyph /> Upload
-              <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(e.target.files); e.target.value = ''; }} />
+              <input type="file" multiple hidden disabled={busy} onChange={(e) => { if (e.target.files) upload(e.target.files); e.target.value = ''; }} />
             </label>
           </>
         )}
@@ -1269,6 +1401,48 @@ export default function FilesPane({
           </div>
         )}
         {actErr && <div className="files-new err">{actErr}</div>}
+        {workspaceUploads.length > 0 && (
+          <div className="files-uploads" aria-label="Workspace upload results">
+            <div className="files-uploads-head mono" role="status">
+              <span>{workspaceUploads.length} file{workspaceUploads.length === 1 ? '' : 's'}</span>
+              {workspaceUploadCounts.queued > 0 && <span>{workspaceUploadCounts.queued} queued</span>}
+              {workspaceUploadCounts.uploading > 0 && <span>{workspaceUploadCounts.uploading} uploading</span>}
+              {workspaceUploadCounts.uploaded > 0 && <span>{workspaceUploadCounts.uploaded} uploaded</span>}
+              {workspaceUploadCounts.failed > 0 && <span className="bad">{workspaceUploadCounts.failed} need attention</span>}
+              {workspaceUploadCounts.canceled > 0 && <span>{workspaceUploadCounts.canceled} canceled</span>}
+              <span className="spacer" />
+              <button className="mini-btn" onClick={() => {
+                const next = workspaceUploadsRef.current.filter((item) => !['uploaded', 'canceled'].includes(item.status));
+                workspaceUploadsRef.current = next; setWorkspaceUploads(next);
+              }}>Clear finished</button>
+            </div>
+            <div className="files-upload-list">
+              {workspaceUploads.map((item) => {
+                const percent = item.file.size ? Math.min(100, Math.round((item.loaded / item.file.size) * 100)) : 0;
+                return <div key={item.key} className={`files-upload-row ${item.status}`}>
+                  <span className="files-upload-name" title={item.destination}>{item.file.name}</span>
+                  <span className="files-upload-state mono" title={item.error}>
+                    {item.status === 'uploading' ? `${percent}% · publishing after upload`
+                      : item.status === 'collision' ? item.error
+                        : item.status === 'error' ? item.error
+                          : item.status}
+                  </span>
+                  {item.status === 'collision' && <>
+                    <button className="mini-btn danger-hover" onClick={() => setPendingReplace(item.key)}>Replace…</button>
+                    <button className="mini-btn" onClick={() => cancelWorkspaceUpload(item.key)}>Cancel</button>
+                  </>}
+                  {item.status === 'error' && <>
+                    <button className="mini-btn" disabled={busy || replaceBusy} onClick={() => retryWorkspaceUpload(item.key)}>Retry</button>
+                    <button className="mini-btn" onClick={() => cancelWorkspaceUpload(item.key)}>Dismiss</button>
+                  </>}
+                  {(item.status === 'queued' || item.status === 'uploading') && (
+                    <button className="mini-btn" onClick={() => cancelWorkspaceUpload(item.key)}>Cancel</button>
+                  )}
+                </div>;
+              })}
+            </div>
+          </div>
+        )}
         <Cols
           sort={sort}
           onSort={(k) => setSort((s) => (s.key === k ? { key: k, desc: !s.desc } : { key: k, desc: k !== 'name' }))}
@@ -1277,7 +1451,7 @@ export default function FilesPane({
           className={`files-body tree${dragOver ? ' drag' : ''}`}
           onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
           onDragLeave={() => setDragOver(false)}
-          onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) upload(e.dataTransfer.files); }}
+          onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) void upload(e.dataTransfer.files); }}
         >
           {dir.err && <div className="tree-msg">can't read folder</div>}
           {!dir.err && !dir.entries && <div className="tree-msg">…</div>}
@@ -1292,9 +1466,13 @@ export default function FilesPane({
               target={dest} setTarget={setTarget}
             />
           )}
-          {busy && <div className="tree-msg">Uploading…</div>}
         </div>
       </div>
+
+      {replacement && (
+        <ReplaceUploadDialog upload={replacement} busy={replaceBusy}
+          onReplace={() => void confirmWorkspaceReplace()} onCancel={cancelWorkspaceReplace} />
+      )}
 
       {viewing && confirmClose && edit && (
         <UnsavedDialog

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -17,7 +17,7 @@ import { BackGlyph, CloseGlyph, RefreshGlyph , SearchGlyph } from './icons';
 import * as api from '../api';
 import type { Attachment } from '../api';
 import {
-  MAX_ATTACHMENTS, attachmentFileError, filesFromClipboardItems, filesFromTransfer,
+  attachmentFileError, filesFromClipboardItems, filesFromTransfer,
   transferMayContainFile,
 } from '../lib/attachments';
 
@@ -377,12 +377,7 @@ export default function TerminalPane({
       return;
     }
     if (imageUploadBusyRef.current) return;
-    const candidates = files;
-    if (candidates.length > MAX_ATTACHMENTS) {
-      showImageStatus({ kind: 'error', text: `Attach at most ${MAX_ATTACHMENTS} files at a time` }, 4000);
-      return;
-    }
-    const images = candidates.slice(0, MAX_ATTACHMENTS);
+    const images = files;
     if (!images.length) return;
     const invalid = images.map((file) => attachmentFileError(file)).find(Boolean);
     if (invalid) { showImageStatus({ kind: 'error', text: invalid }, 4000); return; }

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -6,7 +6,8 @@ import type { Session } from '../../types';
 import { isRemote } from '../../types';
 import {
   buildPendingPrompt, discardPendingAttachment, discardPendingAttachments,
-  pendingAttachmentsFromFiles, revokePendingAttachments, uploadPendingAttachments,
+  filesFromTransfer, pendingAttachmentsFromFiles, revokePendingAttachments,
+  transferMayContainFile, uploadPendingAttachments,
 } from '../../lib/attachments';
 import type { PendingAttachment, PendingPrompt } from '../../lib/attachments';
 import { recallReading, rememberReading } from './readingPosition';
@@ -50,6 +51,7 @@ export default function ConversationView({
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const attachmentsRef = useRef<PendingAttachment[]>([]);
   const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const [attachmentDrop, setAttachmentDrop] = useState(false);
   const [sending, setSending] = useState(false);
   const [failed, setFailed] = useState<string | null>(null);
   const [sent, setSent] = useState<(PendingPrompt & { at: number }) | null>(null);
@@ -204,7 +206,25 @@ export default function ConversationView({
   useEffect(() => { reportHead.current?.(head); }, [head]);
   useEffect(() => () => reportHead.current?.(null), []);
 
-  return <div className="cxv">
+  return <div className={`cxv${attachmentDrop ? ' image-drop' : ''}`}
+    onDragEnter={(event) => {
+      if (allowAttachments && !sending && transferMayContainFile(event.dataTransfer)) {
+        event.preventDefault(); setAttachmentDrop(true);
+      }
+    }}
+    onDragOver={(event) => {
+      if (allowAttachments && !sending && transferMayContainFile(event.dataTransfer)) {
+        event.preventDefault(); event.dataTransfer.dropEffect = 'copy';
+      }
+    }}
+    onDragLeave={(event) => {
+      if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setAttachmentDrop(false);
+    }}
+    onDrop={(event) => {
+      if (!allowAttachments || sending || !transferMayContainFile(event.dataTransfer)) return;
+      event.preventDefault(); event.stopPropagation(); setAttachmentDrop(false);
+      addAttachments(filesFromTransfer(event.dataTransfer));
+    }}>
     <div className="cxv-bar cxv-status mono">
       <span>{head ? `${exchanges.length.toLocaleString()} turns loaded` : phase === 'loading' ? 'Reading transcript…' : 'Conversation'}</span>
       <span className="spacer" />

--- a/web/src/lib/attachments.ts
+++ b/web/src/lib/attachments.ts
@@ -3,7 +3,11 @@ import type { Attachment } from '../api';
 
 export const IMAGE_MIMES = ['image/png', 'image/jpeg', 'image/webp', 'image/gif'] as const;
 export const MAX_ATTACHMENT_BYTES = 100 * 1024 * 1024;
-export const MAX_ATTACHMENTS = 5;
+// More files do not mean more simultaneous requests. Three transfers per
+// session keeps a large batch moving without letting repeated picker/drop
+// additions turn into an unbounded fan-out. Other sessions have their own
+// queue, so one large prompt does not hold up another agent.
+export const ACTIVE_UPLOADS_PER_SESSION = 3;
 
 export type PendingAttachmentStatus = 'pending' | 'uploading' | 'uploaded' | 'error';
 
@@ -15,10 +19,10 @@ export interface PendingAttachment {
   uploadedBytes?: number;
   uploadController?: AbortController;
   error?: string;
+  retryable?: boolean;
   attachment?: Attachment;
 }
 
-const identity = (file: File) => `${file.name}\u0000${file.type}\u0000${file.size}`;
 const IMAGE_EXTENSION = /\.(png|jpe?g|gif|webp)$/i;
 
 function normalizedMime(type: string) {
@@ -57,12 +61,8 @@ export function filesFromTransfer(transfer: DataTransfer) {
   if (listed.length) return listed;
 
   const files: File[] = [];
-  const seen = new Set<string>();
   const add = (file: File | null) => {
     if (!file) return;
-    const id = identity(file);
-    if (seen.has(id)) return;
-    seen.add(id);
     files.push(file);
   };
   for (const item of Array.from(transfer.items || [])) {
@@ -104,9 +104,8 @@ export async function filesFromClipboardItems(items: ClipboardItem[]) {
   return files;
 }
 
-export function pendingAttachmentsFromFiles(files: File[], currentCount = 0) {
-  const remaining = Math.max(0, MAX_ATTACHMENTS - currentCount);
-  const accepted = files.slice(0, remaining).map((file): PendingAttachment => {
+export function pendingAttachmentsFromFiles(files: File[], _currentCount = 0) {
+  const accepted = files.map((file): PendingAttachment => {
     const error = attachmentFileError(file);
     return {
       key: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`,
@@ -114,11 +113,12 @@ export function pendingAttachmentsFromFiles(files: File[], currentCount = 0) {
       previewUrl: isPreviewableImageFile(file) ? URL.createObjectURL(file) : undefined,
       status: error ? 'error' : 'pending',
       error,
+      retryable: error ? false : undefined,
     };
   });
   return {
     attachments: accepted,
-    error: files.length > remaining ? `At most ${MAX_ATTACHMENTS} files can be attached.` : null,
+    error: null,
   };
 }
 
@@ -172,14 +172,60 @@ export function buildPendingPrompt(
   return { text: prompt, displayText: `${prompt}\n\n${attachmentText}` };
 }
 
-/** Upload in display order. Already-successful items are reused on retry. */
+type UploadJob<T> = {
+  signal: AbortSignal;
+  run: () => Promise<T>;
+  resolve: (value: T | undefined) => void;
+  reject: (reason: unknown) => void;
+  started: boolean;
+};
+type SessionUploadQueue = { active: number; jobs: UploadJob<unknown>[] };
+const sessionUploadQueues = new Map<string, SessionUploadQueue>();
+
+function drainSessionUploads(sessionId: string) {
+  const queue = sessionUploadQueues.get(sessionId);
+  if (!queue) return;
+  while (queue.active < ACTIVE_UPLOADS_PER_SESSION && queue.jobs.length) {
+    const job = queue.jobs.shift()!;
+    if (job.signal.aborted) { job.resolve(undefined); continue; }
+    job.started = true;
+    queue.active += 1;
+    job.run().then(job.resolve, job.reject).finally(() => {
+      queue.active -= 1;
+      drainSessionUploads(sessionId);
+    });
+  }
+  if (queue.active === 0 && queue.jobs.length === 0) sessionUploadQueues.delete(sessionId);
+}
+
+/** Queue one transfer behind only the other transfers for this same session. */
+function scheduleSessionUpload<T>(sessionId: string, signal: AbortSignal, run: () => Promise<T>) {
+  return new Promise<T | undefined>((resolve, reject) => {
+    const queue = sessionUploadQueues.get(sessionId) || { active: 0, jobs: [] };
+    sessionUploadQueues.set(sessionId, queue);
+    const job: UploadJob<T> = { signal, run, resolve, reject, started: false };
+    const cancelQueued = () => {
+      if (job.started) return; // the XHR owns active cancellation
+      const at = queue.jobs.indexOf(job as UploadJob<unknown>);
+      if (at < 0) return;
+      queue.jobs.splice(at, 1);
+      resolve(undefined);
+      if (queue.active === 0 && queue.jobs.length === 0) sessionUploadQueues.delete(sessionId);
+    };
+    signal.addEventListener('abort', cancelQueued, { once: true });
+    queue.jobs.push(job as UploadJob<unknown>);
+    drainSessionUploads(sessionId);
+  });
+}
+
+/** Upload with bounded per-session concurrency. Already-successful items are reused on retry. */
 export async function uploadPendingAttachments(
   sessionId: string,
   attachments: PendingAttachment[],
   update: (key: string, patch: Partial<PendingAttachment>) => void,
 ) {
-  const uploaded: Attachment[] = [];
-  let firstFailure: Error | null = null;
+  const uploaded: Array<Attachment | undefined> = new Array(attachments.length);
+  const failures: Array<Error | undefined> = new Array(attachments.length);
   const controllers = new Map<string, AbortController>();
   for (const attachment of attachments) {
     if (attachment.attachment || attachmentFileError(attachment.file)) continue;
@@ -187,47 +233,56 @@ export async function uploadPendingAttachments(
     controllers.set(attachment.key, controller);
     update(attachment.key, { uploadController: controller });
   }
-  for (const attachment of attachments) {
+  await Promise.all(attachments.map(async (attachment, index) => {
     if (attachment.attachment) {
-      uploaded.push(attachment.attachment);
-      continue;
+      uploaded[index] = attachment.attachment;
+      return;
     }
     const invalid = attachmentFileError(attachment.file);
     if (invalid) {
       update(attachment.key, { status: 'error', error: invalid });
-      firstFailure ??= new Error(invalid);
-      continue;
+      failures[index] = new Error(invalid);
+      return;
     }
     const controller = controllers.get(attachment.key)!;
-    if (controller.signal.aborted) continue;
-    update(attachment.key, { status: 'uploading', uploadedBytes: 0, error: undefined });
+    if (controller.signal.aborted) return;
     try {
-      const stored = await api.uploadAttachment(sessionId, attachment.file, {
-        signal: controller.signal,
-        onProgress: ({ loaded }) => update(attachment.key, { uploadedBytes: loaded }),
+      const stored = await scheduleSessionUpload(sessionId, controller.signal, () => {
+        update(attachment.key, { status: 'uploading', uploadedBytes: 0, error: undefined, retryable: undefined });
+        return api.uploadAttachment(sessionId, attachment.file, {
+          signal: controller.signal,
+          onProgress: ({ loaded }) => update(attachment.key, { uploadedBytes: loaded }),
+        });
       });
+      if (!stored) return; // cancelled while queued
       // An abort can race the final response: XHR may have settled while the
       // click that removed the chip already marked the controller aborted.
       // In that narrow window we learned the id, so remove the now-unsent file.
       if (controller.signal.aborted) {
         await api.deleteAttachment(sessionId, stored.id).catch(() => undefined);
-        continue;
+        return;
       }
       update(attachment.key, {
         status: 'uploaded', uploadedBytes: attachment.file.size,
         uploadController: undefined, attachment: stored,
       });
-      uploaded.push(stored);
+      uploaded[index] = stored;
     } catch (error) {
       if (controller.signal.aborted) {
         update(attachment.key, { uploadController: undefined });
-        continue;
+        return;
       }
       const message = error instanceof Error ? error.message : 'upload failed';
-      update(attachment.key, { status: 'error', uploadController: undefined, error: message });
-      firstFailure ??= error instanceof Error ? error : new Error(message);
+      const retryable = !(typeof error === 'object' && error !== null
+        && 'retryable' in error && (error as { retryable?: unknown }).retryable === false);
+      update(attachment.key, {
+        status: 'error', uploadController: undefined, error: message,
+        retryable,
+      });
+      failures[index] = error instanceof Error ? error : new Error(message);
     }
-  }
+  }));
+  const firstFailure = failures.find(Boolean);
   if (firstFailure) throw firstFailure;
-  return uploaded;
+  return uploaded.filter((attachment): attachment is Attachment => !!attachment);
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -231,16 +231,23 @@ body {
 .quick-recovery { margin-top: -3px; color: var(--muted); font-size: 9.5px; line-height: 1.35; }
 .cart-row.off { opacity: 0.45; }
 
-/* file attachments: one compact operational row shared by composers */
-.image-attachments { min-width: 0; display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+/* file attachments: a compact aggregate over a bounded, scrollable detail list.
+   Fifty files stay fifty rows without becoming fifty rows TALL in the reader. */
+.image-attachments { min-width: 0; display: flex; flex-direction: column; align-items: stretch; gap: 4px; }
+.image-attachments:not(.has-images) { width: max-content; }
+.image-attachments-head { min-width: 0; display: flex; align-items: center; gap: 6px; }
+.image-attachments-summary { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); font-size: 9.5px; }
+.image-details-toggle { flex: none; padding: 1px 4px; border: 1px solid var(--border); border-radius: var(--r-sm); background: var(--panel-2); color: var(--muted); font: 9px var(--font-mono); cursor: pointer; }
+.image-details-toggle:hover { color: var(--text); border-color: var(--border-strong); }
+.image-attachment-list { min-width: 0; max-height: 152px; overflow-y: auto; overscroll-behavior: contain; display: grid; grid-template-columns: repeat(auto-fill, minmax(min(210px, 100%), 1fr)); gap: 4px; padding-right: 2px; scrollbar-gutter: stable; }
 .image-file-input { display: none; }
 .image-pick { flex: none; width: 28px; height: 28px; padding: 0; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel-2); color: var(--muted); cursor: pointer; }
 .image-pick:hover:not(:disabled) { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); }
 .image-pick:disabled { opacity: 0.38; cursor: not-allowed; }
 .image-pick svg { width: 15px; height: 15px; }
 .image-attachments-note { min-width: 0; color: var(--muted); font-size: 10px; line-height: 1.3; }
-.image-chip { min-width: 0; max-width: 250px; height: 38px; display: flex; align-items: center; gap: 6px; padding: 3px 5px 3px 3px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
-.image-chip.error { max-width: min(100%, 360px); height: auto; min-height: 38px; border-color: color-mix(in srgb, var(--danger) 48%, var(--border)); }
+.image-chip { min-width: 0; width: 100%; height: 38px; display: flex; align-items: center; gap: 6px; padding: 3px 5px 3px 3px; border: 1px solid var(--border); border-radius: var(--r-md); background: var(--panel); }
+.image-chip.error { height: auto; min-height: 38px; border-color: color-mix(in srgb, var(--danger) 48%, var(--border)); }
 .image-chip.uploading { border-color: color-mix(in srgb, var(--accent) 42%, var(--border)); }
 .image-chip-preview { flex: none; width: 29px; height: 28px; border-radius: 3px; overflow: hidden; background: var(--panel-2); }
 .image-chip-preview:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
@@ -257,7 +264,7 @@ body {
 .image-chip > .image-chip-retry { color: var(--danger); font-size: 9px; font-weight: 650; }
 .image-chip > button:hover:not(:disabled) { color: var(--text); }
 .image-chip > button:disabled { opacity: 0.35; cursor: default; }
-.quick .image-attachments { align-items: flex-start; }
+.quick .image-attachments { align-items: stretch; }
 .widget.quick.image-drop { border-style: dashed; border-color: var(--accent); background: color-mix(in srgb, var(--drop) 55%, var(--panel-2)); }
 
 /* new-agent: logo buttons */
@@ -512,6 +519,7 @@ body {
    one-line composer looks exactly as it always has. */
 .ov-composer { --ov-first-line: calc(1.45 * 13px + 4px); display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: start; gap: 7px 8px; border-top: 1px solid var(--border); padding-top: 7px; }
 .ov-composer.image-drop { outline: 1px dashed var(--accent); outline-offset: 5px; background: var(--drop); }
+.cxv.image-drop .cxv-composer { outline: 1px dashed var(--accent); outline-offset: -1px; background: var(--drop); }
 .ov-composer .image-attachments.has-images { grid-column: 1 / -1; }
 .ov-composer .image-attachments.has-note { grid-column: 1 / -1; }
 .ov-composer .image-attachments.has-images + .ov-live,
@@ -1096,6 +1104,16 @@ body {
 .files-new-input:focus { outline: none; border-color: var(--accent); }
 .files-new.danger-row { background: color-mix(in srgb, var(--danger) 8%, var(--panel)); }
 .files-new.err { color: var(--danger); }
+.files-uploads { flex: none; min-height: 0; border-bottom: 1px solid var(--border); background: var(--panel); }
+.files-uploads-head { min-width: 0; display: flex; align-items: center; gap: 8px; padding: 4px 10px; color: var(--muted); font-size: 9.5px; }
+.files-uploads-head .bad { color: var(--danger); }
+.files-upload-list { max-height: 148px; overflow-y: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
+.files-upload-row { min-width: 0; display: flex; align-items: center; gap: 6px; padding: 3px 10px; border-top: 1px solid color-mix(in srgb, var(--border) 70%, transparent); font-size: 10.5px; }
+.files-upload-row.collision, .files-upload-row.error { background: color-mix(in srgb, var(--danger) 6%, var(--panel)); }
+.files-upload-name { min-width: 6em; max-width: 18em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-weight: 600; }
+.files-upload-state { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--muted); }
+.files-upload-row.collision .files-upload-state, .files-upload-row.error .files-upload-state { color: var(--danger); }
+.upload-btn.disabled { opacity: .45; cursor: default; }
 .tw-confirm { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 0; }
 .tw-warn { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 /* A destructive ICON in a row turns red under the pointer, the way the Files

--- a/web/test/attachmentBatches.test.mjs
+++ b/web/test/attachmentBatches.test.mjs
@@ -19,10 +19,11 @@ await build({
     import { createRoot } from 'react-dom/client';
     import Attachments from './src/components/Attachments';
     import {
-      discardPendingAttachment, discardPendingAttachments, filesFromTransfer,
+      ACTIVE_UPLOADS_PER_SESSION, discardPendingAttachment, discardPendingAttachments, filesFromTransfer,
       pendingAttachmentsFromFiles, uploadPendingAttachments,
     } from './src/lib/attachments';
     window.transferFiles = filesFromTransfer;
+    window.activeUploadsPerSession = ACTIVE_UPLOADS_PER_SESSION;
     window.batchApps = {};
     function Batch({ sessionId }) {
       const [items, setItems] = useState([]); const ref = useRef([]);
@@ -69,17 +70,25 @@ await build({
         let done = false;
         const finish = (task) => { if(done)return; done=true; clearTimeout(timer);
           metrics.active[sessionId] -= 1; metrics.total -= 1; signal?.removeEventListener('abort', abort); task(); };
+        const stored = () => ({id:'att_'+String(metrics.starts.length).padStart(24,'0'),kind:'file',name:file.name,mime:file.type,
+          bytes:file.size,path:'/stored/'+sessionId+'/'+metrics.starts.length+'-'+file.name,previewUrl:'',insertText:''});
         const abort = () => {
-          if(file.name === 'late-success.txt') return;
+          // Simulate the server having published just as cancellation arrived:
+          // the id becomes known only after the signal is already aborted.
+          if(file.name === 'late-success.txt') {
+            setTimeout(() => finish(() => resolve(stored())), 0);
+            return;
+          }
           finish(() => reject(new Error('Upload was canceled before it completed.')));
         };
         const number = Number((file.name.match(/(\d+)/) || [0,0])[1]);
         const timer = setTimeout(() => finish(() => {
           if(file.name === 'fail-once.txt' && metrics.attempts[key] === 1) return reject(new Error('connection interrupted'));
           onProgress?.({loaded:file.size,total:file.size});
-          resolve({id:'att_'+String(metrics.starts.length).padStart(24,'0'),kind:'file',name:file.name,mime:file.type,
-            bytes:file.size,path:'/stored/'+sessionId+'/'+metrics.starts.length+'-'+file.name,previewUrl:'',insertText:''});
-        }), file.name.startsWith('cancel-') ? 180 : 8 + (number % 5) * 4);
+          resolve(stored());
+        }), file.name === 'late-success.txt' ? 60_000
+          : file.name.startsWith('cancel-') ? 180
+            : /^(one|two)-/.test(file.name) ? 100 : 8 + (number % 5) * 4);
         signal?.addEventListener('abort', abort, {once:true});
       });
       export const deleteAttachment = (sessionId, id) => { metrics.deletes.push({sessionId,id}); return Promise.resolve({ok:true}); };
@@ -157,7 +166,9 @@ try {
   await input('two').setInputFiles(files(8, 'two'));
   await Promise.all([waitUploaded('one', 8), waitUploaded('two', 8)]);
   metrics = await page.evaluate(() => window.uploadMetrics);
-  assert.ok(metrics.max.one <= 3 && metrics.max.two <= 3 && metrics.maxTotal >= 2, JSON.stringify(metrics));
+  const perSessionLimit = await page.evaluate(() => window.activeUploadsPerSession);
+  assert.ok(metrics.max.one <= perSessionLimit && metrics.max.two <= perSessionLimit
+    && metrics.maxTotal > perSessionLimit, JSON.stringify(metrics));
   const associations = await page.evaluate(() => ({
     one: window.batchApps.one.snapshot(), two: window.batchApps.two.snapshot(),
   }));
@@ -200,7 +211,7 @@ try {
   const late = batch('one').locator('.image-chip', { hasText: 'late-success.txt' });
   await late.getByRole('button', { name: 'Cancel upload late-success.txt' }).click();
   await late.waitFor({ state: 'detached' });
-  await page.waitForFunction((before) => window.uploadMetrics.deletes.length > before, deletesBeforeLate);
+  await page.waitForFunction((before) => window.uploadMetrics.deletes.length > before, deletesBeforeLate, { timeout: 2000 });
   metrics = await page.evaluate(() => window.uploadMetrics);
   assert.equal(metrics.deletes.length, deletesBeforeLate + 1,
     'a server success racing cancellation is explicitly removed');

--- a/web/test/attachmentBatches.test.mjs
+++ b/web/test/attachmentBatches.test.mjs
@@ -1,0 +1,212 @@
+// Dozens of files through the real shared attachment component and scheduler.
+// Network/storage are synthetic; server resolution is covered in attachments.test.mjs.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const WEB = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'am-attachment-batches-'));
+const bundle = path.join(tmp, 'fixture.js');
+
+await build({
+  stdin: { resolveDir: WEB, loader: 'tsx', contents: `
+    import React, { useEffect, useRef, useState } from 'react';
+    import { createRoot } from 'react-dom/client';
+    import Attachments from './src/components/Attachments';
+    import {
+      discardPendingAttachment, discardPendingAttachments, filesFromTransfer,
+      pendingAttachmentsFromFiles, uploadPendingAttachments,
+    } from './src/lib/attachments';
+    window.transferFiles = filesFromTransfer;
+    window.batchApps = {};
+    function Batch({ sessionId }) {
+      const [items, setItems] = useState([]); const ref = useRef([]);
+      const update = (key, patch) => {
+        const next = ref.current.map((item) => item.key === key ? {...item, ...patch} : item);
+        ref.current = next; setItems(next);
+      };
+      const add = (files) => {
+        const next = pendingAttachmentsFromFiles(files, ref.current.length).attachments;
+        ref.current = [...ref.current, ...next]; setItems(ref.current);
+        uploadPendingAttachments(sessionId, next, update).catch(() => {});
+      };
+      const remove = (key) => {
+        const item = ref.current.find((candidate) => candidate.key === key);
+        if (item) discardPendingAttachment(sessionId, item);
+        ref.current = ref.current.filter((candidate) => candidate.key !== key); setItems(ref.current);
+      };
+      const retry = (key) => {
+        const item = ref.current.find((candidate) => candidate.key === key);
+        if (item) uploadPendingAttachments(sessionId, [item], update).catch(() => {});
+      };
+      useEffect(() => { window.batchApps[sessionId] = { clear() {
+        discardPendingAttachments(sessionId, ref.current); ref.current = []; setItems([]);
+      }, snapshot: () => ref.current.map((item) => ({name:item.file.name,path:item.attachment?.path,status:item.status}))
+      }; return () => delete window.batchApps[sessionId]; }, [sessionId]);
+      return <div className="fixture-batch" data-session={sessionId}><Attachments attachments={items}
+        onFiles={add} onRemove={remove} onRetry={retry} /></div>;
+    }
+    createRoot(document.getElementById('root')).render(<><Batch sessionId="one"/><Batch sessionId="two"/></>);
+  ` },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+  plugins: [{ name: 'fake-api', setup(builder) {
+    builder.onResolve({ filter: /(^|\/)api$/ }, () => ({ path: 'api', namespace: 'fixture' }));
+    builder.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({ loader: 'ts', contents: `
+      export const metrics = window.uploadMetrics = {active:{}, max:{}, total:0, maxTotal:0, starts:[], deletes:[], attempts:{}};
+      export const uploadAttachment = (sessionId, file, {signal, onProgress} = {}) => new Promise((resolve, reject) => {
+        const key = sessionId + '/' + file.name;
+        metrics.attempts[key] = (metrics.attempts[key] || 0) + 1;
+        metrics.starts.push({sessionId, name:file.name, attempt:metrics.attempts[key]});
+        metrics.active[sessionId] = (metrics.active[sessionId] || 0) + 1;
+        metrics.max[sessionId] = Math.max(metrics.max[sessionId] || 0, metrics.active[sessionId]);
+        metrics.total += 1; metrics.maxTotal = Math.max(metrics.maxTotal, metrics.total);
+        onProgress?.({loaded:Math.floor(file.size/2),total:file.size});
+        let done = false;
+        const finish = (task) => { if(done)return; done=true; clearTimeout(timer);
+          metrics.active[sessionId] -= 1; metrics.total -= 1; signal?.removeEventListener('abort', abort); task(); };
+        const abort = () => {
+          if(file.name === 'late-success.txt') return;
+          finish(() => reject(new Error('Upload was canceled before it completed.')));
+        };
+        const number = Number((file.name.match(/(\d+)/) || [0,0])[1]);
+        const timer = setTimeout(() => finish(() => {
+          if(file.name === 'fail-once.txt' && metrics.attempts[key] === 1) return reject(new Error('connection interrupted'));
+          onProgress?.({loaded:file.size,total:file.size});
+          resolve({id:'att_'+String(metrics.starts.length).padStart(24,'0'),kind:'file',name:file.name,mime:file.type,
+            bytes:file.size,path:'/stored/'+sessionId+'/'+metrics.starts.length+'-'+file.name,previewUrl:'',insertText:''});
+        }), file.name.startsWith('cancel-') ? 180 : 8 + (number % 5) * 4);
+        signal?.addEventListener('abort', abort, {once:true});
+      });
+      export const deleteAttachment = (sessionId, id) => { metrics.deletes.push({sessionId,id}); return Promise.resolve({ok:true}); };
+    ` }));
+  } }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+const files = (count, prefix = 'file') => Array.from({ length: count }, (_, index) => ({
+  name: `${prefix}-${index}.txt`, mimeType: index % 3 ? 'text/plain' : 'text/markdown', buffer: Buffer.from(`body-${index}`),
+}));
+const input = (session) => page.locator(`[data-session="${session}"] input[type=file]`);
+const batch = (session) => page.locator(`[data-session="${session}"]`);
+const waitUploaded = (session, count) => page.waitForFunction(({ session, count }) =>
+  document.querySelectorAll(`[data-session="${session}"] .image-chip.uploaded`).length === count, { session, count });
+
+try {
+  await page.setContent(`<style>${css}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  await input('one').waitFor({ state: 'attached' });
+
+  const transfer = await page.evaluate(() => {
+    const canonical = new File(['a'], 'same.txt', { type: 'text/plain', lastModified: 1 });
+    const duplicateView = new File(['a'], 'same.txt', { type: 'text/plain', lastModified: 2 });
+    const fromBoth = window.transferFiles({ files: [canonical], items: [{ kind: 'file', getAsFile: () => duplicateView }] });
+    const first = new File(['x'], 'twins.txt', { type: 'text/plain' });
+    const second = new File(['y'], 'twins.txt', { type: 'text/plain' });
+    const itemsOnly = window.transferFiles({ files: [], items: [
+      { kind: 'file', getAsFile: () => first }, { kind: 'file', getAsFile: () => second },
+    ] });
+    return { fromBoth: fromBoth.length, canonical: fromBoth[0] === canonical,
+      itemsOnly: itemsOnly.length, distinct: itemsOnly[0] !== itemsOnly[1] };
+  });
+  assert.deepEqual(transfer, { fromBoth: 1, canonical: true, itemsOnly: 2, distinct: true });
+
+  for (const count of [6, 30]) {
+    await input('one').setInputFiles(files(count, `batch${count}`));
+    await waitUploaded('one', count);
+    assert.match(await batch('one').locator('.image-attachments-summary').textContent(), new RegExp(`^${count} files`));
+    await page.evaluate(() => window.batchApps.one.clear());
+  }
+
+  // Overlapping additions share one FIFO and still preserve visible selection order.
+  const longFirst = 'first-with-an-intentionally-long-reader-attachment-name-that-must-ellipsize';
+  const longSecond = 'second-with-an-intentionally-long-reader-attachment-name-that-must-ellipsize';
+  await input('one').setInputFiles(files(30, longFirst));
+  await input('one').setInputFiles(files(20, longSecond));
+  await waitUploaded('one', 50);
+  const fifty = await batch('one').evaluate((root) => {
+    const list = root.querySelector('.image-attachment-list');
+    return {
+      summary: root.querySelector('.image-attachments-summary')?.textContent,
+      names: [...root.querySelectorAll('.image-chip-name')].map((node) => node.textContent),
+      listHeight: list.getBoundingClientRect().height,
+      scrollable: list.scrollHeight > list.clientHeight,
+      overflow: root.scrollWidth > root.clientWidth,
+    };
+  });
+  assert.match(fifty.summary, /^50 files/);
+  assert.deepEqual(fifty.names, [...files(30, longFirst), ...files(20, longSecond)].map((file) => file.name));
+  assert.ok(fifty.listHeight <= 153 && fifty.scrollable && !fifty.overflow, JSON.stringify(fifty));
+  let metrics = await page.evaluate(() => window.uploadMetrics);
+  assert.ok(metrics.max.one <= 3, `same-session active uploads: ${metrics.max.one}`);
+  await page.evaluate(() => window.batchApps.one.clear());
+
+  await input('one').setInputFiles(files(75, 'over-fifty'));
+  await waitUploaded('one', 75);
+  assert.match(await batch('one').locator('.image-attachments-summary').textContent(), /^75 files/);
+  await page.evaluate(() => window.batchApps.one.clear());
+
+  // Independent sessions each start work; neither waits for the other's queue.
+  await input('one').setInputFiles(files(8, 'one'));
+  await input('two').setInputFiles(files(8, 'two'));
+  await Promise.all([waitUploaded('one', 8), waitUploaded('two', 8)]);
+  metrics = await page.evaluate(() => window.uploadMetrics);
+  assert.ok(metrics.max.one <= 3 && metrics.max.two <= 3 && metrics.maxTotal >= 2, JSON.stringify(metrics));
+  const associations = await page.evaluate(() => ({
+    one: window.batchApps.one.snapshot(), two: window.batchApps.two.snapshot(),
+  }));
+  assert.ok(associations.one.every((item) => item.path.includes('/one/'))
+    && associations.two.every((item) => item.path.includes('/two/')), JSON.stringify(associations));
+  await page.evaluate(() => { window.batchApps.one.clear(); window.batchApps.two.clear(); });
+
+  const cancelFiles = [...files(7, 'cancel'), { name: 'fail-once.txt', mimeType: 'text/plain', buffer: Buffer.from('retry') }];
+  await input('one').setInputFiles(cancelFiles);
+  await page.waitForFunction(() => document.querySelectorAll('[data-session="one"] .image-chip.uploading').length === 3);
+  const queuedCancel = batch('one').getByRole('button', { name: 'Cancel upload cancel-6.txt' });
+  await queuedCancel.focus(); await page.keyboard.press('Enter');
+  await batch('one').getByRole('button', { name: 'Cancel upload cancel-0.txt' }).click();
+  const failed = batch('one').locator('.image-chip.error', { hasText: 'fail-once.txt' });
+  await failed.waitFor().catch(async (error) => {
+    console.error('batch state at failure timeout', await page.evaluate(() => ({
+      metrics: window.uploadMetrics, items: window.batchApps.one.snapshot(),
+    })));
+    throw error;
+  });
+  await batch('one').getByRole('button', { name: 'hide' }).click();
+  assert.equal(await batch('one').locator('.image-chip').count(), 1, 'collapsed details keep the blocking failure visible');
+  const retry = failed.getByRole('button', { name: 'Retry fail-once.txt' });
+  await retry.focus(); await page.keyboard.press('Space');
+  await page.waitForFunction(() => document.querySelector('[data-session="one"] .image-attachments-summary')
+    ?.textContent?.includes('6 uploaded'));
+  await page.waitForTimeout(80);
+  await batch('one').getByRole('button', { name: 'details' }).click();
+  const canceled = await batch('one').locator('.image-chip-name').allTextContents();
+  assert.ok(!canceled.includes('cancel-0.txt') && !canceled.includes('cancel-6.txt'));
+  metrics = await page.evaluate(() => window.uploadMetrics);
+  assert.equal(metrics.attempts['one/fail-once.txt'], 2);
+  for (const name of canceled.filter((name) => name !== 'fail-once.txt')) {
+    assert.equal(metrics.attempts[`one/${name}`], 1, `${name} was re-uploaded`);
+  }
+
+  await page.evaluate(() => window.batchApps.one.clear());
+  const deletesBeforeLate = await page.evaluate(() => window.uploadMetrics.deletes.length);
+  await input('one').setInputFiles({ name: 'late-success.txt', mimeType: 'text/plain', buffer: Buffer.from('late') });
+  const late = batch('one').locator('.image-chip', { hasText: 'late-success.txt' });
+  await late.getByRole('button', { name: 'Cancel upload late-success.txt' }).click();
+  await late.waitFor({ state: 'detached' });
+  await page.waitForFunction((before) => window.uploadMetrics.deletes.length > before, deletesBeforeLate);
+  metrics = await page.evaluate(() => window.uploadMetrics);
+  assert.equal(metrics.deletes.length, deletesBeforeLate + 1,
+    'a server success racing cancellation is explicitly removed');
+
+  console.log('attachment batch browser tests passed');
+} finally {
+  await browser.close();
+  fs.rmSync(tmp, { recursive: true, force: true });
+}

--- a/web/test/fileUploadReplace.test.mjs
+++ b/web/test/fileUploadReplace.test.mjs
@@ -19,7 +19,7 @@ fs.writeFileSync(stub, `
     constructor(message,status,body){super(message);this.status=status;
       if(body?.code==='file-exists'||body?.code==='replacement-stale')this.collision=body;}
   }
-  window.fileCalls=[]; window.revisions={existing:'token-existing',stale:'token-stale-1'};
+  window.fileCalls=[]; window.revisions={existing:'token-existing',stale:'token-stale-1'}; window.vanished=false;
   export const listFiles=()=>Promise.resolve({path:'',root:'workspace',entries:[
     {name:'target',dir:true,size:0,mtime:1},{name:'existing.txt',dir:false,size:8,mtime:1,kind:'text'}]});
   export const uploadFile=(_id,folder,file,{replaceToken,onProgress,signal}={})=>new Promise((resolve,reject)=>{
@@ -35,6 +35,12 @@ fs.writeFileSync(stub, `
         {code:'file-exists',name:'stale.txt',path:'target/stale.txt',revision:'sha256:5:a',replaceToken:window.revisions.stale}));
       if(file.name==='stale.txt'&&replaceToken==='token-stale-1')return reject(new WorkspaceUploadError('"stale.txt" changed after replacement was confirmed',409,
         {code:'replacement-stale',name:'stale.txt',path:'target/stale.txt',revision:'sha256:7:b',replaceToken:'token-stale-2'}));
+      if(file.name==='vanished.txt'&&!replaceToken&&!window.vanished)return reject(new WorkspaceUploadError('"vanished.txt" already exists',409,
+        {code:'file-exists',name:'vanished.txt',path:'target/vanished.txt',revision:'sha256:4:c',replaceToken:'token-vanished'}));
+      if(file.name==='vanished.txt'&&replaceToken==='token-vanished'){
+        window.vanished=true; return reject(new WorkspaceUploadError('"vanished.txt" no longer exists — upload it again',409,
+          {code:'replacement-stale',name:'vanished.txt',path:'target/vanished.txt',revision:null,replaceToken:null}));
+      }
       onProgress?.({loaded:file.size,total:file.size}); resolve({ok:true,path:folder+'/'+file.name,size:file.size,mtime:2});
     },file.name==='slow.txt'?500:15);
   });
@@ -113,6 +119,18 @@ try {
   await row('stale.txt').locator('.files-upload-state', { hasText: 'uploaded' }).waitFor();
   assert.equal((await page.evaluate(() => window.fileCalls)).filter((call) => call.name === 'stale.txt').at(-1).replaceToken,
     'token-stale-2', 'a stale choice requires the fresh server token');
+
+  await input.setInputFiles({ name: 'vanished.txt', mimeType: 'text/plain', buffer: Buffer.from('create-after-delete') });
+  await row('vanished.txt').getByRole('button', { name: 'Replace…' }).click();
+  await page.getByRole('dialog', { name: 'Replace vanished.txt?' }).getByRole('button', { name: 'Replace', exact: true }).click();
+  await row('vanished.txt').locator('.files-upload-state', { hasText: 'no longer exists' }).waitFor();
+  assert.equal(await row('vanished.txt').getByRole('button', { name: 'Replace…' }).count(), 0,
+    'a missing destination has no replacement token and must not offer an inert Replace action');
+  await row('vanished.txt').getByRole('button', { name: 'Retry' }).click();
+  await row('vanished.txt').locator('.files-upload-state', { hasText: 'uploaded' }).waitFor();
+  const vanishedCalls = (await page.evaluate(() => window.fileCalls)).filter((call) => call.name === 'vanished.txt');
+  assert.deepEqual(vanishedCalls.map((call) => call.replaceToken), [null, 'token-vanished', null],
+    'Retry after deletion is a plain create, not another replacement');
 
   await input.setInputFiles({ name: 'slow.txt', mimeType: 'text/plain', buffer: Buffer.alloc(2000) });
   await row('slow.txt').getByRole('button', { name: 'Cancel' }).click();

--- a/web/test/fileUploadReplace.test.mjs
+++ b/web/test/fileUploadReplace.test.mjs
@@ -1,0 +1,132 @@
+// Files pane replacement consent: exact destination, Cancel by default, and a
+// separate token-bound request only after the operator chooses Replace.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const WEB = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'am-file-replace-ui-'));
+const bundle = path.join(tmp, 'fixture.js');
+const stub = path.join(tmp, 'api.ts');
+fs.writeFileSync(stub, `
+  export class TraceUnavailable extends Error {}
+  export class WorkspaceUploadError extends Error {
+    constructor(message,status,body){super(message);this.status=status;
+      if(body?.code==='file-exists'||body?.code==='replacement-stale')this.collision=body;}
+  }
+  window.fileCalls=[]; window.revisions={existing:'token-existing',stale:'token-stale-1'};
+  export const listFiles=()=>Promise.resolve({path:'',root:'workspace',entries:[
+    {name:'target',dir:true,size:0,mtime:1},{name:'existing.txt',dir:false,size:8,mtime:1,kind:'text'}]});
+  export const uploadFile=(_id,folder,file,{replaceToken,onProgress,signal}={})=>new Promise((resolve,reject)=>{
+    const call={folder,name:file.name,replaceToken:replaceToken||null,aborted:false}; window.fileCalls.push(call);
+    signal?.addEventListener('abort',()=>{call.aborted=true;reject(new WorkspaceUploadError('Upload was canceled before it completed.',0));},{once:true});
+    onProgress?.({loaded:Math.floor(file.size/2),total:file.size});
+    setTimeout(()=>{
+      if(call.aborted)return;
+      if(file.name==='fail.txt')return reject(new WorkspaceUploadError('disk unavailable',500));
+      if(file.name==='existing.txt'&&!replaceToken)return reject(new WorkspaceUploadError('"existing.txt" already exists',409,
+        {code:'file-exists',name:'existing.txt',path:'target/existing.txt',revision:'sha256:8:a',replaceToken:'token-existing'}));
+      if(file.name==='stale.txt'&&!replaceToken)return reject(new WorkspaceUploadError('"stale.txt" already exists',409,
+        {code:'file-exists',name:'stale.txt',path:'target/stale.txt',revision:'sha256:5:a',replaceToken:window.revisions.stale}));
+      if(file.name==='stale.txt'&&replaceToken==='token-stale-1')return reject(new WorkspaceUploadError('"stale.txt" changed after replacement was confirmed',409,
+        {code:'replacement-stale',name:'stale.txt',path:'target/stale.txt',revision:'sha256:7:b',replaceToken:'token-stale-2'}));
+      onProgress?.({loaded:file.size,total:file.size}); resolve({ok:true,path:folder+'/'+file.name,size:file.size,mtime:2});
+    },file.name==='slow.txt'?500:15);
+  });
+  export const previewFile=()=>Promise.reject(new Error('not used'));
+  export const rawUrl=()=>''; export const downloadUrl=()=>'';
+  export const createFolder=()=>Promise.resolve({}); export const createFile=()=>Promise.resolve({});
+  export const renameEntry=()=>Promise.resolve({path:''}); export const moveEntry=()=>Promise.resolve({path:''});
+  export const deleteEntry=()=>Promise.resolve({}); export const writeFile=()=>Promise.resolve({size:0,mtime:0,tag:''});
+  export const getFileTraceWindow=()=>new Promise(()=>{}); export const getFileTraceSummary=()=>new Promise(()=>{});
+`);
+await build({
+  stdin: { resolveDir: WEB, loader: 'tsx', contents: `
+    import React from 'react'; import {createRoot} from 'react-dom/client';
+    import FilesPane from './src/components/FilesPane';
+    const session={id:'files-1',cli:'files',name:'Files',state:'stopped',running:false,everStarted:false,path:null,createdAt:new Date().toISOString()};
+    createRoot(document.getElementById('root')).render(<FilesPane session={session} focused zoom={100} onClose={()=>{}}/>);
+  ` }, outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+  plugins: [{ name: 'stub-api', setup(builder) {
+    builder.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub }));
+  } }],
+});
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await browser.newPage({ viewport: { width: 390, height: 700 } });
+const input = page.locator('.upload-btn input[type=file]');
+const row = (name) => page.locator('.files-upload-row', { has: page.locator('.files-upload-name', { hasText: name }) }).last();
+try {
+  await page.setContent(`<style>${fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8')}
+    html,body,#root{width:100%;height:100%;margin:0}.slot{height:100%}</style><div id="root"></div>`);
+  await page.addScriptTag({ path: bundle });
+  await input.waitFor({ state: 'attached' });
+  await page.getByText('target', { exact: true }).click();
+
+  await input.setInputFiles([
+    { name: 'existing.txt', mimeType: 'text/plain', buffer: Buffer.from('replacement') },
+    { name: 'good.txt', mimeType: 'text/plain', buffer: Buffer.from('good') },
+    { name: 'fail.txt', mimeType: 'text/plain', buffer: Buffer.from('failure') },
+  ]);
+  await row('existing.txt').waitFor();
+  await row('good.txt').locator('.files-upload-state', { hasText: 'uploaded' }).waitFor();
+  await row('fail.txt').locator('.files-upload-state', { hasText: 'disk unavailable' }).waitFor();
+  assert.equal(await page.locator('.files-upload-row').count(), 3, 'mixed outcomes all remain visible');
+  assert.match(await page.locator('.files-uploads-head').textContent(), /1 uploaded/);
+  assert.match(await page.locator('.files-uploads-head').textContent(), /2 need attention/);
+  assert.equal((await page.evaluate(() => window.fileCalls)).filter((call) => call.replaceToken).length, 0,
+    'a collision alone never authorizes replacement');
+
+  await row('existing.txt').getByRole('button', { name: 'Replace…' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Replace existing.txt?' });
+  await dialog.waitFor();
+  assert.match(await dialog.textContent(), /existing\.txt/);
+  assert.match(await dialog.textContent(), /workspace\/target\/existing\.txt/);
+  assert.equal(await dialog.getByRole('button', { name: 'Cancel' }).evaluate((button) => button === document.activeElement), true,
+    'Cancel is the focused default');
+  await page.keyboard.press('Escape');
+  await dialog.waitFor({ state: 'detached' });
+  assert.equal((await page.evaluate(() => window.fileCalls)).filter((call) => call.replaceToken).length, 0,
+    'Escape does not replace');
+  assert.match(await row('existing.txt').locator('.files-upload-state').textContent(), /canceled/);
+
+  await input.setInputFiles({ name: 'existing.txt', mimeType: 'text/plain', buffer: Buffer.from('replacement') });
+  await row('existing.txt').getByRole('button', { name: 'Replace…' }).click();
+  await page.getByRole('dialog', { name: 'Replace existing.txt?' }).getByRole('button', { name: 'Replace', exact: true }).click();
+  await row('existing.txt').locator('.files-upload-state', { hasText: 'uploaded' }).waitFor();
+  const deliberate = (await page.evaluate(() => window.fileCalls)).filter((call) => call.name === 'existing.txt').at(-1);
+  assert.equal(deliberate.replaceToken, 'token-existing');
+  assert.equal(deliberate.folder, 'target');
+
+  await input.setInputFiles({ name: 'stale.txt', mimeType: 'text/plain', buffer: Buffer.from('replacement') });
+  await row('stale.txt').getByRole('button', { name: 'Replace…' }).click();
+  await page.getByRole('dialog', { name: 'Replace stale.txt?' }).getByRole('button', { name: 'Replace', exact: true }).click();
+  await row('stale.txt').locator('.files-upload-state', { hasText: 'changed after replacement' }).waitFor();
+  assert.equal((await page.evaluate(() => window.fileCalls)).filter((call) => call.name === 'stale.txt').length, 2);
+  await row('stale.txt').getByRole('button', { name: 'Replace…' }).click();
+  await page.getByRole('dialog', { name: 'Replace stale.txt?' }).getByRole('button', { name: 'Replace', exact: true }).click();
+  await row('stale.txt').locator('.files-upload-state', { hasText: 'uploaded' }).waitFor();
+  assert.equal((await page.evaluate(() => window.fileCalls)).filter((call) => call.name === 'stale.txt').at(-1).replaceToken,
+    'token-stale-2', 'a stale choice requires the fresh server token');
+
+  await input.setInputFiles({ name: 'slow.txt', mimeType: 'text/plain', buffer: Buffer.alloc(2000) });
+  await row('slow.txt').getByRole('button', { name: 'Cancel' }).click();
+  await page.waitForTimeout(30);
+  const slow = (await page.evaluate(() => window.fileCalls)).find((call) => call.name === 'slow.txt');
+  assert.equal(slow.aborted, true);
+  assert.match(await row('slow.txt').locator('.files-upload-state').textContent(), /canceled/);
+
+  const geometry = await page.locator('.files-uploads').evaluate((box) => ({
+    overflow: box.scrollWidth > box.clientWidth,
+    height: box.querySelector('.files-upload-list').getBoundingClientRect().height,
+  }));
+  assert.ok(!geometry.overflow && geometry.height <= 149, JSON.stringify(geometry));
+  console.log('workspace replacement UI tests passed');
+} finally {
+  await browser.close(); fs.rmSync(tmp, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes #122

## What changed

### Reader attachment batches

- Removes the five-file limit from picker/repeated additions and server resolution without replacing it with another per-prompt count cap. The existing 100 MiB/file, 500 MiB/session, and 200 stored files/session safeguards remain server-enforced.
- Replaces the 20 uploads/minute admission failure with bounded work: one shared FIFO per originating session starts at most three browser transfers; the server streams and serializes quota/publication work per session. Different sessions remain independent.
- Preserves selection order and distinct IDs for equal display names, while still preferring `DataTransfer.files` over its duplicate `items` representation.
- Adds aggregate counts, a bounded/scrollable detail list, per-file progress, queued/active cancellation, retry for transient errors, and always-visible failure rows when collapsed. Size/storage/validation failures retain their reason without offering a futile retry. Send remains unavailable until every remaining file is confirmed.
- Wires reader drop as well as its picker/paste paths. Overview, quick-create, reader, and terminal keep their existing session-specific delivery behavior.

### Workspace replacement and folder safety

- Makes workspace upload create-only by default. A collision returns the exact relative path, full streamed SHA-256 revision, and an opaque replacement token. The Files pane presents a separate Replace dialog with Cancel focused by default; Escape/backdrop cancellation performs no replacement.
- Binds explicit replacement to the exact resolved destination and content revision. A change before or during upload returns a fresh conflict and requires a new decision.
- Streams every upload to a random exclusive same-directory temporary, revalidates, and only then publishes. Aborts and injected publication failures remove only the operation-owned temporary and preserve the prior bytes. Concurrent creates never overwrite one another; final-entry and parent redirect symlinks are rejected.
- Shares the owned-temp/destination-lock primitive with the existing text writer while retaining its current content-tag API and UI state contract.
- Blocks rename/move/delete for the exact or ancestor directory of configured workspaces and shared skills, using real paths and path-segment containment. Defaults, stopped sessions, shared/nested workspaces, aliases, sibling lookalikes, and safe rename/move no-ops are covered.

## Diagnosis

Before the fix I reproduced three independent failures on `ef08e84`:

- attachment upload 21 returned 429 even though the files were tiny;
- the server rejected six IDs at prompt resolution even if all six had uploaded;
- workspace upload silently overwrote an existing file, and interrupting that replacement removed the old destination entirely.

The last case was the data-loss path: the old route opened the destination itself for truncating output, then unlinked that destination on request failure.

## Deliberately left out

This does not redesign editor save/autosave state, add trash/version history, relocate agent workspaces, introduce a general upload service, add remote-agent attachments, promise durable exactly-once prompt delivery, or redesign the reader. There is no Replace All path. The documented hard-link fallback and the cross-process agent-write/rename gap are not described as transactional guarantees.

## Verification

- `web: npm run typecheck`
- `web: npm run build`
- `web: npm test` — 25/25 discovered suites passed
- `web: node test/attachmentBatches.test.mjs && node test/fileUploadReplace.test.mjs`
- `server: node test/attachments.test.mjs && node test/safe-write.test.mjs && node test/files-safety.test.mjs`
- `server: SCREENSHOT_PORT=7922 ISSUE122_SCREENSHOT=/tmp/issue122-reader-50.png node screenshot-input.test.mjs` — all checks passed, including real XHR/server uploads and 50 ordered IDs in the final request
- `server: npm test` — stops at the known-red `test/crons.test.mjs` test 4. The same failure reproduced on an untouched `ef08e84` worktree. I then ran the 23 remaining discovered non-manual suites explicitly; all passed.

Measured in browser coverage: max 3 active transfers for one session and 6 total across two sessions. Measured at server storage: max 1 stream per session and at least 2 across independent sessions. The tests also exercise 6, 30, 50, and 75 files; same-name files; overlapping additions; partial failure; offline/quota errors; queued/active/late cancellation; retry without reuploading successful siblings; narrow layout; create/replace races; mid-stream content changes; failed publication; temp collisions/symlinks; and folder dependencies.

Mutation checks confirmed the focused suites fail when the old five-file resolver cap is restored, final replacement revalidation is removed, ancestor containment is reduced to equality, or the browser transfer bound is removed.

[50-file reader evidence at 390 px](https://lvwerra-agent-artifacts.static.hf.space/issue-122-files-evidence.html)
