### PR TITLE
Reader: load a useful amount of recent history on a cold open

### DIFF
--- a/docs/reader-architecture.md
+++ b/docs/reader-architecture.md
@@ -38,13 +38,29 @@ available before a transcript exists and survives transcript failures.
    ancestor. Terminal and reader are mutually exclusive rendering surfaces.
 8. A redraw is not model work. The reader's activity indicator uses transcript
    evidence; transport state and terminal-derived session state stay distinct.
+9. A cold reader loads a useful amount of recent conversation on its own, in
+   bounded background steps after the first paint, counted in exchanges rather
+   than transport records. It is opt-in per consumer: children and previews keep
+   their own policy. A count is a target, not a promise — budgets, the start of
+   the conversation, or a cursor that cannot advance end the fill, and the
+   remaining history stays disclosed behind `Load earlier turns`.
+10. History arriving must not move text that is already on screen. The reading
+   position is re-asserted in the same frame as the size change that would
+   otherwise displace it, and a transcript shorter than the window grows upward
+   from the bottom rather than downward from the top.
 
 ## Verification
 
 Regression fixtures cover empty first send, hanging and failed requests, source
 switches and replacement, warm remount, cross-window tool/message/queue/final
 events, mutable SQLite records, bounded forward catch-up, child refresh, long
-history rendering/search, and outer-scroll containment. Existing trace, Markdown,
+history rendering/search, and outer-scroll containment. Initial history has its
+own two suites: `web/test/readerHistory.test.mjs` drives the store against a
+source that honours `bytes`/`min` (budgets, blocked and stalled cursors, warm
+return, release), and `web/test/readerFirstViewport.test.mjs` drives the real
+reader in a browser and measures viewport coverage and per-frame anchor
+displacement. `server/test/trace-index-history.test.mjs` covers the indexed
+first window and conversation isolation inside one database. Existing trace, Markdown,
 attachment, input-required, and terminal tests remain part of the contract.
 
 No transcript contents are emitted as diagnostics. No new runtime framework is
@@ -52,13 +68,27 @@ needed: the store uses immutable snapshots and React's external-store adapter.
 
 ## Bounds and tradeoffs
 
+- Initial history: about 20 recent exchanges, or all of a shorter conversation,
+  paged in after the first paint at one backward page per 50 ms. Bounded by six
+  backward requests, ~3 MiB (indexed rows charged at an assumed 4 KiB each) and
+  20 seconds per fill, whichever comes first. The view may raise the target, up
+  to 60 exchanges, while a page of MEASURED conversation has not yet covered the
+  scroller — twenty one-line exchanges do not fill a tall window, and one long
+  answer fills it without providing any history, so the two criteria run
+  separately. Estimated row heights and spacer divs do not count as coverage.
+  The budget is spent once per transcript: a warm remount finishes an unfinished
+  fill and does not restart a completed or exhausted one.
 - Initial read: 128 KiB / two transport messages. Ordinary pages: 384 KiB;
   the server can extend a page to finish a record, up to its existing 8 MiB
   ceiling. Forward catch-up preserves every intervening page, including backlogs
   larger than that ceiling. Oversized records produce an explicit recovery state.
   Child readers use a bounded 2 MiB initial window, open at its top, and disclose
   when earlier context (including the task) still needs paging. Latest opts into
-  following the child tail.
+  following the child tail. They do not take part in automatic history fill.
+  An INDEXED source treats the first-paint floor as a floor rather than an exact
+  count: it has no span to grow and has already parsed the whole conversation, so
+  returning two rows of it saved nothing and showed one exchange. Backward paging
+  from an indexed source still honours the requested page size exactly.
 - Window and summary requests time out after 12 seconds. Failed reads back off
   to 30 seconds. Visible readers poll every 3–10 seconds; SQLite uses 10 seconds.
   Hidden/inactive readers cancel outstanding requests and do not poll. A browser

--- a/docs/reader-architecture.md
+++ b/docs/reader-architecture.md
@@ -47,7 +47,21 @@ available before a transcript exists and survives transcript failures.
 10. History arriving must not move text that is already on screen. The reading
    position is re-asserted in the same frame as the size change that would
    otherwise displace it, and a transcript shorter than the window grows upward
-   from the bottom rather than downward from the top.
+   from the bottom rather than downward from the top. The first transcript a
+   cold reader PRESENTS is held back — laid out and measured, not painted —
+   until it covers the reader or until one of four bounds ends the wait.
+11. Search has two scopes. Typing filters the loaded stretch, instantly and
+   locally, as it always has. Searching the whole conversation is a separate,
+   explicit action, because it reads the transcript: nothing scans on a
+   keystroke or on mount. Both search the same content, so they cannot disagree
+   about what counts as conversation.
+12. Opening an old result is a read, not a move. It fetches one bounded window
+   named by the result itself and shows it beside the live history rather than
+   inside it: the live cursor does not advance, nothing is spliced, the reader's
+   place is remembered before the window opens and restored when it closes, and
+   nothing about it starts, claims, resizes or types into a terminal.
+13. Speculative work yields. A forward read — Latest, refresh, the live poll —
+   never waits behind an automatic backward page.
 
 ## Verification
 
@@ -69,9 +83,31 @@ needed: the store uses immutable snapshots and React's external-store adapter.
 ## Bounds and tradeoffs
 
 - Initial history: about 20 recent exchanges, or all of a shorter conversation,
-  paged in after the first paint at one backward page per 50 ms. Bounded by six
-  backward requests, ~3 MiB (indexed rows charged at an assumed 4 KiB each) and
-  20 seconds per fill, whichever comes first. The view may raise the target, up
+  paged in after the first response at one backward page per 50 ms. Bounded by
+  six backward requests, ~3 MiB RETAINED (indexed rows charged at an assumed
+  4 KiB each) and 20 seconds per continuous run, whichever comes first. Retained
+  rather than read: a page's size is not knowable before fetching it, so the
+  request that crosses the budget is the last one. What bounds a single read is
+  the message floor a speculative page asks for — one, the smallest that still
+  guarantees progress — which stops the server growing a response beyond a
+  single oversized record. Left to the server's own default of twelve, one page
+  of 900 KiB answers grew to six megabytes.
+- First paint holds until the transcript is worth showing, for at most two
+  seconds, and ends earlier on coverage, the start of the conversation, an
+  unusable source or an exhausted fill. The composer is never part of the wait
+  and a warm store is never hidden.
+- Whole-conversation search: 256 KiB scan pages, at most 40 pages, 12 MiB or
+  four seconds per request, 50 matching messages per page, and a 200-character
+  query. Longer conversations are more bounded requests, continued with a cursor
+  that is a page boundary, so continuing can neither repeat nor skip a match. The
+  scan runs newest-first from the size read when the request started, so output
+  appended while it runs is outside that request rather than something it chases.
+  Results carry the window that opens them; opening one is a single read.
+  Matching is literal and case-insensitive over the text the reader displays —
+  prompts, assistant text, thinking, tool names, tool input and output, shell
+  commands and their streams — and never image data or transport metadata. Where
+  a parser clipped a long block, the scan says so instead of implying it read
+  what was cut. The view may raise the target, up
   to 60 exchanges, while a page of MEASURED conversation has not yet covered the
   scroller — twenty one-line exchanges do not fill a tall window, and one long
   answer fills it without providing any history, so the two criteria run
@@ -114,10 +150,14 @@ needed: the store uses immutable snapshots and React's external-store adapter.
   undetectable from stats alone. An unobserved
   truncate-and-regrow with the same header/inode can still require a full browser
   reload; this is not a content-addressed log protocol.
-- Search means loaded content, not a server-side search of the entire trace. It
-  navigates matching turns, not every individual highlighted word. Virtualization
-  also means native browser Find, selection and accessibility traversal see the
-  mounted stretch; use reader search or the raw download for full-history work.
+- Search has the two scopes above. The instant filter still means loaded content,
+  and still says so. The explicit scope reads the whole transcript on the server
+  and returns places to jump to, not a second transcript: it navigates matching
+  messages, not every highlighted word, and a result opens roughly thirty
+  exchanges of context ending on the match. Bundle and child surfaces keep their
+  existing behaviour; no new search entry point was added to them. Virtualization
+  still means native browser Find, selection and accessibility traversal see the
+  mounted stretch.
 - Working is based on Codex task events and Claude message/stop-reason evidence,
   gated by the session process still being alive. Unknown activity is not promoted
   to working from a terminal repaint. Other formats can add explicit activity

--- a/docs/reader-validation.md
+++ b/docs/reader-validation.md
@@ -29,12 +29,56 @@ Validated on 2026-09-04, based on main `705e32dc`.
 | Operator HTML/XML disappears as harness text | Named harness envelopes in parser and exchange grouping instead of every leading `<` | `<div>Please review this markup</div>` remains a user prompt and opens a prompt band |
 | Existing UI contracts | Retained shared composer, attachment flow and info panel | Full-app reader-info, attachment-input and terminal UI integration suites pass |
 
+## Initial history (issue #129)
+
+Added 2026-09-09, on main `ef08e843`.
+
+| Problem / contract | Implementation | Evidence |
+| --- | --- | --- |
+| A cold reader shows one or two exchanges | Bounded backward fill to ~20 exchanges after the first paint, counted in exchanges; indexed sources get a first-window floor | Tool-heavy JSONL fixture goes from 2 exchanges to 22 with no scrolling, search or summary; a 40-exchange OpenCode database goes from 1 to 20 in its first window |
+| Counting records instead of conversation | `countExchanges` shares `isOperatorPrompt` with the grouping | Nine fixture shapes assert `countExchanges === splitExchanges().length`, including a transcript starting mid-exchange and harness envelopes that are not prompts |
+| A fill that cannot finish keeps trying | Request/byte/time budgets, plus start-of-source, blocked and no-progress stops | 900 KiB answers stop on the byte budget at ≤6 backward reads; a blocked cursor and a cursor that answers without advancing each stop after one retry, and neither claims the beginning of the conversation |
+| Preload competes with the reader | One request slot, 50 ms between steps, opt-in per consumer, cancelled on release | Composer and first text stay available under a 60 s hung summary; releasing a reader mid-fill stops it within one step; no child reader is created by a parent preload |
+| A warm return re-runs the preload | Budget and target are per transcript, not per mount | Remount after a completed fill issues zero further backward reads and keeps its history |
+| The first page does not fill the reader | The view raises the target while MEASURED rows have not covered the scroller's content box | 20 one-line exchanges leave a 2600 px reader uncovered; it continues to 94 and covers it, in one extra backward read |
+| Covering the page is mistaken for having history | Coverage and the exchange target are separate criteria | One 140-line answer covers the reader at 2 exchanges; the fill still reaches 22 |
+| Older history pushes visible text down | Position re-asserted in the same frame as the size change; transcript shorter than the window grows from the bottom | 0.69 px maximum anchor displacement over 110 frames while filling; 0.51 px across the underfilled→scrollable transition over 72 frames; a genuine live append still moves the view 77 px, which is Latest working |
+| Latest quietly stops following mid-preload | Corrections land before the scroll event that reports them | Latest is claimed on every one of 110 frames during the fill |
+
+Removing each mechanism fails a named assertion: no fill → “only 2 exchanges
+became available on their own”; no same-frame re-placement → “Latest is still
+the bottom”; no bottom-growth → 454 px of displacement; no coverage request →
+uncovered 2600 px reader; no indexed floor → “1 prompts in 2 messages”; a
+counter that ignores a leading exchange → the grouping comparison.
+
+### Measurements
+
+Same fixtures, before and after, Chromium at 1000×760. “Before” is main's source
+with the same tests.
+
+| Fixture | Exchanges after settling | First viewport filled | Max anchor drift | Backward reads | Bytes | Composer ready |
+| --- | --- | --- | --- | --- | --- | --- |
+| Tool-heavy, 90 KiB/exchange | 2 → **22** | 28% → **100%** | 0 → 0.69 px | 0 → 5 | 128 KiB → 2.0 MiB | 68 → 61 ms |
+| Large JSONL, 20 KiB answers | 50 → **200** | 100% → 100% | 0 → 0.13 px | 0 → 1 | 128 KiB → 509 KiB | 28 → 19 ms |
+| Ordinary small turns | 200 → 200 | 100% → 100% | 0 → 0.31 px | 0 → 0 | 117 KiB → 117 KiB | 26 → 20 ms |
+| OpenCode database, 40 exchanges | 1 → **20** (first window) | — | — | 0 → 0 | — | — |
+
+Time to a usable composer and to the first transcript paint are unchanged: the
+first window is the same request it always was. “Before” drift is zero because
+nothing arrives to displace anything, not because the old path was stable — the
+displacement this fixes is a property of prepending, which nothing did
+automatically before. Regression budgets for the tool-heavy fixture: ≥20
+exchanges, viewport covered, ≤2 px drift, ≤6 backward reads, ≤3 MiB.
+
 ## Runs
 
 - Web: `npm run build`, `npm test` (23 suites), `npm run test:render`.
+  For #129, re-run: `npm test` (25 suites), `npm run test:render`, `npm run build`.
 - Server: all 27 non-cron default suites passed. This includes trace windows,
   queued prompts, child traces, protocol regressions, attachments, permissions,
   migration, resize and state checkpoint tests.
+  For #129, re-run: every suite individually (the runner still stops at the cron
+  failure below); 30 passed, `test/crons.test.mjs` failed, unchanged from main.
 - Full-app browser integration: `reader-info.test.mjs`,
   `screenshot-input.test.mjs`, `terminal-ui.test.mjs`, using the production build.
 - Final targeted rerun: reader model/browser/protocol, legacy trace windows and

--- a/docs/reader-validation.md
+++ b/docs/reader-validation.md
@@ -45,11 +45,33 @@ Added 2026-09-09, on main `ef08e843`.
 | Older history pushes visible text down | Position re-asserted in the same frame as the size change; transcript shorter than the window grows from the bottom | 0.69 px maximum anchor displacement over 110 frames while filling; 0.51 px across the underfilled→scrollable transition over 72 frames; a genuine live append still moves the view 77 px, which is Latest working |
 | Latest quietly stops following mid-preload | Corrections land before the scroll event that reports them | Latest is claimed on every one of 110 frames during the fill |
 
+### Review round (2026-09-09)
+
+| Finding | Fix | Evidence |
+| --- | --- | --- |
+| The whole-conversation half of #129 was absent | Server scan endpoint, an explicit Reader action, and an old-hit window separate from the live store | A term in exchange 0 of a 120-exchange transcript, with 10 exchanges loaded: one click finds it, one read opens it, and the reader's place is restored on the way back |
+| The first PRESENTED viewport was still the first response | Rows are laid out and measured but not painted until they cover the reader, bounded four ways | The frame the transcript first becomes visible on is asserted covered, on a fixture whose first window is two exchanges and whose older pages are slow |
+| A forward read waited behind speculative history | A forward read cancels an in-flight speculative page instead of inheriting its promise; the abandoned step is uncharged and restartable | With a 300 ms backward page in flight, `loadNewer()` issues an `after` request rather than resolving with the backward one |
+| The documented byte limit was not a limit | A speculative page asks for a floor of one message, so the server cannot grow it past one record; the step is charged before the next is scheduled | On 900 KiB answers: largest page 1.5 MiB (was 6), retained 4.4 MiB against a 3 MiB budget plus the page that crossed it, in four requests |
+
+Two further defects surfaced while testing the fix, both fixed here: the virtual
+list kept correcting the scroller while its own rows were hidden behind an old
+window (every box measures zero, so it scrolled the borrower to the top), and
+scrolling inside a borrowed window could make the live transcript page backward.
+
 Removing each mechanism fails a named assertion: no fill → “only 2 exchanges
 became available on their own”; no same-frame re-placement → “Latest is still
 the bottom”; no bottom-growth → 454 px of displacement; no coverage request →
 uncovered 2600 px reader; no indexed floor → “1 prompts in 2 messages”; a
-counter that ignores a leading exchange → the grouping comparison.
+counter that ignores a leading exchange → the grouping comparison; no
+whole-history scan → the results never appear; a hit opened as a tail → “opened
+with the locator the search handed back”; no run token → “the newest query owns
+the results”; always claiming a complete scan → the partial-coverage line never
+appears; no clipped disclosure → its line never appears; a server scan limited
+to one page → “found the needle far outside the tail (0 hits)”; a database scan
+that ignores the conversation id → the neighbouring conversation leaks in; the
+virtual list not standing down while hidden → “the old window opens on its
+match”; no remembered position → the row returns 704px away instead of 0.
 
 ### Measurements
 
@@ -73,7 +95,7 @@ exchanges, viewport covered, ≤2 px drift, ≤6 backward reads, ≤3 MiB.
 ## Runs
 
 - Web: `npm run build`, `npm test` (23 suites), `npm run test:render`.
-  For #129, re-run: `npm test` (25 suites), `npm run test:render`, `npm run build`.
+  For #129, re-run: `npm test` (26 suites), `npm run test:render`, `npm run build`.
 - Server: all 27 non-cron default suites passed. This includes trace windows,
   queued prompts, child traces, protocol regressions, attachments, permissions,
   migration, resize and state checkpoint tests.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -30,7 +30,7 @@ import {
 // frontend's framing is unchanged.
 const TERM_CTRL = '\x00\x00AM:';
 import { buildUsage } from './usage.js';
-import { buildTraces, traceDigests, digestFor, traceLocation, readTrace, readTraceBundle, readTraceByPath, traceHarnessOf, subagentRoster, readSubagentTrace } from './traces.js';
+import { buildTraces, traceDigests, digestFor, traceLocation, readTrace, readTraceBundle, readTraceByPath, searchTrace, traceHarnessOf, subagentRoster, readSubagentTrace } from './traces.js';
 import { initPush, publicKey, deviceCount, addSubscription, removeSubscription, sendToAll } from './push.js';
 import { startVisibilityWatch, isPublic, visibility } from './visibility.js';
 import { kindOfName, kindOfFile, mimeOf, readTextHead, TEXT_MAX } from './preview.js';
@@ -2693,6 +2693,41 @@ app.get('/api/trace/:id', async (req, res) => {
     }
     console.error('[trace]', e && e.message);
     res.status(500).json({ error: (e && e.message) || 'trace read failed' });
+  }
+});
+
+// Search one conversation's whole transcript, as opposed to the stretch the
+// reader has loaded. Registered before /api/trace/:id/source for the same
+// ordering reason as the routes above.
+//
+// Bounded per request and continued with `cursor`; the reader asks for this
+// explicitly, so nothing here runs on a keystroke or on mount.
+app.get('/api/trace/:id/search', async (req, res) => {
+  const pane = store.get(req.params.id);
+  if (!pane) return res.status(404).json({ error: 'not found' });
+  const source = pane.traceSource || { kind: 'session', ref: pane.id };
+  if (source.kind === 'bundle') {
+    return res.status(400).json({ error: 'searching a shared bundle is not supported yet', code: 'unsupported-harness' });
+  }
+  const target = store.get(source.ref);
+  if (!target) return res.status(404).json({ error: 'source session is gone', code: 'no-trace' });
+  const q = typeof req.query.q === 'string' ? req.query.q : '';
+  const cursor = req.query.cursor === undefined ? undefined : Number(req.query.cursor);
+  if (cursor !== undefined && !Number.isFinite(cursor)) {
+    return res.status(400).json({ error: 'bad cursor', code: 'bad-query' });
+  }
+  try {
+    res.json(await searchTrace(target, { q, cursor,
+      limit: Number(req.query.limit) || undefined,
+      generation: typeof req.query.generation === 'string' ? req.query.generation : undefined }));
+  } catch (e) {
+    if (e && e.code === 'bad-query') return res.status(400).json({ error: e.message, code: e.code });
+    if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
+      return res.status(404).json({ error: e.message, code: e.code });
+    }
+    // The query itself is never logged: it is conversation content.
+    console.error('[trace search]', e && e.message);
+    res.status(500).json({ error: 'trace search failed' });
   }
 });
 

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -2375,3 +2375,199 @@ export async function readTraceBundle(dir, opts = {}) {
     decorate,
   }, opts);
 }
+
+/* ------------------------------------------------------------------ search --
+ *
+ * Searching the WHOLE conversation, as opposed to the stretch the reader has
+ * loaded. The reader keeps its instant filter over loaded exchanges; this is
+ * the explicit action for everything older, and it is explicit precisely
+ * because it reads the transcript.
+ *
+ * Scanning runs backward from the tail, newest first, because that is the order
+ * a reader looks for something in. Each request is bounded in pages, bytes and
+ * wall clock, and hands back a cursor to continue from — a long transcript is
+ * several bounded requests rather than one unbounded one.
+ *
+ * The scan boundary for a live conversation is the size (or message count) read
+ * at the start of the request. Output appended while it runs is outside this
+ * request's stated scope rather than something it chases forever, and the
+ * response says so.
+ */
+const SEARCH_MAX_QUERY = 200;
+const SEARCH_MAX_HITS = 50;
+const SEARCH_PAGE_BYTES = 256 * 1024;
+/** Messages of context an indexed hit opens with, the hit itself last. */
+const SEARCH_INDEX_CONTEXT = 40;
+const SEARCH_MAX_BYTES = 12 * 1024 * 1024;   // scanned per request
+const SEARCH_MAX_MS = 4_000;                 // per request
+const SEARCH_MAX_PAGES = 40;                 // per request
+const SNIPPET_BEFORE = 60;
+const SNIPPET_AFTER = 120;
+
+/**
+ * The text of one turn as the reader would show it, and whether any of it was
+ * clipped on the way here.
+ *
+ * Deliberately the same fields the reader's own loaded-history search uses
+ * (`web/src/components/conversation/readerSearch.ts`), so the two scopes cannot
+ * disagree about what counts as conversation: prompts, assistant text, thinking,
+ * tool names, tool input and output, shell commands and their streams. Image
+ * data and transport metadata are not conversation text.
+ *
+ * `clipped` matters because the parsers cap long blocks: a match in the part
+ * that was cut is a match this scan cannot see, so a scan that passed over a
+ * clipped block must not claim to have searched all of it.
+ */
+function searchableTurn(turn) {
+  const parts = [];
+  let clipped = false;
+  if (turn.event && typeof turn.event.text === 'string') parts.push(turn.event.text);
+  for (const block of turn.blocks || []) {
+    if (block.type === 'image') continue;
+    if (typeof block.name === 'string') parts.push(block.name);
+    for (const key of ['text', 'command', 'stdout', 'stderr']) {
+      if (typeof block[key] === 'string') parts.push(block[key]);
+    }
+    if (block.more) clipped = true;
+  }
+  return { text: parts.join('\n'), clipped };
+}
+
+/** A short, whitespace-collapsed excerpt around the first match, with the
+ * match's position in it — the client highlights, the server does not emit
+ * markup. */
+function snippetOf(text, at, length) {
+  const from = Math.max(0, at - SNIPPET_BEFORE);
+  const to = Math.min(text.length, at + length + SNIPPET_AFTER);
+  const head = (from ? '…' : '') + text.slice(from, at).replace(/\s+/g, ' ');
+  const match = text.slice(at, at + length).replace(/\s+/g, ' ');
+  const tail = text.slice(at + length, to).replace(/\s+/g, ' ') + (to < text.length ? '…' : '');
+  return { text: head + match + tail, at: head.length, length: match.length };
+}
+
+function hitsIn(turns, needle, locator) {
+  const out = [];
+  let clipped = false;
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const turn = turns[i];
+    const { text, clipped: cut } = searchableTurn(turn);
+    if (cut) clipped = true;
+    if (!text) continue;
+    const at = text.toLowerCase().indexOf(needle);
+    if (at < 0) continue;
+    const occurrences = text.toLowerCase().split(needle).length - 1;
+    out.push({
+      id: turn.id || null,
+      role: turn.role,
+      ts: turn.ts || null,
+      occurrences,
+      clipped: cut,
+      snippet: snippetOf(text, at, needle.length),
+      ...locator(i, turn),
+    });
+  }
+  return { hits: out, clipped };
+}
+
+/**
+ * One bounded search request against one located trace.
+ *
+ * Returns hits newest-first with a `window` locator each: the cursor the reader
+ * asks the ordinary window endpoint for to see that message with its
+ * surrounding conversation. Nothing here mutates or advances the reader's live
+ * cursor — a search is a read of the source, not a move through it.
+ */
+async function serveSearch({ key, harness, file, sessionId, size, stat, allowSubagent }, opts) {
+  const q = typeof opts.q === 'string' ? opts.q.trim() : '';
+  if (!q) { const e = new Error('empty search'); e.code = 'bad-query'; throw e; }
+  if (q.length > SEARCH_MAX_QUERY) { const e = new Error('search text is too long'); e.code = 'bad-query'; throw e; }
+  const limit = clampN(Math.trunc(opts.limit) || SEARCH_MAX_HITS, 1, SEARCH_MAX_HITS);
+  const needle = q.toLowerCase();
+  const identity = await traceRevision(file, stat || await fsp.stat(file), !WINDOWABLE.has(harness));
+  // A cursor belongs to the source it was issued for. A replaced transcript
+  // restarts the scan rather than continuing into unrelated bytes.
+  const stale = opts.generation && opts.generation !== identity.generation;
+  const base = { generation: identity.generation, revision: identity.revision, query: q };
+  const started = Date.now();
+
+  if (!WINDOWABLE.has(harness)) {
+    // An indexed source is parsed whole either way, so one request covers the
+    // whole conversation; only the RESULTS are paged, on exact message indices.
+    const parsed = await cachedTrace(`${key}:${identity.revision}`, size, async () =>
+      tracked(PHASE.readTrace, () => parseTraceFile(harness, file, sessionId, null, allowSubagent)));
+    const total = parsed.messages.length;
+    const from = stale ? total : clampN(Math.trunc(opts.cursor ?? total), 0, total);
+    const { hits, clipped } = hitsIn(parsed.messages.slice(0, from), needle,
+      (i) => ({ window: { at: 'before', cursor: i + 1, min: SEARCH_INDEX_CONTEXT } }));
+    const page = hits.slice(0, limit);
+    const more = hits.length > limit;
+    return { ...base, mode: 'index', reset: !!stale, hits: page,
+      next: more ? String(page[page.length - 1].window.cursor - 1) : null,
+      complete: !more, clipped, scanned: from, boundary: total };
+  }
+
+  let at = stale ? size : clampN(Math.trunc(opts.cursor ?? size), 0, size);
+  const hits = [];
+  let clipped = false;
+  let pages = 0;
+  let bytes = 0;
+  let atStart = at <= 0;
+  let blocked = false;
+  // Whole pages only. A cursor points at a page boundary, so continuing from it
+  // can neither repeat a hit already returned nor step over one: `hits` may
+  // overrun `limit` by the tail of the last page rather than be cut mid-page.
+  while (!atStart && hits.length < limit && pages < SEARCH_MAX_PAGES
+    && bytes < SEARCH_MAX_BYTES && Date.now() - started < SEARCH_MAX_MS) {
+    const page = await tracked(PHASE.readTrace, () => readWindow(harness, file, sessionId, size,
+      { at: 'before', cursor: at, bytes: SEARCH_PAGE_BYTES, min: 1, version: 2 }, allowSubagent));
+    pages++;
+    const end = page.cur.end ?? at;
+    // The locator names the WHOLE window, size included, not just its end: the
+    // same request reproduces exactly the page the hit was found in. An end
+    // offset alone would be read back with some other span, and a hit near the
+    // page's leading edge would then sit outside the window it pointed at.
+    const found = hitsIn(page.parsed.messages, needle,
+      () => ({ window: { at: 'before', cursor: end, bytes: SEARCH_PAGE_BYTES } }));
+    if (found.clipped) clipped = true;
+    hits.push(...found.hits);
+    bytes += Math.max(0, at - page.cur.start);
+    if (page.cur.blocked || page.cur.start >= at) { blocked = true; break; }
+    at = page.cur.start;
+    atStart = !!page.cur.atStart || at <= 0;
+  }
+  return {
+    ...base, mode: 'bytes', reset: !!stale, hits,
+    // Where a continuation resumes. `null` means this scan reached the start of
+    // the conversation, or stopped on a record it cannot get past.
+    next: atStart || blocked ? null : String(at),
+    complete: atStart, blocked, clipped, scanned: bytes, boundary: size,
+  };
+}
+
+/** Search a trace by path — the search-side counterpart of readTraceByPath(),
+ * used by tests and by any caller that already located the file. */
+export async function searchTraceByPath(file, opts = {}, allowSubagent = false) {
+  const st = await statRetry(file);
+  if (!st) { const e = new Error('trace file unreadable'); e.code = 'no-trace'; throw e; }
+  const harness = await sniffHarness(file);
+  if (!harness) { const e = new Error('unrecognized trace format'); e.code = 'unsupported-harness'; throw e; }
+  return serveSearch({ key: `f:${file}:${st.mtimeMs}:${st.size}${allowSubagent ? ':sub' : ''}`,
+    stat: st, harness, file, sessionId: null, size: st.size, allowSubagent }, opts);
+}
+
+/** Search one session's transcript. `session` is an Agent Manager session
+ * record; locating the file is delegated to findTrace() exactly as reads are. */
+export async function searchTrace(session, opts = {}) {
+  const hit = await findTrace(session, store.list());
+  if (!hit) { const e = new Error('no trace found for this session'); e.code = 'no-trace'; throw e; }
+  const st = await statRetry(hit.src);
+  if (!st) { const e = new Error(`trace file unreadable: ${hit.src}`); e.code = 'no-trace'; throw e; }
+  return serveSearch({
+    key: `s:${session.id}:${hit.src}:${hit.sessionId || ''}:${st.mtimeMs}:${st.size}`,
+    stat: st,
+    harness: session.cli,
+    file: hit.src,
+    sessionId: hit.sessionId || session.sessionUuid || null,
+    size: st.size,
+  }, opts);
+}

--- a/server/src/traces.js
+++ b/server/src/traces.js
@@ -1966,6 +1966,21 @@ async function readWindow(harness, file, sessionId, size, req, allowSubagent = f
 // a bundle small enough not to matter doesn't need them. They answer the same
 // shape with message INDICES as cursors: the reader treats a cursor as opaque.
 const INDEX_WINDOW_TURNS = 100; // no bytes to seek: page by turns, as index mode always did
+// A first-paint floor for the tail of an indexed source.
+//
+// `min` means two different things to the two window kinds. A byte window grows
+// its span until it holds that many messages, so a small `min` buys a cheap
+// first paint. An index window has no span to grow: the whole conversation is
+// already parsed by the time we get here, and `min` only decides how many of
+// those rows to hand back. Taking it literally is what made a cold reader on a
+// database source show two transport records — one exchange — no matter how
+// long the conversation was, and asking for fewer rows saved nothing, because
+// the parse had already happened.
+//
+// So on a TAIL request `min` is a floor rather than an exact count. Backward
+// paging still honours it exactly: that is a caller walking the conversation a
+// page at a time, and its page size is its own business.
+const INDEX_TAIL_MIN_TURNS = 40;
 
 function windowIndex(parsed, req) {
   const total = parsed.messages.length;
@@ -1977,7 +1992,7 @@ function windowIndex(parsed, req) {
     from = req.version === 2 ? Math.max(0, cursor - INDEX_WINDOW_TURNS) : cursor;
     to = req.version === 2 ? Math.min(total, cursor + min) : total;
   } else if (req.at === 'before' && !reset) { to = cursor; from = Math.max(0, to - min); }
-  else { to = total; from = Math.max(0, total - min); }
+  else { to = total; from = Math.max(0, total - Math.max(min, INDEX_TAIL_MIN_TURNS)); }
   return {
     ...headOf(parsed),
     total,

--- a/server/test/trace-index-history.test.mjs
+++ b/server/test/trace-index-history.test.mjs
@@ -1,0 +1,112 @@
+// How much conversation the FIRST window of an indexed (database) source holds.
+//
+// `min` means different things to the two window kinds, and that difference is
+// what a cold reader on a database session saw: a byte window grows its span
+// until it holds `min` messages, so a small `min` buys a cheap first paint,
+// while an index window has the whole conversation parsed already and `min` only
+// chooses how many rows to return. Taken literally, the reader's first-paint
+// floor of 2 produced two transport records — one exchange — out of any
+// conversation, and asking for fewer rows saved nothing.
+//
+// Run with:  node test/trace-index-history.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-index-history-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.XDG_DATA_HOME = path.join(tmp, 'xdg');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+fs.mkdirSync(path.join(process.env.XDG_DATA_HOME, 'opencode'), { recursive: true });
+
+const { readTrace } = await import('../src/traces.js');
+
+const EXCHANGES = 40;
+const dbFile = path.join(process.env.XDG_DATA_HOME, 'opencode', 'opencode.db');
+const db = new DatabaseSync(dbFile);
+db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT);
+  CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+  CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, time_created INTEGER, data TEXT);
+  INSERT INTO session VALUES ('session','/fixture','Fixture');
+  -- A second conversation in the same database: a window must never reach into it.
+  INSERT INTO session VALUES ('short','/fixture','Short');
+  INSERT INTO message VALUES ('one','short',1,'{"role":"user"}');
+  INSERT INTO part VALUES ('one-p','one',1,'{"type":"text","text":"short prompt"}');
+  INSERT INTO message VALUES ('two','short',2,'{"role":"assistant"}');
+  INSERT INTO part VALUES ('two-p','two',2,'{"type":"text","text":"short answer"}');`);
+const addMessage = db.prepare('INSERT INTO message VALUES (?,?,?,?)');
+const addPart = db.prepare('INSERT INTO part VALUES (?,?,?,?)');
+for (let i = 0; i < EXCHANGES; i++) {
+  addMessage.run(`m${i}u`, 'session', i * 10, JSON.stringify({ role: 'user' }));
+  addPart.run(`p${i}u`, `m${i}u`, i * 10, JSON.stringify({ type: 'text', text: `prompt ${i}` }));
+  addMessage.run(`m${i}a`, 'session', i * 10 + 1, JSON.stringify({ role: 'assistant' }));
+  // A tool call and its result: the records a reader must not mistake for turns.
+  addPart.run(`p${i}t`, `m${i}a`, i * 10 + 1, JSON.stringify({ type: 'tool', tool: 'bash', state: { input: { cmd: `check ${i}` }, output: `ok ${i}` } }));
+  addPart.run(`p${i}a`, `m${i}a`, i * 10 + 2, JSON.stringify({ type: 'text', text: `answer ${i}` }));
+}
+db.close();
+
+const session = { id: 'fixture', cli: 'opencode', path: 'fixture', opencodeSessionId: 'session' };
+const read = (window) => readTrace(session, { window: { version: 2, ...window } });
+const promptsIn = (page) => page.turns.filter((t) => t.role === 'user'
+  && t.blocks.some((b) => b.type === 'text' && b.text.startsWith('prompt '))).length;
+
+// ---- the reader's own first-paint request must arrive readable ----
+// 128 KiB / min 2 is what web/src/lib/readerStore.ts asks for on a cold open.
+const first = await read({ at: 'tail', bytes: 128 * 1024, min: 2 });
+assert.equal(first.window.mode, 'index', 'an opencode session is an indexed source');
+assert.ok(promptsIn(first) >= 20,
+  `a cold open sees a readable stretch of conversation, not two records (got ${promptsIn(first)} prompts in ${first.turns.length} messages)`);
+assert.equal(first.window.atEnd, true, 'and it is the end of the conversation');
+assert.equal(first.window.atStart, false, '40 exchanges are not all of it');
+assert.equal(first.window.end, EXCHANGES * 2, 'the tail ends at the last message');
+
+// A floor, not an override: asking for MORE than the floor still gets more.
+const wide = await read({ at: 'tail', bytes: 128 * 1024, min: 500 });
+assert.equal(wide.turns.length, EXCHANGES * 2, 'a large min still returns the whole conversation');
+assert.equal(wide.window.atStart, true);
+
+// ---- backward paging keeps honouring `min` exactly ----
+// That is a caller walking the conversation a page at a time; its page size is
+// its own business, and rounding it up would hand back rows it already has.
+const back = await read({ at: 'before', cursor: first.window.start, min: 6 });
+assert.equal(back.turns.length, 6, 'a backward page is exactly the size asked for');
+assert.equal(back.window.end, first.window.start, 'and it abuts the window it came from');
+assert.equal(back.window.start, first.window.start - 6);
+
+const tiny = await read({ at: 'before', cursor: back.window.start, min: 1 });
+assert.equal(tiny.turns.length, 1, 'including a single-row page');
+
+// ---- paging back from the first window reaches the beginning exactly once ----
+const seen = [];
+let cursor = first.window.start;
+for (let hops = 0; cursor > 0; hops++) {
+  assert.ok(hops < 100, 'paging back terminates');
+  const page = await read({ at: 'before', cursor, min: 8 });
+  seen.unshift(...page.turns);
+  assert.equal(page.window.end, cursor, 'no gap between pages');
+  cursor = page.window.start;
+}
+const whole = [...seen, ...first.turns];
+assert.equal(whole.length, EXCHANGES * 2, 'every message appears exactly once across the pages');
+assert.deepEqual(
+  whole.filter((t) => t.role === 'user').map((t) => t.blocks.find((b) => b.type === 'text')?.text),
+  Array.from({ length: EXCHANGES }, (_, i) => `prompt ${i}`),
+  'in the order the conversation happened',
+);
+
+// ---- a conversation shorter than the floor is not padded, clipped, or mixed
+// with the other conversation sitting in the same database ----
+const short = await readTrace({ id: 'short', cli: 'opencode', path: 'fixture', opencodeSessionId: 'short' },
+  { window: { version: 2, at: 'tail', bytes: 128 * 1024, min: 2 } });
+assert.equal(short.turns.length, 2, 'a two-message conversation returns two messages');
+assert.equal(short.window.atStart, true, 'and reports the beginning honestly');
+assert.equal(short.window.atEnd, true);
+assert.deepEqual(short.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)),
+  ['short prompt', 'short answer'], 'and only its own messages, not the 40-exchange conversation beside it');
+assert.ok(!first.turns.some((t) => t.blocks.some((b) => b.type === 'text' && b.text.startsWith('short '))),
+  'nor the other way round');
+
+console.log('trace-index-history: ok');

--- a/server/test/trace-search.test.mjs
+++ b/server/test/trace-search.test.mjs
@@ -1,0 +1,147 @@
+// Searching the WHOLE conversation, as opposed to the stretch a reader loaded.
+//
+// The case that matters is the one the reader cannot answer for itself: a term
+// that appears ONLY near the beginning of a transcript far larger than anything
+// the reader retains. If this suite can be satisfied by searching a tail, it is
+// not testing the feature.
+//
+// Run with:  node test/trace-search.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'trace-search-'));
+process.env.DATA_DIR = path.join(tmp, 'data');
+process.env.XDG_DATA_HOME = path.join(tmp, 'xdg');
+fs.mkdirSync(process.env.DATA_DIR, { recursive: true });
+fs.mkdirSync(path.join(process.env.XDG_DATA_HOME, 'opencode'), { recursive: true });
+
+const { readTraceByPath, searchTrace, searchTraceByPath } = await import('../src/traces.js');
+
+// ---------- a Claude transcript far larger than any reader window ----------
+const N = 400;
+const file = path.join(tmp, 'session.jsonl');
+const line = (i, text, extra = {}) => JSON.stringify({
+  type: i % 2 === 0 ? 'user' : 'assistant',
+  cwd: tmp,
+  timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, i)).toISOString(),
+  message: {
+    role: i % 2 === 0 ? 'user' : 'assistant',
+    ...(i % 2 ? { id: `m${i}`, model: 'claude-test' } : {}),
+    content: [{ type: 'text', text }],
+    ...extra,
+  },
+});
+const lines = [];
+// The needle, in the very first exchange, then ~3 MB of unrelated conversation.
+lines.push(line(0, 'please check the ZEPHYRQUARTZ deployment before anything else'));
+lines.push(line(1, 'Looking at ZEPHYRQUARTZ now.'));
+for (let i = 2; i < N; i++) lines.push(line(i, `turn ${i} ${'padding '.repeat(1000)}`));
+// A tool call and its output near the middle, so tool text is covered too.
+lines.push(JSON.stringify({ type: 'assistant', cwd: tmp, timestamp: new Date(Date.UTC(2026, 0, 2)).toISOString(),
+  message: { role: 'assistant', id: 'tool-msg', content: [
+    { type: 'tool_use', id: 'call-1', name: 'Bash', input: { command: 'grep OBSIDIANFERN src' } }] } }));
+lines.push(JSON.stringify({ type: 'user', cwd: tmp, timestamp: new Date(Date.UTC(2026, 0, 2, 0, 1)).toISOString(),
+  message: { role: 'user', content: [
+    { type: 'tool_result', tool_use_id: 'call-1', content: 'src/a.ts: LAPISTHISTLE = 1' }] } }));
+for (let i = N; i < N + 40; i++) lines.push(line(i, `turn ${i} ${'padding '.repeat(1000)}`));
+lines.push(line(N + 40, 'and finally, a quoted "phrase (with punctuation)" plus héllo Ünicode'));
+fs.writeFileSync(file, `${lines.join('\n')}\n`);
+const SIZE = fs.statSync(file).size;
+assert.ok(SIZE > 3 * 1024 * 1024, `the fixture is bigger than any reader budget (${(SIZE / 1048576).toFixed(1)} MiB)`);
+
+// The reader's own cold open cannot see the needle: that is the premise.
+const cold = await readTraceByPath(file, { window: { version: 2, at: 'tail', bytes: 128 * 1024, min: 2 } });
+const coldText = cold.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+assert.ok(!coldText.includes('ZEPHYRQUARTZ'), 'the needle is outside the loaded window');
+assert.equal(cold.window.atStart, false);
+
+const run = (opts) => searchTraceByPath(file, opts);
+
+// ---- a term only at the very beginning is found ----
+const first = await run({ q: 'ZEPHYRQUARTZ' });
+assert.ok(first.hits.length >= 2, `found the needle far outside the tail (${first.hits.length} hits)`);
+assert.equal(first.complete, true, 'and scanned to the beginning of the conversation');
+assert.equal(first.next, null);
+assert.ok(first.hits.every((h) => h.snippet.text.toLowerCase().includes('zephyrquartz')),
+  'every hit carries an excerpt containing the match');
+assert.ok(first.hits[0].snippet.length > 0 && first.hits[0].snippet.at >= 0,
+  'with the match located inside the excerpt rather than marked up');
+assert.ok(first.hits.every((h) => h.window && h.window.at === 'before' && h.window.cursor > 0 && h.window.bytes > 0),
+  'and a complete window locator to open it with');
+
+// ---- case-insensitive, literal, and honest about punctuation/unicode ----
+assert.equal((await run({ q: 'zephyrquartz' })).hits.length, first.hits.length, 'matching is case-insensitive');
+assert.ok((await run({ q: '"phrase (with punctuation)"' })).hits.length >= 1, 'punctuation is literal, not a pattern');
+assert.ok((await run({ q: 'héllo Ünicode' })).hits.length >= 1, 'non-ASCII text matches');
+assert.equal((await run({ q: 'NOTHINGLIKETHISEXISTS' })).hits.length, 0, 'a term that is not there has no hits');
+assert.equal((await run({ q: 'NOTHINGLIKETHISEXISTS' })).complete, true,
+  'and the scan says it covered the conversation, which is what makes "no matches" true');
+
+// ---- tool names, tool input and tool output are conversation text ----
+// A tool call and its result reconcile into one turn, so each of these is one
+// hit — which is also why they need separate needles to be told apart.
+assert.equal((await run({ q: 'OBSIDIANFERN' })).hits.length, 1, "a tool call's input is searched");
+assert.equal((await run({ q: 'LAPISTHISTLE' })).hits.length, 1, 'and its output');
+assert.ok((await run({ q: 'Bash' })).hits.length >= 1, 'and the tool name');
+
+// ---- the locator really opens a window containing the match ----
+const target = first.hits[first.hits.length - 1];
+// Exactly the locator the search handed back — no guessed page size.
+const around = await readTraceByPath(file, { window: { version: 2, ...target.window } });
+const aroundText = around.turns.flatMap((t) => t.blocks.filter((b) => b.type === 'text').map((b) => b.text)).join('\n');
+assert.ok(aroundText.includes('ZEPHYRQUARTZ'),
+  'the window a hit points at contains the match, without loading everything in between');
+assert.ok(around.window.end <= Number(target.window.cursor), 'and stops at the hit rather than running to the tail');
+assert.ok(around.window.end < SIZE, 'so the live tail was never fetched to get there');
+
+// ---- paging is bounded, deterministic and non-overlapping ----
+const paged = [];
+let cursor;
+for (let i = 0; ; i++) {
+  assert.ok(i < 60, 'paging terminates');
+  const page = await run({ q: 'padding', limit: 5, cursor });
+  paged.push(...page.hits.map((h) => `${h.ts}:${h.snippet.at}`));
+  if (!page.next) { assert.equal(page.complete, true, 'the last page reports a completed scan'); break; }
+  assert.notEqual(page.next, cursor, 'each page advances the cursor');
+  cursor = Number(page.next);
+}
+assert.equal(new Set(paged).size, paged.length, 'no hit is returned by two pages');
+assert.ok(paged.length > 100, `paging reaches the whole conversation (${paged.length} hits)`);
+
+// ---- a bad query is refused, not guessed at ----
+for (const bad of ['', '   ']) {
+  await assert.rejects(() => run({ q: bad }), (e) => e.code === 'bad-query', `refuses ${JSON.stringify(bad)}`);
+}
+await assert.rejects(() => run({ q: 'x'.repeat(500) }), (e) => e.code === 'bad-query', 'refuses an oversized query');
+
+// ---- an indexed source searches its own conversation and no other ----
+const dbFile = path.join(process.env.XDG_DATA_HOME, 'opencode', 'opencode.db');
+const db = new DatabaseSync(dbFile);
+db.exec(`CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, title TEXT);
+  CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT, time_created INTEGER, data TEXT);
+  CREATE TABLE part (id TEXT PRIMARY KEY, message_id TEXT, time_created INTEGER, data TEXT);
+  INSERT INTO session VALUES ('mine','/fixture','Mine');
+  INSERT INTO session VALUES ('other','/fixture','Other');
+  INSERT INTO message VALUES ('o1','other',1,'{"role":"user"}');
+  INSERT INTO part VALUES ('o1p','o1',1,'{"type":"text","text":"MARMALADEHILL belongs to the other conversation"}');`);
+const addM = db.prepare('INSERT INTO message VALUES (?,?,?,?)');
+const addP = db.prepare('INSERT INTO part VALUES (?,?,?,?)');
+addM.run('m0', 'mine', 0, JSON.stringify({ role: 'user' }));
+addP.run('p0', 'm0', 0, JSON.stringify({ type: 'text', text: 'the oldest prompt mentions CINNABARWELL once' }));
+for (let i = 1; i < 80; i++) {
+  addM.run(`m${i}`, 'mine', i, JSON.stringify({ role: i % 2 ? 'assistant' : 'user' }));
+  addP.run(`p${i}`, `m${i}`, i, JSON.stringify({ type: 'text', text: `ordinary message ${i}` }));
+}
+db.close();
+const dbSession = { id: 'db-fixture', cli: 'opencode', path: 'fixture', opencodeSessionId: 'mine' };
+const dbHits = await searchTrace(dbSession, { q: 'CINNABARWELL' });
+assert.equal(dbHits.mode, 'index');
+assert.equal(dbHits.hits.length, 1, 'the oldest message in a database conversation is searchable');
+assert.equal(dbHits.complete, true);
+assert.equal((await searchTrace(dbSession, { q: 'MARMALADEHILL' })).hits.length, 0,
+  'and a conversation beside it in the same database is never searched');
+
+console.log('trace-search: ok');

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -655,6 +655,44 @@ export const getTraceWindow = (id: string, req: TraceReq, bytes?: number, min?: 
 export const getTraceSummary = (id: string, signal?: AbortSignal): Promise<TraceSummary> =>
   traceFetch(`/api/trace/${id}?summary=1`, signal);
 
+/** One match, and the window that shows it with its surrounding conversation. */
+export interface TraceHit {
+  id: string | null;
+  role: 'user' | 'assistant' | 'system';
+  ts: number | null;
+  /** Occurrences of the term in this message, which is not the same as hits. */
+  occurrences: number;
+  /** This message's text was clipped by the display cap before being searched. */
+  clipped: boolean;
+  snippet: { text: string; at: number; length: number };
+  window: { at: 'before'; cursor: number; bytes?: number; min?: number };
+}
+export interface TraceSearch {
+  query: string;
+  mode: 'bytes' | 'index';
+  hits: TraceHit[];
+  /** Continue from here, or null when the scan reached the conversation's start. */
+  next: string | null;
+  /** The stated scope was searched to its beginning. Only then is "no matches" true. */
+  complete: boolean;
+  blocked?: boolean;
+  /** Some searched messages were clipped by the display cap, so their tails were not seen. */
+  clipped: boolean;
+  scanned: number;
+  boundary: number;
+  reset?: boolean;
+  generation?: string;
+  revision?: string;
+}
+
+/** Search the whole conversation, not the loaded stretch. Explicit by design:
+ * it reads the transcript, so nothing calls it on a keystroke or on mount. */
+export const searchTraceHistory = (id: string, q: string, cursor?: string | null,
+  generation?: string, signal?: AbortSignal): Promise<TraceSearch> =>
+  traceFetch(`/api/trace/${id}/search?q=${encodeURIComponent(q)}`
+    + `${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ''}`
+    + `${generation ? `&generation=${encodeURIComponent(generation)}` : ''}`, signal);
+
 export const getFileTraceWindow = (id: string, p: string, req: TraceReq, bytes?: number, min?: number, signal?: AbortSignal): Promise<TraceWindow> =>
   traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&${traceRange(req)}${windowSize(bytes, min)}`, signal);
 

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -1,10 +1,17 @@
 import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../../api';
-import type { SubAgentEntry } from '../../api';
+import type { SubAgentEntry, TraceHit, TraceSearch, TraceTurn } from '../../api';
+import { reconcileTrace } from '../../lib/readerModel';
 import {
   HISTORY_MAX_EXCHANGES, HISTORY_TARGET_EXCHANGES, useTraceWindows,
   type TraceHeadInfo, type TraceSource,
 } from '../../lib/traceWindows';
+
+/** Longest a cold reader will hold its first transcript back (see `preparing`). */
+const PREPARE_MAX_MS = 2_000;
+/** Exchanges rendered around an old hit. The window the server points at is
+ * bounded already; this bounds the DOM as well, and the hit is its last turn. */
+const HIT_CONTEXT_EXCHANGES = 30;
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
 import {
@@ -59,6 +66,22 @@ export default function ConversationView({
   const allowAttachments = !isRemote(session.cli);
   const [openWork, setOpenWork] = useState(new Map<string, boolean>());
   const [restoreNotice, setRestoreNotice] = useState<string | null>(null);
+  /**
+   * Whole-conversation search, and the old part of the conversation a result
+   * opens. Both are deliberately separate from the reader's live history: the
+   * scan is an explicit action that reads the transcript, and a result opens an
+   * explicit historical window rather than paging the live store back to it.
+   */
+  const [scan, setScan] = useState<{
+    q: string; state: 'searching' | 'done' | 'failed'; hits: TraceHit[];
+    next: string | null; complete: boolean; clipped: boolean; error?: string;
+  } | null>(null);
+  const [historic, setHistoric] = useState<{
+    hit: TraceHit; turns: TraceTurn[]; loading: boolean; error?: string } | null>(null);
+  const beforeHit = useRef<{ end: boolean; key?: string; offset?: number } | null>(null);
+  const scanRun = useRef(0);
+  const scanAbort = useRef<AbortController | null>(null);
+  const hitAbort = useRef<AbortController | null>(null);
 
   const src = useMemo<TraceSource>(() => ({
     window: (req, bytes, min, signal) => api.getTraceWindow(session.id, req, bytes, min, signal),
@@ -76,6 +99,21 @@ export default function ConversationView({
   const shown = useMemo(() => exchanges.map((x, n) => ({ x, n })).filter(({ n }) => !q || index[n].includes(q)), [exchanges, index, q]);
   const keys = useMemo(() => shown.map(({ x }) => x.key), [shown]);
   const virtual = useVirtualRows(keys, scroller, following);
+  const keysRef = useRef(keys); keysRef.current = keys;
+  /**
+   * A cold reader holds the first transcript back until it is worth showing.
+   *
+   * The first window is 128 KiB, which on a tool-heavy trace is two exchanges.
+   * Bottom-anchoring stops the pages that follow from pushing that text down,
+   * but it does not make two messages and a screen of empty space an acceptable
+   * first page — the reader is supposed to open on a page of conversation.
+   * Rows are laid out and measured throughout, so this is a paint delay and not
+   * a fetch delay, and it is bounded four ways: coverage, the start of the
+   * conversation, an unusable source, and a deadline. The composer is never
+   * part of it, and a warm store starts revealed because its text is already
+   * readable.
+   */
+  const [preparing, setPreparing] = useState(() => !reader.turns.current.length);
   // A terminal redraw is not evidence of work. Only transcript lifecycle
   // events light the working line; connection/recovery is separate chrome.
   const live = !!session.running && reader.activityConfirmed && head?.activity === 'working' && !session.inputRequired;
@@ -154,9 +192,6 @@ export default function ConversationView({
     setQuery(value);
   };
   useEffect(() => {
-    if (searchOpen) searchBox.current?.focus(); else setQuery('');
-  }, [searchOpen]);
-  useEffect(() => {
     if (q) {
       following.current = false; setAtLatest(false); setHit(0); virtual.scrollTo(0);
     } else if (beforeSearch.current) {
@@ -169,6 +204,103 @@ export default function ConversationView({
     const next = (hit + direction + shown.length) % shown.length;
     setHit(next); virtual.scrollTo(next);
   };
+
+  // ---- whole-conversation search -------------------------------------------
+  // The instant filter above stays exactly as it was. This is the separate,
+  // explicit action for everything older than the loaded stretch: it is started
+  // by a button or ⌘/Ctrl+Enter, never by typing, and each request is bounded
+  // and continued with a cursor. Results are bound to the query and the run
+  // that asked for them, so a late answer to an abandoned query is dropped.
+  const stopScan = useCallback(() => {
+    scanRun.current++;
+    scanAbort.current?.abort(); scanAbort.current = null;
+  }, []);
+  const runScan = async (more = false) => {
+    const text = query.trim();
+    if (!text) return;
+    stopScan();
+    const run = scanRun.current;
+    const cursor = more ? scan?.next ?? null : null;
+    const controller = new AbortController();
+    scanAbort.current = controller;
+    setScan((prev) => ({
+      q: text, state: 'searching', clipped: prev && more ? prev.clipped : false,
+      hits: more && prev && prev.q === text ? prev.hits : [], next: null, complete: false,
+    }));
+    try {
+      const page: TraceSearch = await api.searchTraceHistory(
+        session.id, text, cursor, head?.generation, controller.signal);
+      if (run !== scanRun.current) return;                  // a newer query won
+      setScan((prev) => ({
+        q: text, state: 'done',
+        hits: [...(more && prev && prev.q === text ? prev.hits : []), ...page.hits],
+        next: page.next, complete: page.complete && !page.next,
+        clipped: (more && prev ? prev.clipped : false) || page.clipped,
+      }));
+    } catch (error) {
+      if (run !== scanRun.current) return;
+      setScan((prev) => ({
+        q: text, state: 'failed', hits: prev?.q === text ? prev.hits : [], next: prev?.next ?? null,
+        complete: false, clipped: !!prev?.clipped,
+        error: error instanceof Error ? error.message : 'The search could not finish.',
+      }));
+    } finally { if (scanAbort.current === controller) scanAbort.current = null; }
+  };
+  const openHit = async (target: TraceHit) => {
+    // Remember the live reading position explicitly before borrowing the
+    // scroller. The virtual list cannot hold it for us: history keeps arriving
+    // while the old window is up, and by the time we come back the row may be
+    // outside the rendered window, where a measured correction has nothing to
+    // measure. `scrollTo` is the same path a remembered position from a
+    // previous session is restored through, and it survives re-measurement.
+    if (!historic) beforeHit.current = following.current
+      ? { end: true }
+      : { end: false, key: virtual.anchor.current?.key || '', offset: virtual.anchor.current?.offset || 0 };
+    hitAbort.current?.abort();
+    const controller = new AbortController();
+    hitAbort.current = controller;
+    setHistoric({ hit: target, turns: [], loading: true });
+    try {
+      const page = await api.getTraceWindow(session.id,
+        { at: 'before', cursor: target.window.cursor, generation: head?.generation },
+        target.window.bytes, target.window.min, controller.signal);
+      if (hitAbort.current !== controller) return;
+      setHistoric({ hit: target, turns: reconcileTrace(page.turns), loading: false });
+    } catch (error) {
+      if (hitAbort.current !== controller) return;
+      setHistoric({ hit: target, turns: [], loading: false,
+        error: error instanceof Error ? error.message : 'That part of the conversation could not be read.' });
+    }
+  };
+  const closeHistoric = () => {
+    hitAbort.current?.abort(); hitAbort.current = null;
+    setHistoric(null);
+    const saved = beforeHit.current; beforeHit.current = null;
+    if (!saved) return;
+    // After the live rows are mounted again, not during this event.
+    queueMicrotask(() => {
+      if (saved.end) { latest(); return; }
+      const index = keysRef.current.indexOf(saved.key);
+      if (index >= 0) { virtual.scrollTo(index, saved.offset); setAtLatest(false); }
+      else latest();
+    });
+  };
+  // A historical window is read-only and detached: it never advances the live
+  // cursor, and leaving it puts the reader back where it was.
+  const historicExchanges = useMemo(
+    () => (historic ? splitExchanges(historic.turns).slice(-HIT_CONTEXT_EXCHANGES) : []),
+    [historic],
+  );
+  useEffect(() => {
+    if (searchOpen) searchBox.current?.focus();
+    else { setQuery(''); stopScan(); setScan(null); setHistoric(null); }
+  }, [searchOpen, stopScan]);
+  useEffect(() => () => { stopScan(); hitAbort.current?.abort(); }, [stopScan]);
+  useEffect(() => { stopScan(); setScan(null); setHistoric(null); }, [session.id, stopScan]);
+  useLayoutEffect(() => {
+    // The hit is the last turn of its window, so the bottom of the list is it.
+    if (historic && !historic.loading && scroller.current) scroller.current.scrollTop = scroller.current.scrollHeight;
+  }, [historic]);
 
   const position = useRef<ReturnType<typeof recallReading>>(null);
   const restore = useRef({ done: false, hops: 0 });
@@ -187,7 +319,7 @@ export default function ConversationView({
     restore.current.hops++; void loadOlder();
   }, [head, version, loading, paused, q, atStart, blocked, error, shown, session.id, loadOlder, virtual.scrollTo]);
   const capture = () => {
-    if (!touched.current || q) return;
+    if (!touched.current || q || historic) return;
     const at = virtual.anchor.current;
     const exchange = at && shown.find(({ x }) => x.key === at.key)?.x;
     if (following.current) position.current = { ts: 0, off: 0, end: true };
@@ -204,12 +336,26 @@ export default function ConversationView({
    * cannot walk the whole transcript, and by `atStart`, so a genuinely short
    * conversation settles immediately.
    */
-  useLayoutEffect(() => {
+  const covered = () => {
     const el = scroller.current;
-    if (paused || !el || atStart || blocked || error || !exchanges.length) return;
-    if (el.clientHeight && virtual.measuredHeight() >= el.clientHeight) return;
+    return !!el && el.clientHeight > 0 && virtual.measuredHeight() >= el.clientHeight;
+  };
+  useLayoutEffect(() => {
+    if (paused || atStart || blocked || error || !exchanges.length || covered()) return;
     reader.wantHistory(Math.min(HISTORY_MAX_EXCHANGES, exchanges.length + 8));
   }, [virtual.offsets, virtual.measuredHeight, exchanges.length, atStart, blocked, error, paused, reader.wantHistory]);
+  useLayoutEffect(() => {
+    if (!preparing) return;
+    // Anything that means more history is not coming, or is not needed.
+    if (atStart || blocked || error || phase === 'empty' || reader.fill === 'limited' || covered()) setPreparing(false);
+  }, [preparing, atStart, blocked, error, phase, reader.fill, virtual.offsets, exchanges.length]);
+  useEffect(() => {
+    if (!preparing) return;
+    // The safety bound. Preparation is meant to be brief; if the source is slow
+    // enough that it is not, an honestly partial page beats a spinner.
+    const timer = setTimeout(() => setPreparing(false), PREPARE_MAX_MS);
+    return () => clearTimeout(timer);
+  }, [preparing]);
 
   const settle = useRef<ReturnType<typeof setTimeout>>();
   const interact = () => { touched.current = true; virtual.cancelTarget(); };
@@ -236,11 +382,23 @@ export default function ConversationView({
       <button className="cxv-mini" onClick={() => void reload()} aria-label="Refresh transcript" title="Refresh transcript">↻</button>
     </div>
     {searchOpen && <div className="cxv-bar mono">
-      <input ref={searchBox} className="cxv-search" aria-label="Search loaded conversation" placeholder="Search loaded conversation…" value={query}
-        onChange={(event) => changeQuery(event.target.value)} onKeyDown={(event) => { if (event.key === 'Escape') onCloseSearch?.(); if (event.key === 'Enter') nextHit(event.shiftKey ? -1 : 1); }} />
+      <input ref={searchBox} className="cxv-search" aria-label="Search the conversation" placeholder="Search loaded conversation…" value={query}
+        onChange={(event) => changeQuery(event.target.value)} onKeyDown={(event) => {
+          if (event.key === 'Escape') { if (historic) closeHistoric(); else onCloseSearch?.(); return; }
+          if (event.key !== 'Enter') return;
+          // Enter walks the loaded matches, as it always has. Starting a scan of
+          // the whole transcript is a different, deliberate keystroke, so an
+          // edited query cannot start one by accident or start two at once.
+          if (event.metaKey || event.ctrlKey) void runScan();
+          else nextHit(event.shiftKey ? -1 : 1);
+        }} />
       {q && <span className="cxv-hits">{shown.length ? `${Math.min(hit + 1, shown.length)}/${shown.length} turns` : 'No matches'}</span>}
       <button className="cxv-mini" disabled={!q || !shown.length} onClick={() => nextHit(-1)} aria-label="Previous matching turn">↑</button>
       <button className="cxv-mini" disabled={!q || !shown.length} onClick={() => nextHit(1)} aria-label="Next matching turn">↓</button>
+      <button className="cxv-mini" disabled={!q || scan?.state === 'searching'} onClick={() => void runScan()}
+        title="Search every message in this conversation, including history that is not loaded (⌘/Ctrl+Enter)">
+        {scan?.state === 'searching' ? 'Searching all…' : 'Search all history'}</button>
+      {scan?.state === 'searching' && <button className="cxv-mini" onClick={stopScan} aria-label="Cancel the whole-history search">Cancel</button>}
     </div>}
     <input ref={filePicker} className="image-file-input" type="file" multiple disabled={sending || !allowAttachments}
       onChange={(event) => { addAttachments(Array.from(event.currentTarget.files || [])); event.currentTarget.value = ''; }} />
@@ -248,6 +406,11 @@ export default function ConversationView({
       onWheel={interact} onTouchStart={interact} onPointerDown={interact} onKeyDown={interact}
       onScroll={(event) => {
         const el = event.currentTarget;
+        // A historical window borrows the scroller but is not the live
+        // conversation: reading follow intent, an anchor or a saved position
+        // out of its geometry would answer questions about the wrong content,
+        // and leaving it would then land somewhere nobody asked for.
+        if (historic) return;
         following.current = !q && el.scrollHeight - el.scrollTop - el.clientHeight < 48;
         setAtLatest(following.current); virtual.onScroll(); capture();
         clearTimeout(settle.current); settle.current = setTimeout(() => { if (position.current) rememberReading(session.id, position.current); }, 150);
@@ -261,7 +424,52 @@ export default function ConversationView({
         </button>}
         {head?.note && <div className="cxv-msg mono">{head.note}</div>}
         {q && <div className="cxv-msg mono">{shown.length} of {exchanges.length} loaded turns match{atStart ? '' : ' · Earlier history has not been searched'}</div>}
-        <div className={exchanges.length ? 'cxv-rows' : undefined} ref={virtual.container}>
+        {preparing && <div className="cxv-msg mono" role="status">Opening the conversation…</div>}
+        {scan && <div className="cxv-scan mono">
+          <div className="cxv-msg" role="status">
+            {scan.state === 'searching' ? `Searching the whole conversation for “${scan.q}”…`
+              : scan.state === 'failed' ? scan.error
+              : scan.hits.length ? `${scan.hits.length}${scan.next ? '+' : ''} message${scan.hits.length === 1 ? '' : 's'} match “${scan.q}”`
+              : scan.complete ? `No message in this conversation contains “${scan.q}”`
+              : `No matches yet in the part searched so far`}
+            {scan.clipped && ' · some very long messages were searched only as far as the reader displays them'}
+            {!scan.complete && scan.state === 'done' && ' · not the whole conversation yet'}
+            {' '}
+            {scan.next && scan.state !== 'searching'
+              && <button className="cxv-mini" onClick={() => void runScan(true)}>Keep searching earlier</button>}
+            {scan.state === 'failed' && <button className="cxv-mini" onClick={() => void runScan()}>Try again</button>}
+            <button className="cxv-mini" onClick={() => { stopScan(); setScan(null); closeHistoric(); }}>Clear</button>
+          </div>
+          {scan.hits.map((h, i) => <button key={`${h.window.cursor}:${h.id ?? i}:${h.ts ?? i}`}
+            className={`cxv-hitrow${historic?.hit === h ? ' on' : ''}`} onClick={() => void openHit(h)}>
+            <span className="cxv-hitwho">{h.role === 'user' ? 'you' : h.role === 'assistant' ? 'agent' : h.role}</span>
+            <span className="cxv-hittext">
+              {h.snippet.text.slice(0, h.snippet.at)}
+              <mark>{h.snippet.text.slice(h.snippet.at, h.snippet.at + h.snippet.length)}</mark>
+              {h.snippet.text.slice(h.snippet.at + h.snippet.length)}
+            </span>
+            {h.occurrences > 1 && <span className="cxv-hitwho">×{h.occurrences}</span>}
+          </button>)}
+        </div>}
+        {historic && <div className="cxv-msg mono" role="status">
+          Showing an older part of the conversation. The latest messages are not below this.
+          {' '}<button className="cxv-mini" onClick={closeHistoric}>Back to the current view</button>
+        </div>}
+        {historic && <div className="cxv-rows">
+          {historic.loading && <div className="cxv-msg mono" role="status">Reading that part of the conversation…</div>}
+          {historic.error && <div className="cxv-msg bad mono" role="status">{historic.error}</div>}
+          {historic.hit.clipped && !historic.loading && !historic.error && <div className="cxv-msg mono">
+            This message is longer than the reader displays; the match may be in the part not shown.
+          </div>}
+          {historicExchanges.map((x, n) => <div key={`h:${x.key}`} data-x={x.key} data-historic="1">
+            <ExchangeView x={x} n={n + 1} total={historicExchanges.length} q={scan?.q.toLowerCase() || undefined}
+              baseModel={head?.model || undefined} open={false} onToggle={() => {}}
+              turns={historic.turns} sessionId={session.id} live={false} roster={roster} />
+          </div>)}
+        </div>}
+        <div hidden={!!historic}
+          className={`${exchanges.length ? 'cxv-rows' : ''}${preparing ? ' cxv-preparing' : ''}`.trim() || undefined}
+          ref={virtual.container}>
           <div aria-hidden="true" style={{ height: virtual.before }} />
           {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => virtual.measure(x.key, node)}>
             <ExchangeView x={x} n={n + 1} total={exchanges.length} q={q || undefined} baseModel={head?.model || undefined}

--- a/web/src/components/conversation/ConversationView.tsx
+++ b/web/src/components/conversation/ConversationView.tsx
@@ -1,7 +1,10 @@
 import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import * as api from '../../api';
 import type { SubAgentEntry } from '../../api';
-import { useTraceWindows, type TraceHeadInfo, type TraceSource } from '../../lib/traceWindows';
+import {
+  HISTORY_MAX_EXCHANGES, HISTORY_TARGET_EXCHANGES, useTraceWindows,
+  type TraceHeadInfo, type TraceSource,
+} from '../../lib/traceWindows';
 import type { Session } from '../../types';
 import { isRemote } from '../../types';
 import {
@@ -62,7 +65,9 @@ export default function ConversationView({
     summary: (signal) => api.getTraceSummary(session.id, signal),
   }), [session.id]);
   const onReset = useCallback(() => { following.current = true; setAtLatest(true); }, []);
-  const reader = useTraceWindows(src, `session:${session.id}`, { paused, onReset });
+  // The main reader asks for a useful amount of recent conversation up front.
+  // Child transcripts and previews deliberately do not (see the hook).
+  const reader = useTraceWindows(src, `session:${session.id}`, { paused, onReset, history: HISTORY_TARGET_EXCHANGES });
   const { head, error, phase, loading, notice, version, atStart, blocked, loadOlder, loadNewer, reload } = reader;
   const loadingEarlier = loading === 'tail' || loading === 'before';
   const turns = reader.turns.current;
@@ -188,6 +193,24 @@ export default function ConversationView({
     if (following.current) position.current = { ts: 0, off: 0, end: true };
     else if (exchange?.startTs) position.current = { ts: exchange.startTs, off: at!.offset, end: false };
   };
+  /**
+   * A page of conversation, not a page of estimates.
+   *
+   * The exchange target is about how much HISTORY is available; this is about
+   * whether the first thing shown fills the reader. They are different
+   * questions — twenty one-line exchanges do not cover a tall window, and one
+   * long answer covers it without giving any history — so both run, and each
+   * stops on its own terms. Bounded by HISTORY_MAX_EXCHANGES, so short rows
+   * cannot walk the whole transcript, and by `atStart`, so a genuinely short
+   * conversation settles immediately.
+   */
+  useLayoutEffect(() => {
+    const el = scroller.current;
+    if (paused || !el || atStart || blocked || error || !exchanges.length) return;
+    if (el.clientHeight && virtual.measuredHeight() >= el.clientHeight) return;
+    reader.wantHistory(Math.min(HISTORY_MAX_EXCHANGES, exchanges.length + 8));
+  }, [virtual.offsets, virtual.measuredHeight, exchanges.length, atStart, blocked, error, paused, reader.wantHistory]);
+
   const settle = useRef<ReturnType<typeof setTimeout>>();
   const interact = () => { touched.current = true; virtual.cancelTarget(); };
   useEffect(() => () => { clearTimeout(settle.current); if (position.current) rememberReading(session.id, position.current); }, [session.id]);
@@ -238,7 +261,7 @@ export default function ConversationView({
         </button>}
         {head?.note && <div className="cxv-msg mono">{head.note}</div>}
         {q && <div className="cxv-msg mono">{shown.length} of {exchanges.length} loaded turns match{atStart ? '' : ' · Earlier history has not been searched'}</div>}
-        <div ref={virtual.container}>
+        <div className={exchanges.length ? 'cxv-rows' : undefined} ref={virtual.container}>
           <div aria-hidden="true" style={{ height: virtual.before }} />
           {shown.slice(virtual.start, virtual.end).map(({ x, n }) => <div key={x.key} data-x={x.key} data-row-key={x.key} ref={(node) => virtual.measure(x.key, node)}>
             <ExchangeView x={x} n={n + 1} total={exchanges.length} q={q || undefined} baseModel={head?.model || undefined}

--- a/web/src/components/conversation/exchanges.ts
+++ b/web/src/components/conversation/exchanges.ts
@@ -3,6 +3,11 @@
 // One prompt, the work, the answer. Every surface in the app is some depth of
 // this, so the grouping lives here and not in a component.
 import type { TraceBlock, TraceTurn } from '../../api';
+import { isOperatorPrompt } from '../../lib/readerModel';
+
+// Re-exported: the rule moved next to the reconciliation the store also counts
+// with, so there is one definition rather than two that can disagree.
+export { isOperatorPrompt };
 
 export interface Exchange {
   key: string;
@@ -26,17 +31,6 @@ export interface Exchange {
   toolCalls: number;
   model?: string;
 }
-
-// Mirrors the trace normalizer's named harness envelopes. A leading '<' alone
-// can be an operator's HTML/XML prompt and must not hide its prompt band.
-export const isOperatorPrompt = (t: TraceTurn) => {
-  if (t.role !== 'user') return false;
-  const text = t.blocks.filter((b) => b.type === 'text').map((b) => ('text' in b ? b.text : '')).join('').trim();
-  if (!text) return t.blocks.some((b) => b.type === 'image');
-  return !/^<(?:task-notification|environment_context|system-reminder|app-context|recommended_plugins|fork-boilerplate)(?:\s|>)/.test(text)
-    && !text.startsWith('[Request interrupted')
-    && !text.startsWith('[SYSTEM NOTIFICATION');
-};
 
 const usageOf = (t: TraceTurn) => (t.usage ? (t.usage.in || 0) + (t.usage.out || 0) : 0);
 

--- a/web/src/components/conversation/useVirtualRows.ts
+++ b/web/src/components/conversation/useVirtualRows.ts
@@ -39,13 +39,31 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
     return out;
   }, [keys, measurement]);
   const current = useRef({ keys, offsets }); current.current = { keys, offsets };
+  const keysRef = useRef(keys); keysRef.current = keys;
+  /**
+   * Is the list this hook owns the thing on screen?
+   *
+   * The reader can borrow its scroller for something else — an old part of the
+   * conversation opened from a search result — and hide this list while it
+   * does. Every position below is computed from these rows' boxes, and a
+   * `display: none` subtree reports every box as zero, so continuing to read or
+   * write the scroll offset against it scrolls the borrower to the top and
+   * loses the place the reader was going to come back to.
+   */
+  const mounted = () => {
+    const list = container.current;
+    return !!list && (!keysRef.current.length || list.getClientRects().length > 0);
+  };
   const origin = useCallback(() => {
     const el = scroller.current, list = container.current;
     return el && list ? list.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop : 0;
   }, [scroller]);
   const update = useCallback(() => {
     const el = scroller.current;
-    if (!el) return;
+    // Same reason as `mounted()` below: while the scroller is showing something
+    // else, its offset says nothing about where this list is being read, and
+    // adopting it as the anchor throws away the place to come back to.
+    if (!el || !mounted()) return;
     const top = el.scrollTop - origin();
     const { keys: list, offsets: positions } = current.current;
     const index = lower(positions, top);
@@ -63,7 +81,7 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
    */
   const place = useCallback(() => {
     const el = scroller.current;
-    if (!el) return;
+    if (!el || !mounted()) return;
     const put = (top: number) => { el.scrollTop = top; placedAt.current = el.scrollHeight; };
     if (following.current) { put(el.scrollHeight); return; }
     const wanted = target.current || anchor.current;
@@ -88,7 +106,7 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
    */
   const hold = useCallback(() => {
     const el = scroller.current;
-    if (!el) return;
+    if (!el || !mounted()) return;
     placedAt.current = el.scrollHeight;
     if (following.current) { el.scrollTop = el.scrollHeight; return; }
     const wanted = target.current || anchor.current;

--- a/web/src/components/conversation/useVirtualRows.ts
+++ b/web/src/components/conversation/useVirtualRows.ts
@@ -21,6 +21,17 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
   const anchor = useRef<{ key: string; offset: number } | null>(null);
   const target = useRef<{ key: string; offset: number } | null>(null);
   const [measurement, measured] = useState(0);
+  /**
+   * The scroller height the reading position was last asserted against.
+   *
+   * The reason a height needs remembering: a scroll event is also how the
+   * browser reports a correction this hook applied, and one delivered after the
+   * content grew looks exactly like the user scrolling away from the bottom.
+   * Rather than teach every consumer to tell those apart, the correction is
+   * applied in the same frame as the size change (see below), so by the time
+   * any scroll event is delivered the position is already right.
+   */
+  const placedAt = useRef(-1);
   const [viewport, setViewport] = useState({ top: 0, height: 700 });
   const offsets = useMemo(() => {
     const out = [0];
@@ -41,6 +52,51 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
     anchor.current = list[index] ? { key: list[index], offset: top - positions[index] } : null;
     setViewport((v) => v.top === top && v.height === el.clientHeight ? v : { top, height: el.clientHeight });
   }, [origin, scroller]);
+  /**
+   * Re-assert the current reading intent from the MODEL: the end when
+   * following, otherwise the anchored row's offset in `offsets`.
+   *
+   * This is the right source immediately after a render, where `offsets` is
+   * fresh and the anchored row may not even be mounted. `hold()` below is the
+   * same intent read from the DOM instead, for the moments when `offsets` is
+   * the stale one.
+   */
+  const place = useCallback(() => {
+    const el = scroller.current;
+    if (!el) return;
+    const put = (top: number) => { el.scrollTop = top; placedAt.current = el.scrollHeight; };
+    if (following.current) { put(el.scrollHeight); return; }
+    const wanted = target.current || anchor.current;
+    if (!wanted) return;
+    const { keys: list, offsets: positions } = current.current;
+    const index = list.indexOf(wanted.key);
+    if (index >= 0) put(origin() + positions[index] + wanted.offset);
+  }, [following, origin, scroller]);
+  /**
+   * Hold the reading position using the DOM, not the model.
+   *
+   * Runs inside the ResizeObserver callback, which is before paint — the
+   * correction has to land in the same frame as the size change. Waiting for
+   * React to re-render from the new heights is one frame too late, and that
+   * frame is visible: a prepended page measured taller than its estimate
+   * dropped the text on screen ~217px and the next frame pulled it back.
+   *
+   * Measured rather than computed because `offsets` is rebuilt in a later
+   * render pass and is stale here by definition, and a correction from stale
+   * offsets is its own jump. The anchor says "the top of the viewport is
+   * `offset` px into row `key`", which the row's live box answers directly.
+   */
+  const hold = useCallback(() => {
+    const el = scroller.current;
+    if (!el) return;
+    placedAt.current = el.scrollHeight;
+    if (following.current) { el.scrollTop = el.scrollHeight; return; }
+    const wanted = target.current || anchor.current;
+    const node = wanted && nodes.current.get(wanted.key);
+    if (!wanted || !node) return;
+    const rowTop = node.getBoundingClientRect().top - el.getBoundingClientRect().top + el.scrollTop;
+    el.scrollTop = rowTop + wanted.offset;
+  }, [following, scroller]);
   useLayoutEffect(() => {
     const resize = new ResizeObserver((entries) => {
       let changed = false;
@@ -50,6 +106,9 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
         const height = entry.borderBoxSize?.[0]?.blockSize ?? (entry.target as HTMLElement).offsetHeight;
         if (height > 0 && heights.current.get(key) !== height) { heights.current.set(key, height); changed = true; }
       }
+      // Before paint, whatever changed: a row that grew past its estimate, the
+      // scroller itself, a font settling. Only then let React catch up.
+      hold();
       if (changed) measured((n) => n + 1);
       else update();
     });
@@ -57,7 +116,7 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
     for (const node of nodes.current.values()) resize.observe(node);
     if (scroller.current) resize.observe(scroller.current);
     return () => { resize.disconnect(); observer.current = null; };
-  }, [scroller, update]);
+  }, [hold, scroller, update]);
   const measure = useCallback((key: string, node: HTMLElement | null) => {
     const old = nodes.current.get(key);
     if (old === node) return;
@@ -66,18 +125,12 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
     else nodes.current.delete(key);
   }, []);
   useLayoutEffect(() => {
-    const el = scroller.current;
-    if (!el) return;
-    const wanted = target.current || anchor.current;
-    if (following.current) el.scrollTop = el.scrollHeight;
-    else if (wanted) {
-      const index = keys.indexOf(wanted.key);
-      if (index >= 0) el.scrollTop = origin() + offsets[index] + wanted.offset;
-    }
+    if (!scroller.current) return;
+    place();
     // Keep an explicit target until its estimate has been measured.
     if (target.current && heights.current.has(target.current.key)) target.current = null;
     update();
-  }, [keys, offsets, following, origin, scroller, update]);
+  }, [keys, offsets, place, scroller, update]);
   const scrollTo = useCallback((index: number, offset = 0) => {
     const el = scroller.current;
     const { keys: list, offsets: positions } = current.current;
@@ -85,14 +138,49 @@ export function useVirtualRows(keys: string[], scroller: RefObject<HTMLDivElemen
     following.current = false;
     target.current = anchor.current = { key: list[index], offset };
     el.scrollTop = origin() + positions[index] + offset;
+    placedAt.current = el.scrollHeight;
     update();
   }, [following, origin, scroller, update]);
   // scrollTo itself emits a scroll event. Keep its semantic target until the
   // row is measured, even if its saved offset exceeds the initial estimate.
   // Only fresh user input should cancel that pending restoration.
   const cancelTarget = useCallback(() => { target.current = null; }, []);
+  /**
+   * Real conversation height, in pixels that were actually measured.
+   *
+   * Estimated row heights and the spacer divs are excluded on purpose: the
+   * question this answers is "is a page of conversation really available", and
+   * an estimate cannot answer it. Unmeasured rows count as zero, so the number
+   * is a lower bound — it can ask for one page too many, never one too few.
+   */
+  const measuredHeight = useCallback(
+    () => keys.reduce((sum, key) => sum + (heights.current.get(key) ?? 0), 0),
+    [keys],
+  );
+  /**
+   * After every commit, before paint, and last of this hook's effects: if the
+   * scroller is a different height than when the position was last asserted,
+   * assert it again.
+   *
+   * The height is the trigger because it is the thing that actually moves text,
+   * and the renders that change it are not the renders `keys`/`offsets` can
+   * describe. A prepend commits with a viewport-derived row slice computed from
+   * the PREVIOUS scroll position; the effect above then corrects the viewport,
+   * which re-renders with the right slice and a different real height — and
+   * that render changes neither the keys nor the offsets, so no effect keyed on
+   * them runs for it. The frame it painted was a visible jump, undone only when
+   * the newly observed rows reported in on the following frame.
+   *
+   * Deliberately no `update()`: reading the anchor back here would adopt the
+   * displaced position instead of correcting it, and would make this a loop.
+   */
+  useLayoutEffect(() => {
+    const el = scroller.current;
+    if (!el || el.scrollHeight === placedAt.current) return;
+    hold();
+  });
   const start = lower(offsets, Math.max(0, viewport.top - OVERSCAN));
   const end = Math.min(keys.length, lower(offsets, viewport.top + viewport.height + OVERSCAN) + 1);
-  return { container, measure, scrollTo, onScroll: update, cancelTarget, anchor, offsets,
+  return { container, measure, scrollTo, onScroll: update, cancelTarget, anchor, offsets, measuredHeight,
     start, end, before: offsets[start], after: offsets[keys.length] - offsets[end] };
 }

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -457,6 +457,24 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
  * Applied only when there ARE exchanges, so an empty reader keeps its welcome
  * text where it has always been. */
 .cxv-rows { margin-top: auto; }
+/* Laid out and measured, not painted. `visibility` rather than `display` or
+   `content-visibility` precisely because the rows must still have real boxes:
+   the question being answered while this is on is whether a page of measured
+   conversation exists yet, which an unlaid-out subtree cannot answer. */
+.cxv-preparing { visibility: hidden; }
+/* Whole-conversation results: a list of places, not a second transcript. It
+   sits above the reader's own content and scrolls with it, so there is still
+   exactly one scroll owner. */
+.cxv-scan { display: flex; flex-direction: column; gap: 1px; padding-bottom: 6px; }
+.cxv-hitrow { display: flex; gap: 8px; align-items: baseline; width: 100%; text-align: left;
+  padding: 4px 6px; border: 1px solid transparent; border-radius: 3px; background: transparent;
+  color: var(--text); font: inherit; cursor: pointer; }
+.cxv-hitrow:hover { background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.cxv-hitrow:focus-visible { outline: 1px solid var(--accent); outline-offset: -1px; }
+.cxv-hitrow.on { border-color: var(--accent); }
+.cxv-hitwho { flex: none; color: var(--muted); font-size: 0.85em; min-width: 3.2em; }
+.cxv-hittext { flex: 1; min-width: 0; font-size: 0.85em; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cxv-hittext mark { background: var(--accent); color: var(--panel); }
 .cxv-msg { font-size: 0.85em; color: var(--muted); padding: 6px 0; }
 /* The line above the oldest loaded exchange. Fixed height on purpose: it sits
    above everything in the column, so a line that grew or vanished when the

--- a/web/src/conversation.css
+++ b/web/src/conversation.css
@@ -398,7 +398,7 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
    between the last line and the composer's border while the blocks above it are
    12px apart, which reads as one blank line too many at the end of every
    conversation. 12px makes the end of the flow spaced like the flow. */
-.cxv-body { --cx-gutter: 14px; --cx-tail: 12px; flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; background: var(--panel); padding: 4px var(--cx-gutter) var(--cx-tail); }
+.cxv-body { --cx-gutter: 14px; --cx-tail: 12px; flex: 1; min-height: 0; overflow-y: auto; overscroll-behavior: contain; background: var(--panel); padding: 4px var(--cx-gutter) var(--cx-tail); display: flex; flex-direction: column; }
 
 /* The scrollbar is invisible until something scrolls, then fades back out.
    `.cxv-scrolling` is put on the node by the reader itself, on every scroll
@@ -440,7 +440,23 @@ mark.cx-hit.on { background: var(--accent); color: var(--panel); }
      delay too, so the bar simply goes rather than lingering. */
   .cxv-body, .cxv-body::-webkit-scrollbar-thumb { transition: none; }
 }
-.cxv-col { display: flex; flex-direction: column; min-width: 0; }
+/* `flex: 1 0 auto` rather than `min-height: 100%`: a percentage resolves
+   against the scroller's CONTENT box, so a full-height column plus the
+   scroller's own padding is taller than the scroller and every short
+   conversation gets 16px of scrollbar it has no content for. */
+.cxv-col { display: flex; flex-direction: column; min-width: 0; flex: 1 0 auto; }
+/* Conversation grows from the BOTTOM while it is shorter than the window.
+ *
+ * The reader opens following the latest message, so once the transcript is
+ * taller than the window a prepended older page moves nothing on screen: the
+ * bottom stays the bottom. Below that height there is no scroll offset to
+ * compensate with, and a top-aligned transcript would be pushed down the screen
+ * by every page of history that arrived after it. Anchoring the rows to the
+ * bottom removes that case instead of trying to correct it, and costs nothing
+ * once the content is tall enough — `auto` margins absorb only free space.
+ * Applied only when there ARE exchanges, so an empty reader keeps its welcome
+ * text where it has always been. */
+.cxv-rows { margin-top: auto; }
 .cxv-msg { font-size: 0.85em; color: var(--muted); padding: 6px 0; }
 /* The line above the oldest loaded exchange. Fixed height on purpose: it sits
    above everything in the column, so a line that grew or vanished when the

--- a/web/src/lib/readerModel.ts
+++ b/web/src/lib/readerModel.ts
@@ -1,6 +1,41 @@
 import type { TraceBlock, TraceTurn } from '../api';
 
 const queueKey = (text: string) => text.replace(/\s+/g, ' ').trim();
+
+// Mirrors the trace normalizer's named harness envelopes. A leading '<' alone
+// can be an operator's HTML/XML prompt and must not hide its prompt band.
+//
+// This lives with the model rather than with the grouping because the store has
+// to count exchanges to decide how much history it still owes the reader, and a
+// second copy of the rule would drift from the one the view groups by.
+export const isOperatorPrompt = (t: TraceTurn) => {
+  if (t.role !== 'user') return false;
+  const text = t.blocks.filter((b) => b.type === 'text').map((b) => ('text' in b ? b.text : '')).join('').trim();
+  if (!text) return t.blocks.some((b) => b.type === 'image');
+  return !/^<(?:task-notification|environment_context|system-reminder|app-context|recommended_plugins|fork-boilerplate)(?:\s|>)/.test(text)
+    && !text.startsWith('[Request interrupted')
+    && !text.startsWith('[SYSTEM NOTIFICATION');
+};
+
+/**
+ * How many exchanges a reconciled turn list holds — the unit the reader shows
+ * and the operator counts, as opposed to transport records, tool results or
+ * lifecycle events.
+ *
+ * Deliberately only the OPENING rule from `splitExchanges`: an operator prompt
+ * starts an exchange, and turns before the first prompt form one leading
+ * exchange. Nothing else in that function can change the count, and
+ * `exchanges.test.mjs` pins the two together against shared fixtures.
+ */
+export function countExchanges(turns: TraceTurn[]): number {
+  let count = 0;
+  let open = false;
+  for (const turn of turns) {
+    if (isOperatorPrompt(turn)) { count++; open = true; }
+    else if (!open) { count++; open = true; }
+  }
+  return count;
+}
 const sameBlocks = (a: TraceBlock[], b: TraceBlock[]) => a.length === b.length && a.every((v, i) => v === b[i]);
 
 /** Transport fragments → one immutable conversation. Never mutate cached pages.

--- a/web/src/lib/readerStore.ts
+++ b/web/src/lib/readerStore.ts
@@ -30,12 +30,36 @@ export const HISTORY_TARGET_EXCHANGES = 20;
 export const HISTORY_MAX_EXCHANGES = 60;
 /** Backward pages one fill may spend. Six 384 KiB pages ≈ 2.3 MiB. */
 export const FILL_MAX_REQUESTS = 6;
-/** Bytes (or index rows) one fill may pull in beyond the first window. */
-export const FILL_MAX_BYTES = 3 * 1024 * 1024;
+/**
+ * Transcript one fill may ADD to what the reader retains, in bytes (indexed
+ * rows charged at an assumed size).
+ *
+ * Retained, not read: a page's size is not knowable before fetching it, so the
+ * request that crosses this is the last one — the ceiling is this plus one
+ * page. And a server page reads a little more than it returns, because it
+ * discards the partial record at its leading edge. What bounds the READ is
+ * `FILL_MIN_TURNS` below, which stops the server growing one response beyond a
+ * single oversized record; the request count bounds how many such pages there
+ * can be. On 900 KiB answers that is four pages reading 1.5 MiB each and
+ * retaining 4.4 MiB, where an unbounded floor grew single pages to six.
+ */
+export const FILL_MAX_RETAINED_BYTES = 3 * 1024 * 1024;
 /** Wall clock one continuous run may span, including waits between steps. */
 export const FILL_MAX_MS = 20_000;
 /** Between steps, so the paint, the live poll and user input all get a turn. */
 export const FILL_STEP_MS = 50;
+/**
+ * Message floor a speculative backward page asks for.
+ *
+ * Not a page size: the server grows one response until it holds this many whole
+ * records, so the floor is what bounds a single request on a trace of huge
+ * records. Omitting it left the server's own default of twelve in charge, which
+ * on 900 KiB answers grew one page to six megabytes — a budget the client then
+ * charged for only after the next page had already been scheduled. One is the
+ * tightest floor that still guarantees a page makes progress; on ordinary
+ * traces the first 384 KiB span satisfies it immediately and nothing changes.
+ */
+export const FILL_MIN_TURNS = 1;
 /** Assumed cost of one indexed row, so both source kinds share one byte budget. */
 const INDEX_ROW_COST = 4 * 1024;
 
@@ -108,7 +132,7 @@ export class ReaderStore {
   private observers = new Set<(change: ReaderChange) => void>();
   private consumers = 0;
   private sequence = 0;
-  private request: { abort: AbortController; token: number; promise: Promise<number> } | null = null;
+  private request: { abort: AbortController; token: number; promise: Promise<number>; speculative: boolean } | null = null;
   private summaryRequest: AbortController | null = null;
   private poll: ReturnType<typeof setTimeout> | null = null;
   private summaryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -119,7 +143,9 @@ export class ReaderStore {
   private want = 0;
   private fillTimer: ReturnType<typeof setTimeout> | null = null;
   private spent = { requests: 0, bytes: 0, since: 0 };
-  private lastStart: number | null = null;
+  /** A speculative page in flight, and where the cursor was before it. */
+  private step: { from: number; held: number } | null = null;
+  private stalled = false;
   constructor(private source: TraceSource) {}
   getSnapshot = () => this.state;
   subscribe = (listener: () => void) => { this.listeners.add(listener); return () => { this.listeners.delete(listener); }; };
@@ -221,13 +247,15 @@ export class ReaderStore {
     // Requests and bytes stay cumulative, so total work per transcript is still
     // capped however many times it is reopened.
     this.spent.since = 0;
+    this.step = null;
     if (this.state.fill === 'filling') this.publish({ fill: 'idle' });
   }
   /** A fresh transcript (or an explicit refresh) is allowed a fresh budget. */
   private resetFill() {
     this.stopFill();
     this.spent = { requests: 0, bytes: 0, since: 0 };
-    this.lastStart = null;
+    this.step = null;
+    this.stalled = false;
     if (this.state.fill !== 'idle') this.publish({ fill: 'idle' });
   }
   /**
@@ -235,37 +263,49 @@ export class ReaderStore {
    * after every accepted read, so a fill that a user page or a live append
    * interrupted simply continues from wherever the store now is.
    */
+  /**
+   * Charge the step that just finished, before anything decides on the next
+   * one. Deliberately not in a `.then()` chained onto the read: `read()`'s
+   * `finally` calls this, and a promise callback attached downstream of it runs
+   * afterwards — so the budget was still reading zero when the following page
+   * was scheduled, and one more request always went out over the limit.
+   */
+  private settleStep() {
+    const step = this.step;
+    if (!step) return;
+    this.step = null;
+    const cursor = this.state.cursor;
+    if (!cursor) return;
+    // An index source has no byte offsets, so its rows are charged at an assumed
+    // size: one budget both kinds of source can exhaust, not an exact count.
+    const advance = cursor.mode === 'index'
+      ? Math.max(0, this.state.turns.length - step.held) * INDEX_ROW_COST
+      : Math.max(0, step.from - cursor.start);
+    this.spent.bytes += advance;
+    // A page that moved nothing cannot be retried into progress: an oversized
+    // record is in the way, or the source has nothing more to give.
+    if (!advance) this.stalled = true;
+  }
   private planFill() {
+    this.settleStep();
     if (this.fillTimer || !this.want || !this.active) return;
     const { cursor, turns } = this.state;
     if (!cursor || this.state.loading) return;             // wait for the read in flight
     const have = countExchanges(turns);
     if (have >= this.want) { if (this.state.fill !== 'done') this.publish({ fill: 'done' }); return; }
     // Nothing more to fetch, or nothing we can fetch: an honest partial view.
-    if (cursor.atStart || cursor.blocked || this.state.error) return this.limited();
-    // A backward page that did not move the cursor cannot be retried into
-    // progress — an oversized record is in the way.
-    if (this.lastStart !== null && cursor.start >= this.lastStart) return this.limited();
+    if (cursor.atStart || cursor.blocked || this.state.error || this.stalled) return this.limited();
     if (!this.spent.since) this.spent.since = Date.now();
-    if (this.spent.requests >= FILL_MAX_REQUESTS || this.spent.bytes >= FILL_MAX_BYTES
+    if (this.spent.requests >= FILL_MAX_REQUESTS || this.spent.bytes >= FILL_MAX_RETAINED_BYTES
       || Date.now() - this.spent.since >= FILL_MAX_MS) return this.limited();
     if (this.state.fill !== 'filling') this.publish({ fill: 'filling' });
     this.fillTimer = setTimeout(() => {
       this.fillTimer = null;
-      if (!this.want || !this.active || this.state.loading) return this.planFill();
       const from = this.state.cursor;
-      const held = this.state.turns.length;
-      this.lastStart = from ? from.start : null;
+      if (!this.want || !this.active || this.state.loading || !from) return this.planFill();
+      this.step = { from: from.start, held: this.state.turns.length };
       this.spent.requests++;
-      void this.read('before').then(() => {
-        const to = this.state.cursor;
-        // What this step actually cost. An index source has no byte offsets, so
-        // its rows are charged at an assumed size — the point is a single
-        // budget that both kinds of source can exhaust, not an exact byte count.
-        this.spent.bytes += from && to && to.mode !== 'index'
-          ? Math.max(0, from.start - to.start)
-          : Math.max(0, this.state.turns.length - held) * INDEX_ROW_COST;
-      });
+      void this.read('before', true);
     }, FILL_STEP_MS);
   }
   private limited() {
@@ -279,19 +319,34 @@ export class ReaderStore {
     const cadence = this.state.cursor?.mode === 'index' ? 10_000 : recent ? 3_000 : 10_000;
     this.poll = setTimeout(() => { this.poll = null; void this.loadNewer(); }, delay ?? (this.failures ? Math.min(30_000, 1500 * 2 ** Math.min(this.failures, 5)) : cadence));
   }
-  private read(direction: 'tail' | 'before' | 'after'): Promise<number> {
+  private read(direction: 'tail' | 'before' | 'after', speculative = false): Promise<number> {
     const cursor = this.state.cursor;
     if (direction === 'before' && (!cursor || cursor.atStart || cursor.blocked)) return Promise.resolve(0);
-    if (this.request) return this.request.promise;
+    if (this.request) {
+      // Going forward is live output and explicit user intent; going backward
+      // speculatively is neither. Handing a forward caller the fill's promise
+      // means Latest, refresh and the poll all quietly wait for a backward page
+      // and never ask for the newest messages at all. The abandoned step is
+      // uncharged and un-stalled — it simply did not happen — and `planFill`
+      // starts it again once this read settles.
+      if (direction === 'before' || !this.request.speculative) return this.request.promise;
+      this.step = null;
+      this.cancel();
+    }
     if (direction === 'after' && !cursor) direction = 'tail';
     const token = ++this.sequence;
     const abort = new AbortController();
     const req: TraceReq = direction === 'tail' ? { at: 'tail' } : { at: direction,
       cursor: direction === 'before' ? cursor.start : cursor.end, generation: cursor.generation };
     this.publish({ loading: direction });
+    // A speculative page asks for the smallest floor that still makes progress,
+    // so the server cannot grow one response past a single oversized record.
+    // An indexed source reads `min` as an exact page size instead of a floor to
+    // grow to, so it keeps the ordinary page.
+    const floor = direction === 'tail' ? INITIAL_WINDOW_TURNS
+      : speculative && cursor?.mode !== 'index' ? FILL_MIN_TURNS : undefined;
     const promise = bounded((signal) => this.source.window(req,
-      direction === 'tail' ? INITIAL_WINDOW_BYTES : WINDOW_BYTES,
-      direction === 'tail' ? INITIAL_WINDOW_TURNS : undefined, signal), abort)
+      direction === 'tail' ? INITIAL_WINDOW_BYTES : WINDOW_BYTES, floor, signal), abort)
       .then((response) => {
         if (token !== this.sequence) return 0;
         const { turns: got, window: win, ...metadata } = response;
@@ -351,7 +406,7 @@ export class ReaderStore {
         // or a live append interrupted just continues from where the store is.
         this.planFill();
       });
-    this.request = { abort, token, promise };
+    this.request = { abort, token, promise, speculative };
     return promise;
   }
 

--- a/web/src/lib/readerStore.ts
+++ b/web/src/lib/readerStore.ts
@@ -1,5 +1,5 @@
 import type { TraceCursor, TraceReq, TraceSummary, TraceTurn, TraceWindow } from '../api';
-import { reconcileTrace } from './readerModel';
+import { countExchanges, reconcileTrace } from './readerModel';
 
 export const INITIAL_WINDOW_BYTES = 128 * 1024;
 export const INITIAL_WINDOW_TURNS = 2;
@@ -7,6 +7,37 @@ export const WINDOW_BYTES = 384 * 1024;
 export const REQUEST_TIMEOUT_MS = 12_000;
 export const SUMMARY_DELAY_MS = 400;
 export const SUMMARY_REFRESH_MS = 5 * 60_000;
+
+/* ---- automatic recent-history fill (docs/reader-architecture.md §Initial history) ----
+ *
+ * The first window is deliberately small so the first paint is cheap. That is
+ * also why a cold reader used to show one or two exchanges: 128 KiB is one
+ * exchange of a tool-heavy trace, and an indexed source took `min` literally.
+ * So after the first window lands, the store keeps paging backward on its own
+ * until it holds a useful amount of recent conversation.
+ *
+ * A count is a target, never a promise: a trace whose records are huge will hit
+ * a budget first, and the reader still discloses the remaining history behind
+ * `Load earlier turns`. Every bound below exists so that a pathological trace
+ * costs a bounded amount of work rather than looping. */
+
+/** Exchanges a cold reader tries to have available. A starting point, tuned
+ * against the fixtures in `web/test/readerHistory.test.mjs`; the operator asked
+ * for "a bit more extensive" history, not for an exact number. */
+export const HISTORY_TARGET_EXCHANGES = 20;
+/** A viewport of very short exchanges can ask for more than the target. Past
+ * this the reader stops raising it, so tiny rows cannot page a whole trace. */
+export const HISTORY_MAX_EXCHANGES = 60;
+/** Backward pages one fill may spend. Six 384 KiB pages ≈ 2.3 MiB. */
+export const FILL_MAX_REQUESTS = 6;
+/** Bytes (or index rows) one fill may pull in beyond the first window. */
+export const FILL_MAX_BYTES = 3 * 1024 * 1024;
+/** Wall clock one continuous run may span, including waits between steps. */
+export const FILL_MAX_MS = 20_000;
+/** Between steps, so the paint, the live poll and user input all get a turn. */
+export const FILL_STEP_MS = 50;
+/** Assumed cost of one indexed row, so both source kinds share one byte budget. */
+const INDEX_ROW_COST = 4 * 1024;
 
 const sameFields = (a: object, b: object) => {
   const keys = Object.keys(a);
@@ -33,6 +64,10 @@ export interface ReaderSnapshot {
   lastSuccess: number;
   activityConfirmed: boolean;
   version: number;
+  /** Automatic recent-history fill: 'filling' while it pages backward, 'done'
+   * when the target is met, 'limited' when a budget or the source stopped it
+   * first (the reader keeps disclosing earlier history either way). */
+  fill: 'idle' | 'filling' | 'done' | 'limited';
 }
 
 export function mergeMeta(prev: Meta | null, next: Meta): Meta {
@@ -65,7 +100,7 @@ async function bounded<T>(run: (signal: AbortSignal) => Promise<T>, abort: Abort
 
 export class ReaderStore {
   private state: ReaderSnapshot = { turns: [], head: null, cursor: null, phase: 'loading', loading: null,
-    error: null, errorCode: null, notice: null, lastSuccess: 0, activityConfirmed: false, version: 0 };
+    error: null, errorCode: null, notice: null, lastSuccess: 0, activityConfirmed: false, version: 0, fill: 'idle' };
   private raw: TraceTurn[] = [];
   private meta: Meta | null = null;
   private summary: TraceSummary | null = null;
@@ -80,6 +115,11 @@ export class ReaderStore {
   private failures = 0;
   private summaryAt = 0;
   private summaryFailures = 0;
+  /** 0 = this consumer does not want automatic history (child readers, previews). */
+  private want = 0;
+  private fillTimer: ReturnType<typeof setTimeout> | null = null;
+  private spent = { requests: 0, bytes: 0, since: 0 };
+  private lastStart: number | null = null;
   constructor(private source: TraceSource) {}
   getSnapshot = () => this.state;
   subscribe = (listener: () => void) => { this.listeners.add(listener); return () => { this.listeners.delete(listener); }; };
@@ -112,11 +152,18 @@ export class ReaderStore {
 
   retain() {
     this.consumers++;
-    if (this.consumers === 1) { void this.read(this.state.cursor ? 'after' : 'tail'); this.scheduleSummary(); }
+    if (this.consumers === 1) {
+      void this.read(this.state.cursor ? 'after' : 'tail'); this.scheduleSummary();
+      // A warm store keeps its history and its spent budget: coming back to a
+      // pane must not re-run the preload, but it may still finish one that a
+      // budget or an unmount cut short.
+      this.planFill();
+    }
     return () => {
       this.consumers = Math.max(0, this.consumers - 1);
       if (!this.consumers) {
         this.cancel();
+        this.stopFill();
         clearTimeout(this.poll); this.poll = null;
         clearTimeout(this.summaryTimer); this.summaryTimer = null;
         this.summaryRequest?.abort(); this.summaryRequest = null;
@@ -134,7 +181,7 @@ export class ReaderStore {
   }
   /** Explicit refresh/foreground recovery replaces a possibly frozen request. */
   refresh = () => {
-    this.cancel(); this.failures = 0;
+    this.cancel(); this.resetFill(); this.failures = 0;
     this.summaryRequest?.abort(); this.summaryRequest = null;
     clearTimeout(this.summaryTimer); this.summaryTimer = null;
     this.summaryFailures = 0; this.summaryAt = 0; this.scheduleSummary();
@@ -149,6 +196,81 @@ export class ReaderStore {
   };
   loadNewer = () => this.read(this.state.cursor ? 'after' : 'tail');
   dismissNotice = () => this.publish({ notice: null });
+
+  /**
+   * How many recent exchanges this reader wants available without being asked.
+   * Consumers opt in: a child transcript opens at the top of its own context
+   * and a collapsed preview should not page anything, so both leave it at 0.
+   *
+   * Raising it (the view does, when a page of very short exchanges has not
+   * covered the scroller yet) resumes a fill that had reached the old target.
+   * It never resets a budget that a real limit already exhausted.
+   */
+  wantHistory = (exchanges: number) => {
+    const next = Math.min(Math.max(0, Math.trunc(exchanges)), HISTORY_MAX_EXCHANGES);
+    if (next <= this.want) return;
+    this.want = next;
+    if (this.state.fill === 'done') this.publish({ fill: 'idle' });
+    this.planFill();
+  };
+
+  private stopFill() {
+    clearTimeout(this.fillTimer); this.fillTimer = null;
+    // The wall clock measures one continuous run: it exists to stop a slow
+    // source filling forever, not to forbid a fill on a pane reopened later.
+    // Requests and bytes stay cumulative, so total work per transcript is still
+    // capped however many times it is reopened.
+    this.spent.since = 0;
+    if (this.state.fill === 'filling') this.publish({ fill: 'idle' });
+  }
+  /** A fresh transcript (or an explicit refresh) is allowed a fresh budget. */
+  private resetFill() {
+    this.stopFill();
+    this.spent = { requests: 0, bytes: 0, since: 0 };
+    this.lastStart = null;
+    if (this.state.fill !== 'idle') this.publish({ fill: 'idle' });
+  }
+  /**
+   * Decide whether to take another backward step, and why not if not. Called
+   * after every accepted read, so a fill that a user page or a live append
+   * interrupted simply continues from wherever the store now is.
+   */
+  private planFill() {
+    if (this.fillTimer || !this.want || !this.active) return;
+    const { cursor, turns } = this.state;
+    if (!cursor || this.state.loading) return;             // wait for the read in flight
+    const have = countExchanges(turns);
+    if (have >= this.want) { if (this.state.fill !== 'done') this.publish({ fill: 'done' }); return; }
+    // Nothing more to fetch, or nothing we can fetch: an honest partial view.
+    if (cursor.atStart || cursor.blocked || this.state.error) return this.limited();
+    // A backward page that did not move the cursor cannot be retried into
+    // progress — an oversized record is in the way.
+    if (this.lastStart !== null && cursor.start >= this.lastStart) return this.limited();
+    if (!this.spent.since) this.spent.since = Date.now();
+    if (this.spent.requests >= FILL_MAX_REQUESTS || this.spent.bytes >= FILL_MAX_BYTES
+      || Date.now() - this.spent.since >= FILL_MAX_MS) return this.limited();
+    if (this.state.fill !== 'filling') this.publish({ fill: 'filling' });
+    this.fillTimer = setTimeout(() => {
+      this.fillTimer = null;
+      if (!this.want || !this.active || this.state.loading) return this.planFill();
+      const from = this.state.cursor;
+      const held = this.state.turns.length;
+      this.lastStart = from ? from.start : null;
+      this.spent.requests++;
+      void this.read('before').then(() => {
+        const to = this.state.cursor;
+        // What this step actually cost. An index source has no byte offsets, so
+        // its rows are charged at an assumed size — the point is a single
+        // budget that both kinds of source can exhaust, not an exact byte count.
+        this.spent.bytes += from && to && to.mode !== 'index'
+          ? Math.max(0, from.start - to.start)
+          : Math.max(0, this.state.turns.length - held) * INDEX_ROW_COST;
+      });
+    }, FILL_STEP_MS);
+  }
+  private limited() {
+    if (this.state.fill !== 'limited') this.publish({ fill: 'limited' });
+  }
 
   private schedule(delay?: number) {
     clearTimeout(this.poll);
@@ -206,11 +328,15 @@ export class ReaderStore {
           errorCode: null, lastSuccess: Date.now(), version: this.state.version + (changed || reset ? 1 : 0),
           activityConfirmed: direction !== 'before' ? !!win.atEnd : this.state.activityConfirmed,
           notice: reset && cursor ? 'The transcript changed or was replaced. Showing its current content.' : this.state.notice }, change);
+        if (reset) this.resetFill();
         this.scheduleSummary();
         return Math.max(0, count);
       }).catch((error) => {
         if (token !== this.sequence) return 0;
         this.failures++;
+        // Failure ends the fill; the text and composer that are already here
+        // stay, and Earlier/Retry remain the way forward.
+        this.stopFill();
         const code = typeof error?.code === 'string' ? error.code : null;
         this.publish({ error: code === 'no-trace' && !this.state.head ? null : error?.message || 'Could not read the transcript',
           errorCode: code, activityConfirmed: false, phase: this.state.head ? this.state.phase : code === 'no-trace' ? 'empty' : 'error' });
@@ -220,6 +346,10 @@ export class ReaderStore {
         this.request = null; this.publish({ loading: null });
         const catchup = direction !== 'before' && this.state.cursor && !this.state.cursor.atEnd && !this.failures && !this.state.error;
         this.schedule(catchup ? 50 : undefined);
+        // After the slot is free, so a fill step never races the read that
+        // produced it. Every accepted read re-decides: a fill that a user page
+        // or a live append interrupted just continues from where the store is.
+        this.planFill();
       });
     this.request = { abort, token, promise };
     return promise;

--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { readerFor, type TraceSource } from './readerStore';
 export {
-  FILL_MAX_BYTES, FILL_MAX_MS, FILL_MAX_REQUESTS, HISTORY_MAX_EXCHANGES, HISTORY_TARGET_EXCHANGES,
+  FILL_MAX_MS, FILL_MAX_REQUESTS, FILL_MAX_RETAINED_BYTES, FILL_MIN_TURNS, HISTORY_MAX_EXCHANGES, HISTORY_TARGET_EXCHANGES,
   INITIAL_WINDOW_BYTES, INITIAL_WINDOW_TURNS, WINDOW_BYTES, mergeMeta,
 } from './readerStore';
 export type { TraceSource, Meta, TraceHeadInfo } from './readerStore';

--- a/web/src/lib/traceWindows.ts
+++ b/web/src/lib/traceWindows.ts
@@ -2,7 +2,10 @@
 // Parent readers, file previews and expanded children share the same lifecycle.
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { readerFor, type TraceSource } from './readerStore';
-export { INITIAL_WINDOW_BYTES, INITIAL_WINDOW_TURNS, WINDOW_BYTES, mergeMeta } from './readerStore';
+export {
+  FILL_MAX_BYTES, FILL_MAX_MS, FILL_MAX_REQUESTS, HISTORY_MAX_EXCHANGES, HISTORY_TARGET_EXCHANGES,
+  INITIAL_WINDOW_BYTES, INITIAL_WINDOW_TURNS, WINDOW_BYTES, mergeMeta,
+} from './readerStore';
 export type { TraceSource, Meta, TraceHeadInfo } from './readerStore';
 
 export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
@@ -12,6 +15,13 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
   paused?: boolean;
   /** Activity is a presentation hint; even an idle transcript can change. */
   live?: boolean;
+  /**
+   * Recent exchanges this reader wants loaded without the user asking. Opt-in:
+   * omitting it (children, previews, file consumers) keeps the old behaviour of
+   * one window until something asks for more. One store shared by several
+   * subscribers still fills once — the work belongs to the store, not the hook.
+   */
+  history?: number;
 } = {}) {
   const store = useMemo(() => readerFor(srcKey, src), [srcKey, src]);
   const state = useSyncExternalStore(store.subscribe, store.getSnapshot);
@@ -24,8 +34,11 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
     else callbacks.current.onAppend?.(change.count);
   }), [store]);
   useEffect(() => {
-    if (!opts.paused && !hidden) return store.retain();
-  }, [store, opts.paused, hidden]);
+    if (opts.paused || hidden) return;
+    // Only a reader someone is actually looking at does speculative work.
+    if (opts.history) store.wantHistory(opts.history);
+    return store.retain();
+  }, [store, opts.paused, hidden, opts.history]);
   useEffect(() => {
     const visibility = () => setHidden(document.hidden);
     const recover = () => { if (!document.hidden && !callbacks.current.paused) void store.refresh(); };
@@ -41,5 +54,5 @@ export function useTraceWindows(src: TraceSource, srcKey: string, opts: {
   }, [store]);
   return { ...state, turns, meta: state.head, atStart: !!state.cursor?.atStart,
     blocked: !!state.cursor?.blocked, loadOlder: store.loadOlder, loadNewer: store.loadNewer,
-    reload: store.refresh, dismissNotice: store.dismissNotice };
+    reload: store.refresh, dismissNotice: store.dismissNotice, wantHistory: store.wantHistory };
 }

--- a/web/test/exchanges.test.mjs
+++ b/web/test/exchanges.test.mjs
@@ -6,8 +6,11 @@
 // that came after it), and mid-task the last message was promoted to the answer
 // slot (so an agent's aside read as its reply, in the wrong place).
 //
-// No test runner: esbuild is already here for vite, so the module is transpiled
-// and imported directly. Run with:  node test/exchanges.test.mjs
+// No test runner: esbuild is already here for vite, so the module is bundled
+// and imported directly. Bundled rather than transpiled because the grouping
+// shares `isOperatorPrompt` with lib/readerModel, which the store counts
+// exchanges with — one definition, so the two cannot disagree.
+// Run with:  node test/exchanges.test.mjs
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import os from 'node:os';
@@ -19,9 +22,19 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
 const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'exch-')), 'exchanges.mjs');
 await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
-  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+  outfile: out, format: 'esm', bundle: true, logLevel: 'error',
 });
 const { splitExchanges, stepsOf, stepSummary, fmtTok } = await import(pathToFileURL(out).href);
+// The store decides how much history it still owes the reader by counting
+// exchanges, and it cannot import the grouping to do it. `countExchanges` is
+// therefore a second implementation of the same question, and the two agreeing
+// is pinned below rather than assumed.
+const modelOut = path.join(path.dirname(out), 'readerModel.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/readerModel.ts')],
+  outfile: modelOut, format: 'esm', bundle: true, logLevel: 'error',
+});
+const { countExchanges } = await import(pathToFileURL(modelOut).href);
 
 let ts = 1_700_000_000_000;
 const at = () => (ts += 30_000);
@@ -212,6 +225,36 @@ const kinds = (steps) => steps.map((s) => (s.kind === 'tools' ? `${s.name}×${s.
   ]);
   assert.match(said(x.answer), /^Only the health-check/);
   assert.equal(x.answerAt, undefined, 'nothing to remember: it is simply last');
+}
+
+// ---------------------------------------------- counting without grouping
+// Every shape in this file, plus the ones that decide the count on their own:
+// a transcript that starts mid-exchange, envelopes that are not prompts, and
+// records that carry no prose at all.
+{
+  const cases = {
+    empty: [],
+    'one prompt': [user('hello')],
+    'answer first': [agent([text('picking up where we left off')], 'final'), user('thanks'), agent([text('ok')], 'final')],
+    'three exchanges': [user('a'), agent([text('1')], 'final'), user('b'), agent([text('2')], 'final'), user('c'), agent([text('3')], 'final')],
+    'tool-heavy single exchange': [user('check it'),
+      agent([call('Read', { file_path: 'a' }), result('a')]),
+      agent([call('Bash', { command: 'ls' }), result('a b')]),
+      agent([text('checked')], 'final')],
+    'envelopes are not prompts': [user('real prompt'),
+      { role: 'user', ts: at(), blocks: [text('<system-reminder>be careful</system-reminder>')] },
+      { role: 'user', ts: at(), blocks: [text('<task-notification> done')] },
+      agent([text('done')], 'final')],
+    'interrupted': [user('go'), { role: 'user', ts: at(), blocks: [text('[Request interrupted by user]')] },
+      user('again'), agent([text('ok')], 'final')],
+    'system only': [{ role: 'system', ts: at(), blocks: [text('compacted')] }],
+    'image prompt': [{ role: 'user', ts: at(), blocks: [{ type: 'image', src: 'data:image/png;base64,AAA' }] },
+      agent([text('a screenshot')], 'final')],
+  };
+  for (const [label, turns] of Object.entries(cases)) {
+    assert.equal(countExchanges(turns), splitExchanges(turns).length,
+      `${label}: counted without grouping matches grouping`);
+  }
 }
 
 // ------------------------------------------------------------- formatting

--- a/web/test/pendingExchange.test.mjs
+++ b/web/test/pendingExchange.test.mjs
@@ -61,7 +61,9 @@ const { formatAttachmentDelivery } = await import(
 const exOut = path.join(outDir, 'exchanges-meta.mjs');
 await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
-  outfile: exOut, format: 'esm', bundle: false, logLevel: 'error',
+// Bundled, not just transpiled: the grouping shares `isOperatorPrompt` with
+// lib/readerModel, which the store counts exchanges with.
+  outfile: exOut, format: 'esm', bundle: true, logLevel: 'error',
 });
 const { stepSummary, stepsOf: stepsOfEx } = await import(pathToFileURL(exOut).href);
 const stepSummaryOf = (x) => stepSummary(x, stepsOfEx(x.steps));

--- a/web/test/readerFirstViewport.test.mjs
+++ b/web/test/readerFirstViewport.test.mjs
@@ -1,0 +1,360 @@
+// Real React, real layout, real measured rows; a synthetic source only.
+//
+// Two properties this covers that no unit test can:
+//   1. the first transcript a cold reader presents FILLS the reader, with real
+//      conversation rows rather than estimated spacer height, and
+//   2. the older pages that arrive afterwards do not push that text down the
+//      screen — measured every frame, not only at the end.
+//
+// The fixture serves byte windows and HONOURS `bytes`/`min` the way
+// server/src/traces.js does. A fixture that returns all of its synthetic turns
+// whatever was asked for cannot fail when the reader asks for two, which is the
+// defect this exists to catch.
+//
+// Run with:  node test/readerFirstViewport.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reader-first-viewport-'));
+const bundle = path.join(tmp, 'fixture.js');
+
+await build({
+  stdin: { resolveDir: web, loader: 'tsx', contents: `
+    import React from 'react'; import {createRoot} from 'react-dom/client'; import {flushSync} from 'react-dom';
+    import ConversationView from './src/components/conversation/ConversationView';
+    import {HISTORY_TARGET_EXCHANGES, HISTORY_MAX_EXCHANGES, FILL_MAX_REQUESTS} from './src/lib/traceWindows';
+    window.HISTORY_TARGET_EXCHANGES = HISTORY_TARGET_EXCHANGES;
+    window.HISTORY_MAX_EXCHANGES = HISTORY_MAX_EXCHANGES;
+    window.FILL_MAX_REQUESTS = FILL_MAX_REQUESTS;
+    window.WebSocket = class { static OPEN=1; readyState=1; send(){} close(){} };
+    window.reads = []; window.__case = 0;
+
+    // ---- a byte-addressed transcript, served as real windows ----
+    const WINDOW_MIN_TURNS = 12, WINDOW_MAX_BYTES = 8*1024*1024;
+    let cfg = {}, records = [], size = 0, root;
+    function lay(options){
+      const {count, promptBytes, toolBytes, answerLines, lastAnswerLines} = options;
+      records = []; let at = 0;
+      const put = (turn, bytes) => { records.push({at, size: bytes, turn}); at += bytes; };
+      for (let i = 0; i < count; i++) {
+        put({id:'u'+i, role:'user', ts:100000+i*10, blocks:[{type:'text', text:'Question '+i}]}, promptBytes);
+        if (toolBytes) put({id:'t'+i, role:'assistant', ts:100001+i*10, blocks:[
+          {type:'tool_use', id:'c'+i, name:'Bash', text:'{"command":"check '+i+'"}'},
+          {type:'tool_result', id:'c'+i, text:'output for '+i}]}, toolBytes);
+        const lines = (i === count-1 && lastAnswerLines) ? lastAnswerLines : answerLines;
+        put({id:'a'+i, role:'assistant', ts:100002+i*10, kind:'final', blocks:[{type:'text',
+          text:'Answer '+i+'.'+(lines>1 ? '\\n\\n'+Array.from({length:lines-1},(_,k)=>'body line '+k+' of answer '+i).join('\\n') : '')}]},
+          Math.max(400, lines*60));
+      }
+      size = at;
+    }
+    const inside = (from,to) => records.filter((r) => r.at >= from && r.at + r.size <= to);
+    const page = (from,to) => {
+      const got = inside(from,to);
+      const start = got.length ? got[0].at : to;
+      const end = got.length ? got[got.length-1].at + got[got.length-1].size : to;
+      return {harness:'claude',harnessLabel:'Fixture',sessionId:'s',title:'',model:null,cwd:null,
+        firstTs:0,lastTs:0,usage:null,source:null,sharedBy:null,note:null,truncated:false,
+        total:null,userTurns:null,activity:'waiting',generation:'g1',revision:'r1',turns:got.map((r)=>r.turn),
+        window:{mode:'bytes',start,end,atStart:start<=0,atEnd:to>=size,generation:'g1',revision:'r1'}};
+    };
+    const wait = (ms) => ms ? new Promise((r)=>setTimeout(r,ms)) : Promise.resolve();
+    window.fixtureApi = {
+      async window(id, req, bytes, min){
+        window.reads.push({id, at:req.at, bytes, min});
+        if (id === 'child') { await wait(cfg.childDelay||0); return page(0, size); }
+        await wait(req.at === 'before' ? (cfg.beforeDelay||0) : (cfg.tailDelay||0));
+        if (req.at === 'after') return page(req.cursor, size);
+        const to = req.at === 'before' ? req.cursor : size;
+        const floor = Math.trunc(min) || WINDOW_MIN_TURNS;
+        for (let span = bytes || 384*1024; ; span = Math.min(span*2, WINDOW_MAX_BYTES)) {
+          const from = Math.max(0, to - span);
+          if (inside(from,to).length >= floor || from === 0 || span >= WINDOW_MAX_BYTES) return page(from,to);
+        }
+      },
+      summary(){ return wait(cfg.summaryDelay||0).then(()=>({...page(0,0), total:records.length, userTurns:[]})); },
+      roster(){ return cfg.child ? [{agentId:'child',toolUseId:'c0',hasTranscript:true}] : []; },
+    };
+
+    // .pane-reader is what gives .cxv its definite height in the app; without
+    // it the scroller has no resolved height and the layout under test is not
+    // the layout that ships.
+    function App(){ return <div style={{position:'absolute',inset:0,display:'flex'}}>
+      <div className="pane-reader">
+        <ConversationView session={{id:cfg.id,cli:'claude',name:'Fixture',state:'waiting',running:false,
+          everStarted:true,path:null,createdAt:new Date().toISOString()}} isMobile={false} />
+      </div></div>; }
+
+    window.fixture = {
+      mount(options){
+        // A distinct id per case: reader stores are cached by session, so
+        // reusing one would hand the next case the previous case's warm
+        // history and spent budget.
+        cfg = {id:'s'+(++window.__case), count:200, promptBytes:200, toolBytes:0, answerLines:1, ...options};
+        lay(cfg);
+        if (root) flushSync(()=>root.unmount());
+        window.reads = [];
+        root = createRoot(document.getElementById('fixture-root'));
+        flushSync(()=>root.render(<App/>));
+      },
+      set(options){ Object.assign(cfg, options); },
+      // Append a genuinely new exchange, the way a live agent would.
+      append(){
+        const i = cfg.count;
+        cfg.count = i + 1;
+        let at = size;
+        records.push({at, size:200, turn:{id:'u'+i,role:'user',ts:100000+i*10,blocks:[{type:'text',text:'Question '+i}]}});
+        records.push({at:at+200, size:400, turn:{id:'a'+i,role:'assistant',ts:100002+i*10,kind:'final',blocks:[{type:'text',text:'Answer '+i+'.'}]}});
+        size = at + 600;
+      },
+    };
+
+    // ---- measurement helpers, run in the page ----
+    const scroller = () => document.querySelector('.cxv-body');
+    window.probe = {
+      exchanges(){ return Number((document.querySelector('.cxv-status span')?.textContent||'').replace(/[^0-9]/g,'')) || 0; },
+      // Does the PRESENTED viewport consist of real conversation rows?
+      // Spacer divs and estimated heights cannot satisfy this: it asks whether
+      // measured row boxes span the visible band top to bottom.
+      coverage(){
+        const el = scroller(); if (!el) return null;
+        // The band a reader can actually read in: the scroller's CONTENT box,
+        // so its own padding is not counted as conversation.
+        const box = el.getBoundingClientRect();
+        const style = getComputedStyle(el);
+        const top = box.top + parseFloat(style.paddingTop);
+        const bottom = box.bottom - parseFloat(style.paddingBottom);
+        const usable = Math.round(bottom - top);
+        const rows = [...document.querySelectorAll('[data-x]')].map((r)=>r.getBoundingClientRect());
+        if (!rows.length) return {usable, rowsTop:null, rowsBottom:null, covered:false, scrollable:false};
+        const rowsTop = Math.min(...rows.map((r)=>r.top)), rowsBottom = Math.max(...rows.map((r)=>r.bottom));
+        return {usable, top:Math.round(top), bottom:Math.round(bottom),
+          rowsTop:Math.round(rowsTop), rowsBottom:Math.round(rowsBottom),
+          scrollable: el.scrollHeight - el.clientHeight > 1,
+          covered: rowsTop <= top + 1 && rowsBottom >= bottom - 1};
+      },
+      atBottom(){ const el = scroller(); return !!el && el.scrollHeight - el.scrollTop - el.clientHeight < 2; },
+      // What the reader TELLS the user about following, which drives the saved
+      // reading position and whether a new reply scrolls into view.
+      latestLabel(){ return [...document.querySelectorAll('.cxv-status button')]
+        .map((b)=>b.textContent).find((s)=>s === 'At latest' || s === '↓ Latest') || null; },
+      track(text){
+        window.samples = []; window.trackText = text;
+        const find = () => [...document.querySelectorAll('[data-x]')]
+          .find((r)=>r.textContent && r.textContent.includes(text));
+        window.labels = [];
+        const step = () => {
+          const el = find();
+          if (el) {
+            window.samples.push(Math.round(el.getBoundingClientRect().top * 100) / 100);
+            window.labels.push(window.probe.latestLabel());
+          }
+          window._raf = requestAnimationFrame(step);
+        };
+        step();
+      },
+      stop(){ cancelAnimationFrame(window._raf); return window.samples || []; },
+    };
+  ` }, bundle: true, outfile: bundle, format: 'iife', platform: 'browser',
+  define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent',
+  plugins: [{ name: 'fixture-api', setup(builder) {
+    builder.onResolve({ filter: /^\.\.?(?:\/\.\.)*\/api$/ }, () => ({ path: 'fixture-api', namespace: 'fixture' }));
+    builder.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({ resolveDir: web, loader: 'ts', contents: `
+      export * from ${JSON.stringify(path.join(web, 'src/api.ts'))};
+      export const getTraceWindow=(id,...args)=>window.fixtureApi.window(id,...args);
+      export const getTraceSummary=()=>window.fixtureApi.summary();
+      export const getSubAgentWindow=(id,agentId,...args)=>window.fixtureApi.window(agentId,...args);
+      export const getSubAgentSummary=()=>window.fixtureApi.summary();
+      export const getSubAgents=()=>Promise.resolve({agents:window.fixtureApi.roster()});
+      export const sendInput=()=>Promise.resolve({});
+    ` }));
+  } }],
+});
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const errors = [];
+const results = [];
+try {
+  const p = await browser.newPage({ viewport: { width: 1000, height: 760 } });
+  p.on('pageerror', (error) => errors.push(error.message));
+  await p.route('**/*', (route) => route.abort());
+  await p.setContent('<div id="fixture-root" style="position:absolute;inset:8px;display:flex"></div>');
+  // The reader's own two stylesheets are the layout under test; the bundle
+  // emits none of its own because ConversationView imports no CSS.
+  await p.addStyleTag({ content: fs.readFileSync(path.join(web, 'src/styles.css'), 'utf8')
+    + fs.readFileSync(path.join(web, 'src/conversation.css'), 'utf8') });
+  await p.addScriptTag({ path: bundle });
+  const TARGET = await p.evaluate(() => window.HISTORY_TARGET_EXCHANGES);
+  const MAX = await p.evaluate(() => window.HISTORY_MAX_EXCHANGES);
+  const MAX_REQUESTS = await p.evaluate(() => window.FILL_MAX_REQUESTS);
+
+  const settled = async (least) => {
+    try {
+      await p.waitForFunction((n) => window.probe.exchanges() >= n, least, { timeout: 20_000 });
+    } catch {
+      assert.fail(`only ${await p.evaluate(() => window.probe.exchanges())} exchanges became `
+        + `available on their own; expected at least ${least}. Backward reads: `
+        + `${await p.evaluate(() => window.reads.filter((r) => r.at === 'before').length)}`);
+    }
+    await p.waitForFunction(() => {
+      const now = window.probe.exchanges();
+      if (window.__last === now) return true;
+      window.__last = now; return false;
+    }, null, { timeout: 20_000, polling: 400 });
+    await p.evaluate(() => { delete window.__last; });
+  };
+
+  // ---------- 1. a tool-heavy cold open reaches the target on its own ----------
+  await p.evaluate(() => window.fixture.mount({ count: 200, toolBytes: 90 * 1024, answerLines: 6 }));
+  await p.getByText('Question 199', { exact: true }).waitFor();
+  const firstWindow = await p.evaluate(() => window.probe.exchanges());
+  assert.ok(firstWindow < TARGET,
+    `the first window alone holds ${firstWindow} exchanges — the case that needs filling`);
+  await settled(TARGET);
+  const heavy = await p.evaluate(() => window.probe.exchanges());
+  assert.ok(heavy >= TARGET, `a cold open reaches ${TARGET} exchanges without scrolling or search (got ${heavy})`);
+  assert.equal(await p.evaluate(() => window.reads.some((r) => r.at === 'before')), true,
+    'and it got there by paging backward, not by asking for one huge window');
+  const cov = await p.evaluate(() => window.probe.coverage());
+  assert.ok(cov.scrollable, 'the transcript is taller than the reader');
+  assert.ok(cov.covered, `real rows span the visible band (${JSON.stringify(cov)})`);
+  assert.ok(await p.evaluate(() => window.probe.atBottom()), 'and Latest is still the bottom');
+  results.push({ case: 'tool-heavy cold open', firstWindow, exchanges: heavy, covered: cov.covered });
+
+  // ---------- 2. no history-induced drift, measured every frame ----------
+  // The source is fixed and older pages are slow, so any movement of already
+  // visible text is the prepends' fault and nothing else's.
+  await p.evaluate(() => window.fixture.mount({ count: 200, toolBytes: 90 * 1024, answerLines: 6, beforeDelay: 220 }));
+  await p.getByText('Question 199', { exact: true }).waitFor();
+  await p.evaluate(() => window.probe.track('Question 199'));
+  await settled(TARGET);
+  const samples = await p.evaluate(() => window.probe.stop());
+  assert.ok(samples.length > 8, `the anchor was sampled across frames (${samples.length} samples)`);
+  const drift = Math.max(...samples) - Math.min(...samples);
+  assert.ok(drift <= 2, `already-visible text does not move while history loads (max ${drift}px over ${samples.length} frames)`);
+  // Following is intent, not geometry. Our own corrections are reported back as
+  // scroll events, and taking one for a deliberate scroll upward drops Latest
+  // mid-preload: the indicator lies, the saved reading position stops being the
+  // end, and the next reply no longer scrolls into view.
+  const labels = await p.evaluate(() => window.labels);
+  const lost = labels.filter((l) => l !== 'At latest').length;
+  assert.equal(lost, 0, `Latest is never given up while history loads (${lost} of ${labels.length} frames said otherwise)`);
+  results.push({ case: 'anchor drift while filling', samples: samples.length, driftPx: drift, framesNotAtLatest: lost });
+
+  // ---------- 3. underfilled → scrollable is the same story ----------
+  // Two exchanges do not fill the reader. The pages that follow must grow the
+  // transcript upward, not push the two that were already readable downward.
+  await p.evaluate(() => window.fixture.mount({ count: 40, toolBytes: 200 * 1024, answerLines: 2, beforeDelay: 200 }));
+  await p.getByText('Question 39', { exact: true }).waitFor();
+  const before = await p.evaluate(() => window.probe.coverage());
+  assert.ok(!before.scrollable, 'the first window really is shorter than the reader');
+  await p.evaluate(() => window.probe.track('Question 39'));
+  await settled(Math.min(TARGET, 20));
+  const under = await p.evaluate(() => window.probe.stop());
+  const underDrift = Math.max(...under) - Math.min(...under);
+  assert.ok(underDrift <= 2,
+    `underfilled → scrollable does not displace visible text (max ${underDrift}px over ${under.length} frames)`);
+  const grown = await p.evaluate(() => window.probe.coverage());
+  assert.ok(grown.scrollable && grown.covered, 'and it ends up covering the reader');
+  results.push({ case: 'underfilled → scrollable', samples: under.length, driftPx: underDrift });
+
+  // ---------- 4. a tall answer covers the page but history still loads ----------
+  // Slow older pages, so the state where ONE answer covers the reader and the
+  // history target is still unmet is observable rather than a race.
+  await p.evaluate(() => window.fixture.mount({
+    count: 200, toolBytes: 90 * 1024, answerLines: 3, lastAnswerLines: 140, beforeDelay: 400 }));
+  await p.getByText('Question 199', { exact: true }).waitFor();
+  await p.waitForFunction(() => window.probe.coverage()?.covered, null, { timeout: 15_000 });
+  const tallCover = await p.evaluate(() => ({ ...window.probe.coverage(), ex: window.probe.exchanges() }));
+  assert.ok(tallCover.covered, 'one long answer already fills the reader');
+  assert.ok(tallCover.ex < TARGET,
+    `and it did so with only ${tallCover.ex} exchanges — coverage is not the history target`);
+  await settled(TARGET);
+  const tall = await p.evaluate(() => window.probe.exchanges());
+  assert.ok(tall >= TARGET,
+    `covering the viewport is not a reason to stop loading history (got ${tall} of ${TARGET})`);
+  results.push({ case: 'tall answer fills page', exchanges: tall });
+
+  // ---------- 5. very short exchanges: more than the target to fill a page ----------
+  // One-line turns in a tall window. Each record is large in BYTES and small on
+  // screen, which is the shape that makes the exchange target insufficient: the
+  // window budget is spent long before the viewport is covered.
+  await p.setViewportSize({ width: 820, height: 2600 });
+  await p.evaluate(() => window.fixture.mount({ count: 400, promptBytes: 5200, answerLines: 1 }));
+  await p.getByText('Question 399', { exact: true }).waitFor();
+  await p.waitForFunction((n) => window.probe.exchanges() >= n, TARGET, { timeout: 20_000 });
+  const atTarget = await p.evaluate(() => window.probe.coverage());
+  assert.ok(!atTarget.covered,
+    `${TARGET} one-line exchanges do not fill a 2600px reader — this is the case coverage is for`);
+  await settled(TARGET + 1);
+  const tinyCov = await p.evaluate(() => window.probe.coverage());
+  const tiny = await p.evaluate(() => window.probe.exchanges());
+  assert.ok(tinyCov.covered, `so it keeps going until they do (${tiny} exchanges, ${JSON.stringify(tinyCov)})`);
+  assert.ok(tiny > TARGET, `which took more than the target (${tiny} > ${TARGET})`);
+  const tinyReads = await p.evaluate(() => window.reads.filter((r) => r.at === 'before').length);
+  assert.ok(tinyReads <= MAX_REQUESTS, `and stayed inside the request budget (${tinyReads} <= ${MAX_REQUESTS})`);
+  results.push({ case: 'tiny exchanges, tall viewport', exchanges: tiny, backwardReads: tinyReads, covered: tinyCov.covered });
+  await p.setViewportSize({ width: 1000, height: 760 });
+
+  // ---------- 6. a genuinely short conversation settles at once ----------
+  for (const count of [0, 1, 2, 5]) {
+    await p.evaluate((n) => window.fixture.mount({ count: n }), count);
+    if (count) await p.getByText(`Question ${count - 1}`, { exact: true }).waitFor();
+    else await p.getByText('Start the conversation.', { exact: true }).waitFor();
+    await p.waitForFunction((n) => window.probe.exchanges() === n, count, { timeout: 10_000 });
+    assert.equal(await p.locator('.cxv-top').getAttribute('disabled'), '',
+      `a ${count}-exchange conversation reports the beginning rather than spinning`);
+    // Making the column fill the reader must not invent a scroll range for a
+    // conversation that has nothing to scroll.
+    const slack = await p.evaluate(() => { const el = document.querySelector('.cxv-body');
+      return el.scrollHeight - el.clientHeight; });
+    assert.ok(slack <= 1, `and nothing to scroll (${slack}px of slack at ${count} exchanges)`);
+  }
+  results.push({ case: 'short conversations', exchanges: 'all of them' });
+
+  // ---------- 7. a live append still moves the view; that is not drift ----------
+  await p.evaluate(() => window.fixture.mount({ count: 30, promptBytes: 200, answerLines: 4 }));
+  await p.getByText('Question 29', { exact: true }).waitFor();
+  await settled(Math.min(TARGET, 30));
+  await p.evaluate(() => window.probe.track('Question 29'));
+  await p.evaluate(() => window.fixture.append());
+  await p.getByText('Question 30', { exact: true }).waitFor({ timeout: 20_000 });
+  const live = await p.evaluate(() => window.probe.stop());
+  assert.ok(Math.max(...live) - Math.min(...live) > 2,
+    'a new reply scrolls the follower, which is Latest behaving, not history drift');
+  assert.ok(await p.evaluate(() => window.probe.atBottom()), 'and Latest is the bottom again');
+  results.push({ case: 'live append', movedPx: Math.round(Math.max(...live) - Math.min(...live)) });
+
+  // ---------- 8. a slow summary cannot hold up history ----------
+  await p.evaluate(() => window.fixture.mount({ count: 200, toolBytes: 90 * 1024, answerLines: 6, summaryDelay: 60_000 }));
+  await p.getByText('Question 199', { exact: true }).waitFor();
+  await settled(TARGET);
+  assert.ok(await p.evaluate(() => window.probe.exchanges()) >= TARGET,
+    'recent history does not wait for a whole-transcript summary');
+  assert.equal(await p.locator('.cxv-composer textarea').count(), 1, 'and the composer is there throughout');
+  results.push({ case: 'hung summary', exchanges: await p.evaluate(() => window.probe.exchanges()) });
+
+  // ---------- 9. a child transcript keeps its own top-of-context policy ----------
+  await p.evaluate(() => window.fixture.mount({ count: 200, toolBytes: 90 * 1024, answerLines: 6 }));
+  await p.getByText('Question 199', { exact: true }).waitFor();
+  await settled(TARGET);
+  const parentReads = await p.evaluate(() => window.reads.filter((r) => r.id !== 'child').length);
+  assert.ok(await p.evaluate(() => window.reads.every((r) => r.id !== 'child')),
+    'no speculative child reader is created by the parent preload');
+  assert.ok(parentReads <= 12, `the whole cold open is a bounded number of requests (${parentReads})`);
+  assert.ok(await p.locator('[data-x]').count() < 40, 'and the rendered window stays virtualized');
+  results.push({ case: 'requests for a cold open', reads: parentReads });
+
+  assert.deepEqual(errors, [], 'no page errors');
+} finally {
+  await browser.close();
+}
+console.log(JSON.stringify(results, null, 1));
+console.log('reader-first-viewport: ok');

--- a/web/test/readerFirstViewport.test.mjs
+++ b/web/test/readerFirstViewport.test.mjs
@@ -93,7 +93,7 @@ await build({
       </div></div>; }
 
     window.fixture = {
-      mount(options){
+      mount(options){ window.t0 = performance.now();
         // A distinct id per case: reader stores are cached by session, so
         // reusing one would hand the next case the previous case's warm
         // history and spent budget.
@@ -141,6 +141,24 @@ await build({
           covered: rowsTop <= top + 1 && rowsBottom >= bottom - 1};
       },
       atBottom(){ const el = scroller(); return !!el && el.scrollHeight - el.scrollTop - el.clientHeight < 2; },
+      // Is the transcript actually being SHOWN? Rows are laid out and measured
+      // while the first page is prepared, so their existence is not the answer.
+      shown(){ const r = document.querySelector('.cxv-rows, [data-x]');
+        return !!r && getComputedStyle(r.closest('.cxv-rows') || r).visibility !== 'hidden'
+          && document.querySelectorAll('[data-x]').length > 0; },
+      // Sample the very first frame on which the transcript becomes visible.
+      watchReveal(){
+        window.reveal = null;
+        const step = () => {
+          if (!window.reveal && window.probe.shown()) {
+            window.reveal = { ...window.probe.coverage(), ex: window.probe.exchanges(),
+              atMs: Math.round(performance.now() - window.t0) };
+          }
+          window._rv = requestAnimationFrame(step);
+        };
+        step();
+      },
+      stopReveal(){ cancelAnimationFrame(window._rv); return window.reveal; },
       // What the reader TELLS the user about following, which drives the saved
       // reading position and whether a new reply scrolls into view.
       latestLabel(){ return [...document.querySelectorAll('.cxv-status button')]
@@ -211,6 +229,31 @@ try {
     await p.evaluate(() => { delete window.__last; });
   };
 
+  // ---------- 0. the FIRST transcript the user sees is a page of conversation ----------
+  // Not "eventually covered": covered on the frame it first becomes visible.
+  // The first window is two exchanges on this fixture, and older pages are slow,
+  // so a reader that painted its first response would be caught here.
+  await p.evaluate(() => window.fixture.mount({
+    count: 200, toolBytes: 90 * 1024, answerLines: 6, beforeDelay: 250 }));
+  await p.evaluate(() => window.probe.watchReveal());
+  await p.waitForFunction(() => window.probe.shown(), null, { timeout: 20_000 });
+  const reveal = await p.evaluate(() => window.probe.stopReveal());
+  assert.ok(reveal, 'the transcript became visible');
+  assert.ok(reveal.covered,
+    `the first transcript the reader shows covers it (${JSON.stringify(reveal)})`);
+  assert.ok(reveal.ex > 2,
+    `and is more than the first window's two exchanges (${reveal.ex})`);
+  assert.equal(await p.locator('.cxv-composer textarea').count(), 1,
+    'the composer was never part of the wait');
+  results.push({ case: 'first visible transcript', exchanges: reveal.ex,
+    covered: reveal.covered, revealedAtMs: reveal.atMs });
+
+  // A conversation with nothing more to load must not wait for anything.
+  await p.evaluate(() => window.fixture.mount({ count: 3, answerLines: 2, beforeDelay: 5_000 }));
+  await p.getByText('Question 2', { exact: true }).waitFor({ timeout: 3_000 });
+  assert.ok(await p.evaluate(() => window.probe.shown()),
+    'a short conversation is shown at once rather than held back');
+
   // ---------- 1. a tool-heavy cold open reaches the target on its own ----------
   await p.evaluate(() => window.fixture.mount({ count: 200, toolBytes: 90 * 1024, answerLines: 6 }));
   await p.getByText('Question 199', { exact: true }).waitFor();
@@ -248,22 +291,28 @@ try {
   assert.equal(lost, 0, `Latest is never given up while history loads (${lost} of ${labels.length} frames said otherwise)`);
   results.push({ case: 'anchor drift while filling', samples: samples.length, driftPx: drift, framesNotAtLatest: lost });
 
-  // ---------- 3. underfilled → scrollable is the same story ----------
-  // Two exchanges do not fill the reader. The pages that follow must grow the
-  // transcript upward, not push the two that were already readable downward.
-  await p.evaluate(() => window.fixture.mount({ count: 40, toolBytes: 200 * 1024, answerLines: 2, beforeDelay: 200 }));
-  await p.getByText('Question 39', { exact: true }).waitFor();
-  const before = await p.evaluate(() => window.probe.coverage());
-  assert.ok(!before.scrollable, 'the first window really is shorter than the reader');
-  await p.evaluate(() => window.probe.track('Question 39'));
-  await settled(Math.min(TARGET, 20));
-  const under = await p.evaluate(() => window.probe.stop());
-  const underDrift = Math.max(...under) - Math.min(...under);
-  assert.ok(underDrift <= 2,
-    `underfilled → scrollable does not displace visible text (max ${underDrift}px over ${under.length} frames)`);
-  const grown = await p.evaluate(() => window.probe.coverage());
-  assert.ok(grown.scrollable && grown.covered, 'and it ends up covering the reader');
-  results.push({ case: 'underfilled → scrollable', samples: under.length, driftPx: underDrift });
+  // ---------- 3. a transcript shorter than the reader sits at the bottom ----------
+  // Preparation means a cold reader rarely reveals an underfilled transcript,
+  // but a conversation that IS shorter than the window is revealed at once, and
+  // it must sit against the composer rather than floating at the top. That is
+  // also what makes any later page grow the transcript upward instead of
+  // pushing the readable text down.
+  await p.evaluate(() => window.fixture.mount({ count: 3, answerLines: 2 }));
+  await p.getByText('Question 2', { exact: true }).waitFor();
+  const short = await p.evaluate(() => {
+    const el = document.querySelector('.cxv-body');
+    const box = el.getBoundingClientRect();
+    const style = getComputedStyle(el);
+    const rows = [...document.querySelectorAll('[data-x]')].map((r) => r.getBoundingClientRect());
+    return { scrollable: el.scrollHeight - el.clientHeight > 1,
+      gapBelow: Math.round(box.bottom - parseFloat(style.paddingBottom) - Math.max(...rows.map((r) => r.bottom))),
+      gapAbove: Math.round(Math.min(...rows.map((r) => r.top)) - (box.top + parseFloat(style.paddingTop))) };
+  });
+  assert.ok(!short.scrollable, 'three short exchanges really are shorter than the reader');
+  assert.ok(short.gapBelow <= 2,
+    `and sit against the bottom of it (${short.gapBelow}px below, ${short.gapAbove}px above)`);
+  assert.ok(short.gapAbove > 20, 'with the empty space above them, not below');
+  results.push({ case: 'short transcript anchoring', gapBelow: short.gapBelow, gapAbove: short.gapAbove });
 
   // ---------- 4. a tall answer covers the page but history still loads ----------
   // Slow older pages, so the state where ONE answer covers the reader and the
@@ -289,10 +338,8 @@ try {
   await p.setViewportSize({ width: 820, height: 2600 });
   await p.evaluate(() => window.fixture.mount({ count: 400, promptBytes: 5200, answerLines: 1 }));
   await p.getByText('Question 399', { exact: true }).waitFor();
-  await p.waitForFunction((n) => window.probe.exchanges() >= n, TARGET, { timeout: 20_000 });
-  const atTarget = await p.evaluate(() => window.probe.coverage());
-  assert.ok(!atTarget.covered,
-    `${TARGET} one-line exchanges do not fill a 2600px reader — this is the case coverage is for`);
+  // Non-vacuity is the OUTCOME here: the fill stops at the exchange target on
+  // its own, so going past it can only be the coverage rule asking for more.
   await settled(TARGET + 1);
   const tinyCov = await p.evaluate(() => window.probe.coverage());
   const tiny = await p.evaluate(() => window.probe.exchanges());

--- a/web/test/readerHistory.test.mjs
+++ b/web/test/readerHistory.test.mjs
@@ -1,0 +1,280 @@
+// Automatic recent-history fill: how much conversation a cold reader ends up
+// holding, and what stops it.
+//
+// The store is driven directly, against a source that HONOURS `bytes` and `min`
+// the way server/src/traces.js does. That matters: a fixture which returns every
+// synthetic turn regardless of the window asked for cannot fail when the reader
+// only asks for two, which is exactly the defect this covers.
+//
+// Run with:  node test/readerHistory.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'reader-history-')), 'store.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/readerStore.ts')],
+  outfile: out, format: 'esm', bundle: true, logLevel: 'error',
+});
+const {
+  ReaderStore, countExchanges: storeCount, HISTORY_TARGET_EXCHANGES, HISTORY_MAX_EXCHANGES,
+  FILL_MAX_REQUESTS, FILL_MAX_BYTES, FILL_MAX_MS, FILL_STEP_MS,
+} = await import(pathToFileURL(out).href);
+const model = await build({
+  entryPoints: [path.join(HERE, '../src/lib/readerModel.ts')],
+  outfile: out.replace('store.mjs', 'model.mjs'), format: 'esm', bundle: true, logLevel: 'error',
+}).then(() => import(pathToFileURL(out.replace('store.mjs', 'model.mjs')).href));
+const { countExchanges } = model;
+
+const WINDOW_MIN_TURNS = 12;         // server/src/traces.js
+const WINDOW_MAX_BYTES = 8 * 1024 * 1024;
+const tick = (ms = 0) => new Promise((resolve) => setTimeout(resolve, ms));
+/** Let the store finish its bounded fill: each step waits FILL_STEP_MS. */
+const settle = async (store, budget = FILL_MAX_REQUESTS + 4) => {
+  for (let i = 0; i < budget * 4; i++) {
+    await tick(FILL_STEP_MS + 5);
+    if (store.getSnapshot().fill === 'done' || store.getSnapshot().fill === 'limited') break;
+  }
+  await tick(FILL_STEP_MS + 5);
+  return store.getSnapshot();
+};
+
+/**
+ * A byte-addressed transcript of `n` exchanges, laid out as records at real
+ * offsets, served through the same growth rule the server uses: widen the span
+ * until it holds `min` messages, the start of the source, or the ceiling.
+ */
+function source(n, opts = {}) {
+  const { promptBytes = 200, toolBytes = 0, answerBytes = 400, blockAt = null, stall = false, fail = null } = opts;
+  const records = [];
+  let at = 0;
+  const put = (turn, size) => { records.push({ at, size, turn }); at += size; };
+  for (let i = 0; i < n; i++) {
+    put({ id: `u${i}`, role: 'user', ts: 1000 + i * 10, blocks: [{ type: 'text', text: `prompt ${i}` }] }, promptBytes);
+    if (toolBytes) put({ id: `t${i}`, role: 'assistant', ts: 1001 + i * 10,
+      blocks: [{ type: 'tool_use', id: `c${i}`, name: 'Bash', text: 'run' }, { type: 'tool_result', id: `c${i}`, text: 'o'.repeat(64) }] }, toolBytes);
+    put({ id: `a${i}`, role: 'assistant', ts: 1002 + i * 10, kind: 'final', blocks: [{ type: 'text', text: `answer ${i}` }] }, answerBytes);
+  }
+  const size = at;
+  const state = { calls: [], bytes: 0 };
+  const inside = (from, to) => records.filter((r) => r.at >= from && r.at + r.size <= to);
+  const page = (from, to) => {
+    const got = inside(from, to);
+    const start = got.length ? got[0].at : to;
+    const end = got.length ? got[got.length - 1].at + got[got.length - 1].size : to;
+    state.bytes += Math.max(0, to - from);
+    return {
+      harness: 'claude', harnessLabel: 'Fixture', sessionId: 's', title: '', model: null, cwd: null,
+      firstTs: 0, lastTs: 0, usage: null, source: null, sharedBy: null, note: null, truncated: false,
+      total: null, userTurns: null, activity: 'waiting', generation: 'g1', revision: 'r1',
+      turns: got.map((r) => r.turn),
+      window: { mode: 'bytes', start, end, atStart: start <= 0, atEnd: to >= size, generation: 'g1', revision: 'r1' },
+    };
+  };
+  return {
+    state,
+    size,
+    async window(req, bytes, min) {
+      state.calls.push({ at: req.at, bytes, min });
+      if (fail && state.calls.length >= fail) throw new Error('read failed');
+      await tick(0);
+      // A source that answers without moving the cursor and WITHOUT saying it
+      // is blocked — a window whose whole span is one record it could not
+      // parse. Nothing in the response says stop, so only the store's
+      // no-progress rule can end the fill.
+      if (stall && req.at === 'before') {
+        const p = page(req.cursor, req.cursor);
+        return { ...p, window: { ...p.window, start: req.cursor, end: req.cursor, atStart: false } };
+      }
+      // An oversized record no window can get past: the source stops advancing.
+      if (blockAt !== null && req.at === 'before' && req.cursor <= blockAt) {
+        const p = page(req.cursor, req.cursor);
+        return { ...p, window: { ...p.window, start: req.cursor, end: req.cursor, blocked: true, atStart: false } };
+      }
+      const to = req.at === 'before' ? req.cursor : size;
+      const floor = Math.trunc(min) || WINDOW_MIN_TURNS;
+      for (let span = bytes || 384 * 1024; ; span = Math.min(span * 2, WINDOW_MAX_BYTES)) {
+        const from = Math.max(0, to - span);
+        const got = inside(from, to);
+        if (got.length >= floor || from === 0 || span >= WINDOW_MAX_BYTES) return page(from, to);
+      }
+    },
+    async summary() { await tick(0); return { total: records.length, userTurns: [], revision: 'r1' }; },
+  };
+}
+
+// ---- the count the target is expressed in is the count the view groups by ----
+{
+  const src = source(3, { toolBytes: 500 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  await settle(store);
+  const turns = store.getSnapshot().turns;
+  assert.equal(countExchanges(turns), 3, 'three prompts are three exchanges, not nine records');
+  assert.ok(turns.length > 3, 'and there really are more records than exchanges');
+  release();
+}
+
+// ---- a cold reader reaches the recent-history target on its own ----
+for (const [label, opts, needsFill] of [
+  ['tool-heavy: barely an exchange per initial window', { toolBytes: 120 * 1024 }, true],
+  ['multiline answers', { answerBytes: 20 * 1024 }, true],
+  ['ordinary turns', {}, false],
+]) {
+  const src = source(200, opts);
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  const first = store.getSnapshot();
+  assert.equal(first.fill, 'idle', 'a reader nobody asked for history does not start one');
+  release();
+
+  const wanted = new ReaderStore(src);
+  const stop = wanted.retain();
+  wanted.wantHistory(HISTORY_TARGET_EXCHANGES);
+  await tick(5);
+  // What ONE window holds — the whole of the old cold-open behaviour. A case
+  // that already covers the target here would pass without any fill at all,
+  // so the fixtures that are meant to exercise the fill assert that it cannot.
+  const initial = countExchanges(wanted.getSnapshot().turns);
+  if (needsFill) assert.ok(initial < HISTORY_TARGET_EXCHANGES,
+    `${label}: the first window alone holds ${initial}, short of the target — this is the case that needs filling`);
+  const state = await settle(wanted);
+  const have = countExchanges(state.turns);
+  assert.ok(have >= HISTORY_TARGET_EXCHANGES,
+    `${label}: reached the target without scrolling or searching (got ${have})`);
+  assert.equal(state.fill, 'done', `${label}: and stopped once it had them`);
+  assert.ok(!state.turns.some((t, i) => state.turns.findIndex((o) => o.id === t.id) !== i),
+    `${label}: no duplicated records across pages`);
+  const ids = state.turns.map((t) => t.id);
+  assert.deepEqual(ids, [...ids].sort((a, b) => Number(a.slice(1)) - Number(b.slice(1)) || 0).length === ids.length ? ids : ids,
+    `${label}: order preserved`);
+  stop();
+}
+
+// ---- shorter conversations load all of themselves and stop ----
+for (const n of [0, 1, 2, 5]) {
+  const src = source(n);
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.equal(countExchanges(state.turns), n, `a ${n}-exchange conversation loads all ${n}`);
+  assert.ok(state.cursor?.atStart !== false || n === 0, `and knows it is at the beginning`);
+  assert.ok(state.fill !== 'filling', 'the fill has settled rather than spinning');
+  release();
+}
+
+// ---- budgets: a fill stops, and says it stopped short ----
+{
+  // 3 MiB of answer per exchange: the byte budget goes before the count does.
+  const src = source(200, { answerBytes: 900 * 1024 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.equal(state.fill, 'limited', 'a budget ends the fill');
+  assert.ok(countExchanges(state.turns) < HISTORY_TARGET_EXCHANGES, 'honestly short of the target');
+  assert.ok(state.cursor && !state.cursor.atStart, 'and does not claim the beginning of the conversation');
+  const backward = src.state.calls.filter((c) => c.at === 'before').length;
+  assert.ok(backward <= FILL_MAX_REQUESTS, `bounded request count (${backward} <= ${FILL_MAX_REQUESTS})`);
+  release();
+}
+
+// ---- an oversized record blocks progress: stop, do not loop ----
+{
+  const src = source(200, { toolBytes: 120 * 1024, blockAt: Number.MAX_SAFE_INTEGER });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.equal(state.fill, 'limited', 'a cursor that cannot advance ends the fill');
+  const backward = src.state.calls.filter((c) => c.at === 'before').length;
+  assert.ok(backward <= 2, `and does not retry it forever (${backward} backward reads)`);
+  release();
+}
+
+// ---- a cursor that answers without advancing: stop, do not loop ----
+{
+  const src = source(200, { toolBytes: 120 * 1024, stall: true });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.equal(state.fill, 'limited', 'a stalled cursor ends the fill');
+  assert.ok(state.cursor && !state.cursor.atStart,
+    'and never reports the beginning of a conversation it could not reach');
+  const backward = src.state.calls.filter((c) => c.at === 'before').length;
+  assert.ok(backward <= 2,
+    `one backward read proves it, a second is the retry — not ${backward} of them`);
+  release();
+}
+
+// ---- a failing read leaves the reader usable ----
+{
+  const src = source(200, { toolBytes: 120 * 1024, fail: 2 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.ok(state.turns.length > 0, 'the first window survives a failed fill');
+  assert.equal(state.loading, null, 'and the busy slot is released');
+  assert.notEqual(state.fill, 'filling', 'the fill is not left in flight');
+  release();
+}
+
+// ---- warm return fills only what is missing ----
+{
+  const src = source(200, { toolBytes: 60 * 1024 });
+  const store = new ReaderStore(src);
+  const first = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const warm = await settle(store);
+  const held = warm.turns.length;
+  const spent = src.state.calls.length;
+  first();
+  await tick(5);
+  const again = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  await settle(store);
+  const after = store.getSnapshot();
+  assert.ok(after.turns.length >= held, 'a warm store keeps the history it had');
+  const extra = src.state.calls.filter((c) => c.at === 'before').length
+    - src.state.calls.slice(0, spent).filter((c) => c.at === 'before').length;
+  assert.equal(extra, 0, 'and does not repeat the preload on remount');
+  again();
+}
+
+// ---- releasing a reader stops its fill ----
+{
+  const src = source(200, { toolBytes: 120 * 1024 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  await tick(FILL_STEP_MS + 5);
+  release();
+  const spent = src.state.calls.length;
+  await tick(FILL_STEP_MS * 6);
+  assert.ok(src.state.calls.length - spent <= 1,
+    `an unmounted reader stops paging (${src.state.calls.length - spent} extra reads)`);
+}
+
+// ---- the coverage request is bounded ----
+{
+  const src = source(500, { promptBytes: 60, answerBytes: 60 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  for (let i = 0; i < 40; i++) store.wantHistory(HISTORY_MAX_EXCHANGES + i * 10);
+  const state = await settle(store);
+  assert.ok(countExchanges(state.turns) >= HISTORY_TARGET_EXCHANGES, 'tiny exchanges still reach the target');
+  const backward = src.state.calls.filter((c) => c.at === 'before').length;
+  assert.ok(backward <= FILL_MAX_REQUESTS, 'raising the target past the cap cannot page the whole trace');
+  release();
+}
+
+assert.ok(FILL_MAX_MS > 0 && FILL_MAX_BYTES > 0, 'the documented budgets exist');
+assert.equal(storeCount, undefined, 'the store does not re-export a second counter');
+console.log('reader-history: ok');

--- a/web/test/readerHistory.test.mjs
+++ b/web/test/readerHistory.test.mjs
@@ -22,7 +22,7 @@ await build({
 });
 const {
   ReaderStore, countExchanges: storeCount, HISTORY_TARGET_EXCHANGES, HISTORY_MAX_EXCHANGES,
-  FILL_MAX_REQUESTS, FILL_MAX_BYTES, FILL_MAX_MS, FILL_STEP_MS,
+  FILL_MAX_REQUESTS, FILL_MAX_RETAINED_BYTES, FILL_MAX_MS, FILL_STEP_MS,
 } = await import(pathToFileURL(out).href);
 const model = await build({
   entryPoints: [path.join(HERE, '../src/lib/readerModel.ts')],
@@ -60,13 +60,14 @@ function source(n, opts = {}) {
     put({ id: `a${i}`, role: 'assistant', ts: 1002 + i * 10, kind: 'final', blocks: [{ type: 'text', text: `answer ${i}` }] }, answerBytes);
   }
   const size = at;
-  const state = { calls: [], bytes: 0 };
+  const state = { calls: [], bytes: 0, spans: [] };
   const inside = (from, to) => records.filter((r) => r.at >= from && r.at + r.size <= to);
   const page = (from, to) => {
     const got = inside(from, to);
     const start = got.length ? got[0].at : to;
     const end = got.length ? got[got.length - 1].at + got[got.length - 1].size : to;
     state.bytes += Math.max(0, to - from);
+    state.spans.push(Math.max(0, to - from));
     return {
       harness: 'claude', harnessLabel: 'Fixture', sessionId: 's', title: '', model: null, cwd: null,
       firstTs: 0, lastTs: 0, usage: null, source: null, sharedBy: null, note: null, truncated: false,
@@ -80,6 +81,7 @@ function source(n, opts = {}) {
     size,
     async window(req, bytes, min) {
       state.calls.push({ at: req.at, bytes, min });
+      if (opts.hold && req.at === 'before') await tick(opts.hold);
       if (fail && state.calls.length >= fail) throw new Error('read failed');
       await tick(0);
       // A source that answers without moving the cursor and WITHOUT saying it
@@ -184,6 +186,57 @@ for (const n of [0, 1, 2, 5]) {
   release();
 }
 
+// ---- a forward read is never swallowed by speculative history ----
+// Latest, an explicit refresh and the live poll all go forward. The single
+// request slot is shared with the fill, and returning the fill's promise to a
+// forward caller means new output simply does not arrive until some later poll.
+{
+  const src = source(200, { toolBytes: 120 * 1024, hold: 300 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  // wait until a speculative backward read is actually in flight
+  for (let i = 0; i < 60 && store.getSnapshot().loading !== 'before'; i++) await tick(10);
+  assert.equal(store.getSnapshot().loading, 'before', 'a speculative page is in flight');
+  const before = src.state.calls.filter((c) => c.at === 'after' || c.at === 'tail').length;
+  await store.loadNewer();
+  const after = src.state.calls.filter((c) => c.at === 'after' || c.at === 'tail').length;
+  assert.ok(after > before,
+    'asking for the latest while history is loading actually asks the source for it');
+  await settle(store);
+  assert.ok(countExchanges(store.getSnapshot().turns) >= 2, 'and the transcript survives');
+  release();
+}
+
+// ---- the byte budget is a budget ----
+// A backward page with no floor of its own lets the server grow one response
+// until it holds a dozen messages, which on a trace of huge records is
+// megabytes per request — and charging for it only after the next step has
+// been scheduled lets one more go out on top.
+{
+  const src = source(200, { answerBytes: 900 * 1024 });
+  const store = new ReaderStore(src);
+  const release = store.retain();
+  store.wantHistory(HISTORY_TARGET_EXCHANGES);
+  const state = await settle(store);
+  assert.equal(state.fill, 'limited', 'the fill stops');
+  const backward = src.state.spans.slice(1);              // spans[0] is the tail
+  const total = backward.reduce((n, v) => n + v, 0);
+  const biggest = Math.max(0, ...backward);
+  const retained = state.cursor ? src.size - state.cursor.start : 0;
+  const MiB = (n) => `${(n / 1048576).toFixed(1)} MiB`;
+  // Three separate bounds, because they are three separate quantities.
+  assert.ok(biggest <= 2 * 1024 * 1024,
+    `the server cannot grow one speculative page to megabytes (largest ${MiB(biggest)})`);
+  assert.ok(retained <= FILL_MAX_RETAINED_BYTES + biggest,
+    `retained history stays inside the budget plus the page that crossed it `
+    + `(${MiB(retained)} for a ${MiB(FILL_MAX_RETAINED_BYTES)} budget, largest page ${MiB(biggest)})`);
+  assert.ok(total <= backward.length * 2 * 1024 * 1024,
+    `and the whole run's reads stay inside requests x page ceiling (${MiB(total)})`);
+  assert.ok(backward.length <= FILL_MAX_REQUESTS, `in ${backward.length} requests`);
+  release();
+}
+
 // ---- an oversized record blocks progress: stop, do not loop ----
 {
   const src = source(200, { toolBytes: 120 * 1024, blockAt: Number.MAX_SAFE_INTEGER });
@@ -275,6 +328,6 @@ for (const n of [0, 1, 2, 5]) {
   release();
 }
 
-assert.ok(FILL_MAX_MS > 0 && FILL_MAX_BYTES > 0, 'the documented budgets exist');
+assert.ok(FILL_MAX_MS > 0 && FILL_MAX_RETAINED_BYTES > 0, 'the documented budgets exist');
 assert.equal(storeCount, undefined, 'the store does not re-export a second counter');
 console.log('reader-history: ok');

--- a/web/test/readerRedesign.test.mjs
+++ b/web/test/readerRedesign.test.mjs
@@ -195,7 +195,12 @@ try {
   const afterSwitch = await anchor();
   assert.equal(afterSwitch.key, beforeSwitch.key, 'returning to a retained reader restores the manually read row');
   assert.ok(Math.abs(afterSwitch.offset-beforeSwitch.offset)<2, 'returning restores the manual pixel offset after measuring rows again');
-  await p.evaluate(() => window.fixture.mount({ id: 'paging-priority', count: 500, from: 490, hangAfter: true }));
+  // `from` has to leave more history loaded than the reader now fetches by
+  // itself: this case is about an explicit Earlier competing with a hung
+  // refresh, and a first window smaller than the automatic recent-history
+  // target would be filled to the beginning before the click, leaving nothing
+  // earlier to page to and no Earlier button to click.
+  await p.evaluate(() => window.fixture.mount({ id: 'paging-priority', count: 500, from: 400, hangAfter: true }));
   await p.getByText('Question 499', { exact: true }).waitFor();
   await p.getByRole('button', { name: 'Refresh transcript', exact: true }).click();
   await p.waitForFunction(() => window.reads.some((r) => r.id === 'paging-priority' && r.req.at === 'after'));

--- a/web/test/readerSearch.test.mjs
+++ b/web/test/readerSearch.test.mjs
@@ -1,0 +1,357 @@
+// Whole-conversation search in the real Reader: finding a message the reader
+// never loaded, and opening it without dragging every page in between through
+// the browser.
+//
+// The premise every case here depends on: the needle is in the FIRST exchange
+// of a transcript far larger than the reader's history budget, so a test that
+// could be satisfied by filtering loaded turns would fail immediately.
+//
+// Run with:  node test/readerSearch.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'reader-search-'));
+const bundle = path.join(tmp, 'fixture.js');
+
+await build({
+  stdin: { resolveDir: web, loader: 'tsx', contents: `
+    import React from 'react'; import {createRoot} from 'react-dom/client'; import {flushSync} from 'react-dom';
+    import ConversationView from './src/components/conversation/ConversationView';
+    window.WebSocket = class { static OPEN=1; readyState=1; constructor(){window.sockets.push(this);} send(){} close(){} };
+    window.sockets = []; window.sends = []; window.reads = []; window.searches = []; window.__case = 0;
+
+    const WINDOW_MIN_TURNS = 12, WINDOW_MAX_BYTES = 8*1024*1024;
+    let cfg = {}, records = [], size = 0, root;
+    // Exchange 0 carries the needle; everything after it is bulk. 90 KiB of tool
+    // output per exchange means the reader's whole budget covers a couple of
+    // dozen at the tail and never reaches the start.
+    function lay(o){
+      records = []; let at = 0;
+      const put = (turn,b)=>{records.push({at,size:b,turn}); at+=b;};
+      for (let i=0;i<o.count;i++){
+        const prompt = i === 0 ? 'first of all, check the ZEPHYRQUARTZ deployment' : 'Question '+i;
+        put({id:'u'+i,role:'user',ts:100000+i*10,blocks:[{type:'text',text:prompt}]}, 300);
+        put({id:'t'+i,role:'assistant',ts:100001+i*10,blocks:[
+          {type:'tool_use',id:'c'+i,name:'Bash',text:'{"command":"check '+i+'"}'},
+          {type:'tool_result',id:'c'+i,text:'output for '+i}]}, o.toolBytes);
+        put({id:'a'+i,role:'assistant',ts:100002+i*10,kind:'final',
+          blocks:[{type:'text',text:'Answer '+i+'.'+(i===0?' ZEPHYRQUARTZ looks fine.':'')}]}, 600);
+      }
+      size = at;
+    }
+    const inside=(f,t)=>records.filter(r=>r.at>=f&&r.at+r.size<=t);
+    const page=(f,t)=>{const g=inside(f,t);const s=g.length?g[0].at:t;const e=g.length?g[g.length-1].at+g[g.length-1].size:t;
+      return {harness:'claude',harnessLabel:'F',sessionId:'s',title:'',model:null,cwd:null,firstTs:0,lastTs:0,usage:null,
+        source:null,sharedBy:null,note:null,truncated:false,total:null,userTurns:null,activity:'waiting',
+        generation:'g1',revision:'r1',turns:g.map(r=>r.turn),
+        window:{mode:'bytes',start:s,end:e,atStart:s<=0,atEnd:t>=size,generation:'g1',revision:'r1'}};};
+    const wait=(ms)=>ms?new Promise(r=>setTimeout(r,ms)):Promise.resolve();
+
+    // A stand-in for the server scan: same contract, same page-boundary cursors.
+    const SCAN_PAGE = 256*1024;
+    const textOf=(turn)=>turn.blocks.map(b=>[b.name||'',b.text||''].join('\\n')).join('\\n');
+    window.fixtureApi = {
+      async window(id, req, bytes, min, signal){
+        window.reads.push({at:req.at, cursor:req.cursor, bytes});
+        await wait(req.at==='before' ? (cfg.beforeDelay||0) : 0);
+        if (signal?.aborted) throw Object.assign(new Error('aborted'), {name:'AbortError'});
+        if (req.at==='after') return page(req.cursor, size);
+        const to = req.at==='before' ? req.cursor : size;
+        const floor = Math.trunc(min) || WINDOW_MIN_TURNS;
+        for (let span = bytes || 384*1024;; span = Math.min(span*2, WINDOW_MAX_BYTES)) {
+          const from = Math.max(0, to-span);
+          if (inside(from,to).length>=floor || from===0 || span>=WINDOW_MAX_BYTES) return page(from,to);
+        }
+      },
+      async search(id, q, cursor, generation, signal){
+        const call = {q, cursor}; window.searches.push(call);
+        // The ABANDONED query is the slow one, so its answer lands after the
+        // newer query's. A stale result that arrives first is overwritten by
+        // the fresh one anyway and proves nothing.
+        await wait(cfg.slowQuery && q.includes(cfg.slowQuery) ? 800 : (cfg.searchDelay||0));
+        // A transport that answers an abandoned request anyway. Suspended tabs
+        // and cached responses both do this, and the reader's own window store
+        // already carries a comment about it, so the guard cannot rely on the
+        // abort arriving as a rejection.
+        if (signal?.aborted && !cfg.searchIgnoresAbort) throw Object.assign(new Error('aborted'), {name:'AbortError'});
+        if (cfg.searchFails) throw new Error('the search could not finish');
+        const needle = q.toLowerCase();
+        let at = cursor === null || cursor === undefined ? size : Number(cursor);
+        const hits = []; let pages = 0; let atStart = at <= 0;
+        while (!atStart && hits.length < (cfg.searchLimit||50) && pages < 200) {
+          const from = Math.max(0, at - SCAN_PAGE);
+          const got = inside(from, at); pages++;
+          const end = got.length ? got[got.length-1].at+got[got.length-1].size : at;
+          for (let i = got.length-1; i >= 0; i--) {
+            const text = textOf(got[i].turn);
+            const idx = text.toLowerCase().indexOf(needle);
+            if (idx < 0) continue;
+            hits.push({id:got[i].turn.id, role:got[i].turn.role, ts:got[i].turn.ts, occurrences:1, clipped:false,
+              snippet:{text:text.slice(Math.max(0,idx-20), idx+needle.length+40), at:Math.min(20,idx), length:needle.length},
+              window:{at:'before', cursor:end, bytes:SCAN_PAGE}});
+          }
+          const next = got.length ? got[0].at : from;
+          if (next >= at) break;
+          at = next; atStart = at <= 0;
+        }
+        return {query:q, mode:'bytes', hits, next: atStart ? null : String(at),
+          complete: atStart, blocked:false, clipped:!!cfg.searchClipped, scanned:size-at, boundary:size,
+          generation:'g1', revision:'r1'};
+      },
+      summary(){ return Promise.resolve({...page(0,0), total:records.length, userTurns:[]}); },
+    };
+
+    function App(){ return <div style={{position:'absolute',inset:0,display:'flex'}}><div className="pane-reader">
+      <ConversationView session={{id:cfg.id,cli:'claude',name:'F',state:'waiting',running:false,everStarted:true,
+        path:null,createdAt:new Date().toISOString()}} isMobile={false} searchOpen={cfg.searchOpen !== false}
+        onCloseSearch={()=>{}} /></div></div>; }
+    window.fixture = {
+      mount(options){
+        cfg = {id:'s'+(++window.__case), count:120, toolBytes:90*1024, searchOpen:true, ...options};
+        lay(cfg);
+        if (root) flushSync(()=>root.unmount());
+        window.reads = []; window.searches = []; window.sends = []; window.sockets = [];
+        root = createRoot(document.getElementById('fixture-root'));
+        flushSync(()=>root.render(<App/>));
+      },
+      set(o){ Object.assign(cfg, o); },
+    };
+    window.probe = {
+      exchanges(){ return Number((document.querySelector('.cxv-status span')?.textContent||'').replace(/[^0-9]/g,''))||0; },
+      hitRows(){ return document.querySelectorAll('.cxv-hitrow').length; },
+      historic(){ return document.querySelectorAll('[data-historic]').length; },
+      shown(){ const r=document.querySelector('.cxv-rows');
+        return !!r && getComputedStyle(r).visibility !== 'hidden' && document.querySelectorAll('[data-x]').length>0; },
+      atBottom(){ const el=document.querySelector('.cxv-body'); return !!el && el.scrollHeight-el.scrollTop-el.clientHeight<2; },
+      text(){ return document.querySelector('.cxv-body')?.innerText || ''; },
+      // The TRANSCRIPT only. The results list quotes the match too, so reading
+      // the whole pane would answer a different question than the one asked.
+      transcript(){ return [...document.querySelectorAll('[data-x]')].map((r)=>r.innerText).join(' '); },
+    };
+  ` }, bundle: true, outfile: bundle, format: 'iife', platform: 'browser',
+  define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent',
+  plugins: [{ name: 'fixture-api', setup(builder) {
+    builder.onResolve({ filter: /^\.\.?(?:\/\.\.)*\/api$/ }, () => ({ path: 'fixture-api', namespace: 'fixture' }));
+    builder.onLoad({ filter: /.*/, namespace: 'fixture' }, () => ({ resolveDir: web, loader: 'ts', contents: `
+      export * from ${JSON.stringify(path.join(web, 'src/api.ts'))};
+      export const getTraceWindow=(id,...a)=>window.fixtureApi.window(id,...a);
+      export const getTraceSummary=()=>window.fixtureApi.summary();
+      export const searchTraceHistory=(id,...a)=>window.fixtureApi.search(id,...a);
+      export const getSubAgentWindow=(i,a,...r)=>window.fixtureApi.window(a,...r);
+      export const getSubAgentSummary=()=>window.fixtureApi.summary();
+      export const getSubAgents=()=>Promise.resolve({agents:[]});
+      export const sendInput=(id,text)=>{window.sends.push({id,text});return Promise.resolve({});};
+    ` }));
+  } }],
+});
+
+const browser = await chromium.launch(chromiumLaunchOptions());
+const errors = [];
+const results = [];
+try {
+  const p = await browser.newPage({ viewport: { width: 1000, height: 760 } });
+  p.on('pageerror', (e) => errors.push(e.message));
+  await p.route('**/*', (r) => r.abort());
+  await p.setContent('<div id="fixture-root" style="position:absolute;inset:8px;display:flex"></div>');
+  await p.addStyleTag({ content: fs.readFileSync(path.join(web, 'src/styles.css'), 'utf8')
+    + fs.readFileSync(path.join(web, 'src/conversation.css'), 'utf8') });
+  await p.addScriptTag({ path: bundle });
+
+  const box = p.locator('.cxv-search');
+  const searchAll = p.getByRole('button', { name: /Search all history|Searching all/ });
+  const open = async (options = {}) => {
+    await p.evaluate((o) => window.fixture.mount(o), options);
+    await p.waitForFunction(() => window.probe.shown(), null, { timeout: 20_000 });
+  };
+
+  // ---------- the premise: the needle is nowhere near the loaded stretch ----------
+  await open();
+  const loaded = await p.evaluate(() => window.probe.exchanges());
+  assert.ok(loaded > 1 && loaded < 100, `the reader loaded a tail, not the conversation (${loaded} of 120)`);
+  assert.ok(!(await p.evaluate(() => window.probe.transcript())).includes('ZEPHYRQUARTZ'),
+    'and the needle is not in it');
+  await box.fill('ZEPHYRQUARTZ');
+  await p.waitForFunction(() => document.querySelector('.cxv-hits')?.textContent === 'No matches');
+
+  // ---------- typing never scans the transcript ----------
+  assert.deepEqual(await p.evaluate(() => window.searches), [],
+    'typing filters the loaded stretch and nothing else');
+
+  // ---------- the explicit action finds it ----------
+  await searchAll.click();
+  await p.waitForFunction(() => window.probe.hitRows() > 0, null, { timeout: 20_000 });
+  const found = await p.evaluate(() => window.probe.hitRows());
+  assert.ok(found >= 2, `the whole conversation is searched (${found} matching messages)`);
+  assert.equal(await p.evaluate(() => window.searches.length), 1, 'one scan, not one per keystroke');
+  await p.getByText(/messages match “ZEPHYRQUARTZ”/).waitFor();
+  results.push({ case: 'unloaded match found', loadedExchanges: loaded, hits: found });
+
+  // ---------- opening a hit does not drag the transcript back to it ----------
+  await p.locator('.cxv-hitrow').last().click();
+  await p.waitForFunction(() => window.probe.historic() > 0, null, { timeout: 20_000 });
+  // Counting reads outright would be flaky — the live reader keeps polling and
+  // may still be filling. The invariants that actually distinguish a jump from
+  // a walk are the SHAPE of the read and the total: reaching exchange 0 of this
+  // fixture page by page is roughly 28 backward windows.
+  const jump = await p.evaluate(() => {
+    const opened = window.reads[window.reads.length - 1];
+    return { opened, backward: window.reads.filter((r) => r.at === 'before').length };
+  });
+  assert.equal(jump.opened.at, 'before', 'a hit is opened with the locator the search handed back');
+  assert.equal(jump.opened.bytes, 256 * 1024, 'including its window size, so it is that exact page');
+  assert.ok(jump.backward <= 10,
+    `and nothing walked the transcript back to it (${jump.backward} backward reads in total)`);
+  assert.ok((await p.evaluate(() => window.probe.transcript())).includes('ZEPHYRQUARTZ'),
+    'the match is on screen with its surrounding conversation');
+  assert.ok(await p.evaluate(() => window.probe.historic()) <= 30, 'with a bounded number of rows');
+  await p.getByText(/Showing an older part of the conversation/).waitFor();
+  // The reader was following the latest message when this hit was opened. The
+  // header must not go on saying so while the pane shows something from the
+  // middle of the conversation — the old window's geometry is not the live
+  // view's, and reading follow state out of it is how that claim gets made.
+  await new Promise((r) => setTimeout(r, 400));
+  assert.notEqual(await p.evaluate(() => [...document.querySelectorAll('.cxv-status button')]
+    .map((b) => b.textContent)[1]), 'At latest',
+    'the reader does not claim to be at the latest message while showing an old one');
+  assert.equal(await p.evaluate(() => window.sockets.length), 0, 'reading old history starts no terminal');
+  assert.deepEqual(await p.evaluate(() => window.sends), [], 'and types nothing into the agent');
+  results.push({ case: 'jump to old hit', backwardReads: jump.backward });
+
+  // ---------- and leaving it puts the reader back where it was ----------
+  // The old window borrows the one scroller, so scrolling inside it must not
+  // become the live view's reading position. With a query that DOES match
+  // loaded turns, coming back has a definite right answer: the same row, in the
+  // same place.
+  await p.getByRole('button', { name: 'Back to the current view' }).click();
+  await p.waitForFunction(() => window.probe.historic() === 0);
+  assert.ok(!(await p.evaluate(() => window.probe.transcript())).includes('ZEPHYRQUARTZ'),
+    'showing the live conversation again, not the old window');
+  assert.ok(await p.evaluate(() => window.probe.hitRows()) > 0,
+    'while the results you came from are still there to go back to');
+
+  await box.fill('Question');
+  await p.waitForFunction(() => document.querySelectorAll('[data-x]').length > 2);
+  await p.evaluate(() => { document.querySelector('.cxv-body').scrollTop = 140; });
+  await new Promise((r) => setTimeout(r, 250));
+  const anchored = await p.evaluate(() => {
+    const el = document.querySelector('.cxv-body');
+    const edge = el.getBoundingClientRect().top;
+    const row = [...document.querySelectorAll('[data-x]')].find((r) => r.getBoundingClientRect().bottom > edge);
+    return { key: row.dataset.x, top: Math.round(row.getBoundingClientRect().top),
+      st: el.scrollTop, sh: el.scrollHeight, ch: el.clientHeight,
+      rows: document.querySelectorAll('[data-x]').length };
+  });
+  await searchAll.click();
+  await p.waitForFunction(() => window.probe.hitRows() > 0, null, { timeout: 20_000 });
+  await p.locator('.cxv-hitrow').last().click();
+  await p.waitForFunction(() => window.probe.historic() > 0, null, { timeout: 20_000 });
+  // Opened from a position part-way up the live transcript, so the live list's
+  // own anchor points at a row that is now hidden and measures as nothing. The
+  // old window must still land on its match rather than being dragged to the
+  // top by a correction computed against a display:none subtree.
+  await new Promise((r) => setTimeout(r, 400));
+  assert.ok(await p.evaluate(() => {
+    const el = document.querySelector('.cxv-body');
+    return el.scrollHeight - el.scrollTop - el.clientHeight < 4;
+  }), 'the old window opens on its match, not wherever the hidden live list points');
+  // Scrolling to the top of a BORROWED window is not the reader reaching the
+  // top of the live transcript, and must not make it page backward — with the
+  // query cleared, the live view's own "near the top, load earlier" rule would
+  // otherwise fire on someone else's scroll position.
+  await box.fill('');
+  await new Promise((r) => setTimeout(r, 200));
+  const beforeScroll = await p.evaluate(() => window.reads.filter((r) => r.at === 'before').length);
+  await p.evaluate(() => { document.querySelector('.cxv-body').scrollTop = 0; });
+  await new Promise((r) => setTimeout(r, 500));
+  assert.equal(await p.evaluate(() => window.reads.filter((r) => r.at === 'before').length), beforeScroll,
+    'scrolling inside an old window does not page the live transcript');
+  await box.fill('Question');
+  await new Promise((r) => setTimeout(r, 200));
+  await p.getByRole('button', { name: 'Back to the current view' }).click();
+  await p.waitForFunction(() => window.probe.historic() === 0);
+  await new Promise((r) => setTimeout(r, 400));
+  const returned = await p.evaluate((key) => {
+    const row = document.querySelector(`[data-x="${key}"]`);
+    return row ? Math.round(row.getBoundingClientRect().top) : null;
+  }, anchored.key);
+  assert.notEqual(returned, null, 'the row that was being read is still rendered');
+  assert.ok(Math.abs(returned - anchored.top) <= 2,
+    `and in the same place (${anchored.top}px before opening a hit, ${returned}px after coming back)`);
+  results.push({ case: 'return from an old hit', anchorDriftPx: Math.abs(returned - anchored.top) });
+
+  // ---------- a term that is nowhere is reported as nowhere, once complete ----------
+  await open();
+  await box.fill('NOTHINGLIKETHISEXISTS');
+  await searchAll.click();
+  await p.getByText(/No message in this conversation contains/).waitFor({ timeout: 20_000 });
+  results.push({ case: 'no matches', reported: 'complete' });
+
+  // ---------- a partial scan never claims to be complete ----------
+  await open({ searchLimit: 2 });
+  await box.fill('Question');
+  await searchAll.click();
+  await p.waitForFunction(() => window.probe.hitRows() > 0, null, { timeout: 20_000 });
+  await p.getByText(/not the whole conversation yet/).waitFor();
+  const more = p.getByRole('button', { name: 'Keep searching earlier' });
+  await more.waitFor();
+  const firstPage = await p.evaluate(() => window.probe.hitRows());
+  await more.click();
+  await p.waitForFunction((n) => window.probe.hitRows() > n, firstPage, { timeout: 20_000 });
+  assert.equal(await p.evaluate(() => window.searches.length), 2, 'continuing is one more bounded request');
+  assert.ok(await p.evaluate(() => window.searches[1].cursor) !== null, 'and it continues from a cursor');
+  results.push({ case: 'partial scan', firstPage, thenMore: await p.evaluate(() => window.probe.hitRows()) });
+
+  // ---------- a failed scan says so and can be retried ----------
+  await open({ searchFails: true });
+  await box.fill('ZEPHYRQUARTZ');
+  await searchAll.click();
+  await p.getByText(/could not finish/).waitFor({ timeout: 20_000 });
+  await p.evaluate(() => window.fixture.set({ searchFails: false }));
+  await p.getByRole('button', { name: 'Try again' }).click();
+  await p.waitForFunction(() => window.probe.hitRows() > 0, null, { timeout: 20_000 });
+  results.push({ case: 'failed then retried', ok: true });
+
+  // ---------- a late answer to an abandoned query cannot win ----------
+  // Twice: once where the abandoned request rejects on abort, and once where it
+  // resolves anyway — only the second reaches the code that binds a result to
+  // the run that asked for it.
+  for (const searchIgnoresAbort of [false, true]) {
+  await open({ searchDelay: 30, slowQuery: 'ZEPHYRQUARTZ', searchIgnoresAbort });
+  // The button disables itself while a scan runs, so overlap has to come from
+  // the keyboard shortcut — which is exactly the path a user hurrying through
+  // a re-typed query takes.
+  await box.fill('ZEPHYRQUARTZ');
+  await box.press('Control+Enter');
+  await p.waitForFunction(() => window.searches.length === 1);
+  await box.fill('Answer 5');
+  await box.press('Control+Enter');
+  await p.waitForFunction(() => window.searches.length === 2);
+  await p.waitForFunction(() => window.probe.hitRows() > 0, null, { timeout: 20_000 });
+  await new Promise((r) => setTimeout(r, 1200));
+  const shownQuery = await p.evaluate(() => document.querySelector('.cxv-scan .cxv-msg')?.textContent || '');
+  assert.ok(shownQuery.includes('Answer 5'), `the newest query owns the results (${shownQuery.slice(0, 80)})`);
+  assert.ok(!shownQuery.includes('ZEPHYRQUARTZ'),
+    `the abandoned one does not come back (abort ${searchIgnoresAbort ? 'ignored' : 'honoured'})`);
+  results.push({ case: `stale scan discarded (abort ${searchIgnoresAbort ? 'ignored' : 'honoured'})`, ok: true });
+  }
+
+  // ---------- clipped coverage is disclosed rather than glossed over ----------
+  await open({ searchClipped: true });
+  await box.fill('ZEPHYRQUARTZ');
+  await searchAll.click();
+  await p.getByText(/searched only as far as the reader displays them/).waitFor({ timeout: 20_000 });
+  results.push({ case: 'clipped disclosure', ok: true });
+
+  assert.deepEqual(errors, [], 'no page errors');
+} finally {
+  await browser.close();
+}
+console.log(JSON.stringify(results, null, 1));
+console.log('reader-search: ok');

--- a/web/test/stepMarkdown.test.mjs
+++ b/web/test/stepMarkdown.test.mjs
@@ -59,7 +59,9 @@ fs.mkdirSync(outDir, { recursive: true });
 const exOut = path.join(outDir, 'exchanges-md.mjs');
 await build({
   entryPoints: [path.join(path.dirname(fileURLToPath(import.meta.url)), '../src/components/conversation/exchanges.ts')],
-  outfile: exOut, format: 'esm', bundle: false, logLevel: 'error',
+// Bundled, not just transpiled: the grouping shares `isOperatorPrompt` with
+// lib/readerModel, which the store counts exchanges with.
+  outfile: exOut, format: 'esm', bundle: true, logLevel: 'error',
 });
 const { proseOf, stepsOf, oneLine } = await import(pathToFileURL(exOut).href);
 

--- a/web/test/subagents.test.mjs
+++ b/web/test/subagents.test.mjs
@@ -26,7 +26,9 @@ fs.mkdirSync(outDir, { recursive: true });
 const out = path.join(outDir, 'exchanges-subagents.mjs');
 await build({
   entryPoints: [path.join(HERE, '../src/components/conversation/exchanges.ts')],
-  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+// Bundled, not just transpiled: the grouping shares `isOperatorPrompt` with
+// lib/readerModel, which the store counts exchanges with.
+  outfile: out, format: 'esm', bundle: true, logLevel: 'error',
 });
 const { splitExchanges, agentSpawnsOf, agentCounts, agentStatus, isLive, anyLive, canOpenAgent, capRows, railIsLast, stepsOf, stepSummary, MAX_NEST, STALE_MS } = await import(pathToFileURL(out).href);
 


### PR DESCRIPTION
Closes #129

## Scope

All three parts of the agreed scope: fuller initial history, whole-conversation
search, and direct navigation to unloaded old hits. The first commit did the
history half and deliberately left search; the review was right that they were
agreed as inseparable, so the second commit adds search, hit navigation, and
four review fixes. See the [review reply](https://github.com/huggingface/agent-manager/pull/144#issuecomment-5606237664)
for the fix-by-fix account.

## The defect, reproduced first

Reproduced against `main` at `ef08e843` before any change, with the real server window code and the real exchange grouping, on synthetic fixtures:

| Fixture | Exchanges the cold reader showed | Exchanges available |
| --- | --- | --- |
| OpenCode SQLite session | **1** | 40 |
| Claude JSONL, 60 KiB tool output per exchange | **3** | 60 |
| Claude JSONL, small turns | 137 | 200 |

Two distinct causes:

- **Indexed sources take `min` literally.** `windowIndex` slices exactly `min` messages off the tail, and the reader's first-paint floor is `2`. Unlike a byte window there is no span to grow — the whole conversation is parsed before `windowIndex` is reached — so asking for fewer rows saved nothing and cost the reader its history.
- **128 KiB is one tool-heavy exchange**, and nothing loaded more until the user scrolled, clicked Earlier or opened Search.

The third row is why this is conditional rather than universal, and why the fix is a fill rather than a bigger first window.

## What changed

**The first window is untouched** — same bytes, same floor, same cost to first paint. After it lands, `ReaderStore` pages backward on its own toward ~20 exchanges.

- Counted as **reconciled exchanges**, not records, tool results or lifecycle events. `countExchanges` shares `isOperatorPrompt` with `splitExchanges` (moved into `readerModel.ts` so there is one definition), and nine fixture shapes assert the two agree.
- **Bounded**: 6 backward requests, ~3 MiB, 20 s per continuous run, 50 ms between steps. Stops at the start of the source, on a blocked record, on a cursor that answers without advancing, and on any read failure. Requests and bytes are cumulative per transcript; the wall clock is per run.
- **Opt-in per consumer** (`useTraceWindows({ history })`). Child transcripts keep their 2 MiB top-of-context policy and previews page nothing. One store shared by several subscribers still fills once.
- **Warm return finishes an unfinished fill and never repeats a finished one.**
- `windowIndex` treats `min` as a floor **on a tail request only**; backward paging still honours the requested page size exactly, since that is a caller walking the conversation deliberately.

**First-viewport coverage** is a separate criterion from the exchange target, because they answer different questions. The view keeps raising the target, to a cap of 60, while the sum of *measured* row heights has not covered the scroller's content box. Estimated heights, spacers and record counts cannot satisfy it.

**No initial text drift** needed three fixes in `useVirtualRows`, each found by measuring the anchor every frame rather than only at the end:

1. A transcript shorter than the window now grows **upward from the bottom** (`flex: 1 0 auto` + `margin-top: auto`, applied only when there are exchanges so the empty state is unchanged). Below the window height there is no scroll offset to compensate with, so a top-aligned transcript was pushed down by every page that arrived. `flex` rather than `min-height: 100%` because a percentage resolves against the content box and the scroller's own padding then becomes 16 px of phantom scroll — which is itself worth 12 px of drift.
2. The reading position is re-asserted whenever the scroller's height differs from the height it was last asserted against. A prepend commits with a row slice derived from the *previous* scroll position; correcting the viewport re-renders with the right slice and a different real height, and that render changes neither `keys` nor `offsets`, so no effect keyed on those ran for it. The frame it painted was a 217–325 px jump, undone a frame later.
3. That correction runs **inside the ResizeObserver callback**, before paint, instead of waiting for React to re-render from the new heights — one frame too late, and the frame is visible.

Latest is preserved through all of it: the position is corrected before the scroll event that would otherwise report our own correction as the user scrolling away.

## Measurements

Identical fixtures, Chromium 1000×760, "before" is `main`'s source with the same tests.

| Fixture | Exchanges | First viewport filled | Max anchor drift | Backward reads | Bytes | Composer ready |
| --- | --- | --- | --- | --- | --- | --- |
| Tool-heavy, 90 KiB/exchange | 2 → **22** | 28% → **100%** | 0 → 0.69 px | 0 → 5 | 128 KiB → 2.0 MiB | 68 → 61 ms |
| Large JSONL, 20 KiB answers | 50 → **200** | 100% → 100% | 0 → 0.13 px | 0 → 1 | 128 KiB → 509 KiB | 28 → 19 ms |
| Ordinary small turns | 200 → 200 | 100% → 100% | 0 → 0.31 px | 0 → 0 | 117 KiB → 117 KiB | 26 → 20 ms |
| OpenCode SQLite, 40 exchanges | 1 → **20** (first window) | — | — | 0 → 0 | — | — |

Time to a usable composer and to first paint are unchanged. **"Before" drift is 0 because nothing arrives to displace anything**, not because the old path was stable — automatic prepending is new here, so there is no honest before-number for it. Regression budgets for the tool-heavy fixture: ≥20 exchanges, viewport covered, ≤2 px drift, ≤6 backward reads, ≤3 MiB.

## Tests

New: `web/test/readerHistory.test.mjs` (store, against a source that honours `bytes`/`min` the way `traces.js` does), `web/test/readerFirstViewport.test.mjs` (real reader in Chromium: coverage, per-frame drift, live append, hung summary, short conversations, request bounds), `server/test/trace-index-history.test.mjs` (indexed first window, exact backward paging, two conversations in one database). Extended `web/test/exchanges.test.mjs` to pin `countExchanges` against `splitExchanges`.

The issue warns that existing browser fixtures return all synthetic turns whatever was asked for. Both new fixtures serve real byte windows and grow the span until the floor is met, so a passing test cannot hide the two-message default — and the tool-heavy case asserts the first window is *short* of the target before asserting the fill reaches it.

Mutation-checked; each reverted mechanism fails a named assertion:

| Reverted | Fails with |
| --- | --- |
| Automatic fill | `only 2 exchanges became available on their own; expected at least 20` |
| Same-frame re-placement | `and Latest is still the bottom` |
| Bottom growth | `already-visible text does not move while history loads (max 454.63px…)` |
| `min-height: 100%` instead of flex | `…(max 12.09px…)` |
| Coverage request | `so it keeps going until they do (24 exchanges, …covered: false)` |
| Indexed tail floor | `a cold open sees a readable stretch of conversation, not two records (got 1 prompts in 2 messages)` |
| Leading-exchange counting rule | `answer first: counted without grouping matches grouping` |
| Fill budgets | `a budget ends the fill` |
| No-progress guard | `one backward read proves it, a second is the retry — not 6 of them` |

## Runs

- `web`: `npx tsc --noEmit`, `node ../scripts/run-suites.mjs` (**25 suites passed**), `npm run test:render` (all checks passed), `npm run build` (succeeds; retains the pre-existing large-chunk warning).
- `server`: the suite runner still stops at `test/crons.test.mjs`, so **every suite was run individually: 30 passed, `test/crons.test.mjs` failed.** That is the documented date-sensitive failure (#4, "run on restart fires once for enabled running jobs, not stopped ones"), confirmed on unchanged `main` before any edit; no cron code is touched here.
- `test/cron-api.test.mjs` failed **once** inside a 30-suite back-to-back local loop and has passed 6/6 since, including three times immediately after `crons.test.mjs`. It starts a server on a fixed port; I am reporting it rather than hiding it, but I could not reproduce it and nothing here touches cron or that port.
- `git diff --check` clean. All fixtures are synthetic and disposable; no production session was prompted or restarted, nothing was deployed, and no transcript content appears in any diagnostic.

## Whole-conversation search

Typing still filters the loaded stretch instantly. Searching everything older is
a separate explicit action (button, or ⌘/Ctrl+Enter) because it reads the
transcript: nothing scans on a keystroke or on mount.

`GET /api/trace/:id/search` scans backward from the tail in bounded pages —
256 KiB per page, ≤40 pages, ≤12 MiB, ≤4 s, ≤50 matching messages per request,
≤200-character query — continued with a cursor that is a page boundary, so
continuing can neither repeat a match nor step over one. The scan boundary for a
live conversation is the size read when the request started. Matching is literal
and case-insensitive over exactly the fields the Reader's own loaded search uses;
where a parser clipped a long block, the response says so rather than implying it
read what was cut. Empty, searching, partial, failed, cancelled and no-matches
are distinct states, and only a scan that reached the beginning says no message
contains the term.

Opening a result is **one read** of the window that result names, rendered
beside the live history rather than inside it: the live cursor never advances,
nothing is spliced, ≤30 exchanges of context ending on the match, no socket and
no input. The reader's place is captured before the window opens and restored
when it closes — verified to the pixel through 1152 px of history arriving while
the old window was up.

Reproduced first, as a test: a term in exchange 0 of a 120-exchange transcript
with 10 exchanges loaded. One click finds it; one read opens it.

## Things a reviewer should push back on if they disagree

- **Four test files switched from `bundle: false` to `bundle: true`.** Moving `isOperatorPrompt` into `readerModel.ts` gives `exchanges.ts` its first import, which an unbundled transpile cannot resolve. Bundling is strictly more faithful, but it is churn in files this PR is otherwise not about. The alternative was a second copy of the prompt-envelope rule, which would drift.
- **`ConversationView` gained a layout effect that reads `measuredHeight()` on every measurement pass.** It is a sum over loaded keys and it stops early once covered, but it is work in a hot path.
- **The post-commit height check reads `scrollHeight` on every commit**, including ones caused by typing in the composer. That is one forced reflow per commit, in line with the `origin()` reads the hook already does, but it is a real cost.
- **20 / 60 / 6 / 3 MiB / 20 s are starting points**, validated against the fixtures above and nothing else. The issue asks for them to be tuned against representative traces; real ones would be better evidence than mine.
- I removed a guard I had added to `onScroll` (distinguishing our own scroll corrections from the user's) once fixing the root cause made it redundant — the mutation showed the suite passing without it. If you would rather keep belt-and-braces there, say so.
- **Search results render above the transcript, inside the same scroller.** One scroll owner, no second pane — but on a narrow window a long result list pushes the conversation down until you clear it.
- **A hit's context is the window it was found in**, so it ends on the match with preceding context and none after it. Showing text on both sides would need a second read; I did not add one.
- **The whole-history scan is server-side and synchronous per page.** It reuses the existing window reader rather than a new index, which keeps it bounded and cache-friendly but means a very large transcript is several requests rather than one fast one. No new database or search infrastructure.
- **Bundle and child surfaces have no search entry point.** The issue said adding them was not required; the endpoint refuses a bundle explicitly rather than searching the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

