### PR TITLE
Filter credentials from full API audit logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ on local POSIX storage and is restored/checkpointed by
 database backups rather than copying live WAL files. See
 [`docs/agent-state-checkpoints.md`](docs/agent-state-checkpoints.md).
 Scheduled prompts are documented in [`docs/cron-jobs.md`](docs/cron-jobs.md).
+API audit retention and credential filtering are documented in
+[`docs/api-audit-log.md`](docs/api-audit-log.md).
 
 ## Architecture
 

--- a/docs/api-audit-log.md
+++ b/docs/api-audit-log.md
@@ -1,0 +1,81 @@
+# API audit log: retained content and credential filtering
+
+Agent Manager appends accepted mutating API calls, plus resolved agent waits, to
+`operations.jsonl` under the private data directory. The log is meant to answer
+who asked whom to do what and what happened, so it retains full non-secret
+request, prompt, file-write, result and error content. It has no route allowlist,
+payload cap, hashes-only mode or retention setting.
+
+This is a **sensitive private audit log**, not an export-safe artifact. Deleting
+a source session or file does not delete the copy already recorded here. Keep
+the Space and its bucket private.
+
+## New-record filtering policy
+
+Version 2 records carry:
+
+```json
+{"version":2,"audit":{"credentialFilter":{"policy":"credentials-v1","status":"applied"}}}
+```
+
+The filter operates on a detached audit representation immediately before JSON
+serialization and append. The handler, agent input, file content, response and
+session objects keep the original values.
+
+| Rule | What `credentials-v1` replaces |
+|---|---|
+| Sensitive structured fields | Values under normalized credential names such as `authorization`, `password`, `token`, `api_key`, `clientSecret`, `private_key`, `subscription` and `endpoint`. A short value is still removed when its field is explicitly sensitive. Similar ordinary names such as `tokenizer` and `secretary` are retained. |
+| Provider/standard shapes | Hugging Face `hf_…`; Anthropic `sk-ant-…`; OpenAI `sk-…` including `sk-proj-…`/`sk-svcacct-…`; OpenRouter `sk-or-v1-…`; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` and `github_pat_`; AWS `AKIA…` access-key ids; Google `AIza…`, `AQ.…` and `ya29.…`; three-part JWT-shaped strings. Boundaries and minimum lengths prevent short examples and ordinary identifiers from matching. |
+| Explicit text | Values in authorization text (`Authorization: Bearer …`, Basic or Token) and credential assignments such as `OPENAI_API_KEY="…"`, `password: …`, query-string `token=…`, and the same shapes in an escaped embedded JSON string. The label and surrounding ordinary text remain. |
+| Private keys | A complete matching `BEGIN … PRIVATE KEY` through `END … PRIVATE KEY` block, including PKCS, RSA, EC, OpenSSH and PGP-style labels. The whole block becomes one placeholder. An incomplete marker is retained because there is no safe block boundary to remove. |
+| Configured values | Exact values, at least eight non-whitespace characters long, from the Space's existing injected-secret catalog. Duplicates are removed, overlaps run longest-first, and one URL-encoded form is matched. The catalog is read for each new record, so rotation does not retain an obsolete matcher. Values are never sent to the browser. |
+| Buffers | UTF-8 Buffers use the text policy. Other Buffers use a one-byte mapping so recognizable ASCII credentials cannot evade filtering merely because the stored representation is base64. The retained byte length, checksum and base64 are all derived from the filtered bytes. |
+
+The provider prefixes follow provider-owned references: [Hugging Face user
+tokens](https://huggingface.co/docs/hub/security-tokens), [OpenAI API
+keys](https://help.openai.com/en/articles/6882433-incorrect-api-key-provided),
+[Anthropic SDK credential examples](https://github.com/anthropics/anthropic-sdk-python/blob/main/examples/workload_identity.py),
+[OpenRouter keys](https://openrouter.ai/docs/api/reference/authentication),
+[GitHub token formats](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-authentication-to-github),
+and [Google's Gemini tooling recognizers](https://github.com/google-gemini/gemini-skills).
+
+Every replacement is the fixed string `[redacted]`. No rule name, secret hash,
+preview or per-secret fingerprint is retained.
+
+## What the filter cannot promise
+
+An arbitrary unlabeled password has no reliable shape. If it is not a supported
+token, explicit assignment/private-key block, sensitive structured field or one
+of the currently injected values, it remains. Ordinary base64/hex strings,
+archives, compressed data and nested encodings are not recursively decoded.
+Opaque binary receives only the direct ASCII checks described above. The filter
+does not scan workspaces, CLI credential files, the home directory, historical
+logs or backups, and it makes no network calls.
+
+These deliberate limits avoid erasing long IDs, URLs, code samples and ordinary
+words while keeping work bounded by the retained input, the fixed rule set and
+the small injected-value set. There is no scan cutoff or raw unscanned tail.
+The focused test prints baseline/filter/event-loop timings for a representative
+multi-megabyte value; filtering remains synchronous with the existing append,
+so that measured duration is also the event-loop delay for that write.
+
+Filtering is best effort, not a confidentiality guarantee. Do not publish an
+audit record merely because its metadata says the filter ran.
+
+## Checksums, failures and compatibility
+
+Text `chars` and `sha256`, and Buffer `bytes`/`sha256`, describe the **stored
+filtered value**. Unchanged text keeps its ordinary checksum. Different original
+credentials can both become `[redacted]`, so an equal v2 checksum proves only
+that the retained payloads match; the API-log UI says this explicitly.
+
+If sanitizing a new record throws, Agent Manager writes one minimal v2 audit
+failure entry containing generated identifiers and fixed diagnostic text—never
+the raw path, labels, payload or exception. If append itself fails, it logs one
+fixed server diagnostic and does not retry an append that may have partially
+landed. Neither failure changes or replays the completed API operation, and the
+next healthy event can still be recorded.
+
+Records without `audit.credentialFilter` are legacy records. This change is
+prospective: existing JSONL bytes and backups are not inspected, rewritten,
+migrated or deleted, and older entries must not be assumed filtered.

--- a/docs/api-audit-log.md
+++ b/docs/api-audit-log.md
@@ -60,7 +60,9 @@ credential label, structured sensitive field or configured-value match when
 that material must be recognized. These deliberate limits avoid erasing long
 IDs, URLs, code samples and ordinary words while keeping work bounded by the
 retained input, the fixed rule set and the small injected-value set. There is no
-payload scan cutoff or raw unscanned tail.
+payload scan cutoff, traversal-depth limit or raw unscanned tail. Payload
+traversal and JSONL serialization use heap-backed work lists so deeply nested
+valid JSON does not fall through to a generic filter-failure entry.
 The focused test prints baseline/filter/event-loop timings for a representative
 multi-megabyte value; filtering remains synchronous with the existing append,
 so that measured duration is also the event-loop delay for that write.

--- a/docs/api-audit-log.md
+++ b/docs/api-audit-log.md
@@ -26,7 +26,7 @@ session objects keep the original values.
 |---|---|
 | Sensitive structured fields | Values under normalized credential names such as `authorization`, `password`, `token`, `api_key`, `clientSecret`, `private_key`, `subscription` and `endpoint`. A short value is still removed when its field is explicitly sensitive. Similar ordinary names such as `tokenizer` and `secretary` are retained. |
 | Provider/standard shapes | Hugging Face `hf_…`; Anthropic `sk-ant-…`; OpenAI `sk-…` including `sk-proj-…`/`sk-svcacct-…`; OpenRouter `sk-or-v1-…`; GitHub `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` and `github_pat_`; AWS `AKIA…` access-key ids; Google `AIza…`, `AQ.…` and `ya29.…`; three-part JWT-shaped strings. Boundaries and minimum lengths prevent short examples and ordinary identifiers from matching. |
-| Explicit text | Values in authorization text (`Authorization: Bearer …`, Basic or Token) and credential assignments such as `OPENAI_API_KEY="…"`, `password: …`, query-string `token=…`, and the same shapes in an escaped embedded JSON string. The label and surrounding ordinary text remain. |
+| Explicit text | Values in authorization text (`Authorization: Bearer …`, Basic or Token), bounded compound credential assignments such as `OPENAI_API_KEY="…"`/`access_token=…`, quoted bare sensitive fields in embedded JSON, uppercase environment-style bare assignments, and the same quoted shapes in an escaped embedded JSON string. Parsed query-string `token` fields are covered structurally. The label and surrounding ordinary text remain. |
 | Private keys | A complete matching `BEGIN … PRIVATE KEY` through `END … PRIVATE KEY` block, including PKCS, RSA, EC, OpenSSH and PGP-style labels. The whole block becomes one placeholder. An incomplete marker is retained because there is no safe block boundary to remove. |
 | Configured values | Exact values, at least eight non-whitespace characters long, from the Space's existing injected-secret catalog. Duplicates are removed, overlaps run longest-first, and one URL-encoded form is matched. The catalog is read for each new record, so rotation does not retain an obsolete matcher. Values are never sent to the browser. |
 | Buffers | UTF-8 Buffers use the text policy. Other Buffers use a one-byte mapping so recognizable ASCII credentials cannot evade filtering merely because the stored representation is base64. The retained byte length, checksum and base64 are all derived from the filtered bytes. |
@@ -52,9 +52,15 @@ Opaque binary receives only the direct ASCII checks described above. The filter
 does not scan workspaces, CLI credential files, the home directory, historical
 logs or backups, and it makes no network calls.
 
-These deliberate limits avoid erasing long IDs, URLs, code samples and ordinary
-words while keeping work bounded by the retained input, the fixed rule set and
-the small injected-value set. There is no scan cutoff or raw unscanned tail.
+Assignment labels are bounded to 128 characters, which keeps malformed
+dash-joined input linear rather than repeatedly scanning the same suffix.
+Ambiguous lowercase, unquoted bare assignments such as `key=value` are retained
+because they are common in source code, YAML and prose; use a compound
+credential label, structured sensitive field or configured-value match when
+that material must be recognized. These deliberate limits avoid erasing long
+IDs, URLs, code samples and ordinary words while keeping work bounded by the
+retained input, the fixed rule set and the small injected-value set. There is no
+payload scan cutoff or raw unscanned tail.
 The focused test prints baseline/filter/event-loop timings for a representative
 multi-megabyte value; filtering remains synchronous with the existing append,
 so that measured duration is also the event-loop delay for that write.

--- a/server/src/audit-credentials.js
+++ b/server/src/audit-credentials.js
@@ -51,10 +51,8 @@ const AUTHORIZATION = new RegExp(
 // at every word boundary and allowed unlimited `word-` prefixes; on a long
 // dash-joined line it repeatedly re-walked the suffix (quadratic event-loop
 // work) even though the line contained no assignment operator at all.
-const ASSIGNMENT_VALUE = new RegExp(
-  String.raw`((?::|=)\s*)(${VALUE})`,
-  'g',
-);
+const ASSIGNMENT_OPERATOR = /[:=]/g;
+const VALUE_AT = new RegExp(VALUE, 'y');
 const COMPOUND_ASSIGNMENT_SUFFIXES = [
   'apikey', 'accesstoken', 'refreshtoken', 'authtoken', 'apitoken',
   'clientsecret', 'secretkey', 'privatekey',
@@ -178,6 +176,29 @@ function labelBeforeAssignment(input, operatorOffset) {
   return input.slice(start, end);
 }
 
+function redactAssignments(text) {
+  const pieces = [];
+  let copiedThrough = 0;
+  ASSIGNMENT_OPERATOR.lastIndex = 0;
+  for (let operator; (operator = ASSIGNMENT_OPERATOR.exec(text));) {
+    const label = labelBeforeAssignment(text, operator.index);
+    if (!label) continue;
+
+    let valueStart = operator.index + 1;
+    while (valueStart < text.length && /\s/.test(text[valueStart])) valueStart++;
+    VALUE_AT.lastIndex = valueStart;
+    const valueMatch = VALUE_AT.exec(text);
+    if (!valueMatch || !isExplicitCredentialAssignment(label, valueMatch[0])) continue;
+
+    pieces.push(text.slice(copiedThrough, valueStart), redactValue(valueMatch[0]));
+    copiedThrough = valueStart + valueMatch[0].length;
+    ASSIGNMENT_OPERATOR.lastIndex = copiedThrough;
+  }
+  if (!pieces.length) return text;
+  pieces.push(text.slice(copiedThrough));
+  return pieces.join('');
+}
+
 function exactValues(values) {
   const unique = new Set();
   for (const candidate of Array.isArray(values) ? values : []) {
@@ -203,11 +224,7 @@ export function createCredentialFilter(knownValues = []) {
     for (const value of exact) out = out.split(value).join(REDACTED_CREDENTIAL);
     for (const pattern of TOKEN_PATTERNS) out = out.replace(pattern, REDACTED_CREDENTIAL);
     out = out.replace(AUTHORIZATION, (_whole, prefix, value) => `${prefix}${redactValue(value, true)}`);
-    out = out.replace(ASSIGNMENT_VALUE, (whole, prefix, value, offset, inputText) => {
-      const label = labelBeforeAssignment(inputText, offset);
-      return isExplicitCredentialAssignment(label, value) ? `${prefix}${redactValue(value)}` : whole;
-    });
-    return out;
+    return redactAssignments(out);
   };
 }
 

--- a/server/src/audit-credentials.js
+++ b/server/src/audit-credentials.js
@@ -11,11 +11,15 @@ export const REDACTED_CREDENTIAL = '[redacted]';
 export const MIN_KNOWN_CREDENTIAL_LENGTH = 8;
 const SENSITIVE_EXACT = new Set([
   'authorization', 'credential', 'credentials', 'password', 'passwd', 'secret', 'secrets',
-  'token', 'tokens', 'key', 'subscription', 'endpoint', 'privatekey', 'apikey', 'accesskey',
+  'token', 'tokens', 'subscription', 'endpoint', 'privatekey', 'apikey', 'accesskey', 'secretkey',
 ]);
 const SENSITIVE_SUFFIXES = [
-  'credential', 'password', 'passwd', 'secret', 'token', 'privatekey', 'apikey', 'accesskey', 'endpoint',
+  'credential', 'password', 'passwd', 'secret', 'token', 'privatekey', 'apikey', 'accesskey', 'secretkey', 'endpoint',
 ];
+const SENSITIVE_KEY_WORDS = new Set([
+  'authorization', 'credential', 'credentials', 'password', 'passwd', 'secret', 'secrets',
+  'subscription', 'endpoint', 'token',
+]);
 
 // Fixed-count, bounded recognizers. Keep this list aligned with
 // docs/api-audit-log.md, including its source links and limitations.
@@ -38,15 +42,24 @@ const TOKEN_PATTERNS = [
 // field after the outer JSON body has already been parsed.
 const VALUE = String.raw`(?:\\"(?:\\\\.|[^"\\\r\n])*\\"|\\'(?:\\\\.|[^'\\\r\n])*\\'|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|\x60(?:\\.|[^\x60\\\r\n])*\x60|[^\s,;&'"\x60]+)`;
 const AUTH_VALUE = String.raw`(?:\\"(?:\\\\.|[^"\\\r\n])*\\"|\\'(?:\\\\.|[^'\\\r\n])*\\'|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|\x60(?:\\.|[^\x60\\\r\n])*\x60|(?:Bearer|Basic|Token)\s+[^\s,;&'"\x60]+|[^\s,;&'"\x60]+)`;
-const CREDENTIAL_LABEL = String.raw`(?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret[_-]?key|private[_-]?key|password|passwd|credential|token|secret|key)`;
 const AUTHORIZATION = new RegExp(
   String.raw`(\bauthorization\b(?:\\?["'])?\s*(?::|=)\s*)(${AUTH_VALUE})`,
   'gi',
 );
-const ASSIGNMENT = new RegExp(
-  String.raw`(\b${CREDENTIAL_LABEL}\b(?:\\?["'])?\s*(?::|=)\s*)(${VALUE})`,
-  'gi',
+// Find assignment operators once from left to right, then inspect at most 128
+// label characters immediately before each one. An earlier expression started
+// at every word boundary and allowed unlimited `word-` prefixes; on a long
+// dash-joined line it repeatedly re-walked the suffix (quadratic event-loop
+// work) even though the line contained no assignment operator at all.
+const ASSIGNMENT_VALUE = new RegExp(
+  String.raw`((?::|=)\s*)(${VALUE})`,
+  'g',
 );
+const COMPOUND_ASSIGNMENT_SUFFIXES = [
+  'apikey', 'accesstoken', 'refreshtoken', 'authtoken', 'apitoken',
+  'clientsecret', 'secretkey', 'privatekey',
+];
+const BARE_ASSIGNMENT_LABELS = new Set(['password', 'passwd', 'credential', 'token', 'secret']);
 
 const PRIVATE_KEY_MARKER = /-----(BEGIN|END) ((?:[A-Z0-9]+ )*PRIVATE KEY(?: BLOCK)?)-----/g;
 
@@ -126,6 +139,45 @@ function redactValue(value, keepAuthorizationScheme = false) {
   return `${open}${scheme}${REDACTED_CREDENTIAL}${tail}${close}`;
 }
 
+function isQuotedValue(value) {
+  return ['\\"', "\\'", '"', "'", '`'].some((quote) => value.startsWith(quote));
+}
+
+function isExplicitCredentialAssignment(label, value) {
+  const normalized = label.toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (COMPOUND_ASSIGNMENT_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) return true;
+
+  const lower = label.toLowerCase();
+  const parts = lower.split(/[_-]+/).filter(Boolean);
+  if (parts.length > 1 && ['password', 'passwd', 'credential'].includes(parts.at(-1))) return true;
+  if (!BARE_ASSIGNMENT_LABELS.has(lower)) return false;
+
+  // Quoting gives an embedded structured field a definite value boundary.
+  // An all-caps bare label is the conventional shell/env assignment form.
+  // Lowercase unquoted `key=`, `token:` and `password:` are too ambiguous with
+  // ordinary source code, YAML and prose to remove safely from a full log.
+  return isQuotedValue(value) || label === label.toUpperCase();
+}
+
+function labelBeforeAssignment(input, operatorOffset) {
+  let end = operatorOffset;
+  while (end > 0 && /\s/.test(input[end - 1])) end--;
+  if (input[end - 1] === '"' || input[end - 1] === "'") {
+    end--;
+    if (input[end - 1] === '\\') end--;
+  }
+
+  let start = end;
+  let remaining = 128;
+  while (start > 0 && remaining > 0 && /[A-Za-z0-9_-]/.test(input[start - 1])) {
+    start--;
+    remaining--;
+  }
+  if (start === end || (remaining === 0 && /[A-Za-z0-9_-]/.test(input[start - 1] || ''))) return '';
+  if (/[A-Za-z0-9_]/.test(input[start - 1] || '')) return '';
+  return input.slice(start, end);
+}
+
 function exactValues(values) {
   const unique = new Set();
   for (const candidate of Array.isArray(values) ? values : []) {
@@ -151,7 +203,10 @@ export function createCredentialFilter(knownValues = []) {
     for (const value of exact) out = out.split(value).join(REDACTED_CREDENTIAL);
     for (const pattern of TOKEN_PATTERNS) out = out.replace(pattern, REDACTED_CREDENTIAL);
     out = out.replace(AUTHORIZATION, (_whole, prefix, value) => `${prefix}${redactValue(value, true)}`);
-    out = out.replace(ASSIGNMENT, (_whole, prefix, value) => `${prefix}${redactValue(value)}`);
+    out = out.replace(ASSIGNMENT_VALUE, (whole, prefix, value, offset, inputText) => {
+      const label = labelBeforeAssignment(inputText, offset);
+      return isExplicitCredentialAssignment(label, value) ? `${prefix}${redactValue(value)}` : whole;
+    });
     return out;
   };
 }
@@ -162,7 +217,19 @@ export function createCredentialFilter(knownValues = []) {
  * fields, while `access_token` and `clientSecret` are not.
  */
 export function isSensitiveAuditKey(key) {
-  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+  const source = String(key);
+  const normalized = source.toLowerCase().replace(/[^a-z0-9]/g, '');
   if (SENSITIVE_EXACT.has(normalized)) return true;
-  return SENSITIVE_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+  if (SENSITIVE_SUFFIXES.some((suffix) => normalized.endsWith(suffix))) return true;
+
+  // Preserve main's protection for compound fields such as `passwordHash`,
+  // `endpointUrl`, `SECRET_KEY` and `Ocp-Apim-Subscription-Key` without its
+  // substring false positives for ordinary `tokenizer`/`secretary` fields.
+  const words = source
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  return words.some((word) => SENSITIVE_KEY_WORDS.has(word));
 }

--- a/server/src/audit-credentials.js
+++ b/server/src/audit-credentials.js
@@ -1,0 +1,168 @@
+/**
+ * Credential filtering for newly persisted API-operation records.
+ *
+ * This is deliberately narrower than a general secret scanner. It recognizes
+ * documented provider prefixes, explicit credential labels, complete private
+ * key blocks, and exact configured values supplied by the caller. Everything
+ * else stays byte-for-byte useful in the private audit log.
+ */
+export const AUDIT_CREDENTIAL_POLICY = 'credentials-v1';
+export const REDACTED_CREDENTIAL = '[redacted]';
+export const MIN_KNOWN_CREDENTIAL_LENGTH = 8;
+const SENSITIVE_EXACT = new Set([
+  'authorization', 'credential', 'credentials', 'password', 'passwd', 'secret', 'secrets',
+  'token', 'tokens', 'key', 'subscription', 'endpoint', 'privatekey', 'apikey', 'accesskey',
+]);
+const SENSITIVE_SUFFIXES = [
+  'credential', 'password', 'passwd', 'secret', 'token', 'privatekey', 'apikey', 'accesskey', 'endpoint',
+];
+
+// Fixed-count, bounded recognizers. Keep this list aligned with
+// docs/api-audit-log.md, including its source links and limitations.
+const TOKEN_PATTERNS = [
+  /\bhf_[A-Za-z0-9_]{20,}\b/g,
+  /\bsk-ant-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-or-v1-[A-Za-z0-9_-]{20,}\b/g,
+  /\bsk-(?:(?:proj|svcacct)-)?[A-Za-z0-9_-]{32,}\b/g,
+  /\bgh[pousr]_[A-Za-z0-9_]{30,}\b/g,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/g,
+  /\bAKIA[0-9A-Z]{16}\b/g,
+  /\bAIza[0-9A-Za-z_-]{35}\b/g,
+  /\bAQ\.[0-9A-Za-z_-]{20,}\b/g,
+  /\bya29\.[0-9A-Za-z_-]{20,}\b/g,
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/g,
+];
+
+// Quoted values include their delimiters so replacement keeps the surrounding
+// syntax valid. The escaped forms cover JSON embedded inside an ordinary text
+// field after the outer JSON body has already been parsed.
+const VALUE = String.raw`(?:\\"(?:\\\\.|[^"\\\r\n])*\\"|\\'(?:\\\\.|[^'\\\r\n])*\\'|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|\x60(?:\\.|[^\x60\\\r\n])*\x60|[^\s,;&'"\x60]+)`;
+const AUTH_VALUE = String.raw`(?:\\"(?:\\\\.|[^"\\\r\n])*\\"|\\'(?:\\\\.|[^'\\\r\n])*\\'|"(?:\\.|[^"\\\r\n])*"|'(?:\\.|[^'\\\r\n])*'|\x60(?:\\.|[^\x60\\\r\n])*\x60|(?:Bearer|Basic|Token)\s+[^\s,;&'"\x60]+|[^\s,;&'"\x60]+)`;
+const CREDENTIAL_LABEL = String.raw`(?:[a-z0-9]+[_-])*(?:api[_-]?key|access[_-]?token|refresh[_-]?token|auth[_-]?token|client[_-]?secret|secret[_-]?key|private[_-]?key|password|passwd|credential|token|secret|key)`;
+const AUTHORIZATION = new RegExp(
+  String.raw`(\bauthorization\b(?:\\?["'])?\s*(?::|=)\s*)(${AUTH_VALUE})`,
+  'gi',
+);
+const ASSIGNMENT = new RegExp(
+  String.raw`(\b${CREDENTIAL_LABEL}\b(?:\\?["'])?\s*(?::|=)\s*)(${VALUE})`,
+  'gi',
+);
+
+const PRIVATE_KEY_MARKER = /-----(BEGIN|END) ((?:[A-Z0-9]+ )*PRIVATE KEY(?: BLOCK)?)-----/g;
+
+// One pass over markers: unlike a lazy `BEGIN[\s\S]*?END` expression, repeated
+// incomplete BEGIN lines cannot make this scan revisit an ever-growing tail.
+function redactPrivateKeyBlocks(text) {
+  const opens = new Map();
+  const intervals = [];
+  for (const match of text.matchAll(PRIVATE_KEY_MARKER)) {
+    if (match[1] === 'BEGIN') {
+      const stack = opens.get(match[2]) || [];
+      stack.push(match.index);
+      opens.set(match[2], stack);
+      continue;
+    }
+    const stack = opens.get(match[2]);
+    if (!stack?.length) continue;
+    intervals.push({ start: stack.pop(), end: match.index + match[0].length });
+    if (!stack.length) opens.delete(match[2]);
+  }
+
+  if (!intervals.length) return text;
+  // Matches arrive in ascending END order. Merge from right to left, which is
+  // linear even for nested/crossed fake markers and leaves no overlapping raw
+  // sibling range behind.
+  const mergedRightToLeft = [];
+  for (let i = intervals.length - 1; i >= 0; i--) {
+    const interval = intervals[i];
+    const right = mergedRightToLeft.at(-1);
+    if (right && interval.end >= right.start) {
+      right.start = Math.min(right.start, interval.start);
+      right.end = Math.max(right.end, interval.end);
+    } else {
+      mergedRightToLeft.push({ ...interval });
+    }
+  }
+  const pieces = [];
+  let copiedThrough = 0;
+  for (let i = mergedRightToLeft.length - 1; i >= 0; i--) {
+    const interval = mergedRightToLeft[i];
+    pieces.push(text.slice(copiedThrough, interval.start), REDACTED_CREDENTIAL);
+    copiedThrough = interval.end;
+  }
+  pieces.push(text.slice(copiedThrough));
+  return pieces.join('');
+}
+
+function redactValue(value, keepAuthorizationScheme = false) {
+  let open = '';
+  let close = '';
+  let inner = value;
+  for (const quote of ['\\"', "\\'", '"', "'", '`']) {
+    if (value.startsWith(quote) && value.endsWith(quote) && value.length >= quote.length * 2) {
+      open = close = quote;
+      inner = value.slice(quote.length, -quote.length);
+      break;
+    }
+  }
+  const existingScheme = keepAuthorizationScheme ? inner.match(/^(?:Bearer|Basic|Token)\s+/i)?.[0] || '' : '';
+  const retained = inner.slice(existingScheme.length);
+  if (retained === REDACTED_CREDENTIAL
+      || (retained.startsWith(REDACTED_CREDENTIAL)
+        && /^[.!?:)\]}]+$/.test(retained.slice(REDACTED_CREDENTIAL.length)))) return value;
+  // An unquoted assignment in prose often ends at sentence punctuation. The
+  // matcher has to admit dots for opaque/JWT-style values, so peel only a
+  // trailing prose delimiter back off rather than erasing it with the value.
+  let tail = '';
+  if (!open) {
+    const punctuation = inner.match(/[.!?:)\]}]+$/)?.[0] || '';
+    if (punctuation) {
+      tail = punctuation;
+      inner = inner.slice(0, -punctuation.length);
+    }
+  }
+  const scheme = keepAuthorizationScheme ? inner.match(/^(?:Bearer|Basic|Token)\s+/i)?.[0] || '' : '';
+  if (inner.slice(scheme.length) === REDACTED_CREDENTIAL) return value;
+  return `${open}${scheme}${REDACTED_CREDENTIAL}${tail}${close}`;
+}
+
+function exactValues(values) {
+  const unique = new Set();
+  for (const candidate of Array.isArray(values) ? values : []) {
+    if (typeof candidate !== 'string') continue;
+    if (candidate.length < MIN_KNOWN_CREDENTIAL_LENGTH || candidate.trim().length < MIN_KNOWN_CREDENTIAL_LENGTH) continue;
+    unique.add(candidate);
+    // Query parsers decode this form, but paths and embedded URL text may not.
+    // This is one exact derivative, not general recursive decoding.
+    try {
+      const encoded = encodeURIComponent(candidate);
+      if (encoded !== candidate && encoded.length >= MIN_KNOWN_CREDENTIAL_LENGTH) unique.add(encoded);
+    } catch { /* an invalid Unicode scalar still gets exact raw matching */ }
+  }
+  return [...unique].sort((a, b) => b.length - a.length || (a < b ? -1 : a > b ? 1 : 0));
+}
+
+/** Create one deterministic string filter for one audit record. */
+export function createCredentialFilter(knownValues = []) {
+  const exact = exactValues(knownValues);
+  return (input) => {
+    let out = redactPrivateKeyBlocks(String(input));
+    // Longest first makes overlapping configured values deterministic.
+    for (const value of exact) out = out.split(value).join(REDACTED_CREDENTIAL);
+    for (const pattern of TOKEN_PATTERNS) out = out.replace(pattern, REDACTED_CREDENTIAL);
+    out = out.replace(AUTHORIZATION, (_whole, prefix, value) => `${prefix}${redactValue(value, true)}`);
+    out = out.replace(ASSIGNMENT, (_whole, prefix, value) => `${prefix}${redactValue(value)}`);
+    return out;
+  };
+}
+
+/**
+ * Structural credential labels. Normalize separators/case, then require an
+ * exact label or credential suffix: `tokenizer` and `secretary` are ordinary
+ * fields, while `access_token` and `clientSecret` are not.
+ */
+export function isSensitiveAuditKey(key) {
+  const normalized = String(key).toLowerCase().replace(/[^a-z0-9]/g, '');
+  if (SENSITIVE_EXACT.has(normalized)) return true;
+  return SENSITIVE_SUFFIXES.some((suffix) => normalized.endsWith(suffix));
+}

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -255,6 +255,10 @@ const resolveOperationTarget = (req) => {
 app.use(operationMiddleware({
   resolveOrigin: resolveOperationOrigin,
   resolveTarget: resolveOperationTarget,
+  // The same injected-secret catalog shown in Settings, but values stay here.
+  // It is evaluated per record so rotation drops obsolete values immediately;
+  // no workspace, harness credential file, home directory or history is read.
+  getKnownCredentialValues: () => injectedEnvKeys().map((key) => process.env[key]),
   // Test servers explicitly opt out so old endpoint-focused fixtures do not
   // have to pretend to be the operator. Production never sets this switch.
   allowMissing: process.env.AM_ALLOW_MISSING_ORIGIN === '1',
@@ -980,7 +984,8 @@ const hfToken = () => process.env.HF_TOKEN || process.env.HUGGING_FACE_HUB_TOKEN
 
 // Env var names that existed at build time (baked in by the Dockerfile). Names
 // present at runtime but NOT here were injected by HF → the Space's secrets and
-// variables. We never read their values, only report the names.
+// variables. Settings reports only their names; operationMiddleware also reads
+// values from this same bounded catalog server-side to filter new audit records.
 const BUILD_ENV_KEYS = (() => {
   try {
     return new Set(fs.readFileSync('/app/build-env-keys.txt', 'utf8').split('\n').map((s) => s.trim()).filter(Boolean));
@@ -1336,8 +1341,11 @@ Hermes — alongside plain shells and a file browser.
 The manager exposes a small HTTP API on \`localhost:\${AM_PORT:-${PORT}}\`. You are \`$AM_ID\`
 (\`$AM_NAME\` is your display name). Every call that changes something takes
 \`?from=$AM_ID\` so the other agent, and the operator reading the log later, can
-tell who asked. The manager durably records these operations and their outcomes;
-prompt and file contents are hashed rather than copied into the audit log.
+tell who asked. The manager durably records these operations and their outcomes,
+including full non-secret prompt, file and response content. New records apply
+best-effort filtering for recognizable credentials before persistence. The log
+remains sensitive and private: filtering cannot identify every unlabeled secret,
+deleting a source does not delete its audit copy, and older records were not rewritten.
 
 To reconstruct recent manager operations (newest first):
 

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -29,9 +29,6 @@ const shouldLog = (req) => MUTATING.has(req.method)
 // the checksum travels beside the value, and `chars` is what the log's compact
 // list column reads.
 const MAX_TEXT = 500;
-// A backstop against a cyclic object, not a limit on how much is kept: a request
-// body is the output of a JSON or text parser and cannot contain a cycle, but
-// JSON.stringify throwing here would lose the whole entry.
 // How far back a read will go looking for complete records. One enormous entry
 // must not hide the log, and reading a whole year of it must not exhaust memory.
 const MAX_TAIL = 256 * 1024 * 1024;
@@ -49,45 +46,86 @@ function textSummary(value) {
 /**
  * The call as it was made, whole, with a checksum attached to anything long
  * enough to want one. Credentials are the single exception and are replaced by
- * `[redacted]` wherever the documented best-effort policy recognizes them.
+ * `[redacted]` wherever the documented best-effort policy recognizes them. The
+ * heap-backed traversal preserves valid JSON deeper than the JavaScript call
+ * stack; `active` is only a cycle guard, not a capture-depth limit.
  */
-export function summarizePayload(value, key = '', filterString = (text) => text, seen = new WeakSet()) {
-  if (key && isSensitiveAuditKey(key)) return REDACTED_CREDENTIAL;
-  if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
-  if (Buffer.isBuffer(value)) {
-    // UTF-8 text gets normal string semantics. For an opaque Buffer, latin1 is
-    // a one-byte mapping that still catches ASCII credential material without
-    // claiming to decode the binary format or inspect an archive.
-    const utf8 = value.toString('utf8');
-    const validUtf8 = Buffer.from(utf8, 'utf8').equals(value);
-    const filtered = validUtf8
-      ? Buffer.from(filterString(utf8), 'utf8')
-      : Buffer.from(filterString(value.toString('latin1')), 'latin1');
-    return { bytes: filtered.length, sha256: digest(filtered), base64: filtered.toString('base64') };
-  }
-  if (typeof value === 'string') {
-    const filtered = filterString(value);
-    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(filtered);
-    return filtered;
-  }
-  if (typeof value !== 'object') return filterString(String(value));
-  if (seen.has(value)) return '[circular]';
-  seen.add(value);
-  if (Array.isArray(value)) {
-    const out = value.map((v) => summarizePayload(v, key, filterString, seen));
-    seen.delete(value);
-    return out;
-  }
-  if (typeof value === 'object') {
-    const out = {};
-    for (const [k, v] of Object.entries(value)) {
-      let storedKey = filterString(k);
-      for (let n = 2; Object.hasOwn(out, storedKey); n++) storedKey = `${filterString(k)}#${n}`;
-      out[storedKey] = summarizePayload(v, k, filterString, seen);
+export function summarizePayload(value, key = '', filterString = (text) => text) {
+  const root = { value: undefined };
+  const active = new WeakSet();
+  const stack = [{ type: 'visit', value, key, parent: root, slot: 'value' }];
+
+  while (stack.length) {
+    const frame = stack.pop();
+    if (frame.type === 'leave') {
+      active.delete(frame.value);
+      continue;
     }
-    seen.delete(value);
-    return out;
+
+    const { value: current, key: currentKey, parent, slot } = frame;
+    if (currentKey && isSensitiveAuditKey(currentKey)) {
+      parent[slot] = REDACTED_CREDENTIAL;
+      continue;
+    }
+    if (current == null || typeof current === 'boolean' || typeof current === 'number') {
+      parent[slot] = current;
+      continue;
+    }
+    if (Buffer.isBuffer(current)) {
+      // UTF-8 text gets normal string semantics. For an opaque Buffer, latin1
+      // is a one-byte mapping that still catches ASCII credential material
+      // without claiming to decode the binary format or inspect an archive.
+      const utf8 = current.toString('utf8');
+      const validUtf8 = Buffer.from(utf8, 'utf8').equals(current);
+      const filtered = validUtf8
+        ? Buffer.from(filterString(utf8), 'utf8')
+        : Buffer.from(filterString(current.toString('latin1')), 'latin1');
+      parent[slot] = { bytes: filtered.length, sha256: digest(filtered), base64: filtered.toString('base64') };
+      continue;
+    }
+    if (typeof current === 'string') {
+      const filtered = filterString(current);
+      parent[slot] = CONTENT_KEY.test(currentKey) || current.length > MAX_TEXT
+        ? textSummary(filtered)
+        : filtered;
+      continue;
+    }
+    if (typeof current !== 'object') {
+      parent[slot] = filterString(String(current));
+      continue;
+    }
+    if (active.has(current)) {
+      parent[slot] = '[circular]';
+      continue;
+    }
+
+    active.add(current);
+    stack.push({ type: 'leave', value: current });
+    if (Array.isArray(current)) {
+      const out = new Array(current.length);
+      parent[slot] = out;
+      for (let i = current.length - 1; i >= 0; i--) {
+        if (Object.hasOwn(current, i)) {
+          stack.push({ type: 'visit', value: current[i], key: currentKey, parent: out, slot: i });
+        }
+      }
+      continue;
+    }
+
+    const out = {};
+    parent[slot] = out;
+    const children = [];
+    for (const [childKey, child] of Object.entries(current)) {
+      let storedKey = filterString(childKey);
+      for (let n = 2; Object.hasOwn(out, storedKey); n++) storedKey = `${filterString(childKey)}#${n}`;
+      // Establish keys in source order before LIFO traversal processes values.
+      out[storedKey] = undefined;
+      children.push({ value: child, key: childKey, parent: out, slot: storedKey });
+    }
+    for (let i = children.length - 1; i >= 0; i--) stack.push({ type: 'visit', ...children[i] });
   }
+
+  return root.value;
 }
 
 function sanitizeMetadata(value, filterString, seen = new WeakSet()) {
@@ -111,9 +149,60 @@ function sanitizeMetadata(value, filterString, seen = new WeakSet()) {
   return out;
 }
 
+function stringifyAuditRecord(value) {
+  // JSON.stringify itself overflows on input depths JSON.parse and Express
+  // accept. Serialize the already-filtered representation with the same JSON
+  // scalar/container rules, but keep the traversal stack on the heap.
+  const chunks = [];
+  const seen = new WeakSet();
+  const stack = [{ type: 'value', value, arrayItem: false }];
+  while (stack.length) {
+    const frame = stack.pop();
+    if (frame.type === 'raw') {
+      chunks.push(frame.value);
+      continue;
+    }
+    if (frame.type === 'leave') {
+      seen.delete(frame.value);
+      continue;
+    }
+    const current = frame.value;
+    if (!current || typeof current !== 'object') {
+      const encoded = JSON.stringify(current);
+      chunks.push(encoded === undefined ? (frame.arrayItem ? 'null' : '') : encoded);
+      continue;
+    }
+    if (seen.has(current)) throw new TypeError('circular audit representation');
+    seen.add(current);
+
+    if (Array.isArray(current)) {
+      stack.push({ type: 'leave', value: current });
+      stack.push({ type: 'raw', value: ']' });
+      for (let i = current.length - 1; i >= 0; i--) {
+        if (i < current.length - 1) stack.push({ type: 'raw', value: ',' });
+        stack.push({ type: 'value', value: current[i], arrayItem: true });
+      }
+      stack.push({ type: 'raw', value: '[' });
+      continue;
+    }
+
+    const entries = Object.entries(current).filter(([, child]) => child !== undefined);
+    stack.push({ type: 'leave', value: current });
+    stack.push({ type: 'raw', value: '}' });
+    for (let i = entries.length - 1; i >= 0; i--) {
+      const [childKey, child] = entries[i];
+      if (i < entries.length - 1) stack.push({ type: 'raw', value: ',' });
+      stack.push({ type: 'value', value: child, arrayItem: false });
+      stack.push({ type: 'raw', value: `${JSON.stringify(childKey)}:` });
+    }
+    stack.push({ type: 'raw', value: '{' });
+  }
+  return chunks.join('');
+}
+
 function append(record) {
   fs.mkdirSync(path.dirname(OPERATIONS_FILE), { recursive: true });
-  fs.appendFileSync(OPERATIONS_FILE, `${JSON.stringify(record)}\n`, { mode: 0o600 });
+  fs.appendFileSync(OPERATIONS_FILE, `${stringifyAuditRecord(record)}\n`, { mode: 0o600 });
 }
 
 const requestOrigin = (req) => String(

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -2,6 +2,9 @@ import crypto from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import { DATA_DIR } from './config.js';
+import {
+  AUDIT_CREDENTIAL_POLICY, REDACTED_CREDENTIAL, createCredentialFilter, isSensitiveAuditKey,
+} from './audit-credentials.js';
 
 export const OPERATIONS_FILE = path.join(DATA_DIR, 'operations.jsonl');
 
@@ -29,11 +32,9 @@ const MAX_TEXT = 500;
 // A backstop against a cyclic object, not a limit on how much is kept: a request
 // body is the output of a JSON or text parser and cannot contain a cycle, but
 // JSON.stringify throwing here would lose the whole entry.
-const MAX_DEPTH = 20;
 // How far back a read will go looking for complete records. One enormous entry
 // must not hide the log, and reading a whole year of it must not exhaust memory.
 const MAX_TAIL = 256 * 1024 * 1024;
-const SENSITIVE_KEY = /(authorization|credential|password|secret|subscription|token|endpoint|private.?key)/i;
 const CONTENT_KEY = /(body|content|data|prompt|text)/i;
 
 const digest = (value) => crypto.createHash('sha256').update(value).digest('hex');
@@ -48,41 +49,71 @@ function textSummary(value) {
 /**
  * The call as it was made, whole, with a checksum attached to anything long
  * enough to want one. Credentials are the single exception and are replaced by
- * `[redacted]` wherever they appear.
+ * `[redacted]` wherever the documented best-effort policy recognizes them.
  */
-export function summarizePayload(value, key = '', depth = 0) {
+export function summarizePayload(value, key = '', filterString = (text) => text, seen = new WeakSet()) {
+  if (key && isSensitiveAuditKey(key)) return REDACTED_CREDENTIAL;
   if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
-  // No route here parses a raw body today, but if one ever does, keep the bytes
-  // rather than a description of them.
   if (Buffer.isBuffer(value)) {
-    return { bytes: value.length, sha256: digest(value), base64: value.toString('base64') };
+    // UTF-8 text gets normal string semantics. For an opaque Buffer, latin1 is
+    // a one-byte mapping that still catches ASCII credential material without
+    // claiming to decode the binary format or inspect an archive.
+    const utf8 = value.toString('utf8');
+    const validUtf8 = Buffer.from(utf8, 'utf8').equals(value);
+    const filtered = validUtf8
+      ? Buffer.from(filterString(utf8), 'utf8')
+      : Buffer.from(filterString(value.toString('latin1')), 'latin1');
+    return { bytes: filtered.length, sha256: digest(filtered), base64: filtered.toString('base64') };
   }
   if (typeof value === 'string') {
-    if (SENSITIVE_KEY.test(key)) return '[redacted]';
-    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(value);
-    return value;
+    const filtered = filterString(value);
+    if (CONTENT_KEY.test(key) || value.length > MAX_TEXT) return textSummary(filtered);
+    return filtered;
   }
-  if (depth >= MAX_DEPTH) return '[max-depth]';
-  if (Array.isArray(value)) return value.map((v) => summarizePayload(v, key, depth + 1));
+  if (typeof value !== 'object') return filterString(String(value));
+  if (seen.has(value)) return '[circular]';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const out = value.map((v) => summarizePayload(v, key, filterString, seen));
+    seen.delete(value);
+    return out;
+  }
   if (typeof value === 'object') {
     const out = {};
     for (const [k, v] of Object.entries(value)) {
-      out[k] = SENSITIVE_KEY.test(k) ? '[redacted]' : summarizePayload(v, k, depth + 1);
+      let storedKey = filterString(k);
+      for (let n = 2; Object.hasOwn(out, storedKey); n++) storedKey = `${filterString(k)}#${n}`;
+      out[storedKey] = summarizePayload(v, k, filterString, seen);
     }
+    seen.delete(value);
     return out;
   }
-  return String(value);
+}
+
+function sanitizeMetadata(value, filterString, seen = new WeakSet()) {
+  if (typeof value === 'string') return filterString(value);
+  if (value == null || typeof value === 'boolean' || typeof value === 'number') return value;
+  if (typeof value !== 'object') return filterString(String(value));
+  if (seen.has(value)) return '[circular]';
+  seen.add(value);
+  if (Array.isArray(value)) {
+    const out = value.map((v) => sanitizeMetadata(v, filterString, seen));
+    seen.delete(value);
+    return out;
+  }
+  const out = {};
+  for (const [key, child] of Object.entries(value)) {
+    let storedKey = filterString(key);
+    for (let n = 2; Object.hasOwn(out, storedKey); n++) storedKey = `${filterString(key)}#${n}`;
+    out[storedKey] = isSensitiveAuditKey(key) ? REDACTED_CREDENTIAL : sanitizeMetadata(child, filterString, seen);
+  }
+  seen.delete(value);
+  return out;
 }
 
 function append(record) {
-  try {
-    fs.mkdirSync(path.dirname(OPERATIONS_FILE), { recursive: true });
-    fs.appendFileSync(OPERATIONS_FILE, `${JSON.stringify(record)}\n`, { mode: 0o600 });
-  } catch (e) {
-    // Auditing must never turn a successfully completed user operation into an
-    // HTTP failure. Make storage trouble loud in the server log instead.
-    console.error('[operations.append]', e && e.message);
-  }
+  fs.mkdirSync(path.dirname(OPERATIONS_FILE), { recursive: true });
+  fs.appendFileSync(OPERATIONS_FILE, `${JSON.stringify(record)}\n`, { mode: 0o600 });
 }
 
 const requestOrigin = (req) => String(
@@ -92,10 +123,10 @@ const requestOrigin = (req) => String(
   || '',
 ).trim();
 
-const cleanQuery = (query) => {
+const cleanQuery = (query, filterString) => {
   const out = { ...(query || {}) };
   delete out.from;
-  return summarizePayload(out, 'query');
+  return summarizePayload(out, 'query', filterString);
 };
 
 /**
@@ -106,7 +137,14 @@ const cleanQuery = (query) => {
  * unknown. It may derive an identity from a protocol route (remote agents do
  * this for backwards compatibility with already-running polling loops).
  */
-export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing = false } = {}) {
+export function operationMiddleware({
+  resolveOrigin,
+  resolveTarget,
+  allowMissing = false,
+  getKnownCredentialValues = () => [],
+  filterFactory = createCredentialFilter,
+  appendRecord = append,
+} = {}) {
   return (req, res, next) => {
     if (!req.path.startsWith('/api/') || !shouldLog(req)) return next();
 
@@ -151,24 +189,59 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
       // Same for a wait the caller abandoned (no body) or one whose target had
       // already gone: nothing came back, so there is nothing to draw.
       if (!MUTATING.has(req.method) && !(responseBody && responseBody.matched === true)) return;
-      append({
-        version: 1,
-        id: operationId,
-        at: new Date(started).toISOString(),
-        origin,
-        // Who it was done TO, snapshotted above. The id is in the path already,
-        // but a name read back later is the name the session has NOW — renamed
-        // or deleted, and the audit trail stops making sense.
-        ...(target ? { target } : {}),
-        method: req.method,
-        path: req.path,
-        query: cleanQuery(req.query),
-        request: summarizePayload(req.body, 'body'),
-        status: res.statusCode,
-        ok: res.statusCode < 400,
-        durationMs: Date.now() - started,
-        result: summarizePayload(responseBody, 'result'),
-      });
+      let entry;
+      try {
+        const filterString = filterFactory(getKnownCredentialValues());
+        entry = {
+          version: 2,
+          id: operationId,
+          at: new Date(started).toISOString(),
+          audit: { credentialFilter: { policy: AUDIT_CREDENTIAL_POLICY, status: 'applied' } },
+          origin: sanitizeMetadata(origin, filterString),
+          // Who it was done TO, snapshotted above. The id is in the path already,
+          // but a name read back later is the name the session has NOW — renamed
+          // or deleted, and the audit trail stops making sense.
+          ...(target ? { target: sanitizeMetadata(target, filterString) } : {}),
+          method: req.method,
+          path: filterString(req.path),
+          query: cleanQuery(req.query, filterString),
+          request: summarizePayload(req.body, 'body', filterString),
+          status: res.statusCode,
+          ok: res.statusCode < 400,
+          durationMs: Date.now() - started,
+          result: summarizePayload(responseBody, 'result', filterString),
+        };
+      } catch {
+        // No raw fallback. Even labels, paths and exception messages may be
+        // attacker-controlled, so a filter failure records only fixed text and
+        // identifiers generated inside this middleware.
+        entry = {
+          version: 2,
+          id: operationId,
+          at: new Date(started).toISOString(),
+          audit: {
+            credentialFilter: {
+              policy: AUDIT_CREDENTIAL_POLICY,
+              status: 'failed',
+              reason: 'credential-filter-failed',
+            },
+          },
+          origin: null,
+          method: 'AUDIT',
+          path: '/audit/credential-filter',
+          query: {},
+          status: 0,
+          ok: false,
+          durationMs: Date.now() - started,
+        };
+      }
+      try {
+        appendRecord(entry);
+      } catch {
+        // Auditing must never change a completed operation or attempt a second
+        // response. Keep this diagnostic fixed: append errors can quote data.
+        console.error('[operations.append] audit append failed');
+      }
     };
     res.once('finish', record);
     res.once('close', record);

--- a/server/test/audit-instructions.test.mjs
+++ b/server/test/audit-instructions.test.mjs
@@ -1,0 +1,61 @@
+// The environment skill is generated at boot. Exercise that output in an
+// isolated data/home tree so its privacy claims cannot drift from the API-log
+// documentation again.
+//
+// Run with: node test/audit-instructions.test.mjs
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-audit-instructions-'));
+const dataDir = path.join(TMP, 'data');
+const homeDir = path.join(TMP, 'home');
+const generated = path.join(dataDir, 'workspaces', 'skills', 'environment.md');
+fs.mkdirSync(homeDir, { recursive: true });
+
+// Do not let a local test child inherit actual configured credential values.
+const env = { ...process.env, DATA_DIR: dataDir, HOME: homeDir, PORT: '0', AM_BASHRC: '/nonexistent' };
+for (const key of Object.keys(env)) {
+  if (/(TOKEN|KEY|SECRET|PASSWORD|CREDENTIAL)/i.test(key)) delete env[key];
+}
+delete env.SPACE_ID;
+delete env.AM_DISTRIBUTE_SKILLS;
+env.AUDIT_TEST_SECRET = 'synthetic-configured-value';
+
+const server = spawn(process.execPath, ['src/index.js'], { env, stdio: ['ignore', 'pipe', 'pipe'] });
+let output = '';
+server.stdout.on('data', (chunk) => { output += chunk; });
+server.stderr.on('data', (chunk) => { output += chunk; });
+
+try {
+  // The normal suite runner starts this immediately after filesystem-heavy
+  // integration tests; allow a cold server boot without making the assertion
+  // depend on host load. The loop still exits as soon as generation completes.
+  for (let i = 0; i < 600 && !fs.existsSync(generated); i++) {
+    if (server.exitCode != null) throw new Error(`server exited ${server.exitCode}: ${output.slice(-2_000)}`);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  assert.ok(fs.existsSync(generated), `environment skill was not generated: ${output.slice(-300)}`);
+  const text = fs.readFileSync(generated, 'utf8');
+  assert.match(text, /full non-secret prompt, file and response content/);
+  assert.match(text, /best-effort filtering for recognizable credentials/);
+  assert.match(text, /remains sensitive and private/);
+  assert.match(text, /deleting a source does not delete its audit copy/);
+  assert.match(text, /older records were not rewritten/);
+  assert.doesNotMatch(text, /prompt and file contents are hashed rather than copied/);
+
+  const docs = fs.readFileSync(path.resolve('..', 'docs', 'api-audit-log.md'), 'utf8');
+  assert.match(docs, /full non-secret\s+request, prompt, file-write, result and error content/);
+  assert.match(docs, /not an export-safe artifact/);
+  assert.match(docs, /existing JSONL bytes and backups are not inspected, rewritten/);
+  console.log('audit-instructions: generated and long-form policy describe retained, filtered, prospective private logs');
+} finally {
+  server.kill('SIGTERM');
+  await Promise.race([
+    new Promise((resolve) => server.once('exit', resolve)),
+    new Promise((resolve) => setTimeout(resolve, 1_000)),
+  ]);
+  fs.rmSync(TMP, { recursive: true, force: true });
+}

--- a/server/test/operation-credentials.test.mjs
+++ b/server/test/operation-credentials.test.mjs
@@ -247,6 +247,52 @@ try {
     assert.equal(cursor.next.text.text, `value-${i}`);
     cursor = cursor.next;
   }
+
+  // Valid JSON can be much deeper than the JavaScript call stack. The audit
+  // copy and its JSONL serialization must keep that full shape rather than let
+  // the caller turn an attributable operation into a generic filter failure.
+  const veryDeep = { level: 0 };
+  let veryDeepInputCursor = veryDeep;
+  for (let i = 1; i <= 5_000; i++) {
+    veryDeepInputCursor.next = { level: i };
+    veryDeepInputCursor = veryDeepInputCursor.next;
+  }
+  veryDeepInputCursor.prompt = `deep leaf ${TOKENS.huggingface}`;
+  const beforeVeryDeep = diskLines().length;
+  const veryDeepCall = invoke({ reqPath: '/api/agents/target-1/prompt', body: veryDeep }, (request, response) => {
+    assert.equal(request.body, veryDeep, 'the deeply nested body reaches the handler unchanged');
+    response.json({ ok: true });
+  });
+  assert.equal(veryDeepCall.res.jsonCalls, 1);
+  assert.equal(diskLines().length, beforeVeryDeep + 1, 'deep traversal and serialization append exactly one record');
+  const veryDeepRecord = newest();
+  assert.equal(veryDeepRecord.audit.credentialFilter.status, 'applied');
+  assert.equal(veryDeepRecord.origin.id, 'agent-1');
+  assert.equal(veryDeepRecord.target.id, 'target-1');
+  assert.equal(veryDeepRecord.method, 'POST');
+  assert.equal(veryDeepRecord.path, '/api/agents/target-1/prompt');
+  let veryDeepStoredCursor = veryDeepRecord.request;
+  for (let i = 0; i <= 5_000; i++) {
+    assert.equal(veryDeepStoredCursor.level, i, `deep level ${i} is retained`);
+    if (i < 5_000) veryDeepStoredCursor = veryDeepStoredCursor.next;
+  }
+  assert.equal(veryDeepStoredCursor.prompt.text, 'deep leaf [redacted]');
+  assert.equal(veryDeepInputCursor.prompt, `deep leaf ${TOKENS.huggingface}`,
+    'deep credential filtering does not mutate the delivered body');
+
+  const sharedBranch = { note: 'shared ordinary branch' };
+  const cyclic = { first: sharedBranch, second: sharedBranch };
+  cyclic.self = cyclic;
+  invoke({ body: cyclic }, (request, response) => {
+    assert.equal(request.body, cyclic);
+    response.json({ ok: true });
+  });
+  assert.deepEqual(newest().request, {
+    first: { note: 'shared ordinary branch' },
+    second: { note: 'shared ordinary branch' },
+    self: '[circular]',
+  }, 'iterative traversal preserves shared branches and marks only actual cycles');
+
   const near = `https://example.test/sketch-${'x'.repeat(40)} hf_short eyJonly.two ${INCOMPLETE_KEY}`;
   invoke({ body: near }, (_req, response) => response.json({ ok: true }));
   assert.equal(newest().request.text, near);

--- a/server/test/operation-credentials.test.mjs
+++ b/server/test/operation-credentials.test.mjs
@@ -1,0 +1,372 @@
+// Credential filtering is a persistence property: assertions inspect the new
+// JSONL bytes and decoded fields, while the fake handlers receive and return the
+// original objects. Every credential below is synthetic.
+//
+// Run with: node test/operation-credentials.test.mjs
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), 'am-operation-credentials-'));
+process.env.DATA_DIR = path.join(TMP, 'data');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+
+const {
+  OPERATIONS_FILE, operationMiddleware, readOperations, summarizePayload,
+} = await import('../src/operations.js');
+const {
+  AUDIT_CREDENTIAL_POLICY, REDACTED_CREDENTIAL, createCredentialFilter,
+} = await import('../src/audit-credentials.js');
+
+const TOKENS = {
+  huggingface: `hf_${'H'.repeat(28)}`,
+  anthropic: `sk-ant-api03-${'A'.repeat(36)}`,
+  openai: `sk-proj-${'O'.repeat(44)}`,
+  openrouter: `sk-or-v1-${'R'.repeat(44)}`,
+  github: `ghp_${'G'.repeat(36)}`,
+  githubFine: `github_pat_${'F'.repeat(36)}`,
+  aws: `AKIA${'W'.repeat(16)}`,
+  google: `AIza${'Q'.repeat(35)}`,
+  googleAuth: `AQ.${'N'.repeat(32)}`,
+  googleOauth: `ya29.${'Y'.repeat(32)}`,
+  jwt: `eyJ${'J'.repeat(12)}.${'K'.repeat(12)}.${'L'.repeat(12)}`,
+};
+const ALL_TOKENS = Object.values(TOKENS);
+const KNOWN_LONG = 'configured-value-with-symbols-!@#$';
+const KNOWN_OVERLAP = 'value-with-symbols-!@#$';
+const KNOWN_SHORT = 'tiny';
+const PRIVATE_ONE = '-----BEGIN PRIVATE KEY-----\nalpha\nbeta\n-----END PRIVATE KEY-----';
+const PRIVATE_TWO = '-----BEGIN OPENSSH PRIVATE KEY-----\ngamma\n-----END OPENSSH PRIVATE KEY-----';
+const INCOMPLETE_KEY = '-----BEGIN PRIVATE KEY-----\nnot complete';
+const CROSSED_KEYS = [
+  '-----BEGIN PRIVATE KEY-----', 'crossed-alpha',
+  '-----BEGIN RSA PRIVATE KEY-----', 'crossed-beta',
+  '-----END PRIVATE KEY-----', 'crossed-gamma',
+  '-----END RSA PRIVATE KEY-----',
+].join('\n');
+const legacy = `${JSON.stringify({
+  version: 1, id: 'legacy-id', at: '2026-09-01T00:00:00.000Z', origin: null,
+  method: 'POST', path: '/api/legacy', query: {}, request: { text: 'legacy bytes stay as written' },
+  status: 200, ok: true, durationMs: 1, result: { ok: true },
+})}\n`;
+fs.writeFileSync(OPERATIONS_FILE, legacy, { mode: 0o600 });
+
+class Response extends EventEmitter {
+  statusCode = 200;
+  body = undefined;
+  jsonCalls = 0;
+  status(code) { this.statusCode = code; return this; }
+  json(body) { this.body = body; this.jsonCalls++; this.emit('finish'); return this; }
+}
+
+let knownValues = [KNOWN_LONG, KNOWN_OVERLAP, KNOWN_LONG, '', '   ', KNOWN_SHORT];
+const originFixture = Object.freeze({ id: 'agent-1', type: 'agent', name: `agent ${TOKENS.anthropic}`, cli: 'codex' });
+const targetFixture = Object.freeze({ id: 'target-1', name: `target ${TOKENS.openai}`, cli: 'claude' });
+const middleware = operationMiddleware({
+  resolveOrigin: () => originFixture,
+  resolveTarget: () => targetFixture,
+  getKnownCredentialValues: () => knownValues,
+});
+const invoke = ({ method = 'POST', reqPath = '/api/test', query = {}, body }, handler) => {
+  const req = { method, path: reqPath, query: { from: 'agent-1', ...query }, headers: {}, body };
+  const res = new Response();
+  middleware(req, res, () => handler(req, res));
+  return { req, res };
+};
+const diskLines = () => fs.readFileSync(OPERATIONS_FILE, 'utf8').split('\n').filter(Boolean);
+const newest = () => JSON.parse(diskLines().at(-1));
+const absentFrom = (text, values) => values.forEach((value) => assert.ok(!text.includes(value), `retained synthetic credential: ${value.slice(0, 12)}…`));
+const deepFreeze = (value) => {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const child of Object.values(value)) deepFreeze(child);
+  return value;
+};
+
+try {
+  // Full supported matrix across ordinary strings, structured sensitive keys,
+  // query/path and user-controlled origin/target/result metadata.
+  const ordinary = `keep before ${ALL_TOKENS.join(' keep between ')} keep after; ${TOKENS.huggingface} repeated`;
+  const embedded = String.raw`embedded {\"password\":\"opaque quoted value\"} and OPENAI_API_KEY='opaque shell value'`;
+  const body = deepFreeze({
+    prompt: `${ordinary}\n${PRIVATE_ONE}\nmiddle\n${PRIVATE_TWO}\n${CROSSED_KEYS}\n${INCOMPLETE_KEY}`,
+    nested: [{ ordinary: `left ${KNOWN_LONG} right` }, true, 42, null],
+    password: 'short field value',
+    token: TOKENS.huggingface,
+    note: TOKENS.huggingface,
+    encoded: encodeURIComponent(KNOWN_LONG),
+    tokenizer: 'ordinary tokenizer field',
+    secretary: 'ordinary secretary field',
+    embedded,
+    [TOKENS.githubFine]: 'a credential can also be an object key',
+  });
+  const bodyBefore = structuredClone(body);
+  const resultBody = deepFreeze({
+    ok: false,
+    error: `ordinary error before ${TOKENS.googleAuth} ordinary error after`,
+    detail: 'Authorization: Bearer opaque-authorization-value. keep punctuation',
+    inline: 'password=opaque-password-value! keep punctuation',
+  });
+  const resultBefore = structuredClone(resultBody);
+  const { req, res } = invoke({
+    reqPath: `/api/test/${TOKENS.huggingface}`,
+    query: { note: `query ${TOKENS.github}`, access_token: 'short-query-secret' },
+    body,
+  }, (request, response) => {
+    assert.deepEqual(request.body, bodyBefore, 'the handler receives the exact original request');
+    response.status(422).json(resultBody);
+  });
+  assert.deepEqual(req.body, bodyBefore, 'auditing does not mutate the request after delivery');
+  assert.deepEqual(res.body, resultBefore, 'the HTTP response remains byte-for-byte the domain response');
+  assert.equal(originFixture.name, `agent ${TOKENS.anthropic}`, 'origin/session metadata is not mutated');
+  assert.equal(targetFixture.name, `target ${TOKENS.openai}`, 'target/session metadata is not mutated');
+  assert.equal(res.statusCode, 422);
+  assert.equal(res.jsonCalls, 1);
+
+  const firstRaw = diskLines().at(-1);
+  const first = JSON.parse(firstRaw);
+  absentFrom(firstRaw, [...ALL_TOKENS, KNOWN_LONG, 'short field value', 'short-query-secret',
+    'opaque quoted value', 'opaque shell value', 'opaque-authorization-value', 'opaque-password-value',
+    'alpha', 'beta', 'gamma', 'crossed-alpha', 'crossed-beta', 'crossed-gamma']);
+  assert.equal(first.version, 2);
+  assert.deepEqual(first.audit, { credentialFilter: { policy: AUDIT_CREDENTIAL_POLICY, status: 'applied' } });
+  assert.match(first.request.prompt.text, /^keep before /);
+  assert.match(first.request.prompt.text, / keep after;/);
+  assert.match(first.request.prompt.text, /middle/);
+  assert.ok(first.request.prompt.text.includes(INCOMPLETE_KEY), 'an incomplete private-key block is retained as documented');
+  assert.equal(first.request.password, REDACTED_CREDENTIAL);
+  assert.equal(first.request.token, REDACTED_CREDENTIAL);
+  assert.equal(first.request.note, REDACTED_CREDENTIAL);
+  assert.equal(first.request.encoded, REDACTED_CREDENTIAL);
+  assert.equal(first.request.tokenizer, 'ordinary tokenizer field');
+  assert.equal(first.request.secretary, 'ordinary secretary field');
+  assert.equal(first.request.nested[0].ordinary, 'left [redacted] right');
+  assert.ok(Object.hasOwn(first.request, REDACTED_CREDENTIAL), 'credential material in a property name is filtered too');
+  assert.equal(first.query.access_token, REDACTED_CREDENTIAL);
+  assert.equal(first.query.note, 'query [redacted]');
+  assert.equal(first.origin.name, 'agent [redacted]');
+  assert.equal(first.target.name, 'target [redacted]');
+  assert.equal(first.result.error, 'ordinary error before [redacted] ordinary error after');
+  assert.equal(first.result.detail, 'Authorization: Bearer [redacted]. keep punctuation');
+  assert.equal(first.result.inline, 'password=[redacted]! keep punctuation');
+
+  const fileInput = `file head\n${TOKENS.anthropic}\nfile tail`;
+  const fileCall = invoke({ reqPath: '/api/files/files-1/write', body: fileInput }, (request, response) => {
+    assert.equal(request.body, fileInput, 'the file handler receives the original content');
+    response.json({ ok: true, text: `response ${TOKENS.google} kept around` });
+  });
+  assert.equal(fileCall.res.body.text, `response ${TOKENS.google} kept around`);
+  assert.equal(newest().request.text, 'file head\n[redacted]\nfile tail');
+  assert.equal(newest().result.text.text, 'response [redacted] kept around');
+
+  // Stored summaries describe the retained string, never the original secret-
+  // bearing one. Two original credentials can therefore intentionally collapse
+  // to the same retained payload/checksum.
+  knownValues = ['first-exact-credential', 'second-exact-credential'];
+  invoke({ body: 'same first-exact-credential body' }, (_req, response) => response.json({ ok: true }));
+  const filteredA = newest();
+  invoke({ body: 'same second-exact-credential body' }, (_req, response) => response.json({ ok: true }));
+  const filteredB = newest();
+  assert.equal(filteredA.request.text, 'same [redacted] body');
+  assert.equal(filteredA.request.chars, filteredA.request.text.length);
+  assert.equal(filteredA.request.sha256, crypto.createHash('sha256').update(filteredA.request.text).digest('hex'));
+  assert.equal(filteredA.request.sha256, filteredB.request.sha256,
+    'checksums compare retained payloads, not the distinct originals');
+
+  // Configured values are fetched for each record: duplicates/overlaps are
+  // deterministic, short/empty values do not erase prose, and rotation does
+  // not keep an obsolete value in memory forever.
+  knownValues = [KNOWN_LONG, KNOWN_OVERLAP, KNOWN_LONG, '', ' ', KNOWN_SHORT];
+  invoke({ body: `a ${KNOWN_LONG} b ${KNOWN_OVERLAP} c ${KNOWN_SHORT}` }, (_req, response) => response.json({ ok: true }));
+  assert.equal(newest().request.text, `a [redacted] b [redacted] c ${KNOWN_SHORT}`);
+  knownValues = ['rotated-configured-value'];
+  invoke({ body: { prompt: `old ${KNOWN_LONG}; new rotated-configured-value`, token: KNOWN_SHORT } },
+    (_req, response) => response.json({ ok: true }));
+  assert.equal(newest().request.prompt.text, `old ${KNOWN_LONG}; new [redacted]`);
+  assert.equal(newest().request.token, REDACTED_CREDENTIAL,
+    'a sensitive field remains protected even when its value is too short for prose matching');
+
+  // Parsed JSON strings keep escapes/newlines/Unicode around the replacement.
+  const escapedText = `quote \\" and slash \\\\ and snowman ☃\n${embedded}\n${PRIVATE_ONE}\nend`;
+  invoke({ body: escapedText }, (_req, response) => response.json({ error: `failed with ${TOKENS.googleOauth}` }));
+  const escaped = newest();
+  assert.match(escaped.request.text, /^quote \\" and slash \\\\ and snowman ☃\n/);
+  assert.match(escaped.request.text, /embedded \{\\"password\\":\\"\[redacted\]\\"\}/);
+  assert.ok(!escaped.request.text.includes('alpha'));
+  assert.match(escaped.request.text, /\[redacted\]\nend$/);
+
+  // A Buffer remains a Buffer-shaped audit representation. Text and ASCII
+  // inside opaque bytes are filtered before the retained bytes/hash/base64 are
+  // derived; no base64-decoding guess is made for ordinary string fields.
+  knownValues = ['buffer-configured-value'];
+  const textBuffer = Buffer.from(`left ${TOKENS.openrouter} and buffer-configured-value right`, 'utf8');
+  invoke({ body: textBuffer }, (request, response) => {
+    assert.ok(request.body.equals(textBuffer));
+    response.json({ ok: true });
+  });
+  const buffered = newest().request;
+  const filteredBuffer = Buffer.from(buffered.base64, 'base64');
+  assert.equal(filteredBuffer.toString('utf8'), 'left [redacted] and [redacted] right');
+  assert.equal(buffered.bytes, filteredBuffer.length);
+  assert.equal(buffered.sha256, crypto.createHash('sha256').update(filteredBuffer).digest('hex'));
+  const mixedBytes = Buffer.concat([Buffer.from([0xff, 0x00]), Buffer.from(TOKENS.github), Buffer.from([0xfe])]);
+  invoke({ body: mixedBytes }, (_req, response) => response.json({ ok: true }));
+  const mixedStored = Buffer.from(newest().request.base64, 'base64');
+  assert.ok(!mixedStored.includes(Buffer.from(TOKENS.github)), 'opaque bytes cannot hide recognizable ASCII behind base64');
+  const harmlessBinary = Buffer.from([0xff, 0x00, 0x01, 0xfe]);
+  invoke({ body: harmlessBinary }, (_req, response) => response.json({ ok: true }));
+  assert.ok(Buffer.from(newest().request.base64, 'base64').equals(harmlessBinary));
+
+  // Ordinary deep/large content remains intact. Near-matches are specifically
+  // not a reason to erase URLs, IDs, code or incomplete key material.
+  const deep = { leaf: 'ordinary' };
+  for (let i = 0, cursor = deep; i < 35; i++) cursor = cursor.next = { level: i, text: `value-${i}` };
+  invoke({ body: deep }, (_req, response) => response.json({ ok: true }));
+  let cursor = newest().request;
+  for (let i = 0; i < 35; i++) {
+    assert.equal(cursor.next.level, i);
+    assert.equal(cursor.next.text.text, `value-${i}`);
+    cursor = cursor.next;
+  }
+  const near = `https://example.test/sketch-${'x'.repeat(40)} hf_short eyJonly.two ${INCOMPLETE_KEY}`;
+  invoke({ body: near }, (_req, response) => response.json({ ok: true }));
+  assert.equal(newest().request.text, near);
+
+  const idempotentFilter = createCredentialFilter([KNOWN_LONG]);
+  const idempotentOnce = idempotentFilter(
+    `${TOKENS.openai} ${KNOWN_LONG} Authorization: Bearer opaque. keep; password=opaque!`,
+  );
+  assert.equal(idempotentFilter(idempotentOnce), idempotentOnce,
+    'filtering an already-filtered record is a no-op');
+
+  // Finish/close races and abandoned clients remain exactly-once. A close has
+  // no body to sanitize, but is still an accepted mutating operation.
+  const beforeRace = diskLines().length;
+  const raced = invoke({ body: 'ordinary race' }, (_req, response) => response.json({ ok: true }));
+  raced.res.emit('close');
+  assert.equal(diskLines().length, beforeRace + 1);
+  const beforeClose = diskLines().length;
+  const closed = invoke({ body: 'ordinary close' }, () => {});
+  closed.res.emit('close');
+  closed.res.emit('finish');
+  assert.equal(diskLines().length, beforeClose + 1);
+
+  // Sanitizer failure has no raw fallback. The next record can recover. Keep
+  // append failure separate: retrying an append that may have partially landed
+  // is how exactly-once logs become duplicates.
+  const privateFailureText = `synthetic failure text ${TOKENS.huggingface}`;
+  let failFilter = true;
+  const safeRecords = [];
+  const failureMiddleware = operationMiddleware({
+    allowMissing: true,
+    filterFactory: (values) => {
+      if (failFilter) { failFilter = false; throw new Error(privateFailureText); }
+      return createCredentialFilter(values);
+    },
+    appendRecord: (record) => safeRecords.push(record),
+  });
+  const failureInvoke = (bodyValue) => {
+    const req = { method: 'POST', path: `/api/private/${privateFailureText}`, query: {}, headers: {}, body: bodyValue };
+    const res = new Response();
+    failureMiddleware(req, res, () => res.json({ ok: true, echo: bodyValue }));
+    res.emit('close');
+    return res;
+  };
+  const failedResponse = failureInvoke(privateFailureText);
+  assert.equal(failedResponse.body.echo, privateFailureText);
+  assert.equal(failedResponse.jsonCalls, 1);
+  assert.equal(safeRecords.length, 1);
+  assert.deepEqual(safeRecords[0].audit.credentialFilter, {
+    policy: AUDIT_CREDENTIAL_POLICY, status: 'failed', reason: 'credential-filter-failed',
+  });
+  assert.equal(safeRecords[0].path, '/audit/credential-filter');
+  assert.ok(!JSON.stringify(safeRecords[0]).includes(privateFailureText));
+  failureInvoke('healthy later event');
+  assert.equal(safeRecords.length, 2);
+  assert.equal(safeRecords[1].request.text, 'healthy later event');
+
+  let appendAttempts = 0;
+  const appended = [];
+  const diagnostics = [];
+  const originalError = console.error;
+  console.error = (...args) => diagnostics.push(args.join(' '));
+  try {
+    const appendMiddleware = operationMiddleware({
+      allowMissing: true,
+      appendRecord: (record) => {
+        appendAttempts++;
+        if (appendAttempts === 1) throw new Error(privateFailureText);
+        appended.push(record);
+      },
+    });
+    const call = (value) => {
+      const req = { method: 'POST', path: '/api/test', query: {}, headers: {}, body: value };
+      const res = new Response();
+      appendMiddleware(req, res, () => res.json({ ok: true, echo: value }));
+      res.emit('close');
+      return res;
+    };
+    const firstResponse = call(privateFailureText);
+    assert.equal(firstResponse.body.echo, privateFailureText);
+    assert.equal(firstResponse.jsonCalls, 1);
+    assert.equal(appendAttempts, 1, 'an append failure is not retried after finish/close');
+    call('later append succeeds');
+    assert.equal(appended.length, 1);
+    assert.equal(appended[0].request.text, 'later append succeeds');
+  } finally {
+    console.error = originalError;
+  }
+  assert.deepEqual(diagnostics, ['[operations.append] audit append failed']);
+  assert.ok(!diagnostics.join(' ').includes(privateFailureText));
+
+  // Prospective only: the exact legacy prefix remains on disk, and both v1/v2
+  // records remain readable through the existing API reader.
+  const finalBytes = fs.readFileSync(OPERATIONS_FILE, 'utf8');
+  assert.ok(finalBytes.startsWith(legacy), 'new appends did not rewrite the legacy prefix');
+  const versions = new Set(readOperations(1000).map((record) => record.version));
+  assert.deepEqual(versions, new Set([1, 2]));
+
+  // Representative cost, printed for the PR rather than hidden behind "pass".
+  // The timer delay is the event-loop impact of this synchronous persistence
+  // seam. Thresholds only catch pathological regressions; measurements matter.
+  const large = `${'ordinary code https://example.test/path id_12345\n'.repeat(45_000)}${TOKENS.openai}`;
+  const heapBefore = process.memoryUsage().heapUsed;
+  const baselineAt = performance.now();
+  const baseline = summarizePayload(large, 'body');
+  const baselineMs = performance.now() - baselineAt;
+  let timerDelayMs = 0;
+  const scheduledAt = performance.now();
+  const timer = new Promise((resolve) => setTimeout(() => { timerDelayMs = performance.now() - scheduledAt; resolve(); }, 0));
+  const filteredAt = performance.now();
+  const measured = summarizePayload(large, 'body', createCredentialFilter(['another-configured-value']));
+  const filteredMs = performance.now() - filteredAt;
+  await timer;
+  knownValues = ['another-configured-value'];
+  const appendAt = performance.now();
+  invoke({ body: large }, (request, response) => {
+    assert.equal(request.body, large);
+    response.json({ ok: true });
+  });
+  const filterAndAppendMs = performance.now() - appendAt;
+  const persistedLarge = newest();
+  const heapDeltaMiB = (process.memoryUsage().heapUsed - heapBefore) / (1024 * 1024);
+  assert.equal(baseline.text.slice(0, -TOKENS.openai.length), measured.text.slice(0, -REDACTED_CREDENTIAL.length));
+  assert.ok(!measured.text.includes(TOKENS.openai));
+  assert.equal(persistedLarge.request.text, measured.text);
+  assert.ok(filteredMs < 2_500 && timerDelayMs < 2_500 && filterAndAppendMs < 5_000,
+    `unexpected matcher cost: filter ${filteredMs.toFixed(1)}ms, event-loop delay ${timerDelayMs.toFixed(1)}ms, append ${filterAndAppendMs.toFixed(1)}ms`);
+  const adversarial = `${`sk-proj-short Authorizationish: Bearerish tokenization=${INCOMPLETE_KEY}\n`.repeat(24_000)}`;
+  const adversarialAt = performance.now();
+  const adversarialFiltered = createCredentialFilter([])(adversarial);
+  const adversarialMs = performance.now() - adversarialAt;
+  assert.equal(adversarialFiltered, adversarial, 'near-matches and incomplete markers are retained whole');
+  assert.ok(adversarialMs < 2_500, `unexpected adversarial matcher cost: ${adversarialMs.toFixed(1)}ms`);
+  console.log(`operation-credentials performance: ${(large.length / 1024 / 1024).toFixed(2)} MiB representative; ${(adversarial.length / 1024 / 1024).toFixed(2)} MiB adversarial; baseline ${baselineMs.toFixed(1)}ms; filtered ${filteredMs.toFixed(1)}ms; adversarial ${adversarialMs.toFixed(1)}ms; event-loop delay ${timerDelayMs.toFixed(1)}ms; filter+append ${filterAndAppendMs.toFixed(1)}ms; heap delta ${heapDeltaMiB.toFixed(1)} MiB`);
+  console.log('operation-credentials: newly persisted bytes filtered; domain values and legacy bytes preserved');
+} finally {
+  fs.rmSync(TMP, { recursive: true, force: true });
+}

--- a/server/test/operation-credentials.test.mjs
+++ b/server/test/operation-credentials.test.mjs
@@ -101,6 +101,14 @@ try {
     encoded: encodeURIComponent(KNOWN_LONG),
     tokenizer: 'ordinary tokenizer field',
     secretary: 'ordinary secretary field',
+    secret_key: 'structural snake secret',
+    SECRET_KEY: 'structural upper secret',
+    secretKey: 'structural camel secret',
+    subscriptionKey: 'structural subscription key',
+    'Ocp-Apim-Subscription-Key': 'structural compound subscription key',
+    passwordHash: 'structural password hash',
+    endpointUrl: 'structural endpoint url',
+    subscription_id: 'structural subscription id',
     embedded,
     [TOKENS.githubFine]: 'a credential can also be an object key',
   });
@@ -109,7 +117,7 @@ try {
     ok: false,
     error: `ordinary error before ${TOKENS.googleAuth} ordinary error after`,
     detail: 'Authorization: Bearer opaque-authorization-value. keep punctuation',
-    inline: 'password=opaque-password-value! keep punctuation',
+    inline: 'login_password=opaque-password-value! keep punctuation',
   });
   const resultBefore = structuredClone(resultBody);
   const { req, res } = invoke({
@@ -131,7 +139,10 @@ try {
   const first = JSON.parse(firstRaw);
   absentFrom(firstRaw, [...ALL_TOKENS, KNOWN_LONG, 'short field value', 'short-query-secret',
     'opaque quoted value', 'opaque shell value', 'opaque-authorization-value', 'opaque-password-value',
-    'alpha', 'beta', 'gamma', 'crossed-alpha', 'crossed-beta', 'crossed-gamma']);
+    'alpha', 'beta', 'gamma', 'crossed-alpha', 'crossed-beta', 'crossed-gamma',
+    'structural snake secret', 'structural upper secret', 'structural camel secret',
+    'structural subscription key', 'structural compound subscription key',
+    'structural password hash', 'structural endpoint url', 'structural subscription id']);
   assert.equal(first.version, 2);
   assert.deepEqual(first.audit, { credentialFilter: { policy: AUDIT_CREDENTIAL_POLICY, status: 'applied' } });
   assert.match(first.request.prompt.text, /^keep before /);
@@ -144,6 +155,10 @@ try {
   assert.equal(first.request.encoded, REDACTED_CREDENTIAL);
   assert.equal(first.request.tokenizer, 'ordinary tokenizer field');
   assert.equal(first.request.secretary, 'ordinary secretary field');
+  for (const field of ['secret_key', 'SECRET_KEY', 'secretKey', 'subscriptionKey',
+    'Ocp-Apim-Subscription-Key', 'passwordHash', 'endpointUrl', 'subscription_id']) {
+    assert.equal(first.request[field], REDACTED_CREDENTIAL, `${field} keeps structural protection`);
+  }
   assert.equal(first.request.nested[0].ordinary, 'left [redacted] right');
   assert.ok(Object.hasOwn(first.request, REDACTED_CREDENTIAL), 'credential material in a property name is filtered too');
   assert.equal(first.query.access_token, REDACTED_CREDENTIAL);
@@ -152,7 +167,7 @@ try {
   assert.equal(first.target.name, 'target [redacted]');
   assert.equal(first.result.error, 'ordinary error before [redacted] ordinary error after');
   assert.equal(first.result.detail, 'Authorization: Bearer [redacted]. keep punctuation');
-  assert.equal(first.result.inline, 'password=[redacted]! keep punctuation');
+  assert.equal(first.result.inline, 'login_password=[redacted]! keep punctuation');
 
   const fileInput = `file head\n${TOKENS.anthropic}\nfile tail`;
   const fileCall = invoke({ reqPath: '/api/files/files-1/write', body: fileInput }, (request, response) => {
@@ -235,6 +250,29 @@ try {
   const near = `https://example.test/sketch-${'x'.repeat(40)} hf_short eyJonly.two ${INCOMPLETE_KEY}`;
   invoke({ body: near }, (_req, response) => response.json({ ok: true }));
   assert.equal(newest().request.text, near);
+
+  // Ambiguous bare labels occur constantly in code, data and prose. Preserve
+  // them when an unquoted value has no high-confidence credential boundary;
+  // compound labels, quoted embedded fields and env-style labels stay covered.
+  const ordinaryAssignments = [
+    'sorted(items, key=lambda x: x[1])',
+    '<li key={item.id}>{item.name}</li>',
+    '{"key": "north", "secret": false, "token": 42}',
+    'key: value',
+    'The password: is required for this example.',
+  ].join('\n');
+  assert.equal(createCredentialFilter([])(ordinaryAssignments), ordinaryAssignments);
+  invoke({ reqPath: '/api/files/files-ordinary/write', body: ordinaryAssignments }, (_req, response) => response.json({ ok: true }));
+  assert.equal(newest().request.text, ordinaryAssignments, 'ordinary assignments survive in persisted file content');
+  const explicitAssignments = [
+    'OPENAI_API_KEY=synthetic-explicit-value',
+    'access_token=synthetic-access-value',
+    'DB_PASSWORD=synthetic-db-value',
+    String.raw`embedded {\"password\":\"synthetic quoted value\"}`,
+  ].join('\n');
+  const explicitFiltered = createCredentialFilter([])(explicitAssignments);
+  for (const value of ['synthetic-explicit-value', 'synthetic-access-value',
+    'synthetic-db-value', 'synthetic quoted value']) assert.ok(!explicitFiltered.includes(value));
 
   const idempotentFilter = createCredentialFilter([KNOWN_LONG]);
   const idempotentOnce = idempotentFilter(
@@ -365,7 +403,18 @@ try {
   const adversarialMs = performance.now() - adversarialAt;
   assert.equal(adversarialFiltered, adversarial, 'near-matches and incomplete markers are retained whole');
   assert.ok(adversarialMs < 2_500, `unexpected adversarial matcher cost: ${adversarialMs.toFixed(1)}ms`);
-  console.log(`operation-credentials performance: ${(large.length / 1024 / 1024).toFixed(2)} MiB representative; ${(adversarial.length / 1024 / 1024).toFixed(2)} MiB adversarial; baseline ${baselineMs.toFixed(1)}ms; filtered ${filteredMs.toFixed(1)}ms; adversarial ${adversarialMs.toFixed(1)}ms; event-loop delay ${timerDelayMs.toFixed(1)}ms; filter+append ${filterAndAppendMs.toFixed(1)}ms; heap delta ${heapDeltaMiB.toFixed(1)} MiB`);
+  const filterDashChain = (count) => {
+    const input = Array.from({ length: count }, (_, i) => `${String(i).padStart(8, '0')}-aaaa-bbbb-cccc-dddddddddddd`).join('-');
+    const startedAt = performance.now();
+    const output = createCredentialFilter([])(input);
+    return { input, output, ms: performance.now() - startedAt };
+  };
+  const dashChainSmall = filterDashChain(1_000);
+  const dashChain = filterDashChain(4_000);
+  assert.equal(dashChain.output, dashChain.input, 'a long dash-joined ordinary line is retained whole');
+  assert.ok(dashChain.ms < 2_500 && dashChain.ms < (dashChainSmall.ms * 8) + 250,
+    `unexpected dash-chain scaling: 1k ${dashChainSmall.ms.toFixed(1)}ms, 4k ${dashChain.ms.toFixed(1)}ms`);
+  console.log(`operation-credentials performance: ${(large.length / 1024 / 1024).toFixed(2)} MiB representative; ${(adversarial.length / 1024 / 1024).toFixed(2)} MiB adversarial; baseline ${baselineMs.toFixed(1)}ms; filtered ${filteredMs.toFixed(1)}ms; adversarial ${adversarialMs.toFixed(1)}ms; dash-chain 1k ${dashChainSmall.ms.toFixed(1)}ms / 4k ${dashChain.ms.toFixed(1)}ms; event-loop delay ${timerDelayMs.toFixed(1)}ms; filter+append ${filterAndAppendMs.toFixed(1)}ms; heap delta ${heapDeltaMiB.toFixed(1)} MiB`);
   console.log('operation-credentials: newly persisted bytes filtered; domain values and legacy bytes preserved');
 } finally {
   fs.rmSync(TMP, { recursive: true, force: true });

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -747,12 +747,14 @@ export const deleteSkill = (name: string) =>
 
 // ---- the API log (Settings → API log) ----
 // Written by operationMiddleware: every mutating call, plus the one read that is
-// an event between two agents — a `wait` that resolved. Payloads are summarised
-// at write time, never stored: a prompt is {present, chars, sha256} and nothing
-// else, so this view can say who asked whom and how long the ask was, never what
-// it said.
-export interface OperationSummary { present?: boolean; chars?: number; sha256?: string; bytes?: number; }
+// an event between two agents — a `wait` that resolved. Full non-secret content
+// is retained; v2 entries apply the documented best-effort credential filter
+// before persistence. Absence of audit metadata means a legacy, unrewritten row.
+export interface OperationSummary {
+  present?: boolean; chars?: number; sha256?: string; bytes?: number; text?: string; base64?: string;
+}
 export interface Operation {
+  version?: number;
   id: string;
   at: string;
   origin: { id: string; type: string; name?: string; cli?: string } | null;
@@ -765,6 +767,7 @@ export interface Operation {
   ok: boolean;
   durationMs: number;
   result?: unknown;
+  audit?: { credentialFilter?: { policy: string; status: 'applied' | 'failed'; reason?: string } };
 }
 export const getOperations = (limit = 500): Promise<{ operations: Operation[]; generatedAt: string }> =>
   fetch(`/api/operations?limit=${limit}`).then(json);

--- a/web/src/components/ApiLog.tsx
+++ b/web/src/components/ApiLog.tsx
@@ -14,9 +14,9 @@
 //          going out and nothing ever coming back.
 //
 // The log stores each call WHOLE — body included, on the operator's instruction —
-// with credentials the one thing withheld. So this can answer who asked whom to
-// do what, when, and in their own words. Equal checksums still mean identical
-// prompts, which is what a repeating job produces, so repeats are marked; and
+// after best-effort credential filtering for new records. So this can answer who
+// asked whom to do what, when, and in their own words. Equal checksums mean equal
+// RETAINED payloads (filtered originals may differ), so repeats are marked; and
 // because an entry is now as big as the call it records, the card decides how
 // much of a body to paint rather than trying to paint all of it.
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -155,9 +155,9 @@ export default function ApiLog() {
   const hidden = (ops || []).length - rows.length;
   const failures = rows.filter((op) => !op.ok).length;
 
-  // Identical prompts have identical checksums. Counting them is the only thing
-  // the log can honestly say about repetition, and it is enough to spot a job
-  // that fires the same text on a schedule.
+  // Identical retained payloads have identical checksums. Credentials collapse
+  // to one placeholder, so this deliberately makes no claim that filtered
+  // originals were identical.
   const repeats = useMemo(() => {
     const n = new Map<string, number>();
     for (const op of rows) {
@@ -226,7 +226,7 @@ function LogTable({ rows, repeats, names }: {
                 <td className="num">{took(op.durationMs)}</td>
                 <td className="al-pay">
                   {pay.text}
-                  {n > 1 && <span className="al-rep" title={`${n} calls with this exact payload — ${pay.sha}`}> ×{n}</span>}
+                  {n > 1 && <span className="al-rep" title={`${n} calls with the same retained payload — filtered originals may differ — ${pay.sha}`}> ×{n}</span>}
                 </td>
               </tr>
             );
@@ -618,9 +618,9 @@ function LogMap({ rows, names }: { rows: api.Operation[]; names: Map<string, str
 }
 
 /** The whole call, pretty-printed, plus the metadata that is not in the body:
- *  who, what it hit, the status and how long it took. The log's request/result
- *  are already summaries — this shows them as they are stored rather than
- *  paraphrasing them into a sentence. */
+ *  who, what it hit, the status, filtering version and how long it took. The
+ *  log's request/result are stored audit copies — this shows them as retained
+ *  rather than paraphrasing them into a sentence. */
 function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
   op: api.Operation | null;
   pinned: boolean;
@@ -643,6 +643,7 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
   }
   const text = promptText(op);
   const body = {
+    log: { version: op.version || 1, ...(op.audit || {}) },
     at: op.at,
     call: `${op.method} ${op.path}`,
     from: op.origin ? `${op.origin.name || op.origin.id}${op.origin.type ? ` (${op.origin.type})` : ''}` : null,
@@ -667,7 +668,7 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
         <div className="al-prompt">
           <div className="al-prompt-lbl">
             <span>
-              body as sent
+              retained body
               {text.length > SHOW_CHARS && (
                 <span className="al-clipped">
                   {' '}· showing the first {SHOW_CHARS.toLocaleString()} of {text.length.toLocaleString()} characters
@@ -693,8 +694,8 @@ function HoverCard({ op, pinned, names, onEnter, onLeave, onClose }: {
       <pre className="al-json">{json(body)}</pre>
       <div className="al-card-foot">
         {text === null
-          ? 'no prompt on this call — bodies that are not prompts stay summarised'
-          : 'stored with the entry; the checksum beside it is what makes a repeated prompt visible'}
+          ? 'no text body on this call — structured request and result content remains in the entry'
+          : 'stored after best-effort filtering; the checksum compares retained text, not necessarily the original'}
         {!pinned && <span className="al-card-hint"> · click the call to keep this open</span>}
       </div>
     </div>

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -784,8 +784,9 @@ export default function SettingsView({
             <h2>API log</h2>
             <p className="s-help">
               Every call that changed something, plus the waits that resolved — who asked whom to do
-              what, when, and in their own words: each entry keeps the call whole, body included.
-              Credentials are the exception and are never written here.
+              what, when, and in their own words. Full non-secret content is retained; new entries use
+              best-effort filtering for recognizable credentials. This remains sensitive private data:
+              deleting the source does not delete its audit copy, and older entries were not rewritten.
             </p>
             <ApiLog />
           </div>

--- a/web/test/apiLog.test.mjs
+++ b/web/test/apiLog.test.mjs
@@ -31,7 +31,9 @@ const bundle = path.join(tmp, 'app.js');
 
 const at = (s) => new Date(Date.UTC(2026, 7, 19, 21, 0, s)).toISOString();
 const PROMPT = '## Review\n\nRead the diff in `web/` and report:\n\n- anything that would **break**\n- anything undocumented\n';
+const AUDITED = { version: 2, audit: { credentialFilter: { policy: 'credentials-v1', status: 'applied' } } };
 const prompt = (i, from, to, chars, ok = true) => ({
+  ...AUDITED,
   id: `p${i}`, at: at(i), method: 'POST', path: `/api/agents/${to}/prompt`,
   origin: { id: from, type: 'agent', name: from },
   target: { id: to, name: to, cli: 'claude' },
@@ -40,6 +42,7 @@ const prompt = (i, from, to, chars, ok = true) => ({
   status: ok ? 200 : 404, ok, durationMs: 303, result: { ok },
 });
 const wait = (i, watcher, watched, ms) => ({
+  ...AUDITED,
   id: `w${i}`, at: at(i), method: 'GET', path: `/api/agents/${watched}/wait`,
   origin: { id: watcher, type: 'agent', name: watcher },
   target: { id: watched, name: watched, cli: 'claude' },
@@ -52,6 +55,7 @@ const wait = (i, watcher, watched, ms) => ({
 // Its target is an agent nothing else in the fixture touches, so the mark it
 // leaves can only have come from this entry.
 const anonymousWait = {
+  ...AUDITED,
   id: 'w0', at: at(2), method: 'GET', path: '/api/agents/lonely/wait',
   origin: null, target: { id: 'lonely', name: 'lonely', cli: 'claude' },
   status: 200, ok: true, durationMs: 12000,
@@ -60,6 +64,7 @@ const anonymousWait = {
 // The operator's own calls: most of a real log, and hidden by default because
 // this view is for what the AGENTS did to each other.
 const mine = (i) => ({
+  ...AUDITED,
   id: `m${i}`, at: at(20 + i), method: 'POST', path: '/api/sessions/shell-1/input',
   origin: { id: 'lvwerra', type: 'operator', name: 'lvwerra' },
   target: { id: 'shell-1', name: 'shell-1', cli: 'shell' },
@@ -69,6 +74,7 @@ const mine = (i) => ({
 // A create names nothing in its path: the session it made is in the result, and
 // the lane it brings into being must not look as though it was always there.
 const create = {
+  ...AUDITED,
   id: 'c1', at: at(1), method: 'POST', path: '/api/agents',
   origin: { id: 'manager', type: 'agent', name: 'manager' },
   query: { cli: 'claude', name: 'poet' },
@@ -87,13 +93,15 @@ const operations = [
   prompt(5, 'operator', 'manager', 4096),
   prompt(4, 'manager', 'builder', 1204),
   { id: 'f1', at: at(3), method: 'PUT', path: '/api/files/files-5/write',
-    origin: { id: 'operator', type: 'operator', name: 'operator' },
+    // Deliberately v1: a visible legacy row exercises mixed-history rendering.
+    origin: { id: 'manager', type: 'agent', name: 'manager' },
     target: { id: 'files-5', name: 'files-5' },
     request: { present: true, chars: 8400, sha256: 'sha-file' },
     status: 200, ok: true, durationMs: 41, result: { ok: true } },
   anonymousWait,
   // manager waits on the agent it just created; 258s of being blocked
   { id: 'w-poet', at: at(2), method: 'GET', path: '/api/agents/poet-1/wait',
+    ...AUDITED,
     origin: { id: 'manager', type: 'agent', name: 'manager' },
     target: { id: 'poet-1', name: 'poet', cli: 'claude' },
     status: 200, ok: true, durationMs: 258000,
@@ -105,6 +113,7 @@ const operations = [
 // to the nearest neighbouring call gave this no span at all — which is the
 // normal shape of waiting, not an edge case.
 const quietWait = {
+  ...AUDITED,
   id: 'wq', at: at(600), method: 'GET', path: '/api/agents/quiet-1/wait',
   origin: { id: 'watcher', type: 'agent', name: 'watcher' },
   target: { id: 'quiet-1', name: 'quiet', cli: 'claude' },
@@ -117,6 +126,7 @@ operations.push(quietWait);
 // Nothing is cut on disk; the card decides how much of it to paint.
 const HUGE = 'q'.repeat(400_000);
 operations.push({
+  ...AUDITED,
   id: 'big', at: at(601), method: 'PUT', path: '/api/files/files-9/write',
   origin: { id: 'manager', type: 'agent', name: 'manager' },
   target: { id: 'files-9', name: 'files-9' },
@@ -274,6 +284,7 @@ try {
     return {
       first: cells.find((c) => c[2].includes('/api/agents/builder/wait')) || cells[0],
       repeats: [...document.querySelectorAll('.al-rep')].map((e) => e.textContent.trim()),
+      repeatTitles: [...document.querySelectorAll('.al-rep')].map((e) => e.getAttribute('title')),
       whos: [...document.querySelectorAll('.al-who')].map((e) => e.textContent.trim()),
       newest: document.querySelector('.al-tbl tbody tr')?.getAttribute('title')?.split(' ')[0],
       big: (() => {
@@ -289,6 +300,8 @@ try {
   check('and the newest row really is the newest', () => assert.equal(list.newest, operations[0].at));
   check('identical prompts are marked as repeats — the checksum still earns its place',
     () => assert.deepEqual(list.repeats, ['×2', '×2']));
+  check('repeat wording compares retained payloads without claiming filtered originals matched',
+    () => list.repeatTitles.forEach((title) => assert.match(title, /same retained payload — filtered originals may differ/)));
   check('an unattributed call still reads as a row, with an em dash for who',
     () => assert.ok(list.whos.includes('—'), list.whos.join(', ')));
   // "just store all the full api calls" — so the VIEWER is what has to stay
@@ -407,8 +420,9 @@ try {
       assert.match(card.status, /^\d{3}$/, `status: ${card.status}`);
       assert.match(card.tookText, /^\d/, `took: ${card.tookText}`);
     });
-  check('and the whole entry as JSON, with the metadata named',
-    () => ['at', 'call', 'from', 'to', 'status', 'took'].forEach((k) => assert.ok(card.keys.includes(k), `${k} missing from ${card.keys.join(', ')}`)));
+  check('and the whole entry as JSON, with the metadata and filter version named',
+    () => ['log', 'version', 'credentialFilter', 'at', 'call', 'from', 'to', 'status', 'took']
+      .forEach((k) => assert.ok(card.keys.includes(k), `${k} missing from ${card.keys.join(', ')}`)));
   check('still never the prompt text', () => assert.ok(!/"text":\s*"/.test(card.json)));
   check('and it sits below the plot rather than covering it',
     () => assert.equal(card.floating, 'static'));
@@ -589,6 +603,19 @@ try {
       assert.match(painted.path || '', /files-9/, `card shows ${painted.path}`);
       assert.ok(painted.drawn <= 20_000, `painted ${painted.drawn} characters`);
       assert.match(painted.note || '', /400,000 characters/, `note: ${painted.note}`);
+    });
+
+  await pressMark(page, 'files-5');
+  const legacyCard = await page.evaluate(() => ({
+    path: document.querySelector('.al-card-path')?.textContent,
+    json: document.querySelector('.al-json')?.textContent,
+  }));
+  check('a legacy entry remains readable and identifies itself without claiming filtering',
+    () => {
+      assert.match(legacyCard.path || '', /files-5/, `card shows ${legacyCard.path}`);
+      assert.ok(legacyCard.json, `legacy card JSON missing: ${JSON.stringify(legacyCard)}`);
+      assert.match(legacyCard.json, /version: 1/);
+      assert.ok(!legacyCard.json.includes('credentialFilter'), legacyCard.json);
     });
 
   // "i want an option to show things in real time, now it seems all actions are


### PR DESCRIPTION
Closes #132

## What changed

- Added one owned `credentials-v1` persistence filter for new API audit records. It filters sensitive structured fields and property names, documented provider token shapes, explicit authorization/credential assignments, complete private-key blocks, and exact values from the existing server-side injected-secret catalog.
- Applied the filter only while building the detached audit copy. Requests delivered to handlers and agents, file contents, responses, and session metadata remain unchanged.
- New records are version 2 and state whether the credential filter was applied or failed. A sanitizer failure writes only a fixed minimal record; an append failure emits one fixed diagnostic and never retries or changes the completed response.
- Derived text lengths, checksums, and Buffer representations from retained filtered values. The API-log repeat wording now says that it compares retained payloads, and its detail view shows record/filter metadata.
- Traversed and serialized detached audit records iteratively, so valid deeply nested JSON keeps full attribution and content without an arbitrary depth limit.
- Corrected Settings, API types/comments, generated environment instructions, and added `docs/api-audit-log.md` with the retention policy, supported rules, limitations, failure behavior, and v1/v2 compatibility.

## Deliberately unchanged

- Full non-secret prompt, nested JSON, file-write, response, and error content is still retained without truncation, hashes-only replacement, route allowlists, or capture caps.
- Accepted mutations and resolved waits are still the only selected events. This does not capture headers, new bodies, streaming traffic, or additional reads.
- Existing JSONL records and backups are not read, rewritten, migrated, purged, or relabeled. Records without filter metadata remain readable as legacy v1 entries.
- This does not add retention settings, sharing/export changes, authentication, secret rotation, workspace/home/history scanning, recursive archive/encoding inspection, or network lookups.

## Policy boundaries

Filtering is a safety aid, not a confidentiality guarantee. Arbitrary unlabeled secrets and unsupported formats can remain, and the audit log stays sensitive/private. Exact configured values are read per new record from the existing injected-secret catalog, remain server-side, ignore empty/short values, deduplicate overlaps longest-first, and do not stay cached across rotation. Opaque Buffers receive direct ASCII-shape/exact-value filtering only; archives and nested encodings are not guessed.

## Verification

- `node ../scripts/run-suites.mjs audit-instructions operation-credentials operations` — 3/3 focused server suites passed.
- `node test/operation-credentials.test.mjs` — persisted-byte matrix, domain immutability, v1/v2, failures, exactly-once, deep/large/adversarial and Buffer cases passed.
- Mutation checks: bypassing the filter fails on the first synthetic provider token; restoring an unbounded assignment-label expression fails the dash-chain scaling assertion; broadening ambiguous bare labels fails persisted ordinary-code checks; removing word-aware structural matching fails the cited field variants; reverting iterative JSONL serialization fails the 5,000-level append assertion.
- `npm test` in `web/` — 23/23 suites passed, including the real-browser API-log test at desktop and phone widths with mixed v1/v2 rows.
- `npm run build` in `web/` — typecheck and production build passed.
- `npm test` in `server/` — the runner discovered and passed the new instruction suite, then stopped only at the documented clean-main failure in `server/test/crons.test.mjs` case 4. The remaining server suites were run explicitly and passed; the queued-prompts prelude also passed.

Latest full-run measurement on this host: 2.10 MiB representative input and 2.20 MiB adversarial near-matches; baseline summary 3.4 ms, filtered summary 47.1 ms, adversarial filter 69.1 ms, 1,000/4,000-segment dash chains 0.2/0.6 ms, event-loop delay 47.4 ms, filter plus append 51.5 ms, heap delta 10.4 MiB. Thresholds are intentionally generous and the test prints the observed values for review.
