### PR TITLE
Standardize API input validation and error handling

### DIFF
--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -41,6 +41,12 @@ allowlisted fields in `ApiError.data`, with bounded strings/collections. It
 retains `status` even for an unreadable proxy response. No automatic retry,
 new timeout policy, mutation replay or delivery guarantee is added.
 
+The audit recorder keeps one outcome. If the connection closes before the
+server finishes responding, `ok:false` and `incomplete:true` distinguish it from
+success; `status:499` is audit-only when no headers were committed. This is not
+evidence that the operation was rolled back or that a replay would be safe.
+Request-body capture and filtering are unchanged.
+
 ## Route / response / mutation inventory
 
 Paths below are relative to `/api`. The handler inventory was checked against

--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -1,0 +1,151 @@
+# HTTP validation and failures
+
+This is the compatibility inventory for the Express **4** request boundary.
+The routes and successful payloads are unchanged. HTTP failures retain the
+top-level `error` string used by copied shell/agent clients, and add `code`:
+
+```json
+{"error":"name: must not be empty","code":"invalid-input","details":[{"field":"name","message":"must not be empty"}]}
+```
+
+`error` is display text, not HTML; clients branch on `code`, not English.
+Expected exceptions use `ApiError`. Arbitrary exceptions (including library
+errors carrying their own `status`) do not authorize exposing their messages.
+Unexpected errors return a generic 500. Legacy local 5xx JSON replies are also
+sanitized before the audit recorder sees them. An optional `requestId` is a
+server-generated UUID, never a request-supplied identifier. No exception body,
+stack, upstream response or new secret-bearing diagnostic is logged here.
+
+## Status and code contract
+
+| Status | Codes | Safe extra data / meaning |
+| --- | --- | --- |
+| 400 | `invalid-input`, `bad-request`, `invalid-json`, `invalid-path` | `details: [{field,message}]`; no rejected values echoed |
+| 400 | `origin-required`, `unknown-origin` | Existing attribution requirement, unchanged ordering |
+| 400 | `bad-repo`, `not-a-bundle` | Existing import refusals |
+| 400 | `request-aborted` | Upload/body interrupted before a response was committed |
+| 403 | `locked` | `reason: public-space`; health/info/visibility remain accessible |
+| 403 | `forbidden`, `no-access`, `no-hf-token`, `backup-unavailable` | Expected access/capability refusal |
+| 404 | `not-found`, `api-not-found` | Missing item versus nonexistent API route |
+| 404 | `no-trace`, `unsupported-harness`, `trace-not-user-conversation` | Expected Reader availability, not a failed fetch substituted with empty content |
+| 409 | `conflict`, `not-archived`, `input-not-ready`, `invalid-workspace`, `remote-agent`, `cron-unavailable`, `backup-running` | Action cannot run in the current state; not permission to replay it |
+| 409 | `file-changed` | Existing `mtime` preserved; browser also retains `tag`/`currentTag` when supplied by file-save endpoints |
+| 409 | `redaction-blocked` | Existing `hits` rule/count map preserved |
+| 409 | `conflict` on paused remote messages | Existing `stop` and `reason` retained, plus additive `error`/`code` |
+| 413 / 415 / 429 | `payload-too-large` / `unsupported-media-type` / `rate-limited` | Body limits, media/encoding policy, existing rate limits |
+| 5xx | `internal-error` | Generic safe message; optional bounded `requestId` |
+
+`reason`, `hint`, `hits`, `mtime`, `tag`, `currentTag`, `retryAfter`, and
+`details` are optional, not universally present. The browser retains these
+allowlisted fields in `ApiError.data`, with bounded strings/collections. It
+retains `status` even for an unreadable proxy response. No automatic retry,
+new timeout policy, mutation replay or delivery guarantee is added.
+
+## Route / response / mutation inventory
+
+Paths below are relative to `/api`. The handler inventory was checked against
+main `ef08e843d1c67fcc4e1c463415819ea351734d6d`, rather than relying on planning
+line numbers. `apiRoutes` covers every API registration in `index.js`, including
+the generated `mkdir`/`touch` routes. Global JSON parsing, privacy lock and
+operation attribution stay in their original order; validation runs after
+route-specific parsers and before the final action. The separate browser-origin
+and audit-filter work is not reimplemented here.
+
+| Routes | Forms and responses | Mutation / compatibility notes |
+| --- | --- | --- |
+| GET `health`, `info`, `visibility`, `clis`, `tree`, `sessions`, `next-name` | JSON | Health/public lock exceptions unchanged; next-name validates CLI |
+| GET `usage`, `operations`, `traces`, `meta`, `meta/:id` | JSON | Provider enum; operation limit 1–1000, existing timestamp cursor; optional provider/digest subsystem fallbacks remain local |
+| POST `push/subscribe`, `push/unsubscribe`, `notify` | JSON command | Subscription structure, endpoint and notification fields validated before dispatch; notification zero-device/per-device partial outcomes remain **200 `ok:false`** |
+| POST `sessions` | JSON creation, 201 | CLI required; optional name/prompt/path; blank name retains generated default, blank path retains workspace root; group must exist; optional prompt still starts asynchronous work |
+| PUT `sessions/:id` | JSON selected-field update | Display name only, no folder rename |
+| POST `sessions/:id/input`, `attachments/insert` | JSON command | Text / attachment ID types checked before resolution or agent input; existing attachment limits and insertion acknowledgement unchanged |
+| POST `sessions/:id/attachments` | Raw bytes, 201 JSON metadata | Any file media type, including JSON, bypasses JSON parser; existing quotas, image validation and cancellation retained |
+| DELETE `sessions/:id/attachments/:attachmentId`; GET `…/raw` | JSON command; binary stream | Stream errors before headers are JSON, after headers terminate; disconnect destroys file source |
+| GET `agents`, `agents/:id`, `…/tail`, `…/subagents`, `…/subagents/:agentId` | JSON | Tail line integer validation with existing 2000-line clamp (including clients requesting more), trace query validation; roster/trace distinctions retained |
+| GET `agents/:id/wait` | JSON long poll | State list, timeout 1–300 s, settle 0–60 s; existing wait/deadline behavior retained, disconnect stops polling |
+| POST `agents`, `agents/:id/prompt`, `agents/:id/stop` | Text body **or** JSON `prompt` / `text`; `from` body/query, launch CLI/name/path/group query aliases | Preserve curl's non-JSON default content type as literal prompt text, not form decoding. Sender, target, installed CLI, self-target and group resolution checks remain before action |
+| GET `remote/:name/ping`, `…/messages`, `sessions/:id/remote`; POST `remote/:name/hello`, `sessions/:id/remote/paused` | JSON | Remote peer strings/paused boolean; scalar sequence cursor; existing remote-origin fallback unchanged |
+| POST `remote/:name/messages`; GET `…/prompt`, `…/stream` | Text/JSON message command; plain-text instructions; heartbeat/NDJSON long poll | Paused poll's **200 stop result** is deliberate; paused message is 409. Stream sends connected/heartbeat/one JSON line, never JSON error appended after bytes. Wait remains 5–1800 s, no global short timeout |
+| POST `demo`, `welcome/seen`, `relaunch`, `update`; GET `update/check` | JSON commands/status | Demo boolean. `no-space`, `no-token`, `cooldown`, `busy`, `upstream-unreachable` and upstream refusal capability results remain **200 `ok:false`**; thrown request failures now return safe 500 |
+| GET/PUT `config` | JSON **replacement** | Omitted sections/fields keep existing replacement defaults; booleans are not coerced; explicit zero, false and backup `exclude:[]` preserved. No durable-store/recovery rewrite |
+| GET/PUT `secrets` | JSON notes-map replacement | Notes contain arbitrary user-defined keys with string values, including empty strings; no global field stripping |
+| GET `backup/status`; POST `backup/run` | JSON status / starts asynchronous Job | Missing prerequisites, already-running and bad IDs explicitly classified; status subsystem's optional lookup fallbacks unchanged; no Job lifecycle redesign |
+| GET `skills`, `skills/:name`; PUT/DELETE `skills/:name` | JSON listing/read; text replacement / delete | PUT must decode to a string, including valid empty text; JSON objects cannot silently overwrite a skill with empty text; distribution remains best effort |
+| GET `files/:id`, `…/preview`, `folders` | JSON | Scalar paths; existing lexical/realpath, file-kind and size checks retained |
+| GET `files/:id/raw`, `…/download`, `trace/:id/download` | Binary/download stream | Existing sandbox/content-disposition headers; explicit callback forwarding; no JSON appended after headers |
+| PUT `files/:id/write` | Text replacement, JSON result | Valid empty text allowed; existing `base` revision precondition, text-size and path checks retained; JSON objects rejected before writing |
+| POST `files/:id/mkdir`, `…/touch`, `…/rename`, `…/move`; DELETE `…/entry` | JSON commands | Single filename / destination types validated before filesystem changes; root/dependency/existing-entry checks retained |
+| POST `files/:id/upload` | Raw bytes → JSON completion | Raw JSON files also bypass body parsing. One completion/error path; abort unpipes/closes destination and releases listeners. Existing overwrite policy unchanged (separate file-protection work) |
+| POST `overview/hidden`, `move`; POST/PUT/DELETE `groups[/id]` | JSON | Hide boolean/ref; live move targets; group PUT is a selected-field patch, not replacement. `layout:null` means auto; explicit layout is 1–3 rows/columns; session ordering retains live membership checks |
+| GET/POST `crons`; PUT/DELETE `crons/:id`; POST `…/run` | JSON; creation 201, manual fire 202 | Create requires name/agent/prompt/five-field schedule/time zone. PUT patches selected fields, nested agent/schedule objects still replace as before. Strict runOnRestart/state types. 202 means accepted, not finished; later failure stays in `last` with safe text. No target identity/scheduling behavior change |
+| GET/POST `sessions/:id/share`; GET/POST `share/access` | JSON | Visibility/name/user lists validated; redaction 409 and successful share's `granted`/`grantErrors` retained. Partial grant errors get a safe message/code; best-effort access-list lookups remain unchanged |
+| POST `trace/import`; GET `trace/bundles` | JSON | Bare repo or pasted dataset URL still supported; known domain codes kept. No safe re-import/transaction changes |
+| GET `trace/:id`, `…/location`, `files/:id/trace`; PUT `trace/:id/source` | JSON trace pages/windows/summary; selected source update | Trace modes mutually exclusive; safe nonnegative integer cursors, v1/v2; existing page/window-size clamps retained (500 turns / 8 MiB). Source kind enum, ref/target checks before storing |
+| POST `sessions/:id/archive`, `…/unarchive`, `…/stop`; DELETE `sessions/:id` | JSON commands | Existing archive/delete and `ifNeverStarted=1` rules unchanged; optional attachment cleanup remains isolated |
+| `/ws` | WebSocket terminal protocol | Not JSON wrapped; framing, origin admission and terminal lifecycle unchanged |
+| Other `/api` paths; static assets and SPA paths | API 404 JSON; ordinary static/SPA responses | API errors never fall through to an HTML application page; non-API failures remain Express/static concerns |
+
+## Validator conventions
+
+- Validate at the route boundary before any domain action, not only in TS.
+  Schema helpers distinguish missing values from null/empty/false; no generic
+  truthiness or numeric-string conversion for JSON. JSON-only routes require
+  `application/json` when a content type is supplied. Malformed JSON, unsupported
+  encodings and parser limits get deliberate JSON errors. Express's strict
+  parser rejects scalar JSON documents (including bare `null`).
+- Queries are scalar strings: duplicate/bracket-structured parameters are
+  rejected. Numeric query fields use complete integer syntax, safe integer
+  bounds and route limits. Existing documented clamping of trace size budgets
+  stays in the domain reader. Paths reject null characters and retain existing
+  containment checks; do not introduce a second path resolver.
+- Unknown fields retain each endpoint's existing handling, usually ignored.
+  No input object is stripped or rewritten by validation. Notes-map extension
+  keys remain supported. Intentional empty group names on creation, empty text
+  file replacement and null group layout keep their special meaning.
+- Schedule validation is reused, with a public validation error instead of
+  arbitrary parser exception text. Store schemas/durability, scheduler identity,
+  import replacement, async work receipts and delivery retries are separate work.
+
+## Adding a handler and client
+
+```js
+// server/src/index.js — register via api, not app, and add its input case to
+// createValidator. Use ApiError only for a message known to be public.
+api.post('/api/example', async (req, res) => {
+  if (!available()) throw new ApiError(409, 'example-unavailable', 'Try after the current task finishes.');
+  res.json(await performValidatedAction(req.body));
+});
+```
+
+Promise rejections and synchronous throws enter one Express error path. For
+event emitters, explicitly forward errors and remove timers/listeners on close;
+the promise wrapper cannot catch unrelated future callbacks. Downloads pass
+their callback error to `next`; `pipeResponse` and `remoteStream` demonstrate
+the before/after-headers distinction. A late failure after a completed response
+is consumed, not sent again. Do not change status or append JSON to committed
+stream bytes.
+
+```ts
+// web/src/api.ts — the existing local fetch keeps attribution; json uses the
+// single decoder. For a text success, use decodeResponse(r, 'text').
+export const example = (body: ExampleInput) =>
+  fetch('/api/example', { method: 'POST', headers: HEADERS, body: JSON.stringify(body) }).then(json);
+// UI: catch ApiError; display .message, branch on .code, inspect .data.
+// Keep the draft and existing explicit failure actions; never replay here.
+```
+
+`decodeResponse` reads a failure body once, capped at 64 KiB, cancels oversized
+reads, and never shows a proxy's HTML/status text. Empty success is allowed;
+malformed expected-JSON success is `unreadable-response`. Legacy `{error:string}`
+still works. AbortError identity remains intact for Reader cancellation;
+`timeout`, `offline`, and `network-error` are distinct transport failures with
+no HTTP status unless headers were already received. XHR remains the upload
+transport: same decoder, progress, explicit cancellation and upload deadline.
+TraceUnavailable and RedactionBlocked remain subclasses with their existing
+constructors/fields; generic HTTP failures are not Reader empty states.
+
+Tests: `server/test/api-boundary.test.mjs` exercises the real Express stack with
+failure injection and fake action counters; `api-http.test.mjs` exercises the
+production routes with isolated roots and mocked external calls. The discovered
+web decoder and control tests exercise real fetch/XHR, Reader/file/share/group
+controls and draft retention. No test sends real agent work or notifications.

--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -28,7 +28,7 @@ stack, upstream response or new secret-bearing diagnostic is logged here.
 | 403 | `forbidden`, `no-access`, `no-hf-token`, `backup-unavailable` | Expected access/capability refusal |
 | 404 | `not-found`, `api-not-found` | Missing item versus nonexistent API route |
 | 404 | `no-trace`, `unsupported-harness`, `trace-not-user-conversation` | Expected Reader availability, not a failed fetch substituted with empty content |
-| 409 | `conflict`, `not-archived`, `input-not-ready`, `invalid-workspace`, `remote-agent`, `cron-unavailable`, `backup-running` | Action cannot run in the current state; not permission to replay it |
+| 409 | `conflict`, `not-archived`, `input-not-ready`, `invalid-workspace`, `remote-agent`, `cron-unavailable`, `backup-running`, `no-transcript` | Action cannot run in the current state; not permission to replay it |
 | 409 | `file-changed` | Existing `mtime` preserved; browser also retains `tag`/`currentTag` when supplied by file-save endpoints |
 | 409 | `redaction-blocked` | Existing `hits` rule/count map preserved |
 | 409 | `conflict` on paused remote messages | Existing `stop` and `reason` retained, plus additive `error`/`code` |

--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -95,8 +95,8 @@ and audit-filter work is not reimplemented here.
 
 - Validate at the route boundary before any domain action, not only in TS.
   Schema helpers distinguish missing values from null/empty/false; no generic
-  truthiness or numeric-string conversion for JSON. JSON-only routes require
-  `application/json` when a content type is supplied. Malformed JSON, unsupported
+  truthiness or numeric-string conversion for JSON. JSON-only payloads require
+  `application/json`; bodyless commands may omit it. Malformed JSON, unsupported
   encodings and parser limits get deliberate JSON errors. Express's strict
   parser rejects scalar JSON documents (including bare `null`).
 - Queries are scalar strings: duplicate/bracket-structured parameters are

--- a/docs/api-errors.md
+++ b/docs/api-errors.md
@@ -33,10 +33,12 @@ stack, upstream response or new secret-bearing diagnostic is logged here.
 | 409 | `redaction-blocked` | Existing `hits` rule/count map preserved |
 | 409 | `conflict` on paused remote messages | Existing `stop` and `reason` retained, plus additive `error`/`code` |
 | 413 / 415 / 429 | `payload-too-large` / `unsupported-media-type` / `rate-limited` | Body limits, media/encoding policy, existing rate limits |
-| 5xx | `internal-error` | Generic safe message; optional bounded `requestId` |
+| 5xx | `internal-error` | Generic safe message; optional bounded `requestId`; a settings write may name its validated data-root-relative file in `details: [{field:"path",message}]` |
 
 `reason`, `hint`, `hits`, `mtime`, `tag`, `currentTag`, `retryAfter`, and
-`details` are optional, not universally present. The browser retains these
+`details` are optional, not universally present. A 5xx never carries an absolute
+path or exception text; the settings filename is relative to the durable data
+root (for example, `am-config.json`). The browser retains these
 allowlisted fields in `ApiError.data`, with bounded strings/collections. It
 retains `status` even for an unreadable proxy response. No automatic retry,
 new timeout policy, mutation replay or delivery guarantee is added.

--- a/server/src/api-errors.js
+++ b/server/src/api-errors.js
@@ -1,0 +1,110 @@
+import { randomUUID } from 'node:crypto';
+
+export const statusCode = (status) => ({
+  400: 'bad-request', 403: 'forbidden', 404: 'not-found', 409: 'conflict',
+  413: 'payload-too-large', 415: 'unsupported-media-type', 429: 'rate-limited',
+}[status] || (status >= 500 ? 'internal-error' : 'request-failed'));
+
+// Only explicitly public failures may expose a domain message. An arbitrary
+// Error.status/statusCode from a library is not permission to expose its text.
+export class ApiError extends Error {
+  constructor(status, code, message, data = {}) {
+    super(message);
+    this.statusCode = status;
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export const invalid = (field, message) => new ApiError(400, 'invalid-input', `${field}: ${message}`, {
+  details: [{ field, message }],
+});
+
+// Express 4 catches synchronous throws, but not returned promises. `next` is
+// once-only even for a handler that forwards an error and subsequently rejects.
+export function asyncHandler(handler) {
+  return (req, res, next) => {
+    let forwarded = false;
+    const forward = (error) => {
+      if (forwarded) return;
+      forwarded = true;
+      next(error);
+    };
+    const fail = (error) => forward(error instanceof Error ? error : new Error('request failed'));
+    try { Promise.resolve(handler(req, res, forward)).catch(fail); }
+    catch (error) { fail(error); }
+  };
+}
+
+// An explicit registration facade, not a patch to Express. Parsers still run
+// before validation; successful bodies/streams are never JSON-wrapped.
+export function apiRoutes(app, validate) {
+  return Object.fromEntries(['get', 'post', 'put', 'patch', 'delete'].map((method) => [method, (route, ...handlers) => {
+    const action = handlers.pop();
+    app[method](route, ...handlers.map(asyncHandler), asyncHandler((req, res, next) => {
+      validate(req, route);
+      next();
+    }), asyncHandler(action));
+  }]));
+}
+
+// Install after the audit middleware: its res.json wrapper must see the final
+// safe envelope, not the arbitrary exception an old local catch handed us.
+export function errorEnvelope(_req, res, next) {
+  const json = res.json;
+  res.json = function (body) {
+    if (res.writableEnded || res.destroyed) return this;
+    if (res.statusCode >= 400) {
+      body = res.statusCode >= 500
+        ? { error: 'The request could not be completed. Please try again.', code: 'internal-error', requestId: randomUUID() }
+        : { ...body, error: typeof body?.error === 'string' ? body.error : 'The request was refused.',
+          code: typeof body?.code === 'string' ? body.code : statusCode(res.statusCode) };
+    }
+    return json.call(this, body);
+  };
+  next();
+}
+
+export function apiNotFound(req, res, next) {
+  if (req.path !== '/api' && !req.path.startsWith('/api/')) return next();
+  res.status(404).json({ error: 'API route not found.', code: 'api-not-found' });
+}
+
+export function apiErrorHandler(error, req, res, next) {
+  if (req.path !== '/api' && !req.path.startsWith('/api/')) return next(error);
+  if (res.writableEnded || res.destroyed) return;
+  if (res.headersSent) { res.destroy(); return; }
+  // A download may have prepared headers without writing its first byte.
+  for (const header of ['content-length', 'content-type', 'content-disposition', 'content-encoding']) res.removeHeader(header);
+  let failure = error;
+  if (!(failure instanceof ApiError)) {
+    const parser = {
+      'entity.parse.failed': [400, 'invalid-json', 'Request body must be valid JSON.'],
+      'entity.too.large': [413, 'payload-too-large', 'Request body is too large.'],
+      'encoding.unsupported': [415, 'unsupported-media-type', 'Request encoding is not supported.'],
+      'charset.unsupported': [415, 'unsupported-media-type', 'Request charset is not supported.'],
+      'request.size.invalid': [400, 'bad-request', 'Request body size is invalid.'],
+      'request.aborted': [400, 'request-aborted', 'Request body was interrupted.'],
+    }[error?.type];
+    failure = parser ? new ApiError(...parser)
+      : error instanceof URIError ? new ApiError(400, 'invalid-path', 'Request path is malformed.')
+      : new ApiError(500, 'internal-error', 'The request could not be completed. Please try again.');
+  }
+  const data = {};
+  for (const key of ['details', 'reason', 'hits', 'mtime', 'tag', 'currentTag', 'retryAfter']) {
+    if (failure.data[key] !== undefined) data[key] = failure.data[key];
+  }
+  res.status(failure.statusCode).json({ ...data, error: failure.message, code: failure.code });
+}
+
+// Attach before piping. Errors before bytes become JSON; errors after bytes
+// terminate the stream. Disconnects release the source without a second reply.
+export function pipeResponse(source, req, res, next) {
+  let failed = false;
+  const close = () => source.destroy();
+  const cleanup = () => res.off('close', close);
+  source.on('error', (error) => { if (!failed) { failed = true; cleanup(); source.destroy(); next(error); } });
+  source.once('end', cleanup);
+  res.once('close', close);
+  source.pipe(res);
+}

--- a/server/src/api-errors.js
+++ b/server/src/api-errors.js
@@ -20,6 +20,25 @@ export const invalid = (field, message) => new ApiError(400, 'invalid-input', `$
   details: [{ field, message }],
 });
 
+// A 5xx message is always replaced below, but a route may deliberately name the
+// relative file whose operation failed. Keep that diagnostic narrow: an
+// absolute/container path, traversal, markup or control text is not public
+// merely because an old local catch put it in a JSON field.
+const publicFailurePath = (value) => typeof value === 'string'
+  && value.length > 0 && value.length <= 256
+  && !/^(?:[/\\]|[a-z]:)/i.test(value)
+  && !/[\\<>\u0000-\u001f]/.test(value)
+  && value.split('/').every((part) => part && part !== '.' && part !== '..');
+
+const public5xxDetails = (body) => {
+  if (!Array.isArray(body?.details)) return undefined;
+  const details = body.details.slice(0, 4)
+    .filter((item) => item && typeof item === 'object'
+      && item.field === 'path' && publicFailurePath(item.message))
+    .map(({ field, message }) => ({ field, message }));
+  return details.length ? details : undefined;
+};
+
 // Express 4 catches synchronous throws, but not returned promises. `next` is
 // once-only even for a handler that forwards an error and subsequently rejects.
 export function asyncHandler(handler) {
@@ -55,10 +74,14 @@ export function errorEnvelope(_req, res, next) {
   res.json = function (body) {
     if (res.writableEnded || res.destroyed) return this;
     if (res.statusCode >= 400) {
-      body = res.statusCode >= 500
-        ? { error: 'The request could not be completed. Please try again.', code: 'internal-error', requestId: randomUUID() }
-        : { ...body, error: typeof body?.error === 'string' ? body.error : 'The request was refused.',
+      if (res.statusCode >= 500) {
+        const details = public5xxDetails(body);
+        body = { error: 'The request could not be completed. Please try again.', code: 'internal-error', requestId: randomUUID(),
+          ...(details ? { details } : {}) };
+      } else {
+        body = { ...body, error: typeof body?.error === 'string' ? body.error : 'The request was refused.',
           code: typeof body?.code === 'string' ? body.code : statusCode(res.statusCode) };
+      }
     }
     return json.call(this, body);
   };

--- a/server/src/api-streams.js
+++ b/server/src/api-streams.js
@@ -1,0 +1,45 @@
+// The remote protocol is unchanged: a connected line, heartbeats, then one
+// JSON line. Every event/timer enters the same request-scoped failure path.
+export function remoteStream(req, res, next, remote, name, since, wait) {
+  let done = false;
+  let heartbeat, timer;
+  let release = () => {};
+  const cleanup = () => {
+    clearInterval(heartbeat); clearTimeout(timer);
+    res.off('close', close); res.off('error', fail);
+    release();
+  };
+  const close = () => { if (!done) { done = true; cleanup(); } };
+  const fail = (error) => {
+    if (done) return;
+    done = true;
+    cleanup();
+    next(error instanceof Error ? error : new Error('stream failed'));
+  };
+  const guard = (fn) => (...args) => { if (!done) { try { fn(...args); } catch (error) { fail(error); } } };
+  const finish = guard((payload) => {
+    const line = `${JSON.stringify(payload)}\n`;
+    res.end(line);
+    close();
+  });
+  res.once('close', close);
+  res.once('error', fail);
+  guard(() => {
+    // Fallible read before headers: failures can still be a structured reply.
+    const pending = remote.pendingFor(name, since);
+    res.set({ 'content-type': 'application/x-ndjson', 'cache-control': 'no-cache, no-transform', 'x-accel-buffering': 'no' });
+    res.write(':connected\n');
+    release = remote.registerStream(name, {
+      since,
+      deliver: guard((messages) => finish({ messages, seq: messages[messages.length - 1].seq })),
+      stop: guard((reason) => finish({ stop: true, reason: reason || 'disconnected from the manager' })),
+    });
+    if (done) { release(); return; } // a registration can synchronously close
+    heartbeat = setInterval(guard(() => res.write(':hb\n')), remote.HEARTBEAT_MS);
+    timer = setTimeout(guard(() => finish({ messages: [], seq: remote.lastSeq(name) })), wait * 1000);
+    if (pending.length) {
+      remote.markDelivered(name, pending[pending.length - 1].seq);
+      finish({ messages: pending, seq: pending[pending.length - 1].seq });
+    }
+  })();
+}

--- a/server/src/api-validation.js
+++ b/server/src/api-validation.js
@@ -1,0 +1,176 @@
+import { ApiError, invalid } from './api-errors.js';
+import { validateSchedule } from './crons.js';
+
+const object = (value, field) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw invalid(field, 'must be an object');
+  return value;
+};
+const text = (value, field, { empty = false, max = Infinity } = {}) => {
+  if (typeof value !== 'string') throw invalid(field, 'must be a string');
+  if (!empty && !value.trim()) throw invalid(field, 'must not be empty');
+  if (value.length > max) throw invalid(field, `must be at most ${max} characters`);
+};
+const boolean = (value, field) => { if (typeof value !== 'boolean') throw invalid(field, 'must be true or false'); };
+const number = (value, field, min, max, integer = true) => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || (integer && !Number.isSafeInteger(value)) || value < min || value > max) {
+    throw invalid(field, `must be ${integer ? 'an integer' : 'a number'} between ${min} and ${max}`);
+  }
+};
+const oneOf = (value, field, values) => { if (!values.includes(value)) throw invalid(field, `must be one of: ${values.join(', ')}`); };
+const strings = (value, field) => {
+  if (!Array.isArray(value)) throw invalid(field, 'must be an array of strings');
+  value.forEach((item) => text(item, field));
+};
+const optional = (body, key, check = text, ...args) => {
+  if (body[key] !== undefined) check(body[key], key, ...args);
+};
+const treeRef = (value, field) => {
+  text(value, field);
+  if (!/^[sg]:[^\s:]+$/.test(value)) throw invalid(field, 'must be a session or group reference');
+};
+const pathText = (value, field) => {
+  text(value, field, { empty: true });
+  if (value.includes('\0')) throw invalid(field, 'must not contain null characters');
+};
+const fileName = (value, field) => {
+  text(value, field, { max: 200 });
+  if (/[\\/\0]/.test(value) || ['.', '..'].includes(value.trim())) throw invalid(field, 'must be a single file name');
+};
+
+// Unknown fields keep the endpoint's old behavior (ignored, or preserved by
+// its own service). Validate recognized fields, never strip an input object.
+export function createValidator({ cliExists, sessionExists, groupExists }) {
+  const cli = (value, field) => { text(value, field); if (!cliExists(value)) throw invalid(field, 'unknown CLI'); };
+  const exists = (value, field, lookup) => { text(value, field); if (!lookup(value)) throw invalid(field, 'does not exist'); };
+  const liveRef = (value, field) => {
+    treeRef(value, field);
+    if (!(value.startsWith('s:') ? sessionExists(value.slice(2)) : groupExists(value.slice(2)))) throw invalid(field, 'does not exist');
+  };
+  return (req, route) => {
+    const q = req.query;
+    // Express's extended query parser produces arrays/objects for duplicates
+    // and bracket notation. None of the current routes accepts either form.
+    for (const [key, value] of Object.entries(q)) {
+      if (typeof value !== 'string') throw invalid('query', 'parameters must have one scalar value');
+      if (value.includes('\0')) throw invalid('query', 'must not contain null characters');
+    }
+    for (const value of Object.values(req.params)) {
+      if (value.includes('\0')) throw invalid('path', 'must not contain null characters');
+    }
+    const queryNumber = (key, min, max = Number.MAX_SAFE_INTEGER) => {
+      if (q[key] === undefined) return;
+      if (!/^\d+$/.test(q[key])) throw invalid(key, 'must be an integer');
+      number(Number(q[key]), key, min, max);
+    };
+    if (route === '/api/operations') queryNumber('limit', 1, 1000);
+    if (route === '/api/usage') {
+      optional(q, 'provider', oneOf, ['', 'claude', 'codex', 'opencode', 'hermes', 'openclaw', 'gemini']);
+      optional(q, 'debug', oneOf, ['0', '1']);
+    }
+    if (route.endsWith('/tail')) queryNumber('lines', 1); // existing clients request >2000; capture still clamps
+    if (route.endsWith('/wait')) {
+      queryNumber('timeout', 1, 300); queryNumber('settle', 0, 60);
+      if (q.state !== undefined) q.state.split(',').forEach((s) => oneOf(s.trim(), 'state', ['waiting', 'idle', 'stopped', 'working', 'input-required']));
+    }
+    if (route.includes('/remote') || route.startsWith('/api/remote/')) {
+      queryNumber('since', 0); queryNumber('wait', 5, 1800);
+      optional(q, 'agent', oneOf, ['0', '1']);
+    }
+    const trace = route.startsWith('/api/trace/:id') || route.endsWith('/trace') || route.endsWith('/subagents/:agentId');
+    if (trace) {
+      for (const key of ['offset', 'before', 'after']) queryNumber(key, 0);
+      // Preserve the existing domain clamps for page/window sizes, but reject
+      // nonnumeric, negative, fractional and unsafe values before any reads.
+      for (const key of ['bytes', 'min']) queryNumber(key, 0);
+      queryNumber('limit', 1);
+      optional(q, 'v', oneOf, ['1', '2']);
+      optional(q, 'generation', text, { max: 64 });
+      if (['summary', 'tail', 'before', 'after'].filter((key) => q[key] !== undefined).length > 1) throw invalid('query', 'choose one trace window or summary');
+    }
+    if (route === '/api/next-name') cli(q.cli, 'cli');
+    optional(q, 'trigger', oneOf, ['manual', 'schedule', 'restart']);
+    if (req.method === 'GET' || req.method === 'HEAD' || req.method === 'DELETE') return;
+
+    const raw = route === '/api/sessions/:id/attachments' || route === '/api/files/:id/upload';
+    if (raw) {
+      if (route.endsWith('/upload')) fileName(q.name, 'name');
+      return;
+    }
+    const plain = route === '/api/skills/:name' || route === '/api/files/:id/write';
+    if (plain) {
+      // body-parser leaves {} for a zero-byte body. An empty text replacement
+      // is valid; a parsed JSON object is not an empty text replacement.
+      if (!/application\/json/i.test(req.headers['content-type'] || '') && !req.headers['transfer-encoding']
+        && (!req.headers['content-length'] || req.headers['content-length'] === '0')) req.body = '';
+      text(req.body, 'body', { empty: true }); return;
+    }
+    const prompt = route === '/api/agents' || route === '/api/agents/:id/prompt' || route === '/api/agents/:id/stop' || route === '/api/remote/:name/messages';
+    if (!prompt && req.headers['content-type'] && !req.is('application/json')) {
+      throw new ApiError(415, 'unsupported-media-type', 'Use application/json for this request.');
+    }
+    const b = prompt && typeof req.body === 'string' ? {} : object(req.body === undefined ? {} : req.body, 'body');
+    if (prompt) {
+      optional(b, 'from'); optional(b, route === '/api/agents' ? 'prompt' : 'text', text, { empty: true });
+      if (route === '/api/agents') { cli(q.cli, 'cli'); optional(q, 'name', text, { empty: true }); optional(q, 'path', pathText); }
+      return; // sender, availability, self-target and nonempty prompt checks remain in the route
+    }
+    if (route === '/api/config') {
+      for (const key of ['artifacts', 'jobs', 'archive', 'revive', 'backup']) optional(b, key, object);
+      if (b.artifacts) { optional(b.artifacts, 'enabled', boolean); optional(b.artifacts, 'space', text, { empty: true }); optional(b.artifacts, 'visibility', oneOf, ['public', 'private']); }
+      if (b.jobs) optional(b.jobs, 'askAboveUsd', number, 0, Number.MAX_SAFE_INTEGER, false);
+      if (b.archive) optional(b.archive, 'after', oneOf, ['week', 'month', 'never']);
+      if (b.revive) { optional(b.revive, 'enabled', boolean); optional(b.revive, 'days', oneOf, [1, 3, 7]); }
+      if (b.backup) { optional(b.backup, 'every', oneOf, ['never', '1h', '3h', '24h']); optional(b.backup, 'dataset', text, { empty: true }); optional(b.backup, 'exclude', strings); }
+    } else if (route === '/api/secrets') {
+      optional(b, 'notes', object);
+      for (const value of Object.values(b.notes || {})) text(value, 'notes entry', { empty: true });
+    } else if (route === '/api/sessions') {
+      cli(b.cli, 'cli'); optional(b, 'name', text, { empty: true }); optional(b, 'prompt', text, { empty: true }); optional(b, 'path', pathText);
+      if (b.groupId !== undefined) exists(b.groupId, 'groupId', groupExists);
+    } else if (route === '/api/sessions/:id') {
+      text(b.name, 'name');
+    } else if (route === '/api/groups' || route === '/api/groups/:id') {
+      optional(b, 'name', text, { empty: route === '/api/groups' });
+      optional(b, 'sessionIds', strings);
+      b.sessionIds?.forEach((id) => exists(id, 'sessionIds', sessionExists));
+      if (b.layout !== undefined && b.layout !== null) {
+        object(b.layout, 'layout'); number(b.layout.cols, 'layout.cols', 1, 3); number(b.layout.rows, 'layout.rows', 1, 3);
+      }
+    } else if (route === '/api/move') {
+      liveRef(b.ref, 'ref'); object(b.to, 'to'); oneOf(b.to.kind, 'to.kind', ['into', 'pair', 'before', 'after']);
+      if (b.to.kind === 'into') exists(b.to.groupId, 'to.groupId', groupExists);
+      else if (b.to.kind === 'pair') exists(b.to.sessionId, 'to.sessionId', sessionExists);
+      else liveRef(b.to.ref, 'to.ref');
+    } else if (route === '/api/overview/hidden') {
+      treeRef(b.ref, 'ref'); boolean(b.hidden, 'hidden');
+    } else if (route === '/api/demo') boolean(b.active, 'active');
+    else if (route === '/api/sessions/:id/remote/paused') boolean(b.paused, 'paused');
+    else if (route === '/api/sessions/:id/input' || route === '/api/sessions/:id/attachments/insert') {
+      optional(b, 'text', text, { empty: true }); optional(b, 'attachmentIds', strings);
+    } else if (route === '/api/remote/:name/hello') {
+      for (const key of ['harness', 'cwd', 'host']) optional(b, key, text, { empty: true });
+    } else if (route === '/api/push/subscribe') {
+      object(b.subscription, 'subscription'); text(b.subscription.endpoint, 'subscription.endpoint');
+      object(b.subscription.keys, 'subscription.keys'); text(b.subscription.keys.p256dh, 'subscription.keys.p256dh'); text(b.subscription.keys.auth, 'subscription.keys.auth');
+    } else if (route === '/api/push/unsubscribe') text(b.endpoint, 'endpoint');
+    else if (route === '/api/notify') { text(b.body, 'body'); optional(b, 'title', text, { empty: true }); optional(b, 'url', text, { empty: true }); }
+    else if (route.startsWith('/api/files/')) {
+      optional(b, 'path', pathText);
+      if (route.endsWith('/move')) pathText(b.to, 'to'); else fileName(b.name, 'name');
+    } else if (route === '/api/sessions/:id/share') {
+      optional(b, 'visibility', oneOf, ['public', 'gated']); optional(b, 'name', text, { empty: true }); optional(b, 'grantTo', strings);
+    } else if (route === '/api/share/access') {
+      text(b.repo, 'repo'); optional(b, 'grant', strings); optional(b, 'revoke', strings);
+    } else if (route === '/api/trace/import') text(b.repo, 'repo');
+    else if (route === '/api/trace/:id/source') { optional(b, 'kind', oneOf, ['session', 'bundle']); text(b.ref, 'ref'); }
+    else if (route === '/api/crons' || route === '/api/crons/:id') {
+      const create = route === '/api/crons';
+      for (const key of ['name', 'prompt']) {
+        if (create || b[key] !== undefined) text(b[key], key, { max: key === 'prompt' ? 100_000 : 160 });
+      }
+      if (create || b.agent !== undefined) { object(b.agent, 'agent'); text(b.agent.name, 'agent.name', { max: 160 }); cli(b.agent.cli, 'agent.cli'); }
+      if (create || b.schedule !== undefined) validateSchedule(b.schedule);
+      optional(b, 'runOnRestart', boolean); optional(b, 'state', oneOf, ['running', 'stopped']);
+    }
+  };
+}

--- a/server/src/api-validation.js
+++ b/server/src/api-validation.js
@@ -108,7 +108,8 @@ export function createValidator({ cliExists, sessionExists, groupExists }) {
     const mediaType = (req.headers['content-type'] || '').split(';', 1)[0].trim().toLowerCase();
     // req.is() returns null for zero-byte bodies, even with a JSON content
     // type. Bodyless commands remain valid with or without that header.
-    if (!prompt && mediaType && mediaType !== 'application/json') {
+    const hasBody = req.headers['transfer-encoding'] || Number(req.headers['content-length']) > 0;
+    if (!prompt && ((mediaType && mediaType !== 'application/json') || (!mediaType && hasBody))) {
       throw new ApiError(415, 'unsupported-media-type', 'Use application/json for this request.');
     }
     const b = prompt && typeof req.body === 'string' ? {} : object(req.body === undefined ? {} : req.body, 'body');

--- a/server/src/api-validation.js
+++ b/server/src/api-validation.js
@@ -105,7 +105,10 @@ export function createValidator({ cliExists, sessionExists, groupExists }) {
       text(req.body, 'body', { empty: true }); return;
     }
     const prompt = route === '/api/agents' || route === '/api/agents/:id/prompt' || route === '/api/agents/:id/stop' || route === '/api/remote/:name/messages';
-    if (!prompt && req.headers['content-type'] && !req.is('application/json')) {
+    const mediaType = (req.headers['content-type'] || '').split(';', 1)[0].trim().toLowerCase();
+    // req.is() returns null for zero-byte bodies, even with a JSON content
+    // type. Bodyless commands remain valid with or without that header.
+    if (!prompt && mediaType && mediaType !== 'application/json') {
       throw new ApiError(415, 'unsupported-media-type', 'Use application/json for this request.');
     }
     const b = prompt && typeof req.body === 'string' ? {} : object(req.body === undefined ? {} : req.body, 'body');

--- a/server/src/attachments.js
+++ b/server/src/attachments.js
@@ -1,4 +1,5 @@
 import crypto from 'node:crypto';
+import { ApiError, statusCode } from './api-errors.js';
 import fs from 'node:fs';
 import path from 'node:path';
 import { Transform } from 'node:stream';
@@ -63,11 +64,7 @@ const ATTACHMENT_FILE = /^att_[a-f0-9]{24}(?:[-.]|$)/;
 const uploadWindows = new Map();
 const uploadLocks = new Map();
 
-function httpError(statusCode, message) {
-  const error = new Error(message);
-  error.statusCode = statusCode;
-  return error;
-}
+function httpError(status, message) { return new ApiError(status, statusCode(status), message); }
 
 function sessionDir(sessionId) {
   // Session ids are server-generated slugs. Keep this check here as a second

--- a/server/src/backup.js
+++ b/server/src/backup.js
@@ -1,3 +1,4 @@
+import { ApiError } from './api-errors.js';
 import { execFile } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
@@ -457,15 +458,15 @@ async function targets(cfg) {
 /** Launch one backup Job now. Returns { job } — the Hub does the rest. */
 export async function runBackupNow(cfg) {
   const blocked = runNowBlockedBy();
-  if (blocked) throw new Error(blocked);
+  if (blocked) throw new ApiError(403, 'backup-unavailable', blocked);
   // Two runs at once would have two Jobs uploading to the same dataset, which
   // race. The timer skips for this reason too; on demand it is worth saying out
   // loud rather than silently doing nothing.
-  if (await isRunning()) throw new Error('a backup is already running');
+  if (await isRunning()) throw new ApiError(409, 'backup-running', 'a backup is already running');
   const source = sourceBucket();
   const { dataset, staging, exclude } = await targets(cfg);
   for (const [label, id] of [['source', source], ['dataset', dataset], ['staging', staging]]) {
-    if (!validRepoId(id)) throw new Error(`${label} "${id}" is not a valid repo id`);
+    if (!validRepoId(id)) throw new ApiError(400, 'invalid-input', `${label} is not a valid repo id`);
   }
   // Nothing is pre-created here. Both destinations are created explicitly
   // private INSIDE the Job and then read back before anything is written —

--- a/server/src/crons.js
+++ b/server/src/crons.js
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { CronExpressionParser } from 'cron-parser';
 import { DATA_DIR } from './config.js';
+import { invalid } from './api-errors.js';
 
 export const CRONS_FILE = path.join(DATA_DIR, 'crons.json');
 const MAX_TIMER_MS = 2_147_000_000;
@@ -13,9 +14,9 @@ let fireJob = null;
 const timers = new Map();
 
 const cleanText = (value, field, max = 160) => {
-  if (typeof value !== 'string' || !value.trim()) throw new Error(`${field} required`);
+  if (typeof value !== 'string' || !value.trim()) throw invalid(field, 'required');
   const text = value.trim();
-  if (text.length > max) throw new Error(`${field} is too long (max ${max} characters)`);
+  if (text.length > max) throw invalid(field, `is too long (max ${max} characters)`);
   return text;
 };
 
@@ -35,9 +36,9 @@ function persist() {
 }
 
 export function validateSchedule(value, id = '') {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('schedule required');
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw invalid('schedule', 'required');
   const cron = cleanText(value.cron, 'schedule.cron', 120).replace(/\s+/g, ' ');
-  if (cron.split(' ').length !== 5) throw new Error('schedule.cron must use the standard five fields: minute hour day month weekday');
+  if (cron.split(' ').length !== 5) throw invalid('schedule.cron', 'must use the standard five fields: minute hour day month weekday');
   const tz = cleanText(value.tz, 'schedule.tz', 100);
   try {
     // Intl is the runtime authority for IANA zone names; cron-parser then
@@ -45,7 +46,7 @@ export function validateSchedule(value, id = '') {
     new Intl.DateTimeFormat('en', { timeZone: tz }).format(new Date());
     CronExpressionParser.parse(cron, { tz, hashSeed: id || 'agent-manager-cron' }).next();
   } catch (e) {
-    throw new Error(`invalid schedule: ${e && e.message ? e.message : e}`);
+    throw invalid('schedule', 'invalid schedule: check the cron expression and time zone');
   }
   return { cron, tz };
 }
@@ -68,9 +69,9 @@ function normalizeInput(input, existing = null) {
     schedule: src.schedule === undefined ? existing.schedule : src.schedule,
   } : src;
   const agent = merged.agent;
-  if (!agent || typeof agent !== 'object' || Array.isArray(agent)) throw new Error('agent required');
+  if (!agent || typeof agent !== 'object' || Array.isArray(agent)) throw invalid('agent', 'required');
   const state = merged.state === undefined ? 'running' : merged.state;
-  if (!VALID_STATES.has(state)) throw new Error("state must be 'running' or 'stopped'");
+  if (!VALID_STATES.has(state)) throw invalid('state', "must be 'running' or 'stopped'");
   const id = existing?.id || `cron_${crypto.randomBytes(5).toString('hex')}`;
   return {
     ...(existing || {}),

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1131,6 +1131,17 @@ function loadSecretNotes() {
 const AM_CONFIG_FILE = path.join(DATA_DIR, 'am-config.json');
 const spaceNamespace = () => (process.env.SPACE_ID || '').split('/')[0] || '';
 const defaultArtifactsSpace = () => (spaceNamespace() ? `${spaceNamespace()}/agent-artifacts` : '');
+
+// Filesystem exception text and the absolute mount path stay private. The
+// settings client only needs the durable-data-relative filename to say which
+// resource failed.
+function settingsWriteError(file) {
+  const relative = path.relative(DATA_DIR, file).split(path.sep).join('/');
+  return new ApiError(500, 'internal-error', 'The settings file could not be saved.', {
+    details: [{ field: 'path', message: relative }],
+  });
+}
+
 function loadAmConfig() {
   let saved = {};
   try { saved = JSON.parse(fs.readFileSync(AM_CONFIG_FILE, 'utf8')); } catch {}
@@ -1194,7 +1205,11 @@ api.put('/api/config', (req, res) => {
       exclude: backup.excludeFromConfig(b.backup?.exclude),
     },
   };
-  fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2));
+  try {
+    fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2));
+  } catch {
+    throw settingsWriteError(AM_CONFIG_FILE);
+  }
   generateEnvSkill(loadSecretNotes());
   res.json({ ok: true });
 });
@@ -1597,7 +1612,11 @@ ${envLines}
 api.get('/api/secrets', (_req, res) => res.json({ detected: injectedEnvKeys(), notes: loadSecretNotes() }));
 api.put('/api/secrets', (req, res) => {
   const notes = (req.body && req.body.notes && typeof req.body.notes === 'object') ? req.body.notes : {};
-  fs.writeFileSync(SECRET_NOTES_FILE, JSON.stringify(notes, null, 2));
+  try {
+    fs.writeFileSync(SECRET_NOTES_FILE, JSON.stringify(notes, null, 2));
+  } catch {
+    throw settingsWriteError(SECRET_NOTES_FILE);
+  }
   generateEnvSkill(notes);
   res.json({ ok: true });
 });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -46,6 +46,9 @@ import {
 import * as runstate from './runstate.js';
 import { installSlowFsProbe } from './slowfs.js';
 import { operationMiddleware, readOperations } from './operations.js';
+import { ApiError, apiRoutes, apiNotFound, apiErrorHandler, errorEnvelope, pipeResponse } from './api-errors.js';
+import { createValidator } from './api-validation.js';
+import { remoteStream } from './api-streams.js';
 
 // Before anything else touches the mount: a sync fs call to /data is ~85ms of
 // frozen event loop here, and nothing else in the stack can see it. See slowfs.js.
@@ -191,12 +194,13 @@ process.on('unhandledRejection', (e) => console.error('[unhandledRejection]', e)
 process.on('uncaughtException', (e) => console.error('[uncaughtException]', e));
 
 const app = express();
+const api = apiRoutes(app, createValidator({ cliExists: cliById, sessionExists: store.get, groupExists: groups.get }));
 const jsonBody = express.json();
 app.use((req, res, next) => {
   // Attachments are raw streaming bodies. Skip JSON parsing even when browser
   // metadata claims application/json, or the global parser would consume a
   // JSON file (and reject mislabeled image bytes) before the upload route.
-  if (req.method === 'POST' && /^\/api\/sessions\/[^/]+\/attachments$/.test(req.path)) return next();
+  if (req.method === 'POST' && /^\/api\/(?:sessions\/[^/]+\/attachments|files\/[^/]+\/upload)$/.test(req.path)) return next();
   return jsonBody(req, res, next);
 });
 
@@ -208,7 +212,7 @@ const OPEN_WHEN_PUBLIC = new Set(['/api/health', '/api/info', '/api/visibility']
 app.use((req, res, next) => {
   if (!isPublic()) return next();
   if (!req.path.startsWith('/api/') || OPEN_WHEN_PUBLIC.has(req.path)) return next();
-  return res.status(403).json({ error: 'locked', reason: 'public-space' });
+  return res.status(403).json({ error: 'locked', code: 'locked', reason: 'public-space' });
 });
 
 // Every state-changing call has an attributable origin and a durable outcome.
@@ -259,35 +263,36 @@ app.use(operationMiddleware({
   // have to pretend to be the operator. Production never sets this switch.
   allowMissing: process.env.AM_ALLOW_MISSING_ORIGIN === '1',
 }));
+app.use(errorEnvelope);
 
-app.get('/api/visibility', (_req, res) => res.json(visibility()));
+api.get('/api/visibility', (_req, res) => res.json(visibility()));
 
-app.get('/api/health', (_req, res) =>
+api.get('/api/health', (_req, res) =>
   res.json({ ok: true, engine: 'libghostty', ghostty: ghosttyReady(), ghosttyError }));
 
-app.get('/api/clis', (_req, res) => res.json(cliCatalog()));
+api.get('/api/clis', (_req, res) => res.json(cliCatalog()));
 
-app.get('/api/usage', async (req, res) => res.json(await buildUsage(req.query.debug === '1', req.query.provider || null)));
+api.get('/api/usage', async (req, res) => res.json(await buildUsage(req.query.debug === '1', req.query.provider || null)));
 
 // Newest first. The JSONL source lives under DATA_DIR; this bounded API is the
 // stable way for the operator or an agent to reconstruct manager operations.
-app.get('/api/operations', (req, res) => {
+api.get('/api/operations', (req, res) => {
   const before = typeof req.query.before === 'string' && req.query.before ? req.query.before : null;
   res.json({ operations: readOperations(req.query.limit, before), generatedAt: new Date().toISOString() });
 });
 
-app.get('/api/traces', async (_req, res) => res.json(await buildTraces()));
+api.get('/api/traces', async (_req, res) => res.json(await buildTraces()));
 
 // ---------- push notifications (agent-initiated, on explicit request) ----------
-app.get('/api/push/key', (_req, res) => res.json({ publicKey: publicKey(), devices: deviceCount() }));
+api.get('/api/push/key', (_req, res) => res.json({ publicKey: publicKey(), devices: deviceCount() }));
 
-app.post('/api/push/subscribe', (req, res) => {
+api.post('/api/push/subscribe', (req, res) => {
   const ok = addSubscription((req.body || {}).subscription, req.headers['user-agent']);
   if (!ok) return res.status(400).json({ error: 'bad subscription' });
   res.json({ ok: true, devices: deviceCount() });
 });
 
-app.post('/api/push/unsubscribe', (req, res) => {
+api.post('/api/push/unsubscribe', (req, res) => {
   removeSubscription((req.body || {}).endpoint);
   res.json({ ok: true, devices: deviceCount() });
 });
@@ -295,7 +300,7 @@ app.post('/api/push/unsubscribe', (req, res) => {
 // Agents (and the Settings test button) call this from inside the container.
 // Rate-limited as a backstop: a confused agent must not buzz a phone in a loop.
 const notifyLog = [];
-app.post('/api/notify', async (req, res) => {
+api.post('/api/notify', async (req, res) => {
   const { title, body, url } = req.body || {};
   const text = typeof body === 'string' ? body.trim().slice(0, 500) : '';
   if (!text) return res.status(400).json({ error: 'body required' });
@@ -317,14 +322,14 @@ app.post('/api/notify', async (req, res) => {
 // Overview cards: every agent's state + what it did since your last prompt.
 // Targeted digest for one session — lets the Overview fill tiles one by one
 // while the bulk build (below) is still chewing through the bucket.
-app.get('/api/meta/:id', async (req, res) => {
+api.get('/api/meta/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const digest = await digestFor(s);
   res.json({ id: s.id, digest });
 });
 
-app.get('/api/meta', async (_req, res) => {
+api.get('/api/meta', async (_req, res) => {
   const digests = await traceDigests();
   const hs = demo.active() ? demo.hiddenSessions() : null;
   const sessions = sessionsWithState()
@@ -353,7 +358,7 @@ const operatorName = () => process.env.SPACE_AUTHOR_NAME || process.env.AM_USER 
  */
 async function deliver(session, { text, attachments = [] }, from) {
   if (isRemote(session.cli)) {
-    if (attachments.length) throw Object.assign(new Error('files are not available for remote agents yet'), { statusCode: 400 });
+    if (attachments.length) throw new ApiError(400, 'invalid-input', 'files are not available for remote agents yet');
     const name = session.remote?.name;
     if (!name) throw new Error('this remote pane has no name recorded');
     // Delivery does NOT un-pause: a disconnected agent isn't listening, so the
@@ -379,7 +384,7 @@ async function deliver(session, { text, attachments = [] }, from) {
   }
   const started = ensureRunning(session);
   if (started && !await waitForInputReady(session.id)) {
-    throw new Error('session did not become ready for input within 30 seconds — prompt was not sent');
+    throw new ApiError(409, 'input-not-ready', 'session did not become ready for input within 30 seconds — prompt was not sent');
   }
   for (const command of prelude) {
     await sendInput(session.id, command);
@@ -405,7 +410,7 @@ function touchInput(id) {
 // Type a prompt into a session's terminal from the Overview — no pane needed.
 // If the agent is stopped, start its backend PTY and give the resumed CLI a
 // moment to boot before the keystrokes land.
-app.post('/api/sessions/:id/input', async (req, res) => {
+api.post('/api/sessions/:id/input', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (PASSIVE_CLIS.includes(s.cli)) return res.status(400).json({ error: `${s.cli} pane takes no input` });
@@ -418,7 +423,7 @@ app.post('/api/sessions/:id/input', async (req, res) => {
     touchInput(s.id);
     res.json({ ok: true, started });
   } catch (e) {
-    res.status(e.statusCode || 409).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
@@ -432,7 +437,7 @@ const terminalAttachmentInsertions = new Map();
 // Managed attachments live under STATE_DIR, never in the user's repository.
 // The raw body is streamed and capped in attachments.js; express.json ignores
 // this exact route, so no middleware buffers uploads first.
-app.post('/api/sessions/:id/attachments', async (req, res) => {
+api.post('/api/sessions/:id/attachments', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (!canAttachFiles(s)) {
@@ -448,7 +453,7 @@ app.post('/api/sessions/:id/attachments', async (req, res) => {
     });
     if (!res.destroyed) res.status(201).json(attachment);
   } catch (e) {
-    if (!res.headersSent && !res.destroyed) res.status(e.statusCode || 500).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
@@ -456,7 +461,7 @@ app.post('/api/sessions/:id/attachments', async (req, res) => {
 // prompt. This server acknowledgement is the source of truth for the terminal
 // overlay; a browser-local xterm paste can be dropped after a disconnect or
 // when another viewer owns the input lease.
-app.post('/api/sessions/:id/attachments/insert', async (req, res) => {
+api.post('/api/sessions/:id/attachments/insert', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (!canAttachFiles(s)) return res.status(400).json({ error: `${s.cli} pane cannot accept files` });
@@ -484,22 +489,22 @@ app.post('/api/sessions/:id/attachments/insert', async (req, res) => {
     for (const attachment of inline) inserted.add(attachment.id);
     return res.json({ ok: true, mode });
   } catch (e) {
-    return res.status(e.statusCode || 409).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
-app.delete('/api/sessions/:id/attachments/:attachmentId', async (req, res) => {
+api.delete('/api/sessions/:id/attachments/:attachmentId', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   try {
     await removeAttachment(s.id, req.params.attachmentId);
     return res.json({ ok: true });
   } catch (e) {
-    return res.status(e.statusCode || 500).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
-app.get('/api/sessions/:id/attachments/:attachmentId/raw', (req, res) => {
+api.get('/api/sessions/:id/attachments/:attachmentId/raw', (req, res, next) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   try {
@@ -515,11 +520,9 @@ app.get('/api/sessions/:id/attachments/:attachmentId/raw', (req, res) => {
       'Content-Security-Policy': 'sandbox',
       'Cache-Control': 'no-store',
     });
-    const stream = fs.createReadStream(attachment.path);
-    stream.on('error', () => { if (!res.headersSent) res.status(404).end(); else res.destroy(); });
-    stream.pipe(res);
+    pipeResponse(fs.createReadStream(attachment.path), req, res, next);
   } catch (e) {
-    res.status(e.statusCode || 404).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
@@ -601,7 +604,7 @@ function agentRow(s, act, d, selfId, mates) {
   };
 }
 
-app.get('/api/agents', async (req, res) => {
+api.get('/api/agents', async (req, res) => {
   const info = agentInfo();
   const digests = await traceDigests();
   const selfId = String(req.query.from || req.query.self || '').trim() || null;
@@ -630,7 +633,7 @@ app.get('/api/agents', async (req, res) => {
   });
 });
 
-app.get('/api/agents/:id', async (req, res) => {
+api.get('/api/agents/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const selfId = String(req.query.from || req.query.self || '').trim() || null;
@@ -648,7 +651,7 @@ app.get('/api/agents/:id', async (req, res) => {
 
 // A peer's screen (plus scrollback) — watch progress without spending a turn on
 // either side. This is the cheap way to answer "how far has it got?".
-app.get('/api/agents/:id/tail', (req, res) => {
+api.get('/api/agents/:id/tail', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const lines = clamp(parseInt(req.query.lines || '80', 10), 1, 2000, 80);
@@ -666,18 +669,17 @@ app.get('/api/agents/:id/tail', (req, res) => {
 // already has for the window it is showing, and inventing an answer from file
 // mtime would be wrong several times an hour (measured: p99 silence 112s inside
 // a live sub-agent, max 601s).
-app.get('/api/agents/:id/subagents', async (req, res) => {
+api.get('/api/agents/:id/subagents', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   try {
     res.json({ id: s.id, ...(await subagentRoster(s)) });
   } catch (e) {
-    console.error('[subagents]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'roster failed' });
+    throw e;
   }
 });
 
-app.get('/api/agents/:id/subagents/:agentId', async (req, res) => {
+api.get('/api/agents/:id/subagents/:agentId', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   try {
@@ -686,8 +688,7 @@ app.get('/api/agents/:id/subagents/:agentId', async (req, res) => {
     if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
       return res.status(404).json({ error: e.message, code: e.code });
     }
-    console.error('[subagent-trace]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'sub-agent trace read failed' });
+    throw e;
   }
 });
 
@@ -696,7 +697,7 @@ app.get('/api/agents/:id/subagents/:agentId', async (req, res) => {
 // some CLIs). The state must HOLD for `settle` seconds before it counts: pane
 // diffing sees brief pauses between tool calls, and a just-prompted agent needs
 // a moment before its screen starts moving.
-app.get('/api/agents/:id/wait', async (req, res) => {
+api.get('/api/agents/:id/wait', async (req, res) => {
   const s0 = store.get(req.params.id);
   if (!s0) return res.status(404).json({ error: 'not found' });
   const want = new Set(String(req.query.state || 'waiting,idle,stopped').split(',').map((x) => x.trim()).filter(Boolean));
@@ -730,7 +731,7 @@ app.get('/api/agents/:id/wait', async (req, res) => {
 // stopped, then type. The [message from x:] prefix goes into the target's own
 // transcript, so both the target and the operator reading it later can see the
 // request came from a peer.
-app.post('/api/agents/:id/prompt', promptBody, async (req, res) => {
+api.post('/api/agents/:id/prompt', promptBody, async (req, res) => {
   const from = sender(req);
   if (from.error) return res.status(400).json({ error: from.error });
   const s = store.get(req.params.id);
@@ -747,12 +748,12 @@ app.post('/api/agents/:id/prompt', promptBody, async (req, res) => {
     const started = await deliver(s, { text: `[message from ${from.session.name}:] ${text}` }, from.session.name);
     res.json({ ok: true, id: s.id, name: s.name, started });
   } catch (e) {
-    res.status(409).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
 // Launch a peer, already working on the prompt you give it.
-app.post('/api/agents', promptBody, (req, res) => {
+api.post('/api/agents', promptBody, (req, res) => {
   const from = sender(req);
   if (from.error) return res.status(400).json({ error: from.error });
   const q = req.query;
@@ -790,7 +791,7 @@ app.post('/api/agents', promptBody, (req, res) => {
 
 // Stop a peer. Kills its CLI; the conversation and files are untouched, and a
 // later prompt wakes it and resumes. Only for when the operator asked.
-app.post('/api/agents/:id/stop', promptBody, (req, res) => {
+api.post('/api/agents/:id/stop', promptBody, (req, res) => {
   const from = sender(req);
   if (from.error) return res.status(400).json({ error: from.error });
   const s = store.get(req.params.id);
@@ -817,7 +818,7 @@ const paneFor = (name) => store.list().find((s) => s.remote?.name === name) || n
 // this, so a disconnected loop ends instead of spinning.
 const STOP_PAUSED = { stop: true, reason: 'disconnected from the manager' };
 
-app.get('/api/remote/:name/ping', (req, res) => {
+api.get('/api/remote/:name/ping', (req, res) => {
   const name = req.params.name;
   const s = paneFor(name);
   // JSON, so the copied prompt can tell "wrong name" (this) from "your token
@@ -837,7 +838,7 @@ app.get('/api/remote/:name/ping', (req, res) => {
   });
 });
 
-app.post('/api/remote/:name/hello', express.json({ limit: '8kb' }), (req, res) => {
+api.post('/api/remote/:name/hello', express.json({ limit: '8kb' }), (req, res) => {
   const name = req.params.name;
   const s = paneFor(name);
   if (!s) return res.status(404).json({ error: `no remote agent named '${name}' in this Space` });
@@ -856,7 +857,7 @@ app.post('/api/remote/:name/hello', express.json({ limit: '8kb' }), (req, res) =
 
 // The one blocking call. Writes ':connected' immediately (which also flushes
 // headers through the edge), ':hb' every 25 s, then exactly one JSON line.
-app.get('/api/remote/:name/stream', (req, res) => {
+api.get('/api/remote/:name/stream', (req, res, next) => {
   const name = req.params.name;
   const s = paneFor(name);
   if (!s) return res.status(404).json({ error: `no remote agent named '${name}' in this Space` });
@@ -868,52 +869,12 @@ app.get('/api/remote/:name/stream', (req, res) => {
   const since = clamp(parseInt(req.query.since || '0', 10), 0, Number.MAX_SAFE_INTEGER, 0);
   const wait = clamp(parseInt(req.query.wait || String(remote.WAIT_DEFAULT), 10), remote.WAIT_MIN, remote.WAIT_MAX, remote.WAIT_DEFAULT);
 
-  res.setHeader('content-type', 'application/x-ndjson');
-  res.setHeader('cache-control', 'no-cache, no-transform');
-  res.setHeader('x-accel-buffering', 'no'); // don't let a proxy buffer the heartbeats
-  res.write(':connected\n');
-
-  let done = false;
-  const finish = (payload) => {
-    if (done) return;
-    done = true;
-    clearInterval(hb);
-    clearTimeout(timer);
-    release();
-    try { res.write(`${JSON.stringify(payload)}\n`); res.end(); } catch { /* client vanished */ }
-  };
-
-  // Anything already waiting is returned at once — that is what makes a
-  // reconnect after a dropped socket lossless.
-  const pending = remote.pendingFor(name, since);
-
-  const hb = setInterval(() => {
-    if (done) return;
-    try { res.write(':hb\n'); } catch { /* handled by the close listener */ }
-  }, remote.HEARTBEAT_MS);
-  const timer = setTimeout(() => finish({ messages: [], seq: remote.lastSeq(name) }), wait * 1000);
-  const release = remote.registerStream(name, {
-    since,
-    deliver: (msgs) => finish({ messages: msgs, seq: msgs[msgs.length - 1].seq }),
-    stop: (reason) => finish({ stop: true, reason: reason || 'disconnected from the manager' }),
-  });
-  res.on('close', () => {
-    if (done) return;
-    done = true;
-    clearInterval(hb);
-    clearTimeout(timer);
-    release();
-  });
-
-  if (pending.length) {
-    remote.markDelivered(name, pending[pending.length - 1].seq);
-    finish({ messages: pending, seq: pending[pending.length - 1].seq });
-  }
+  remoteStream(req, res, next, remote, name, since, wait);
 });
 
 // The same thing without blocking: the short-polling fallback for a proxy that
 // kills long connections, and what the browser pane polls.
-app.get('/api/remote/:name/messages', (req, res) => {
+api.get('/api/remote/:name/messages', (req, res) => {
   const name = req.params.name;
   const s = paneFor(name);
   if (!s) return res.status(404).json({ error: `no remote agent named '${name}' in this Space` });
@@ -931,7 +892,7 @@ app.get('/api/remote/:name/messages', (req, res) => {
 // The agent speaks. text/plain markdown is the primary shape (a heredoc into
 // curl never trips over quoting), JSON {text} also accepted — same convention as
 // the agent-to-agent API.
-app.post('/api/remote/:name/messages', promptBody, (req, res) => {
+api.post('/api/remote/:name/messages', promptBody, (req, res) => {
   const name = req.params.name;
   const s = paneFor(name);
   if (!s) return res.status(404).json({ error: `no remote agent named '${name}' in this Space` });
@@ -945,7 +906,7 @@ app.post('/api/remote/:name/messages', promptBody, (req, res) => {
 });
 
 // The thing the operator copies. Contains no secret — just a URL and a name.
-app.get('/api/remote/:name/prompt', (req, res) => {
+api.get('/api/remote/:name/prompt', (req, res) => {
   const name = req.params.name;
   if (!paneFor(name)) return res.status(404).json({ error: `no remote agent named '${name}' in this Space` });
   const host = process.env.SPACE_HOST || req.headers.host || 'localhost:7860';
@@ -954,7 +915,7 @@ app.get('/api/remote/:name/prompt', (req, res) => {
 
 // ---------- remote panes, addressed by session id (what the browser uses) ----------
 
-app.get('/api/sessions/:id/remote', (req, res) => {
+api.get('/api/sessions/:id/remote', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (!isRemote(s.cli)) return res.status(400).json({ error: 'not a remote agent' });
@@ -967,7 +928,7 @@ app.get('/api/sessions/:id/remote', (req, res) => {
 });
 
 // Disconnect / reconnect — what the sidebar's stop and play buttons mean here.
-app.post('/api/sessions/:id/remote/paused', express.json({ limit: '4kb' }), (req, res) => {
+api.post('/api/sessions/:id/remote/paused', express.json({ limit: '4kb' }), (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (!isRemote(s.cli)) return res.status(400).json({ error: 'not a remote agent' });
@@ -1008,7 +969,7 @@ function injectedEnvKeys() {
     .sort();
 }
 
-app.get('/api/info', (_req, res) => res.json({
+api.get('/api/info', (_req, res) => res.json({
   dataDir: DATA_DIR,
   home: process.env.HOME || null,
   spaceId: process.env.SPACE_ID || null,
@@ -1037,7 +998,7 @@ app.get('/api/info', (_req, res) => res.json({
 
 // Demo mode toggle. Activating snapshots the current sessions/groups as the
 // hidden set; deactivating clears it. Nothing is deleted either way.
-app.post('/api/demo', (req, res) => {
+api.post('/api/demo', (req, res) => {
   const on = !!(req.body || {}).active;
   if (on) demo.activate(store.list().map((s) => s.id), groups.list().map((g) => g.id));
   else demo.deactivate();
@@ -1050,8 +1011,8 @@ const WELCOME_FILE = path.join(DATA_DIR, 'welcome-seen.json');
 function welcomeSeen() {
   try { return !!JSON.parse(fs.readFileSync(WELCOME_FILE, 'utf8')).seen; } catch { return false; }
 }
-app.post('/api/welcome/seen', (_req, res) => {
-  try { fs.writeFileSync(WELCOME_FILE, JSON.stringify({ seen: true, at: new Date().toISOString() })); } catch {}
+api.post('/api/welcome/seen', (_req, res) => {
+  fs.writeFileSync(WELCOME_FILE, JSON.stringify({ seen: true, at: new Date().toISOString() }));
   res.json({ ok: true });
 });
 
@@ -1059,7 +1020,7 @@ app.post('/api/welcome/seen', (_req, res) => {
 // latest published versions, per the Dockerfile) and relaunches everything.
 // Needs an HF token with write access set as a Space secret (HF_TOKEN).
 let lastRelaunchAt = 0;
-app.post('/api/relaunch', async (_req, res) => {
+api.post('/api/relaunch', async (_req, res) => {
   const id = process.env.SPACE_ID;
   const token = hfToken();
   if (!id) return res.json({ ok: false, reason: 'no-space' });
@@ -1073,7 +1034,7 @@ app.post('/api/relaunch', async (_req, res) => {
     });
     if (!r.ok) return res.json({ ok: false, reason: `http-${r.status}` });
     return res.json({ ok: true });
-  } catch (e) { return res.json({ ok: false, reason: String(e.message || e) }); }
+  } catch (e) { throw e; }
 });
 
 // ---------- self-update: pull the latest app from the upstream repo ----------
@@ -1113,7 +1074,7 @@ async function updateSource() {
   return { own, ownSha: info.sha || null, source: SOURCE_SLUG, sourceUrl: SOURCE_URL, latestSha: latest };
 }
 
-app.get('/api/update/check', async (_req, res) => {
+api.get('/api/update/check', async (_req, res) => {
   if (!process.env.SPACE_ID) return res.json({ ok: false, reason: 'no-space' });
   try {
     const src = await updateSource();
@@ -1126,11 +1087,11 @@ app.get('/api/update/check', async (_req, res) => {
       behind: !!(src.ownSha && src.latestSha && src.ownSha !== src.latestSha),
       canUpdate: !!hfToken(),
     });
-  } catch (e) { res.json({ ok: false, reason: String(e.message || e) }); }
+  } catch (e) { throw e; }
 });
 
 let updateBusy = false;
-app.post('/api/update', async (_req, res) => {
+api.post('/api/update', async (_req, res) => {
   const token = hfToken();
   if (!process.env.SPACE_ID) return res.json({ ok: false, reason: 'no-space' });
   if (!token) return res.json({ ok: false, reason: 'no-token' });
@@ -1154,7 +1115,7 @@ app.post('/api/update', async (_req, res) => {
     await git(['push', '--force', 'own', 'HEAD:main'], dir);
     res.json({ ok: true, from: src.ownSha, to: src.latestSha });
   } catch (e) {
-    res.json({ ok: false, reason: String(e.message || e).slice(0, 300) });
+    throw e;
   } finally {
     updateBusy = false;
     try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
@@ -1209,8 +1170,8 @@ function loadAmConfig() {
     },
   };
 }
-app.get('/api/config', (_req, res) => res.json({ ...loadAmConfig(), defaultArtifactsSpace: defaultArtifactsSpace() }));
-app.put('/api/config', (req, res) => {
+api.get('/api/config', (_req, res) => res.json({ ...loadAmConfig(), defaultArtifactsSpace: defaultArtifactsSpace() }));
+api.put('/api/config', (req, res) => {
   const b = req.body || {};
   const cfg = {
     artifacts: {
@@ -1233,19 +1194,17 @@ app.put('/api/config', (req, res) => {
       exclude: backup.excludeFromConfig(b.backup?.exclude),
     },
   };
-  try { fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2)); } catch {}
+  fs.writeFileSync(AM_CONFIG_FILE, JSON.stringify(cfg, null, 2));
   generateEnvSkill(loadSecretNotes());
   res.json({ ok: true });
 });
 
 // ---------- bucket backup: status + run-now (docs/bucket-backup.md) ----------
-app.get('/api/backup/status', async (_req, res) => {
-  try { res.json(await backup.backupStatus(loadAmConfig())); }
-  catch (e) { res.status(500).json({ error: e.message }); }
+api.get('/api/backup/status', async (_req, res) => {
+  res.json(await backup.backupStatus(loadAmConfig()));
 });
-app.post('/api/backup/run', async (_req, res) => {
-  try { res.json(await backup.runBackupNow(loadAmConfig())); }
-  catch (e) { res.status(500).json({ error: e.stderr || e.message }); }
+api.post('/api/backup/run', async (_req, res) => {
+  res.json(await backup.runBackupNow(loadAmConfig()));
 });
 
 // The artifacts section teaches agents to publish rich HTML results to a
@@ -1635,10 +1594,10 @@ ${envLines}
   distributeSkill('environment.md', content);
 }
 
-app.get('/api/secrets', (_req, res) => res.json({ detected: injectedEnvKeys(), notes: loadSecretNotes() }));
-app.put('/api/secrets', (req, res) => {
+api.get('/api/secrets', (_req, res) => res.json({ detected: injectedEnvKeys(), notes: loadSecretNotes() }));
+api.put('/api/secrets', (req, res) => {
   const notes = (req.body && req.body.notes && typeof req.body.notes === 'object') ? req.body.notes : {};
-  try { fs.writeFileSync(SECRET_NOTES_FILE, JSON.stringify(notes, null, 2)); } catch {}
+  fs.writeFileSync(SECRET_NOTES_FILE, JSON.stringify(notes, null, 2));
   generateEnvSkill(notes);
   res.json({ ok: true });
 });
@@ -1711,7 +1670,7 @@ function distributeAllSkills() {
   }
 }
 
-app.get('/api/skills', (_req, res) => {
+api.get('/api/skills', (_req, res) => {
   fs.mkdirSync(SKILLS_DIR, { recursive: true });
   const files = fs.readdirSync(SKILLS_DIR, { withFileTypes: true })
     .filter((e) => e.isFile())
@@ -1720,13 +1679,13 @@ app.get('/api/skills', (_req, res) => {
   res.json(files);
 });
 
-app.get('/api/skills/:name', (req, res) => {
+api.get('/api/skills/:name', (req, res) => {
   const p = skillPath(req.params.name);
   if (!p || !fs.existsSync(p)) return res.status(404).json({ error: 'not found' });
   res.json({ name: req.params.name, content: fs.readFileSync(p, 'utf8') });
 });
 
-app.put('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }), (req, res) => {
+api.put('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }), (req, res) => {
   const p = skillPath(req.params.name);
   if (!p) return res.status(400).json({ error: 'bad name' });
   fs.mkdirSync(SKILLS_DIR, { recursive: true });
@@ -1736,10 +1695,10 @@ app.put('/api/skills/:name', express.text({ type: '*/*', limit: '5mb' }), (req, 
   res.json({ ok: true });
 });
 
-app.delete('/api/skills/:name', (req, res) => {
+api.delete('/api/skills/:name', (req, res) => {
   const p = skillPath(req.params.name);
   if (!p) return res.status(400).json({ error: 'bad name' });
-  try { fs.unlinkSync(p); } catch {}
+  try { fs.unlinkSync(p); } catch (error) { if (error.code !== 'ENOENT') throw error; }
   undistributeSkill(req.params.name);
   res.json({ ok: true });
 });
@@ -1767,7 +1726,7 @@ function resolveSafe(root, rel) {
   } catch { return null; }
 }
 
-app.get('/api/files/:id', (req, res) => {
+api.get('/api/files/:id', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (s.cli === 'files' && !req.query.path) ensureWorkspaceFolders(); // refresh the root view
@@ -1799,7 +1758,7 @@ app.get('/api/files/:id', (req, res) => {
 // What the viewer needs to show one file: its kind, its stats, and — for the
 // text-ish kinds — the content itself, capped. Image/html/pdf are fetched by the
 // browser from /raw instead.
-app.get('/api/files/:id/preview', async (req, res) => {
+api.get('/api/files/:id/preview', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const root = folderPathOf(s);
@@ -1835,7 +1794,7 @@ app.get('/api/files/:id/preview', async (req, res) => {
       const { text, truncated } = readTextHead(f);
       return res.json({ ...meta, text, truncated });
     } catch (e) {
-      return res.status(500).json({ error: String(e && e.message || e) });
+      throw e;
     }
   }
   res.json(meta);
@@ -1848,24 +1807,24 @@ app.get('/api/files/:id/preview', async (req, res) => {
 // origin, so even opened directly in a tab it can't read this app's storage or
 // call its API with the operator's cookies. The iframe's own sandbox attribute
 // decides whether scripts run at all.
-app.get('/api/files/:id/raw', (req, res) => {
+api.get('/api/files/:id/raw', (req, res, next) => {
   const s = store.get(req.params.id);
-  if (!s) return res.status(404).end();
+  if (!s) return res.status(404).json({ error: 'not found', code: 'not-found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
-  if (!f || !fs.existsSync(f) || !fs.statSync(f).isFile()) return res.status(404).end();
+  if (!f || !fs.existsSync(f) || !fs.statSync(f).isFile()) return res.status(404).json({ error: 'not found', code: 'not-found' });
   res.setHeader('content-type', mimeOf(f, kindOfFile(f)));
   res.setHeader('x-content-type-options', 'nosniff');
   res.setHeader('content-security-policy', 'sandbox allow-scripts allow-popups allow-forms allow-modals');
   res.setHeader('content-disposition', `inline; filename="${path.basename(f).replace(/[^\w.\- ]/g, '_')}"`);
-  res.sendFile(f);
+  res.sendFile(f, (error) => { if (error) next(error); });
 });
 
-app.get('/api/files/:id/download', (req, res) => {
+api.get('/api/files/:id/download', (req, res, next) => {
   const s = store.get(req.params.id);
-  if (!s) return res.status(404).end();
+  if (!s) return res.status(404).json({ error: 'not found', code: 'not-found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
-  if (!f || !fs.existsSync(f) || !fs.statSync(f).isFile()) return res.status(404).end();
-  res.download(f);
+  if (!f || !fs.existsSync(f) || !fs.statSync(f).isFile()) return res.status(404).json({ error: 'not found', code: 'not-found' });
+  res.download(f, (error) => { if (error) next(error); });
 });
 
 // Save an edited text file.
@@ -1876,7 +1835,7 @@ app.get('/api/files/:id/download', (req, res) => {
 // a stale buffer is worse than making someone reload. Second, only files we could
 // show WHOLE are writable: the preview serves the first 512 KB of a big file, and
 // saving that back would silently truncate the rest.
-app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (req, res) => {
+api.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
@@ -1893,7 +1852,7 @@ app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (re
   }
   const base = String(req.query.base || '');
   if (base && base !== contentTag(f)) {
-    return res.status(409).json({ error: 'changed on disk since you opened it', mtime: st.mtimeMs });
+    return res.status(409).json({ error: 'changed on disk since you opened it', code: 'file-changed', mtime: st.mtimeMs });
   }
   const text = typeof req.body === 'string' ? req.body : '';
   if (text.length > TEXT_MAX) return res.status(413).json({ error: 'too big to save' });
@@ -1906,7 +1865,7 @@ app.put('/api/files/:id/write', express.text({ limit: '8mb', type: '*/*' }), (re
     fs.renameSync(tmp, f);
   } catch (e) {
     try { fs.unlinkSync(tmp); } catch {}
-    return res.status(500).json({ error: String((e && e.message) || e) });
+    throw e;
   }
   const after = fs.statSync(f);
   res.json({ ok: true, size: after.size, mtime: after.mtimeMs, tag: contentTag(f) });
@@ -1958,7 +1917,7 @@ for (const [verb, make] of [
   // already there, so "new file" can never quietly empty an existing one.
   ['touch', (dest) => fs.closeSync(fs.openSync(dest, 'wx'))],
 ]) {
-  app.post(`/api/files/:id/${verb}`, (req, res) => {
+  api.post(`/api/files/:id/${verb}`, (req, res) => {
     const s = store.get(req.params.id);
     if (!s) return res.status(404).json({ error: 'not found' });
     const dir = resolveSafe(folderPathOf(s), (req.body || {}).path || '');
@@ -1970,7 +1929,7 @@ for (const [verb, make] of [
       fs.mkdirSync(dir, { recursive: true });
       make(dest);
     } catch (e) {
-      return res.status(500).json({ error: String((e && e.message) || e) });
+      throw e;
     }
     res.status(201).json({ ok: true, name });
   });
@@ -1978,7 +1937,7 @@ for (const [verb, make] of [
 
 // Rename one entry in place. The new name is a NAME, so a rename can never also
 // move something — that is the /move route's job (still to come from #9).
-app.post('/api/files/:id/rename', (req, res) => {
+api.post('/api/files/:id/rename', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const root = folderPathOf(s);
@@ -1995,7 +1954,7 @@ app.post('/api/files/:id/rename', (req, res) => {
   try {
     fs.renameSync(from, to);
   } catch (e) {
-    return res.status(500).json({ error: String((e && e.message) || e) });
+    throw e;
   }
   res.json({ ok: true, name, path: path.relative(root, to) });
 });
@@ -2003,7 +1962,7 @@ app.post('/api/files/:id/rename', (req, res) => {
 // Move an entry into another folder under the same root, keeping its name — the
 // drag-and-drop half of rename. `to` is the destination FOLDER ('' = the root).
 // Adapted from PR #9, including the realpath check below.
-app.post('/api/files/:id/move', (req, res) => {
+api.post('/api/files/:id/move', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const root = folderPathOf(s);
@@ -2034,13 +1993,13 @@ app.post('/api/files/:id/move', (req, res) => {
   try {
     fs.renameSync(from, to);
   } catch (e) {
-    return res.status(500).json({ error: String((e && e.message) || e) });
+    throw e;
   }
   res.json({ ok: true, path: path.relative(root, to) });
 });
 
 // Delete one entry. Folders go recursively — the pane says so before asking.
-app.delete('/api/files/:id/entry', (req, res) => {
+api.delete('/api/files/:id/entry', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const root = folderPathOf(s);
@@ -2056,7 +2015,7 @@ app.delete('/api/files/:id/entry', (req, res) => {
   try {
     fs.rmSync(target, { recursive: true, force: true });
   } catch (e) {
-    return res.status(500).json({ error: String((e && e.message) || e) });
+    throw e;
   }
   res.json({ ok: true });
 });
@@ -2088,7 +2047,7 @@ function traceOpts(q) {
   };
 }
 
-app.get('/api/files/:id/trace', async (req, res) => {
+api.get('/api/files/:id/trace', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const f = resolveSafe(folderPathOf(s), req.query.path);
@@ -2103,31 +2062,47 @@ app.get('/api/files/:id/trace', async (req, res) => {
     if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
       return res.status(404).json({ error: e.message, code: e.code });
     }
-    console.error('[trace file]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'trace read failed' });
+    throw e;
   }
 });
 
 // Stream uploads straight to disk — a big drag-drop must not be buffered in the
 // RAM of the process that's also pumping every terminal's PTY data.
-app.post('/api/files/:id/upload', (req, res) => {
+api.post('/api/files/:id/upload', (req, res, next) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const dir = resolveSafe(folderPathOf(s), req.query.path);
   const name = String(req.query.name || '');
   if (!dir || !name || name.includes('/') || name.includes('..')) return res.status(400).json({ error: 'bad path' });
   const dest = path.join(dir, name);
-  try { fs.mkdirSync(dir, { recursive: true }); } catch (e) { return res.status(500).json({ error: e.message }); }
+  fs.mkdirSync(dir, { recursive: true });
   const out = fs.createWriteStream(dest);
-  const fail = (e) => {
-    out.destroy();
-    fs.unlink(dest, () => {}); // don't leave a truncated file behind
-    if (!res.headersSent) res.status(500).json({ error: String(e && e.message || e) });
+  let done = false;
+  const cleanup = () => {
+    req.off('error', fail);
+    req.off('aborted', abort);
+    res.off('close', abort);
   };
+  const fail = (e) => {
+    if (done) return;
+    done = true;
+    cleanup();
+    req.unpipe(out);
+    out.destroy();
+    out.once('close', () => fs.unlink(dest, () => {})); // wait for the descriptor before cleanup
+    next(e);
+  };
+  const abort = () => fail(new ApiError(400, 'request-aborted', 'Upload was interrupted.'));
   out.on('error', fail);
   req.on('error', fail);
-  req.on('aborted', () => fail(new Error('upload aborted')));
-  out.on('finish', () => res.json({ ok: true }));
+  req.once('aborted', abort);
+  res.once('close', abort);
+  out.once('finish', () => {
+    if (done) return;
+    done = true;
+    cleanup();
+    res.json({ ok: true });
+  });
   req.pipe(out);
 });
 
@@ -2145,7 +2120,7 @@ function cleanRelPath(p) {
 }
 
 // Folder listing for the location picker (subfolders of one level).
-app.get('/api/folders', (req, res) => {
+api.get('/api/folders', (req, res) => {
   const rel = cleanRelPath(req.query.path || '');
   if (rel === null) return res.status(400).json({ error: 'bad path' });
   const dir = workspacePath(rel);
@@ -2168,7 +2143,7 @@ function sessionsWithState() {
 }
 
 // The whole sidebar tree in one call: ordered refs + groups + sessions(+state).
-app.get('/api/tree', (_req, res) => {
+api.get('/api/tree', (_req, res) => {
   let sessions = sessionsWithState();
   let groupList = groups.list();
   const groupedIds = new Set(groupList.flatMap((g) => g.sessionIds));
@@ -2207,7 +2182,7 @@ app.get('/api/tree', (_req, res) => {
  * it takes `from` like every other mutating call so the operation log can say who
  * asked. It deliberately does NOT touch the sidebar: that is the way back.
  */
-app.post('/api/overview/hidden', (req, res) => {
+api.post('/api/overview/hidden', (req, res) => {
   const { ref, hidden: want } = req.body || {};
   if (typeof ref !== 'string') return res.status(400).json({ error: 'bad ref' });
   // Only HIDING has to name something real. Unhiding a ref whose group is already
@@ -2221,7 +2196,7 @@ app.post('/api/overview/hidden', (req, res) => {
 });
 
 // Backwards-compatible flat list (used by probes/tests).
-app.get('/api/sessions', (_req, res) => res.json(sessionsWithState()));
+api.get('/api/sessions', (_req, res) => res.json(sessionsWithState()));
 
 // Default name for a new agent: "<cli-label-slug>-<n>", e.g. claude-code-1.
 function nextName(cli) {
@@ -2243,7 +2218,7 @@ function nextName(cli) {
 // The panel treats this as a display value, not an answer — it only sends a
 // name when the operator edits it, so two creations racing on the same prefill
 // still get distinct names from the server (see Sidebar.tsx).
-app.get('/api/next-name', (req, res) => {
+api.get('/api/next-name', (req, res) => {
   const cli = String(req.query.cli || '').trim();
   if (!cliById(cli)) return res.status(400).json({ error: `unknown cli '${cli}'` });
   res.json({ cli, name: nextName(cli) });
@@ -2306,7 +2281,7 @@ function createSession({ name, cli, groupId, path: reqPath, prompt }) {
   return s;
 }
 
-app.post('/api/sessions', (req, res) => {
+api.post('/api/sessions', (req, res) => {
   const { name, cli, groupId, path: reqPath, prompt } = req.body || {};
   if (!cli || !cliById(cli)) return res.status(400).json({ error: 'unknown cli' });
   const s = createSession({ name, cli, groupId, path: reqPath, prompt });
@@ -2342,7 +2317,7 @@ function beginCronFire(job, trigger) {
   const at = new Date();
   const started = Date.now();
   const fail = (error) => {
-    const message = String(error && error.message || error).slice(0, 500);
+    const message = error instanceof ApiError ? error.message : 'Scheduled prompt could not be delivered.';
     crons.recordLast(job.id, {
       at: at.toISOString(), status: 'failed', durationMs: Date.now() - started, trigger, error: message,
     });
@@ -2354,9 +2329,9 @@ function beginCronFire(job, trigger) {
     let agentCreated = false;
     if (!session) {
       const invalid = cronCliError(job.agent.cli);
-      if (invalid) throw new Error(invalid);
+      if (invalid) throw new ApiError(409, 'cron-unavailable', invalid);
       const catalog = cliCatalog().find((candidate) => candidate.id === job.agent.cli);
-      if (!catalog?.available) throw new Error(`${cliById(job.agent.cli).label} is not installed on this Space`);
+      if (!catalog?.available) throw new ApiError(409, 'cron-unavailable', `${cliById(job.agent.cli).label} is not installed on this Space`);
       session = createSession({
         name: job.agent.name,
         cli: job.agent.cli,
@@ -2366,11 +2341,11 @@ function beginCronFire(job, trigger) {
         path: cronAgentFolder(job.agent.name),
       });
       if (!session) throw new Error('could not create the agent workspace');
-      if (session.error) throw new Error(session.error);
+      if (session.error) throw new ApiError(409, 'cron-unavailable', session.error);
       agentCreated = true;
     }
     if (!promptable(session) || isRemote(session.cli)) {
-      throw new Error(`the existing '${session.name}' session (${session.cli}) cannot receive scheduled prompts`);
+      throw new ApiError(409, 'cron-unavailable', 'The existing target session cannot receive scheduled prompts.');
     }
     const text = `[message from cron "${job.name}":] ${job.prompt}`;
     const completion = deliver(session, { text }, `cron: ${job.name}`)
@@ -2382,8 +2357,8 @@ function beginCronFire(job, trigger) {
       .catch((error) => { fail(error); });
     return { agentCreated, completion };
   } catch (error) {
-    const message = fail(error);
-    throw Object.assign(new Error(message), { statusCode: 409 });
+    fail(error);
+    throw error;
   }
 }
 
@@ -2392,36 +2367,36 @@ const validateCronCli = (body) => {
   return typeof cli === 'string' ? cronCliError(cli.trim()) : null;
 };
 
-app.get('/api/crons', (_req, res) => res.json({ crons: crons.list() }));
+api.get('/api/crons', (_req, res) => res.json({ crons: crons.list() }));
 
-app.post('/api/crons', (req, res) => {
+api.post('/api/crons', (req, res) => {
   const cliError = validateCronCli(req.body);
   if (cliError) return res.status(400).json({ error: cliError });
   try {
     const job = crons.create(req.body || {});
     return res.status(201).json(job);
   } catch (e) {
-    return res.status(400).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
-app.put('/api/crons/:id', (req, res) => {
+api.put('/api/crons/:id', (req, res) => {
   if (!crons.get(req.params.id)) return res.status(404).json({ error: 'not found' });
   const cliError = validateCronCli(req.body);
   if (cliError) return res.status(400).json({ error: cliError });
   try {
     return res.json(crons.update(req.params.id, req.body || {}));
   } catch (e) {
-    return res.status(400).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
-app.delete('/api/crons/:id', (req, res) => {
+api.delete('/api/crons/:id', (req, res) => {
   if (!crons.remove(req.params.id)) return res.status(404).json({ error: 'not found' });
   return res.json({ ok: true });
 });
 
-app.post('/api/crons/:id/run', (req, res) => {
+api.post('/api/crons/:id/run', (req, res) => {
   const job = crons.get(req.params.id);
   if (!job) return res.status(404).json({ error: 'not found' });
   const requested = String(req.query.trigger || '');
@@ -2433,12 +2408,12 @@ app.post('/api/crons/:id/run', (req, res) => {
     // has finished. `last` is updated when delivery itself succeeds or fails.
     return res.status(202).json({ ok: true, agentCreated: run.agentCreated });
   } catch (e) {
-    return res.status(e.statusCode || 409).json({ error: String(e.message || e) });
+    throw e;
   }
 });
 
 // Rename = display label only. Folders are never renamed or moved.
-app.put('/api/sessions/:id', (req, res) => {
+api.put('/api/sessions/:id', (req, res) => {
   const name = (req.body || {}).name;
   if (typeof name !== 'string' || !name.trim()) return res.status(400).json({ error: 'bad name' });
   const existing = store.get(req.params.id);
@@ -2456,7 +2431,7 @@ app.put('/api/sessions/:id', (req, res) => {
 // The two roads meet in the sidebar's archived view, but they are not the same
 // road: the window's verdict changes when the setting changes, and this one
 // does not. Only this one unlocks delete — see the DELETE route below.
-app.post('/api/sessions/:id/archive', (req, res) => {
+api.post('/api/sessions/:id/archive', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   // Archiving stops the agent. Putting a session away while its CLI keeps
@@ -2469,13 +2444,13 @@ app.post('/api/sessions/:id/archive', (req, res) => {
 
 // Restore. Deliberately does NOT start the agent again: unarchiving says "I
 // want to see this again", and starting is what opening the pane does.
-app.post('/api/sessions/:id/unarchive', (req, res) => {
+api.post('/api/sessions/:id/unarchive', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   return res.json(store.update(s.id, { archivedAt: undefined }));
 });
 
-app.post('/api/sessions/:id/stop', (req, res) => {
+api.post('/api/sessions/:id/stop', (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   stop(s.id);
@@ -2490,7 +2465,7 @@ app.post('/api/sessions/:id/stop', (req, res) => {
 // Claude and Codex: both write JSONL the Hub renders natively, so the trace
 // ships verbatim. The remaining harnesses need converters (§13 phase 5) — say so
 // plainly rather than producing a broken bundle.
-app.post('/api/sessions/:id/share', async (req, res) => {
+api.post('/api/sessions/:id/share', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   if (!SHAREABLE_CLIS.includes(s.cli)) {
@@ -2512,14 +2487,13 @@ app.post('/api/sessions/:id/share', async (req, res) => {
     if (e.code === 'redaction-blocked') {
       return res.status(409).json({ error: e.message, code: e.code, hits: e.hits });
     }
-    console.error('[share]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'share failed' });
+    throw e;
   }
 });
 
 // Can this session be shared at all, and where would it go? Lets the dialog
 // open in a truthful state instead of failing on submit.
-app.get('/api/sessions/:id/share', async (req, res) => {
+api.get('/api/sessions/:id/share', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   const [namespace, hit] = await Promise.all([shareNamespace(), findTrace(s, store.list())]);
@@ -2532,14 +2506,13 @@ app.get('/api/sessions/:id/share', async (req, res) => {
 });
 
 // Who can see an existing gated share.
-app.get('/api/share/access', async (req, res) => {
+api.get('/api/share/access', async (req, res) => {
   const repo = String(req.query.repo || '');
   if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) return res.status(400).json({ error: 'bad repo' });
-  try { res.json(await shareAccess(repo)); }
-  catch (e) { res.status(500).json({ error: (e && e.message) || 'failed' }); }
+  res.json(await shareAccess(repo));
 });
 
-app.post('/api/share/access', async (req, res) => {
+api.post('/api/share/access', async (req, res) => {
   const b = req.body || {};
   const repo = String(b.repo || '');
   if (!/^[\w.-]+\/[\w.-]+$/.test(repo)) return res.status(400).json({ error: 'bad repo' });
@@ -2549,7 +2522,7 @@ app.post('/api/share/access', async (req, res) => {
     const revoked = await revokeAccess(repo, list(b.revoke));
     res.json({ granted, revoked, ...(await shareAccess(repo)) });
   } catch (e) {
-    res.status(500).json({ error: (e && e.message) || 'failed' });
+    throw e;
   }
 });
 
@@ -2567,7 +2540,7 @@ app.post('/api/share/access', async (req, res) => {
 // render it. This is the manual half of receiving — the same materialisation step
 // accepting an inbox delivery will perform. Works for a private/gated repo: the
 // viewer is blocked there, authenticated download is not.
-app.post('/api/trace/import', async (req, res) => {
+api.post('/api/trace/import', async (req, res) => {
   const repo = String((req.body || {}).repo || '')
     .trim()
     // Accept a pasted dataset URL as readily as a bare id — that is what people
@@ -2581,14 +2554,12 @@ app.post('/api/trace/import', async (req, res) => {
   } catch (e) {
     if (['bad-repo', 'not-a-bundle'].includes(e && e.code)) return res.status(400).json({ error: e.message, code: e.code });
     if (['no-access', 'no-hf-token'].includes(e && e.code)) return res.status(403).json({ error: e.message, code: e.code });
-    console.error('[trace-import]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'import failed' });
+    throw e;
   }
 });
 
-app.get('/api/trace/bundles', async (_req, res) => {
-  try { res.json({ bundles: await listBundles() }); }
-  catch (e) { res.status(500).json({ error: (e && e.message) || 'failed' }); }
+api.get('/api/trace/bundles', async (_req, res) => {
+  res.json({ bundles: await listBundles() });
 });
 
 // Resolve the concrete local source behind a trace pane. Handover uses this to
@@ -2632,7 +2603,7 @@ async function traceFileOf(s) {
   return { path: hit.src, sessionId: hit.sessionId || null, source };
 }
 
-app.get('/api/trace/:id/location', async (req, res) => {
+api.get('/api/trace/:id/location', async (req, res) => {
   const pane = store.get(req.params.id);
   if (!pane || pane.cli !== 'trace') return res.status(404).json({ error: 'not a trace pane' });
   try {
@@ -2640,7 +2611,7 @@ app.get('/api/trace/:id/location', async (req, res) => {
     if (found.error) return res.status(found.status).json({ error: found.error, code: found.code });
     return res.json({ path: found.path, sessionId: found.sessionId, source: found.source });
   } catch (e) {
-    res.status(500).json({ error: (e && e.message) || 'could not resolve trace path' });
+    throw e;
   }
 });
 
@@ -2654,22 +2625,22 @@ app.get('/api/trace/:id/location', async (req, res) => {
 // file to the operator, over the session they are already authenticated on.
 // Publishing is /api/share, which does gate, because that is what puts a
 // transcript somewhere other people can read it.
-app.get('/api/trace/:id/download', async (req, res) => {
+api.get('/api/trace/:id/download', async (req, res, next) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   try {
     const found = await traceFileOf(s);
     if (found.error) return res.status(found.status).json({ error: found.error, code: found.code });
     const stem = slugify(s.name || '') || 'trace';
-    res.download(found.path, `${stem}${path.extname(found.path) || '.jsonl'}`);
+    res.download(found.path, `${stem}${path.extname(found.path) || '.jsonl'}`, (error) => { if (error) next(error); });
   } catch (e) {
-    res.status(500).json({ error: (e && e.message) || 'could not read that trace' });
+    throw e;
   }
 });
 
 // Paginated on purpose: a single session here is 6.15 MB and the panel only ever
 // shows a window of it. `limit` is clamped in readTrace().
-app.get('/api/trace/:id', async (req, res) => {
+api.get('/api/trace/:id', async (req, res) => {
   const pane = store.get(req.params.id);
   if (!pane) return res.status(404).json({ error: 'not found' });
 
@@ -2691,15 +2662,14 @@ app.get('/api/trace/:id', async (req, res) => {
     if (['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(e && e.code)) {
       return res.status(404).json({ error: e.message, code: e.code });
     }
-    console.error('[trace]', e && e.message);
-    res.status(500).json({ error: (e && e.message) || 'trace read failed' });
+    throw e;
   }
 });
 
 // Point a trace pane at a source (used by the "Trace" button on a session row).
 // Creating the pane goes through the normal POST /api/sessions with cli:'trace';
 // this only records what it should show.
-app.put('/api/trace/:id/source', (req, res) => {
+api.put('/api/trace/:id/source', (req, res) => {
   const pane = store.get(req.params.id);
   if (!pane || pane.cli !== 'trace') return res.status(404).json({ error: 'not a trace pane' });
   const b = req.body || {};
@@ -2714,7 +2684,7 @@ app.put('/api/trace/:id/source', (req, res) => {
   res.json({ ok: true, traceSource: { kind, ref } });
 });
 
-app.delete('/api/sessions/:id', async (req, res) => {
+api.delete('/api/sessions/:id', async (req, res) => {
   const s = store.get(req.params.id);
   if (!s) return res.status(404).json({ error: 'not found' });
   // Two guards, answering two different questions, and a session has to satisfy
@@ -2758,19 +2728,19 @@ app.delete('/api/sessions/:id', async (req, res) => {
   res.json({ ok: true });
 });
 
-app.post('/api/groups', (req, res) => {
+api.post('/api/groups', (req, res) => {
   const g = groups.create((req.body || {}).name);
   order.prepend(`g:${g.id}`);
   res.status(201).json(g);
 });
 
-app.put('/api/groups/:id', (req, res) => {
+api.put('/api/groups/:id', (req, res) => {
   const existing = groups.get(req.params.id);
   if (!existing) return res.status(404).json({ error: 'not found' });
   res.json(groups.update(existing.id, { ...(req.body || {}) }));
 });
 
-app.delete('/api/groups/:id', (req, res) => {
+api.delete('/api/groups/:id', (req, res) => {
   const g = groups.get(req.params.id);
   if (!g) return res.status(404).json({ error: 'not found' });
   const idx = order.indexOf(`g:${g.id}`);
@@ -2789,7 +2759,7 @@ app.delete('/api/groups/:id', (req, res) => {
 const splitRef = (r) => [r.slice(0, 1), r.slice(2)];
 const removeSessionEverywhere = (sid) => { groups.detachSession(sid); order.drop(`s:${sid}`); };
 
-app.post('/api/move', (req, res) => {
+api.post('/api/move', (req, res) => {
   const { ref, to } = req.body || {};
   if (typeof ref !== 'string' || !to) return res.status(400).json({ error: 'bad request' });
   const [t, id] = splitRef(ref);
@@ -2839,6 +2809,7 @@ app.post('/api/move', (req, res) => {
   res.json({ ok: true });
 });
 
+app.use(apiNotFound);
 // Serve the built frontend with SPA fallback.
 if (fs.existsSync(PUBLIC_DIR)) {
   app.use(express.static(PUBLIC_DIR));
@@ -2848,6 +2819,7 @@ if (fs.existsSync(PUBLIC_DIR)) {
   });
 }
 
+app.use(apiErrorHandler);
 const server = http.createServer(app);
 // Node kills any request still open at requestTimeout (default 300 s), which
 // would cut a remote agent's long poll off mid-wait and look exactly like a

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -143,7 +143,7 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
       responseBody = body;
       return originalJson(body);
     };
-    const record = () => {
+    const record = (completed) => {
       if (recorded) return;
       recorded = true;
       // A wait is a polling loop: only the call that RESOLVED is an event. The
@@ -165,14 +165,17 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
         path: req.path,
         query: cleanQuery(req.query),
         request: summarizePayload(req.body, 'body'),
-        status: res.statusCode,
-        ok: res.statusCode < 400,
+        // 499 is audit-only when no HTTP response was committed. An aborted
+        // connection says nothing about whether the domain action completed.
+        status: completed || res.headersSent ? res.statusCode : 499,
+        ok: completed && res.statusCode < 400,
+        ...(!completed ? { incomplete: true } : {}),
         durationMs: Date.now() - started,
         result: summarizePayload(responseBody, 'result'),
       });
     };
-    res.once('finish', record);
-    res.once('close', record);
+    res.once('finish', () => record(true));
+    res.once('close', () => record(false));
     next();
   };
 }

--- a/server/src/operations.js
+++ b/server/src/operations.js
@@ -119,6 +119,7 @@ export function operationMiddleware({ resolveOrigin, resolveTarget, allowMissing
     // unattributed wait still records that someone finished waiting on B.
     if (!origin && MUTATING.has(req.method)) {
       return res.status(400).json({
+        code: raw ? 'unknown-origin' : 'origin-required',
         error: raw
           ? `unknown origin '${raw}'`
           : 'from required — mutating calls must pass ?from=<origin id> (agents use $AM_ID)',

--- a/server/src/runner.js
+++ b/server/src/runner.js
@@ -1,3 +1,4 @@
+import { ApiError } from './api-errors.js';
 import os from 'node:os';
 import path from 'node:path';
 import crypto from 'node:crypto';
@@ -1832,7 +1833,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
   // Nothing to start: a remote agent starts itself, on its own machine. Both
   // callers guard this too; keep the refusal here so no future one can spawn
   // a PTY for a pane that can never use it.
-  if (isRemote(session.cli)) throw new Error('a remote agent runs on its own machine — nothing to start here');
+  if (isRemote(session.cli)) throw new ApiError(409, 'remote-agent', 'a remote agent runs on its own machine — nothing to start here');
   const existing = hosts.get(session.id);
   if (existing) return false;
   if (!ghostty) throw new Error(`libghostty-vt unavailable: ${ghosttyError}`);
@@ -1853,7 +1854,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
   const realRoot = fs.realpathSync(WORKSPACES_DIR);
   const realWork = fs.realpathSync(workdir);
   if (realWork !== realRoot && !realWork.startsWith(`${realRoot}${path.sep}`)) {
-    throw new Error(`${folder} resolves to ${realWork}, outside the workspaces root — `
+    throw new ApiError(409, 'invalid-workspace', 'The folder resolves outside the workspaces root — '
       + 'a session has to run inside it. Point the session at a folder in the tree, '
       + 'or copy what you need into one.');
   }
@@ -2058,7 +2059,7 @@ export function ensureRunning(session, cols = 120, rows = 34) {
 export function attach(session, cols, rows) {
   ensureRunning(session, cols, rows);
   const host = hosts.get(session.id);
-  if (!host) throw new Error('session failed to start');
+  if (!host) throw new ApiError(409, 'input-not-ready', 'session failed to start');
 
   const sub = {
     onData: () => {},
@@ -2124,7 +2125,7 @@ export function attach(session, cols, rows) {
 /** Type a line into the session's terminal (works with no browser attached). */
 export async function sendInput(id, text, { confirmEcho = false } = {}) {
   const host = hosts.get(id);
-  if (!host || stopping.has(id)) throw new Error('session is not running');
+  if (!host || stopping.has(id)) throw new ApiError(409, 'input-not-ready', 'session is not running');
   host.inputRequired.observeInput();
   // Multi-line prompts go in as a bracketed paste so the CLI's composer treats
   // the inner newlines as soft line breaks instead of submitting early.
@@ -2143,7 +2144,7 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
     let attempt = 0;
     let echoed = false;
     while (Date.now() < deadline && !echoed) {
-      if (hosts.get(id) !== host) throw new Error('session stopped while waiting for input acknowledgement');
+      if (hosts.get(id) !== host) throw new ApiError(409, 'input-not-ready', 'session stopped while waiting for input acknowledgement');
       if (attempt++) {
         host.pty.write('\x15'); // clear any attempt accepted too late to paint
         await new Promise((r) => setTimeout(r, 100));
@@ -2154,7 +2155,7 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
       host.pty.write(payload);
       const attemptDeadline = Math.min(deadline, Date.now() + 1200);
       while (Date.now() < attemptDeadline) {
-        if (hosts.get(id) !== host) throw new Error('session stopped while waiting for input acknowledgement');
+        if (hosts.get(id) !== host) throw new ApiError(409, 'input-not-ready', 'session stopped while waiting for input acknowledgement');
         let screen = '';
         try { screen = host.vt.getVisibleText(); } catch {}
         echoed = host.outputSeq > beforeOutput && screen !== beforeScreen
@@ -2163,7 +2164,7 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
         await new Promise((r) => setTimeout(r, 50));
       }
     }
-    if (!echoed) throw new Error('session did not acknowledge the input before the timeout — prompt was not submitted');
+    if (!echoed) throw new ApiError(409, 'input-not-ready', 'session did not acknowledge the input before the timeout — prompt was not submitted');
   } else {
     host.pty.write(payload);
   }
@@ -2174,7 +2175,7 @@ export async function sendInput(id, text, { confirmEcho = false } = {}) {
 /** Insert text into a running terminal's composer without submitting it. */
 export function pasteInput(id, text) {
   const host = hosts.get(id);
-  if (!host || stopping.has(id)) throw new Error('session is not running');
+  if (!host || stopping.has(id)) throw new ApiError(409, 'input-not-ready', 'session is not running');
   const value = String(text || '');
   if (!value) return;
   host.inputRequired.observeInput();
@@ -2195,7 +2196,7 @@ export async function waitForInputReady(id, timeoutMs = INPUT_READY_TIMEOUT_MS) 
   const deadline = Date.now() + Math.max(0, timeoutMs);
   while (Date.now() < deadline) {
     const host = hosts.get(id);
-    if (!host) throw new Error('session stopped while waiting for input readiness');
+    if (!host) throw new ApiError(409, 'input-not-ready', 'session stopped while waiting for input readiness');
     const lastActivity = Math.max(host.startedAt || 0, host.lastOutputAt || 0, host.screenChangedAt || 0);
     if (!host.startupHistory && !host.resizeCapture
       && Date.now() - lastActivity >= INPUT_READY_QUIET_MS) return true;

--- a/server/src/share.js
+++ b/server/src/share.js
@@ -548,7 +548,7 @@ export async function shareSession(session, { visibility = 'public', name, grant
         } catch (e) {
           // 400 already-has-access is a success from the caller's point of view.
           if (e.status === 400 && /already/i.test(e.message)) granted.push(user);
-          else grantErrors.push({ user, error: e.message });
+          else grantErrors.push({ user, error: 'Access could not be granted. Check the username and dataset permissions.', code: 'grant-failed' });
         }
       }
     }

--- a/server/src/share.js
+++ b/server/src/share.js
@@ -19,6 +19,7 @@
 //     asking the operator to notice a warning.
 
 import fs from 'node:fs';
+import { ApiError } from './api-errors.js';
 import fsp from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
@@ -53,7 +54,7 @@ const run = (cmd, args, opts = {}) =>
 
 async function hfApi(pathname, { method = 'GET', body } = {}) {
   const token = hfToken();
-  if (!token) throw new Error('no HF_TOKEN — add it as a Space secret to share sessions');
+  if (!token) throw new ApiError(403, 'no-hf-token', 'no HF_TOKEN — add it as a Space secret to share sessions');
   const r = await fetch(`${HF}${pathname}`, {
     method,
     headers: {
@@ -451,7 +452,7 @@ Traces can still contain local paths and command output. Review before relying o
  */
 export async function buildBundle(session, { title, visibility, allSessions = [] }) {
   const hit = await findTrace(session, allSessions);
-  if (!hit) throw new Error('no transcript on disk for this session yet — run it first');
+  if (!hit) throw new ApiError(409, 'no-transcript', 'no transcript on disk for this session yet — run it first');
 
   // The exporter must be present in the image (Dockerfile copies scripts/).
   // Fail with the actual cause rather than an unparseable-output error.
@@ -496,6 +497,7 @@ export async function buildBundle(session, { title, visibility, allSessions = []
  * @param grantTo          usernames to pre-authorize (gated only)
  */
 export async function shareSession(session, { visibility = 'public', name, grantTo = [], allSessions = [] } = {}) {
+  if (!hfToken()) throw new ApiError(403, 'no-hf-token', 'no HF_TOKEN — add it as a Space secret to share sessions');
   if (!['public', 'gated'].includes(visibility)) throw new Error(`bad visibility: ${visibility}`);
   const ns = await shareNamespace();
   if (!ns) throw new Error('cannot resolve the Hub namespace — check HF_TOKEN');

--- a/server/test/api-boundary.test.mjs
+++ b/server/test/api-boundary.test.mjs
@@ -40,7 +40,10 @@ api.post('/api/failure/:mode', (req, res, next) => {
 });
 api.get('/api/expected/:status', (req, _res) => { throw new ApiError(Number(req.params.status), 'fixture-refused', 'Try a different value.', { reason: 'fixture', hits: { rule: 2 }, mtime: 123, tag: 'revision', details: [{ field: 'name', message: 'required' }] }); });
 api.get('/api/legacy', (_req, res) => res.status(409).json({ error: 'changed on disk', tag: 'latest' }));
-api.get('/api/old-internal', (_req, res) => res.status(500).json({ error: secret, raw: secret }));
+api.get('/api/old-internal', (_req, res) => res.status(500).json({ error: secret, raw: secret,
+  details: [{ field: 'path', message: secret }] }));
+api.get('/api/file-diagnostic', (_req, res) => res.status(500).json({ error: secret,
+  details: [{ field: 'path', message: 'am-config.json' }] }));
 api.get('/api/empty', (_req, res) => res.status(204).end());
 api.get('/api/partial', (_req, res) => res.json({ ok: false, reason: 'no-devices', failed: 1 }));
 api.get('/api/healthy', (_req, res) => res.json({ ok: true }));
@@ -139,7 +142,12 @@ try {
       assert.equal(b.code, 'fixture-refused'); assert.equal(b.error, 'Try a different value.'); assert.equal(b.tag, 'revision'); assert.equal(b.hits.rule, 2);
     }
     assert.equal((await (await fetch(base + '/api/legacy')).json()).code, 'conflict');
-    assert.ok(!(await (await fetch(base + '/api/old-internal')).text()).includes(secret));
+    const internal = await (await fetch(base + '/api/old-internal')).json();
+    assert.ok(!JSON.stringify(internal).includes(secret)); assert.equal(internal.details, undefined);
+    const diagnostic = await (await fetch(base + '/api/file-diagnostic')).json();
+    assert.equal(diagnostic.error, 'The request could not be completed. Please try again.');
+    assert.equal(diagnostic.code, 'internal-error');
+    assert.deepEqual(diagnostic.details, [{ field: 'path', message: 'am-config.json' }]);
     assert.equal(await (await fetch(base + '/api/empty')).text(), '');
     assert.deepEqual(await (await fetch(base + '/api/partial')).json(), { ok: false, reason: 'no-devices', failed: 1 });
     assert.equal((await (await fetch(base + '/api/no-such-route')).json()).code, 'api-not-found');

--- a/server/test/api-boundary.test.mjs
+++ b/server/test/api-boundary.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import test from 'node:test';
+import express from 'express';
+
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-api-boundary-'));
+process.env.DATA_DIR = root;
+const { ApiError, apiRoutes, apiErrorHandler, apiNotFound, errorEnvelope, pipeResponse } = await import('../src/api-errors.js');
+const { createValidator } = await import('../src/api-validation.js');
+const { operationMiddleware, readOperations } = await import('../src/operations.js');
+const { remoteStream } = await import('../src/api-streams.js');
+const secret = 'synthetic-private-data /private/example token_fixture <private-markup>';
+const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const app = express();
+app.use(express.json({ limit: '1kb' }));
+app.use(operationMiddleware({ resolveOrigin: (raw) => raw === 'operator' ? { id: raw, type: 'operator' } : null }));
+app.use(errorEnvelope);
+const validate = createValidator({ cliExists: (id) => ['files', 'remote', 'claude'].includes(id), sessionExists: (id) => id === 'one', groupExists: (id) => id === 'group' });
+const api = apiRoutes(app, validate);
+let effects = 0, completed = 0;
+app.use((_req, res, next) => { res.once('finish', () => completed++); next(); });
+const action = (req, res) => { effects++; res.json({ body: req.body, query: req.query }); };
+for (const route of ['/api/sessions', '/api/groups', '/api/move', '/api/notify', '/api/push/subscribe', '/api/push/unsubscribe', '/api/overview/hidden', '/api/demo', '/api/sessions/:id/input', '/api/sessions/:id/remote/paused', '/api/remote/:name/hello', '/api/crons', '/api/share/access', '/api/trace/import', '/api/sessions/:id/share']) api.post(route, action);
+for (const route of ['/api/config', '/api/secrets', '/api/groups/:id', '/api/crons/:id', '/api/trace/:id/source']) api.put(route, action);
+api.post('/api/agents/:id/prompt', express.text({ type: '*/*' }), action);
+api.put('/api/files/:id/write', express.text({ type: '*/*' }), action);
+for (const route of ['/api/trace/:id', '/api/operations', '/api/agents/:id/wait', '/api/agents/:id/tail', '/api/remote/:name/stream']) api.get(route, action);
+api.post('/api/failure/:mode', (req, res, next) => {
+  if (req.params.mode === 'sync') throw new Error(secret);
+  if (req.params.mode === 'immediate') return Promise.reject(new Error(secret));
+  if (req.params.mode === 'delayed') return delay(5).then(() => { throw new Error(secret); });
+  if (req.params.mode === 'non-error') return Promise.reject(secret);
+  if (req.params.mode === 'twice') { next(new Error(secret)); return Promise.reject(new Error(secret)); }
+  if (req.params.mode === 'late') { res.json({ ok: true }); return delay(5).then(() => { throw new Error(secret); }); }
+});
+api.get('/api/expected/:status', (req, _res) => { throw new ApiError(Number(req.params.status), 'fixture-refused', 'Try a different value.', { reason: 'fixture', hits: { rule: 2 }, mtime: 123, tag: 'revision', details: [{ field: 'name', message: 'required' }] }); });
+api.get('/api/legacy', (_req, res) => res.status(409).json({ error: 'changed on disk', tag: 'latest' }));
+api.get('/api/old-internal', (_req, res) => res.status(500).json({ error: secret, raw: secret }));
+api.get('/api/empty', (_req, res) => res.status(204).end());
+api.get('/api/partial', (_req, res) => res.json({ ok: false, reason: 'no-devices', failed: 1 }));
+api.get('/api/healthy', (_req, res) => res.json({ ok: true }));
+let source;
+api.get('/api/file/:mode', (req, res, next) => {
+  source = new PassThrough();
+  res.set({ 'content-type': 'application/octet-stream', 'content-disposition': 'attachment; filename="fixture"' });
+  pipeResponse(source, req, res, next);
+  if (req.params.mode === 'before') setTimeout(() => source.destroy(new Error(secret)), 5);
+  else { source.write('file bytes'); if (req.params.mode === 'after') setTimeout(() => source.destroy(new Error(secret)), 20); }
+});
+let released = 0, entry;
+api.get('/api/poll/:mode', (req, res, next) => remoteStream(req, res, next, {
+  HEARTBEAT_MS: 10,
+  pendingFor: () => { if (req.params.mode === 'before') throw new Error(secret); return []; },
+  registerStream: (_name, value) => { entry = value; return () => { released++; }; },
+  lastSeq: () => { if (req.params.mode === 'timer') throw new Error(secret); return 7; },
+}, 'fixture', 0, 0.03));
+app.use(apiNotFound);
+app.get('*', (_req, res) => res.type('html').send('<html>fixture app</html>'));
+app.use(apiErrorHandler);
+const server = app.listen(0, '127.0.0.1');
+await once(server, 'listening');
+const base = `http://127.0.0.1:${server.address().port}`;
+const request = (url, body, method = 'POST', headers = {}) => fetch(base + url, { method, headers: { 'x-am-origin': 'operator', ...(body === undefined ? {} : { 'content-type': 'application/json' }), ...headers }, body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(2000) });
+
+try {
+  await test('sync, async, non-Error and duplicate forwarding settle once with safe audit outcomes', async () => {
+    const unhandled = [];
+    const listener = (error) => unhandled.push(error);
+    process.on('unhandledRejection', listener);
+    try {
+      for (const mode of ['sync', 'immediate', 'delayed', 'non-error', 'twice', 'late']) {
+        const count = completed;
+        const r = await request(`/api/failure/${mode}`);
+        assert.equal(r.status, mode === 'late' ? 200 : 500);
+        const body = await r.json();
+        if (mode !== 'late') { assert.equal(body.code, 'internal-error'); assert.ok(body.error); }
+        assert.ok(!JSON.stringify(body).includes('private'));
+        await delay(15);
+        assert.equal(completed, count + 1);
+      }
+      assert.deepEqual(unhandled, []);
+      const logs = readOperations(100).filter((entry) => entry.path?.startsWith('/api/failure/'));
+      assert.equal(logs.length, 6);
+      assert.ok(!JSON.stringify(logs).includes('synthetic-private'));
+      assert.equal((await fetch(base + '/api/healthy')).status, 200);
+    } finally { process.off('unhandledRejection', listener); }
+  });
+  await test('validation rejects before fake domain actions; no coercions or duplicate scalar queries', async () => {
+    const cases = [
+      ['/api/sessions', {}], ['/api/sessions', { cli: 'wrong' }], ['/api/sessions', { cli: 'files', name: [] }], ['/api/sessions', { cli: 'files', path: null }],
+      ['/api/groups', null], ['/api/groups', []], ['/api/groups', { name: false }], ['/api/groups/one', { name: '' }, 'PUT'], ['/api/groups/one', { layout: { cols: 0, rows: 1 } }, 'PUT'],
+      ['/api/groups/one', { sessionIds: ['gone'] }, 'PUT'], ['/api/move', { ref: 's:gone', to: { kind: 'into', groupId: 'group' } }],
+      ['/api/config', { artifacts: { enabled: 'false' } }, 'PUT'], ['/api/config', { revive: { days: 4 } }, 'PUT'], ['/api/config', { jobs: { askAboveUsd: -1 } }, 'PUT'], ['/api/config', { backup: { exclude: null } }, 'PUT'],
+      ['/api/secrets', { notes: { fixture: {} } }, 'PUT'], ['/api/notify', { body: '' }], ['/api/notify', { body: 'safe', title: 123 }],
+      ['/api/sessions/one/input', { text: [], attachmentIds: [] }], ['/api/sessions/one/input', { attachmentIds: null }], ['/api/sessions/one/remote/paused', { paused: 'false' }],
+      ['/api/push/subscribe', { subscription: { endpoint: 'https://fixture.test' } }], ['/api/push/unsubscribe', { endpoint: null }],
+      ['/api/overview/hidden', { ref: 's:one', hidden: 0 }], ['/api/demo', { active: null }], ['/api/remote/one/hello', { host: [] }],
+      ['/api/crons', { name: 'job', agent: { name: 'one', cli: 'claude' }, prompt: 'fixture', schedule: { cron: '* * * * *', tz: 'UTC' }, runOnRestart: 'false' }],
+      ['/api/share/access', { repo: 'a/b', grant: [2] }], ['/api/sessions/one/share', { visibility: 'private' }], ['/api/trace/import', { repo: {} }],
+      ['/api/trace/one/source', { ref: 'one', kind: 'wrong' }, 'PUT'], ['/api/files/one/write', { content: 'wrong form' }, 'PUT'],
+      ['/api/trace/one?before=0&after=1', undefined, 'GET'], ['/api/trace/one?offset=NaN', undefined, 'GET'], ['/api/trace/one?limit=0', undefined, 'GET'],
+      ['/api/operations?limit=1&limit=2', undefined, 'GET'], ['/api/operations?limit[x]=1', undefined, 'GET'], ['/api/agents/one/wait?timeout=301', undefined, 'GET'], ['/api/remote/one/stream?wait=4', undefined, 'GET'],
+    ];
+    for (const [url, body, method] of cases) {
+      const before = effects;
+      const r = await request(url, body, method);
+      assert.equal(r.status, 400, url);
+      assert.equal((await r.json()).code, body === null ? 'invalid-json' : 'invalid-input', url);
+      assert.equal(effects, before, url);
+    }
+    const valid = [
+      ['/api/sessions', { cli: 'files', name: '', path: '.' }], ['/api/groups', { name: '' }], ['/api/groups/one', { layout: null, sessionIds: ['one'] }, 'PUT'],
+      ['/api/config', { artifacts: { enabled: false }, jobs: { askAboveUsd: 0 }, backup: { exclude: [] }, extension: 'ignored' }, 'PUT'],
+      ['/api/secrets', { notes: { anyExtension: '' } }, 'PUT'], ['/api/agents/one/wait?settle=0&timeout=300', undefined, 'GET'], ['/api/trace/one?before=0&bytes=8388608', undefined, 'GET'], ['/api/agents/one/tail?lines=5000', undefined, 'GET'],
+    ];
+    for (const [url, body, method] of valid) assert.equal((await request(url, body, method)).status, 200, url);
+    const text = await fetch(base + '/api/agents/one/prompt', { method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/x-www-form-urlencoded' }, body: 'curl text prompt' });
+    assert.equal((await text.json()).body, 'curl text prompt');
+  });
+  await test('additive codes, legacy fields, deliberate empty/partial responses, routing and parser failures', async () => {
+    for (const status of [400, 403, 404, 409, 413, 429]) {
+      const r = await fetch(`${base}/api/expected/${status}`);
+      assert.equal(r.status, status);
+      const b = await r.json();
+      assert.equal(b.code, 'fixture-refused'); assert.equal(b.error, 'Try a different value.'); assert.equal(b.tag, 'revision'); assert.equal(b.hits.rule, 2);
+    }
+    assert.equal((await (await fetch(base + '/api/legacy')).json()).code, 'conflict');
+    assert.ok(!(await (await fetch(base + '/api/old-internal')).text()).includes(secret));
+    assert.equal(await (await fetch(base + '/api/empty')).text(), '');
+    assert.deepEqual(await (await fetch(base + '/api/partial')).json(), { ok: false, reason: 'no-devices', failed: 1 });
+    assert.equal((await (await fetch(base + '/api/no-such-route')).json()).code, 'api-not-found');
+    assert.match(await (await fetch(base + '/some/spa/path')).text(), /fixture app/);
+    const bad = await fetch(base + '/api/sessions', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{' + secret });
+    assert.equal(bad.status, 400); assert.equal((await bad.json()).code, 'invalid-json');
+    const large = await request('/api/sessions', { text: 'x'.repeat(2000) }); assert.equal(large.status, 413);
+    const charset = await fetch(base + '/api/sessions', { method: 'POST', headers: { 'content-type': 'application/json; charset=unsupported' }, body: '{}' });
+    assert.equal(charset.status, 415); assert.equal((await charset.json()).code, 'unsupported-media-type');
+    const malformedPath = await fetch(base + '/api/trace/%zz'); assert.equal(malformedPath.status, 400); assert.equal((await malformedPath.json()).code, 'invalid-path');
+    const denied = await fetch(base + '/api/sessions', { method: 'POST' }); assert.equal((await denied.json()).code, 'origin-required');
+    const before = effects;
+    const media = await fetch(base + '/api/sessions', { method: 'POST', headers: { 'x-am-origin': 'operator' }, body: 'not JSON' });
+    assert.equal(media.status, 415); assert.equal(effects, before);
+  });
+  await test('file and remote callbacks terminate committed streams and release resources', async () => {
+    const before = await fetch(base + '/api/file/before'); assert.equal(before.status, 500); assert.equal((await before.json()).code, 'internal-error');
+    const after = await fetch(base + '/api/file/after'); assert.equal(after.status, 200);
+    const reader = after.body.getReader();
+    assert.equal(new TextDecoder().decode((await reader.read()).value), 'file bytes');
+    await assert.rejects(reader.read());
+    assert.equal(source.destroyed, true);
+    const controller = new AbortController();
+    const open = await fetch(base + '/api/file/open', { signal: controller.signal }); await open.body.getReader().read(); controller.abort();
+    await delay(20); assert.equal(source.destroyed, true);
+    const pre = await fetch(base + '/api/poll/before'); assert.equal(pre.status, 500);
+    const old = released;
+    const timer = await fetch(base + '/api/poll/timer'); await assert.rejects(timer.text());
+    assert.equal(released, old + 1);
+    const late = entry; late.deliver([{ seq: 8 }]); assert.equal(released, old + 1);
+    const good = await fetch(base + '/api/poll/normal'); const bytes = await good.text();
+    assert.match(bytes, /^:connected\n/); assert.match(bytes, /"seq":7/); assert.ok(!bytes.includes('internal-error'));
+    const ac = new AbortController(); const poll = await fetch(base + '/api/poll/normal', { signal: ac.signal }); await poll.body.getReader().read(); ac.abort();
+    await delay(20); assert.equal(released, old + 3);
+  });
+} finally {
+  server.closeAllConnections(); await new Promise((resolve) => server.close(resolve));
+  fs.rmSync(root, { recursive: true, force: true });
+}

--- a/server/test/api-boundary.test.mjs
+++ b/server/test/api-boundary.test.mjs
@@ -36,6 +36,7 @@ api.post('/api/failure/:mode', (req, res, next) => {
   if (req.params.mode === 'non-error') return Promise.reject(secret);
   if (req.params.mode === 'twice') { next(new Error(secret)); return Promise.reject(new Error(secret)); }
   if (req.params.mode === 'late') { res.json({ ok: true }); return delay(5).then(() => { throw new Error(secret); }); }
+  if (req.params.mode === 'disconnected') return delay(100).then(() => res.json({ ok: true }));
 });
 api.get('/api/expected/:status', (req, _res) => { throw new ApiError(Number(req.params.status), 'fixture-refused', 'Try a different value.', { reason: 'fixture', hits: { rule: 2 }, mtime: 123, tag: 'revision', details: [{ field: 'name', message: 'required' }] }); });
 api.get('/api/legacy', (_req, res) => res.status(409).json({ error: 'changed on disk', tag: 'latest' }));
@@ -120,6 +121,15 @@ try {
     for (const [url, body, method] of valid) assert.equal((await request(url, body, method)).status, 200, url);
     const text = await fetch(base + '/api/agents/one/prompt', { method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/x-www-form-urlencoded' }, body: 'curl text prompt' });
     assert.equal((await text.json()).body, 'curl text prompt');
+  });
+  await test('a disconnected mutation is recorded once without claiming success or replaying late work', async () => {
+    const controller = new AbortController();
+    const pending = fetch(base + '/api/failure/disconnected', { method: 'POST', headers: { 'x-am-origin': 'operator' }, signal: controller.signal });
+    setTimeout(() => controller.abort(), 20);
+    await assert.rejects(pending);
+    await delay(150);
+    const rows = readOperations(100).filter((entry) => entry.path === '/api/failure/disconnected');
+    assert.equal(rows.length, 1); assert.equal(rows[0].ok, false); assert.equal(rows[0].incomplete, true);
   });
   await test('additive codes, legacy fields, deliberate empty/partial responses, routing and parser failures', async () => {
     for (const status of [400, 403, 404, 409, 413, 429]) {

--- a/server/test/api-boundary.test.mjs
+++ b/server/test/api-boundary.test.mjs
@@ -154,6 +154,8 @@ try {
     const before = effects;
     const media = await fetch(base + '/api/sessions', { method: 'POST', headers: { 'x-am-origin': 'operator' }, body: 'not JSON' });
     assert.equal(media.status, 415); assert.equal(effects, before);
+    const untyped = await fetch(base + '/api/groups', { method: 'POST', headers: { 'x-am-origin': 'operator' }, body: new Uint8Array([1, 2]) });
+    assert.equal(untyped.status, 415); assert.equal(effects, before);
   });
   await test('file and remote callbacks terminate committed streams and release resources', async () => {
     const before = await fetch(base + '/api/file/before'); assert.equal(before.status, 500); assert.equal((await before.json()).code, 'internal-error');

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -15,21 +15,25 @@ fs.writeFileSync(preload, `
   import fs from 'node:fs';
   import childProcess from 'node:child_process';
   import { syncBuiltinESMExports } from 'node:module';
+  import { isMainThread } from 'node:worker_threads';
   // Startup probes installed CLIs with execFile('--version'). Some write to
   // HOME long after HTTP is ready; keep their parent alive until they close.
-  const execFile = childProcess.execFile;
-  const commands = new Set();
-  childProcess.execFile = (...args) => {
-    const command = execFile(...args);
-    const closed = new Promise((resolve) => command.once('close', resolve));
-    commands.add(closed);
-    closed.then(() => commands.delete(closed));
-    return command;
-  };
-  syncBuiltinESMExports();
-  // Deterministic regression: this grandchild writes only AFTER stop is asked
-  // for, rather than relying on whichever CLI happens to be installed.
-  const lateWrite = childProcess.execFile(process.execPath, ['-e', ${JSON.stringify(`
+  // Workers inherit --import too; only the server's main thread owns probes
+  // and receives the fixture shutdown message.
+  if (isMainThread) {
+    const execFile = childProcess.execFile;
+    const commands = new Set();
+    childProcess.execFile = (...args) => {
+      const command = execFile(...args);
+      const closed = new Promise((resolve) => command.once('close', resolve));
+      commands.add(closed);
+      closed.then(() => commands.delete(closed));
+      return command;
+    };
+    syncBuiltinESMExports();
+    // Controlled regression: this grandchild writes only AFTER stop is asked
+    // for, rather than relying on whichever CLI happens to be installed.
+    const lateWrite = childProcess.execFile(process.execPath, ['-e', ${JSON.stringify(`
     const fs = require('node:fs');
     process.stdin.resume();
     process.stdin.once('end', () => setTimeout(() => {
@@ -37,12 +41,13 @@ fs.writeFileSync(preload, `
       fs.writeFileSync(process.env.HOME + '/fixture-command-closed', process.argv[1]);
     }, 100));
   `)}, String(process.pid)], () => {});
-  process.once('message', async (message) => {
-    if (message !== 'fixture-stop') return;
-    lateWrite.stdin.end();
-    while (commands.size) await Promise.all([...commands]);
-    process.kill(process.pid, 'SIGTERM');
-  });
+    process.once('message', async (message) => {
+      if (message !== 'fixture-stop') return;
+      lateWrite.stdin.end();
+      while (commands.size) await Promise.all([...commands]);
+      process.kill(process.pid, 'SIGTERM');
+    });
+  }
   globalThis.fetch = async () => new Response(JSON.stringify({private:process.env.FIXTURE_PUBLIC !== '1',runtime:{volumes:[]}}), {status:200,headers:{'content-type':'application/json'}});
   const write = fs.writeFileSync;
   fs.writeFileSync = (file, ...args) => {

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -106,6 +106,8 @@ try {
   const noShare = await call(`/api/sessions/${client.id}/share`, { visibility: 'public' }); assert.equal(noShare.status, 403); assert.equal(noShare.body.code, 'no-hf-token');
   assert.equal((await call(`/api/sessions/${client.id}/input`, { text: null })).status, 400);
   assert.equal((await call('/api/relaunch')).body.reason, 'no-space');
+  const emptyCommand = await call('/api/relaunch', undefined, 'POST', { 'content-type': 'application/json' });
+  assert.equal(emptyCommand.status, 200); assert.equal(emptyCommand.body.reason, 'no-space');
   assert.equal((await call('/api/backup/run')).status, 403);
   assert.equal((await call('/api/not-real', undefined, 'GET')).body.code, 'api-not-found');
   assert.match(await (await fetch(base + '/nested/page')).text(), /fixture SPA/);

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import net from 'node:net';
+import http from 'node:http';
 import { spawn } from 'node:child_process';
 import { once } from 'node:events';
 const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-api-http-'));
@@ -72,6 +73,19 @@ try {
   assert.equal(write.status, 409); assert.equal((await write.json()).code, 'file-changed'); assert.equal(fs.readFileSync(file, 'utf8'), 'changed');
   const upload = await fetch(`${base}/api/files/${id}/upload?name=fixture.json`, { method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/json' }, body: '{"raw":"file"}' });
   assert.equal(upload.status, 200); assert.equal(fs.readFileSync(path.join(root, 'data', 'workspaces', 'fixture.json'), 'utf8'), '{"raw":"file"}');
+  const abortedPath = path.join(root, 'data', 'workspaces', 'aborted-fixture.bin');
+  const uploading = http.request(`${base}/api/files/${id}/upload?name=aborted-fixture.bin`, {
+    method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/octet-stream', 'content-length': 1000000 },
+  });
+  uploading.on('error', () => {});
+  uploading.write(Buffer.alloc(1024));
+  for (let i = 0; i < 100 && !fs.existsSync(abortedPath); i++) await new Promise((r) => setTimeout(r, 10));
+  assert.ok(fs.existsSync(abortedPath), 'fixture upload began');
+  uploading.destroy();
+  for (let i = 0; i < 100 && fs.existsSync(abortedPath); i++) await new Promise((r) => setTimeout(r, 10));
+  assert.ok(!fs.existsSync(abortedPath), 'interrupted upload is cleaned up');
+  await new Promise((r) => setTimeout(r, 30));
+  assert.ok(!logs.includes('[uncaughtException]'), 'disconnect must not escape the request boundary');
   const empty = await fetch(`${base}/api/files/${id}/write?path=fixture.txt`, { method: 'PUT', headers: { 'x-am-origin': 'operator', 'content-type': 'text/plain' }, body: '' });
   assert.equal(empty.status, 200); assert.equal(fs.readFileSync(file, 'utf8'), '');
   const remote = (await call('/api/sessions', { cli: 'remote', name: 'fixture-remote' })).body;
@@ -89,6 +103,7 @@ try {
   });
   assert.equal(emptyAttachment.status, 413); assert.equal((await emptyAttachment.json()).code, 'payload-too-large');
   const trace = await call(`/api/trace/${client.id}?tail=1&v=2`, undefined, 'GET'); assert.equal(trace.status, 404); assert.equal(trace.body.code, 'no-trace');
+  const noShare = await call(`/api/sessions/${client.id}/share`, { visibility: 'public' }); assert.equal(noShare.status, 403); assert.equal(noShare.body.code, 'no-hf-token');
   assert.equal((await call(`/api/sessions/${client.id}/input`, { text: null })).status, 400);
   assert.equal((await call('/api/relaunch')).body.reason, 'no-space');
   assert.equal((await call('/api/backup/run')).status, 403);

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -84,6 +84,10 @@ try {
   assert.equal((await call(`/api/sessions/${remote.id}/remote/paused`, { paused: true })).status, 200);
   const paused = await call(`/api/remote/${name}/messages`, { text: 'fixture' }); assert.equal(paused.status, 409); assert.equal(paused.body.stop, true); assert.ok(paused.body.reason); assert.ok(paused.body.code);
   const client = (await call('/api/sessions', { cli: 'claude', name: 'not-started' })).body;
+  const emptyAttachment = await fetch(`${base}/api/sessions/${client.id}/attachments`, {
+    method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/octet-stream', 'x-file-name': 'empty.txt' }, body: '', signal: AbortSignal.timeout(2000),
+  });
+  assert.equal(emptyAttachment.status, 413); assert.equal((await emptyAttachment.json()).code, 'payload-too-large');
   const trace = await call(`/api/trace/${client.id}?tail=1&v=2`, undefined, 'GET'); assert.equal(trace.status, 404); assert.equal(trace.body.code, 'no-trace');
   assert.equal((await call(`/api/sessions/${client.id}/input`, { text: null })).status, 400);
   assert.equal((await call('/api/relaunch')).body.reason, 'no-space');

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -1,0 +1,99 @@
+// Actual production route stack, isolated state, no real agents or network.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-api-http-'));
+const home = path.join(root, 'home'); fs.mkdirSync(home);
+const publicDir = path.join(root, 'public'); fs.mkdirSync(publicDir); fs.writeFileSync(path.join(publicDir, 'index.html'), '<html>fixture SPA</html>');
+const preload = path.join(root, 'preload.mjs');
+fs.writeFileSync(preload, `
+  import fs from 'node:fs';
+  globalThis.fetch = async () => new Response(JSON.stringify({private:process.env.FIXTURE_PUBLIC !== '1',runtime:{volumes:[]}}), {status:200,headers:{'content-type':'application/json'}});
+  const write = fs.writeFileSync;
+  fs.writeFileSync = (file, ...args) => {
+    if (String(file).endsWith('/am-config.json') && fs.existsSync(process.env.DATA_DIR + '/reject-write')) throw new Error('synthetic-private-data /private/example token_fixture');
+    return write(file, ...args);
+  };
+`);
+const free = net.createServer(); free.listen(0, '127.0.0.1'); await once(free, 'listening');
+const port = free.address().port; await new Promise((resolve) => free.close(resolve));
+const base = `http://127.0.0.1:${port}`;
+let child, logs = '';
+const start = async (locked = false) => {
+  child = spawn(process.execPath, ['--import', preload, 'src/index.js'], {
+    env: { PATH: process.env.PATH, HOME: home, DATA_DIR: path.join(root, 'data'), PORT: String(port), PUBLIC_DIR: publicDir,
+      CODEX_HOME: path.join(home, 'codex'), CLAUDE_CONFIG_DIR: path.join(home, 'claude'),
+      XDG_CONFIG_HOME: path.join(home, 'config'), XDG_DATA_HOME: path.join(home, 'share'),
+      AM_REPIN_DIR: path.join(root, 'repin'), AM_INPUT_REQUIRED_DIR: path.join(root, 'input-required'), AM_BASHRC: '/nonexistent',
+      ...(locked ? { SPACE_ID: 'fixture/test', FIXTURE_PUBLIC: '1' } : {}),
+    }, stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  child.stdout.on('data', (c) => { logs += c; }); child.stderr.on('data', (c) => { logs += c; });
+  for (let i = 0; i < 150; i++) {
+    try { if ((await fetch(base + '/api/health')).ok) return; } catch {}
+    if (child.exitCode !== null) throw new Error('fixture server exited');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('fixture server did not start');
+};
+const stop = async () => { if (child && child.exitCode === null) { child.kill('SIGTERM'); await once(child, 'exit'); } };
+const call = async (url, body, method = 'POST', headers = {}) => {
+  const r = await fetch(base + url, { method, headers: { 'x-am-origin': 'operator', ...(body === undefined ? {} : { 'content-type': 'application/json' }), ...headers }, body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(5000) });
+  return { status: r.status, body: await r.json() };
+};
+try {
+  await start();
+  const initial = await call('/api/tree', undefined, 'GET');
+  for (const bad of [{ cli: 'files', name: {} }, { cli: 'files', prompt: false }, { cli: 'files', groupId: 'missing' }]) assert.equal((await call('/api/sessions', bad)).status, 400);
+  assert.deepEqual((await call('/api/tree', undefined, 'GET')).body, initial.body);
+  const session = await call('/api/sessions', { cli: 'files', path: '.', name: 'fixture' }); assert.equal(session.status, 201);
+  const id = session.body.id;
+  const group = (await call('/api/groups', { name: 'fixture group' })).body;
+  assert.equal((await call(`/api/groups/${group.id}`, { sessionIds: [id], layout: { cols: 1, rows: 1 } }, 'PUT')).status, 200);
+  const patch = await call(`/api/groups/${group.id}`, { layout: null }, 'PUT'); assert.deepEqual(patch.body.sessionIds, [id]); assert.equal(patch.body.layout, undefined);
+  assert.equal((await call('/api/config', { artifacts: { enabled: false }, jobs: { askAboveUsd: 0 }, backup: { exclude: [] } }, 'PUT')).status, 200);
+  const config = (await call('/api/config', undefined, 'GET')).body; assert.equal(config.artifacts.enabled, false); assert.deepEqual(config.backup.exclude, []);
+  assert.equal((await call('/api/config', {}, 'PUT')).status, 200);
+  assert.equal((await call('/api/config', undefined, 'GET')).body.artifacts.enabled, true, 'PUT still replaces with defaults');
+  assert.equal((await call('/api/config', { artifacts: { enabled: null } }, 'PUT')).status, 400);
+  fs.writeFileSync(path.join(root, 'data', 'reject-write'), 'fixture');
+  const failedSave = await call('/api/config', {}, 'PUT');
+  assert.equal(failedSave.status, 500); assert.equal(failedSave.body.code, 'internal-error'); assert.ok(!JSON.stringify(failedSave).includes('synthetic-private'));
+  fs.unlinkSync(path.join(root, 'data', 'reject-write'));
+  const file = path.join(root, 'data', 'workspaces', 'fixture.txt'); fs.writeFileSync(file, 'original');
+  const preview = (await call(`/api/files/${id}/preview?path=fixture.txt`, undefined, 'GET')).body;
+  const badWrite = await call(`/api/files/${id}/write?path=fixture.txt`, { text: 'wrong body' }, 'PUT'); assert.equal(badWrite.status, 400); assert.equal(fs.readFileSync(file, 'utf8'), 'original');
+  fs.writeFileSync(file, 'changed');
+  const write = await fetch(`${base}/api/files/${id}/write?path=fixture.txt&base=${encodeURIComponent(preview.tag)}`, { method: 'PUT', headers: { 'x-am-origin': 'operator', 'content-type': 'text/plain' }, body: 'draft' });
+  assert.equal(write.status, 409); assert.equal((await write.json()).code, 'file-changed'); assert.equal(fs.readFileSync(file, 'utf8'), 'changed');
+  const upload = await fetch(`${base}/api/files/${id}/upload?name=fixture.json`, { method: 'POST', headers: { 'x-am-origin': 'operator', 'content-type': 'application/json' }, body: '{"raw":"file"}' });
+  assert.equal(upload.status, 200); assert.equal(fs.readFileSync(path.join(root, 'data', 'workspaces', 'fixture.json'), 'utf8'), '{"raw":"file"}');
+  const empty = await fetch(`${base}/api/files/${id}/write?path=fixture.txt`, { method: 'PUT', headers: { 'x-am-origin': 'operator', 'content-type': 'text/plain' }, body: '' });
+  assert.equal(empty.status, 200); assert.equal(fs.readFileSync(file, 'utf8'), '');
+  const remote = (await call('/api/sessions', { cli: 'remote', name: 'fixture-remote' })).body;
+  const name = remote.remote.name;
+  const prompt = await fetch(`${base}/api/remote/${name}/messages`, { method: 'POST', headers: { 'content-type': 'text/plain' }, body: 'synthetic agent response' });
+  assert.equal(prompt.status, 200, 'remote route fallback remains attributed');
+  const messages = (await call(`/api/sessions/${remote.id}/remote`, undefined, 'GET')).body.messages;
+  const rejected = await call(`/api/remote/${name}/messages`, { text: [] }); assert.equal(rejected.status, 400);
+  assert.deepEqual((await call(`/api/sessions/${remote.id}/remote`, undefined, 'GET')).body.messages, messages);
+  assert.equal((await call(`/api/sessions/${remote.id}/remote/paused`, { paused: true })).status, 200);
+  const paused = await call(`/api/remote/${name}/messages`, { text: 'fixture' }); assert.equal(paused.status, 409); assert.equal(paused.body.stop, true); assert.ok(paused.body.reason); assert.ok(paused.body.code);
+  const client = (await call('/api/sessions', { cli: 'claude', name: 'not-started' })).body;
+  const trace = await call(`/api/trace/${client.id}?tail=1&v=2`, undefined, 'GET'); assert.equal(trace.status, 404); assert.equal(trace.body.code, 'no-trace');
+  assert.equal((await call(`/api/sessions/${client.id}/input`, { text: null })).status, 400);
+  assert.equal((await call('/api/relaunch')).body.reason, 'no-space');
+  assert.equal((await call('/api/backup/run')).status, 403);
+  assert.equal((await call('/api/not-real', undefined, 'GET')).body.code, 'api-not-found');
+  assert.match(await (await fetch(base + '/nested/page')).text(), /fixture SPA/);
+  const operations = (await call('/api/operations?limit=500', undefined, 'GET')).body.operations;
+  assert.ok(operations.some((entry) => entry.status === 500)); assert.ok(!JSON.stringify(operations).includes('synthetic-private')); assert.ok(!logs.includes('synthetic-private'));
+  await stop(); await start(true);
+  for (let i = 0; i < 50 && !(await call('/api/visibility', undefined, 'GET')).body.public; i++) await new Promise((r) => setTimeout(r, 20));
+  const locked = await call('/api/sessions', { cli: 'files' }); assert.equal(locked.status, 403); assert.equal(locked.body.code, 'locked'); assert.equal(locked.body.reason, 'public-space');
+  console.log('Production HTTP: validation, side effects, settings/group semantics, streams/uploads, conflicts, traces, origins, lock and safe errors passed');
+} finally { await stop(); fs.rmSync(root, { recursive: true, force: true }); }

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -110,6 +110,8 @@ try {
   assert.equal((await call('/api/not-real', undefined, 'GET')).body.code, 'api-not-found');
   assert.match(await (await fetch(base + '/nested/page')).text(), /fixture SPA/);
   const operations = (await call('/api/operations?limit=500', undefined, 'GET')).body.operations;
+  const interrupted = operations.filter((entry) => entry.query?.name === 'aborted-fixture.bin');
+  assert.equal(interrupted.length, 1); assert.equal(interrupted[0].ok, false);
   assert.ok(operations.some((entry) => entry.status === 500)); assert.ok(!JSON.stringify(operations).includes('synthetic-private')); assert.ok(!logs.includes('synthetic-private'));
   await stop(); await start(true);
   for (let i = 0; i < 50 && !(await call('/api/visibility', undefined, 'GET')).body.public; i++) await new Promise((r) => setTimeout(r, 20));

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -106,7 +106,12 @@ try {
   assert.equal((await call('/api/config', { artifacts: { enabled: null } }, 'PUT')).status, 400);
   fs.writeFileSync(path.join(root, 'data', 'reject-write'), 'fixture');
   const failedSave = await call('/api/config', {}, 'PUT');
-  assert.equal(failedSave.status, 500); assert.equal(failedSave.body.code, 'internal-error'); assert.ok(!JSON.stringify(failedSave).includes('synthetic-private'));
+  assert.equal(failedSave.status, 500); assert.equal(failedSave.body.code, 'internal-error');
+  assert.equal(failedSave.body.error, 'The request could not be completed. Please try again.');
+  assert.ok(!failedSave.body.error.includes('am-config.json'), 'the filename is not free-text 5xx prose');
+  assert.deepEqual(failedSave.body.details, [{ field: 'path', message: 'am-config.json' }]);
+  assert.ok(!JSON.stringify(failedSave).includes('synthetic-private'));
+  assert.ok(!JSON.stringify(failedSave).includes(path.join(root, 'data')));
   fs.unlinkSync(path.join(root, 'data', 'reject-write'));
   const file = path.join(root, 'data', 'workspaces', 'fixture.txt'); fs.writeFileSync(file, 'original');
   const preview = (await call(`/api/files/${id}/preview?path=fixture.txt`, undefined, 'GET')).body;

--- a/server/test/api-http.test.mjs
+++ b/server/test/api-http.test.mjs
@@ -13,6 +13,36 @@ const publicDir = path.join(root, 'public'); fs.mkdirSync(publicDir); fs.writeFi
 const preload = path.join(root, 'preload.mjs');
 fs.writeFileSync(preload, `
   import fs from 'node:fs';
+  import childProcess from 'node:child_process';
+  import { syncBuiltinESMExports } from 'node:module';
+  // Startup probes installed CLIs with execFile('--version'). Some write to
+  // HOME long after HTTP is ready; keep their parent alive until they close.
+  const execFile = childProcess.execFile;
+  const commands = new Set();
+  childProcess.execFile = (...args) => {
+    const command = execFile(...args);
+    const closed = new Promise((resolve) => command.once('close', resolve));
+    commands.add(closed);
+    closed.then(() => commands.delete(closed));
+    return command;
+  };
+  syncBuiltinESMExports();
+  // Deterministic regression: this grandchild writes only AFTER stop is asked
+  // for, rather than relying on whichever CLI happens to be installed.
+  const lateWrite = childProcess.execFile(process.execPath, ['-e', ${JSON.stringify(`
+    const fs = require('node:fs');
+    process.stdin.resume();
+    process.stdin.once('end', () => setTimeout(() => {
+      fs.mkdirSync(process.env.HOME, { recursive: true });
+      fs.writeFileSync(process.env.HOME + '/fixture-command-closed', process.argv[1]);
+    }, 100));
+  `)}, String(process.pid)], () => {});
+  process.once('message', async (message) => {
+    if (message !== 'fixture-stop') return;
+    lateWrite.stdin.end();
+    while (commands.size) await Promise.all([...commands]);
+    process.kill(process.pid, 'SIGTERM');
+  });
   globalThis.fetch = async () => new Response(JSON.stringify({private:process.env.FIXTURE_PUBLIC !== '1',runtime:{volumes:[]}}), {status:200,headers:{'content-type':'application/json'}});
   const write = fs.writeFileSync;
   fs.writeFileSync = (file, ...args) => {
@@ -31,7 +61,7 @@ const start = async (locked = false) => {
       XDG_CONFIG_HOME: path.join(home, 'config'), XDG_DATA_HOME: path.join(home, 'share'),
       AM_REPIN_DIR: path.join(root, 'repin'), AM_INPUT_REQUIRED_DIR: path.join(root, 'input-required'), AM_BASHRC: '/nonexistent',
       ...(locked ? { SPACE_ID: 'fixture/test', FIXTURE_PUBLIC: '1' } : {}),
-    }, stdio: ['ignore', 'pipe', 'pipe'],
+    }, stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
   });
   child.stdout.on('data', (c) => { logs += c; }); child.stderr.on('data', (c) => { logs += c; });
   for (let i = 0; i < 150; i++) {
@@ -41,7 +71,15 @@ const start = async (locked = false) => {
   }
   throw new Error('fixture server did not start');
 };
-const stop = async () => { if (child && child.exitCode === null) { child.kill('SIGTERM'); await once(child, 'exit'); } };
+const stop = async () => {
+  if (child && child.exitCode === null && child.signalCode === null) {
+    const closed = once(child, 'close');
+    child.send('fixture-stop');
+    await closed;
+    assert.equal(fs.readFileSync(path.join(home, 'fixture-command-closed'), 'utf8'), String(child.pid),
+      'the shutdown-time writer must finish before the server exits and HOME is removed');
+  }
+};
 const call = async (url, body, method = 'POST', headers = {}) => {
   const r = await fetch(base + url, { method, headers: { 'x-am-origin': 'operator', ...(body === undefined ? {} : { 'content-type': 'application/json' }), ...headers }, body: body === undefined ? undefined : JSON.stringify(body), signal: AbortSignal.timeout(5000) });
   return { status: r.status, body: await r.json() };

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -117,7 +117,10 @@ export default function App() {
   // Imported traces already live on the Hub; sharing them means handing on
   // their original dataset link, not publishing a duplicate dataset.
   const [traceShare, setTraceShare] = useState<{ title: string; url: string } | null>(null);
-  const showErr = (msg: string) => (e: unknown) => { console.error(msg, e); setToast(msg); window.setTimeout(() => setToast(null), 4000); };
+  const showErr = (msg: string) => (e: unknown) => {
+    setToast(e instanceof api.ApiError ? `${msg}: ${e.message}` : msg);
+    window.setTimeout(() => setToast(null), 4000);
+  };
   // Overview presentation: tiles (default) or the classic list.
   const [ovView, setOvViewRaw] = useState<'tiles' | 'list'>(() =>
     (readStored('am-ov-view') === 'list' ? 'list' : 'tiles'));
@@ -706,8 +709,10 @@ export default function App() {
   const newSession = (name: string, cli: string, path: string, groupId?: string) =>
     createSession(name, cli, path, groupId ?? activeGroup?.id);
   const newGroup = async (name: string, cart?: { cli: string; count: number }[], path = ROOT_PATH) => {
+    let created: string | null = null;
     try {
       const g = await api.createGroup(name);
+      created = g.id;
       for (const { cli, count } of cart || []) {
         const base = cliMap[cli]?.label || cli;
         for (let i = 0; i < count; i++) {
@@ -717,7 +722,15 @@ export default function App() {
       }
       await refresh();
       setActiveRef(`g:${g.id}`);
-    } catch (e) { showErr('Couldn’t create the group')(e); }
+    } catch (e) {
+      if (created) {
+        void refresh();
+        setActiveRef(`g:${created}`);
+        throw new api.ApiError('The group was created, but not all agents could be added. Check the group before trying again.',
+          e instanceof api.ApiError ? e.status : null, 'group-partially-created');
+      }
+      throw e;
+    }
   };
   // Merging two agents, or dropping one into a group, changes what the pane you
   // are looking at IS — it is now part of a grid. Follow it there rather than

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,27 +1,19 @@
 import type { Cli, Group, MoveTarget, RemoteInfo, RemoteMessage, Session, Tree } from './types';
+import { ApiError, connectionError, decodeJsonText, decodeResponse } from './apiResponse';
+export { ApiError } from './apiResponse';
 
 const HEADERS = { 'content-type': 'application/json' };
 // The browser is the single human operator. Stamp every state-changing request
 // in one place so new API helpers cannot accidentally create unattributed work.
 const fetch = (input: RequestInfo | URL, init?: RequestInit) => {
   const method = String(init?.method || 'GET').toUpperCase();
-  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return globalThis.fetch(input, init);
+  if (!['POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) return globalThis.fetch(input, init).catch((error) => { throw connectionError(error); });
   const headers = new Headers(init?.headers);
   headers.set('x-am-origin', 'operator');
-  return globalThis.fetch(input, { ...init, headers });
+  return globalThis.fetch(input, { ...init, headers }).catch((error) => { throw connectionError(error); });
 };
-// Like `json`, but keeps the server's own words — these routes fail for reasons
-// worth reading ("already exists here").
-const jsonOrError = async (r: Response) => {
-  const body = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(body.error || `${r.status}`);
-  return body;
-};
-
-const json = (r: Response) => {
-  if (!r.ok) throw new Error(`${r.status}`);
-  return r.json();
-};
+const json = (r: Response) => decodeResponse(r);
+const jsonOrError = json;
 
 export const getClis = (): Promise<Cli[]> => fetch('/api/clis').then(json);
 export const getTree = (): Promise<Tree> => fetch('/api/tree').then(json);
@@ -236,10 +228,7 @@ export const sayToRemote = (id: string, text: string) => sendInput(id, text);
 
 // text/plain, and free of secrets by design — safe to put on a clipboard.
 export const getRemotePrompt = (name: string): Promise<string> =>
-  fetch(`/api/remote/${encodeURIComponent(name)}/prompt`).then((r) => {
-    if (!r.ok) throw new Error(`${r.status}`);
-    return r.text();
-  });
+  fetch(`/api/remote/${encodeURIComponent(name)}/prompt`).then((r) => decodeResponse<string>(r, 'text'));
 
 export const setRemotePaused = (id: string, paused: boolean): Promise<RemoteInfo> =>
   fetch(`/api/sessions/${id}/remote/paused`, { method: 'POST', headers: HEADERS, body: JSON.stringify({ paused }) }).then(json);
@@ -263,20 +252,6 @@ export interface AttachmentUploadOptions {
 }
 export const ATTACHMENT_UPLOAD_TIMEOUT_MS = 20 * 60 * 1000;
 
-const attachmentUploadError = (request: XMLHttpRequest) => {
-  let detail = '';
-  try {
-    const body = JSON.parse(request.responseText || '{}');
-    if (typeof body?.error === 'string') detail = body.error;
-  } catch { /* An ingress/proxy error can be HTML. Classify it by status below. */ }
-  if (detail) return detail;
-  if (request.status === 413) return 'The server or its proxy rejected this file as too large (HTTP 413). Try a smaller file.';
-  if (request.status === 408 || request.status === 504) return `The upload timed out (HTTP ${request.status}). Check the connection and retry.`;
-  if (request.status === 429) return 'Too many uploads at once (HTTP 429). Wait a minute, then retry.';
-  if (request.status >= 500) return `The upload server failed (HTTP ${request.status}). Retry in a moment.`;
-  return `Upload failed (HTTP ${request.status}${request.statusText ? ` ${request.statusText}` : ''}).`;
-};
-
 /** XMLHttpRequest is intentional: fetch has no browser upload-progress API. */
 export const uploadAttachment = (
   id: string,
@@ -291,9 +266,12 @@ export const uploadAttachment = (
     signal?.removeEventListener('abort', abort);
     task();
   };
-  const abort = () => request.abort();
+  const abort = () => {
+    request.abort();
+    finish(() => reject(new ApiError('Upload was canceled before it completed.', null, 'canceled')));
+  };
   if (signal?.aborted) {
-    finish(() => reject(new Error('Upload was canceled before it completed.')));
+    finish(() => reject(new ApiError('Upload was canceled before it completed.', null, 'canceled')));
     return;
   }
   request.open('POST', `/api/sessions/${encodeURIComponent(id)}/attachments`);
@@ -310,29 +288,20 @@ export const uploadAttachment = (
   // "bytes sent, awaiting server confirmation", not prematurely "stored".
   request.upload.onload = () => onProgress?.({ loaded: file.size, total: file.size });
   request.onload = () => {
-    if (request.status < 200 || request.status >= 300) {
-      finish(() => reject(new Error(attachmentUploadError(request))));
-      return;
-    }
     try {
-      const attachment = JSON.parse(request.responseText) as Attachment;
+      const attachment = decodeJsonText<Attachment>(request.responseText, request.status);
+      if (!attachment) throw new ApiError('The upload result was empty. Check the result before trying again.', request.status, 'unreadable-response');
       finish(() => resolve(attachment));
-    } catch {
-      finish(() => reject(new Error('The upload completed, but the server returned an unreadable response. Retry the file.')));
+    } catch (error) {
+      finish(() => reject(error));
     }
   };
-  request.onerror = () => finish(() => reject(new Error(
-    typeof navigator !== 'undefined' && navigator.onLine === false
-      ? 'Upload stopped because this device is offline. Reconnect and retry.'
-      : 'Upload connection was interrupted before the server confirmed the file. Check the connection and retry.',
-  )));
-  request.onabort = () => finish(() => reject(new Error('Upload was canceled before it completed.')));
-  request.ontimeout = () => finish(() => reject(new Error(
-    `Upload timed out after ${Math.round(timeoutMs / 60_000)} minutes. Check the connection and retry.`,
-  )));
+  request.onerror = () => finish(() => reject(connectionError(new Error('network'))));
+  request.onabort = () => finish(() => reject(new ApiError('Upload was canceled before it completed.', null, 'canceled')));
+  request.ontimeout = () => finish(() => reject(new ApiError('Upload timed out before the result was confirmed.', null, 'timeout')));
   signal?.addEventListener('abort', abort, { once: true });
   onProgress?.({ loaded: 0, total: file.size });
-  request.send(file);
+  if (!settled) request.send(file);
 });
 
 export const deleteAttachment = (sessionId: string, attachmentId: string): Promise<{ ok: boolean }> =>
@@ -402,12 +371,7 @@ export const previewFile = (id: string, p: string): Promise<FilePreview> =>
 // One page of a transcript sitting in the workspace, shaped exactly like the
 // Trace pane's own pages so the same viewer renders it.
 export const getFileTracePage = async (id: string, p: string, offset = 0, limit = 200): Promise<TracePage> => {
-  const r = await fetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&offset=${offset}&limit=${limit}`);
-  if (!r.ok) {
-    const d = await r.json().catch(() => ({}));
-    throw new TraceUnavailable(d.error || 'could not read this trace', d.code || 'no-trace');
-  }
-  return r.json();
+  return traceFetch(`/api/files/${id}/trace?path=${encodeURIComponent(p)}&offset=${offset}&limit=${limit}`);
 };
 
 export const rawUrl = (id: string, p: string) =>
@@ -455,11 +419,7 @@ export const writeFile = async (id: string, p: string, text: string, base: strin
   const r = await fetch(`/api/files/${id}/write?path=${encodeURIComponent(p)}${q}`, {
     method: 'PUT', headers: { 'content-type': 'text/plain; charset=utf-8' }, body: text,
   });
-  // Unlike the rest of the API, a failed save has something worth reading in it
-  // ("changed on disk since you opened it") — surface it instead of a number.
-  const body = await r.json().catch(() => ({}));
-  if (!r.ok) throw new Error(body.error || `${r.status}`);
-  return body;
+  return json(r);
 };
 
 // ---- session sharing (docs/session-sharing.md) ----
@@ -483,10 +443,10 @@ export interface ShareResult {
 }
 // Thrown when the redaction gate refuses a public share (HTTP 409). Carries the
 // rule names so the dialog can say exactly what tripped instead of "failed".
-export class RedactionBlocked extends Error {
+export class RedactionBlocked extends ApiError {
   hits: Record<string, number>;
   constructor(message: string, hits: Record<string, number>) {
-    super(message);
+    super(message, 409, 'redaction-blocked', { hits });
     this.name = 'RedactionBlocked';
     this.hits = hits;
   }
@@ -499,12 +459,13 @@ export const shareSession = async (
   body: { visibility: 'public' | 'gated'; name?: string; grantTo?: string[] },
 ): Promise<ShareResult> => {
   const r = await fetch(`/api/sessions/${id}/share`, { method: 'POST', headers: HEADERS, body: JSON.stringify(body) });
-  if (r.status === 409) {
-    const d = await r.json().catch(() => ({}));
-    throw new RedactionBlocked(d.error || 'blocked by the redaction gate', d.hits || {});
+  try { return await json(r); }
+  catch (error) {
+    if (error instanceof ApiError && error.status === 409 && (error.code === 'redaction-blocked' || error.legacy)) {
+      throw new RedactionBlocked(error.message, error.data.hits || {});
+    }
+    throw error;
   }
-  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
-  return r.json();
 };
 
 export interface ShareAccess { accepted: string[]; pending: string[] }
@@ -577,23 +538,15 @@ export interface TracePage {
 
 // A 404 here is an expected state (no transcript yet, unsupported CLI, a codex
 // guardian rollout), so the reason travels with it for the pane to render.
-export class TraceUnavailable extends Error {
-  code: string;
+export class TraceUnavailable extends ApiError {
   constructor(message: string, code: string) {
-    super(message);
+    super(message, 404, code);
     this.name = 'TraceUnavailable';
-    this.code = code;
   }
 }
 
 export const getTracePage = async (id: string, offset = 0, limit = 200): Promise<TracePage> => {
-  const r = await fetch(`/api/trace/${id}?offset=${offset}&limit=${limit}`);
-  if (r.status === 404) {
-    const d = await r.json().catch(() => ({}));
-    throw new TraceUnavailable(d.error || 'no trace for this session yet', d.code || 'no-trace');
-  }
-  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
-  return r.json();
+  return traceFetch(`/api/trace/${id}?offset=${offset}&limit=${limit}`);
 };
 
 // ---- windows: how the reader actually reads ----
@@ -638,12 +591,15 @@ const traceRange = (req: TraceReq) => (req.at === 'tail' ? 'tail=1' : `${req.at}
 
 const traceFetch = async <T>(url: string, signal?: AbortSignal): Promise<T> => {
   const r = await fetch(url, { signal });
-  if (r.status === 404) {
-    const d = await r.json().catch(() => ({}));
-    throw new TraceUnavailable(d.error || 'no trace for this session yet', d.code || 'no-trace');
+  try { return await json(r); }
+  catch (error) {
+    if (error instanceof ApiError && error.status === 404 && (error.legacy || ['no-trace', 'unsupported-harness', 'trace-not-user-conversation'].includes(error.code))) {
+      const unavailable = new TraceUnavailable(error.message, error.code === 'not-found' ? 'no-trace' : error.code);
+      unavailable.data = error.data;
+      throw unavailable;
+    }
+    throw error;
   }
-  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
-  return r.json();
 };
 
 const windowSize = (bytes?: number, min?: number) =>
@@ -710,8 +666,7 @@ export interface TraceLocation {
 }
 export const getTraceLocation = async (id: string): Promise<TraceLocation> => {
   const r = await fetch(`/api/trace/${id}/location`);
-  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
-  return r.json();
+  return json(r);
 };
 
 // Receiving: pull a shared trace off the Hub so a pane can render it. Accepts a
@@ -722,8 +677,7 @@ export interface ImportedBundle {
 }
 export const importTraceBundle = async (repo: string): Promise<ImportedBundle> => {
   const r = await fetch('/api/trace/import', { method: 'POST', headers: HEADERS, body: JSON.stringify({ repo }) });
-  if (!r.ok) throw new Error((await r.json().catch(() => ({}))).error || `${r.status}`);
-  return r.json();
+  return json(r);
 };
 
 export interface BundleEntry {

--- a/web/src/apiResponse.ts
+++ b/web/src/apiResponse.ts
@@ -1,0 +1,97 @@
+export type ErrorData = {
+  reason?: string; hint?: string; requestId?: string; retryAfter?: number;
+  mtime?: number; tag?: string | null; currentTag?: string | null;
+  hits?: Record<string, number>; details?: { field: string; message: string }[];
+};
+
+export class ApiError extends Error {
+  legacy = false;
+  constructor(message: string, public status: number | null, public code: string, public data: ErrorData = {}) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+const safeText = (value: unknown): value is string => typeof value === 'string'
+  && value.length > 0 && value.length <= 1024 && !/[<>\u0000-\u0008\u000b\u000c\u000e-\u001f]/.test(value);
+const record = (value: unknown): value is Record<string, unknown> => !!value && typeof value === 'object' && !Array.isArray(value);
+const codes: Record<number, string> = { 400: 'bad-request', 403: 'forbidden', 404: 'not-found', 409: 'conflict', 413: 'payload-too-large', 415: 'unsupported-media-type', 429: 'rate-limited' };
+const fallbackMessage = (status: number) => ({
+  400: 'The request was not valid.', 403: 'This request is not allowed.', 404: 'The requested item was not found.',
+  409: 'The request conflicts with the current state.', 413: 'The server or its proxy rejected this file as too large.',
+  429: 'Too many requests. Wait a moment before trying again.', 408: 'The request timed out.', 504: 'The server timed out.',
+}[status] || (status >= 500 ? 'The server could not complete the request.' : 'The request failed.')) + ` (HTTP ${status})`;
+
+// One allowlist for fetch and XHR. Retain useful domain data, not arbitrary
+// upstream objects, HTML, stacks or response bodies. Error text is never HTML.
+export function httpError(status: number, body: unknown): ApiError {
+  const b = record(body) ? body : {};
+  const data: ErrorData = {};
+  for (const key of ['reason', 'hint', 'requestId'] as const) if (safeText(b[key])) data[key] = b[key];
+  for (const key of ['mtime', 'retryAfter'] as const) if (typeof b[key] === 'number' && Number.isFinite(b[key])) data[key] = b[key];
+  for (const key of ['tag', 'currentTag'] as const) {
+    const value = b[key];
+    if (value === null || safeText(value)) data[key] = value as string | null;
+  }
+  if (record(b.hits)) data.hits = Object.fromEntries(Object.entries(b.hits).slice(0, 100)
+    .filter(([key, value]) => safeText(key) && typeof value === 'number' && Number.isFinite(value))) as Record<string, number>;
+  if (Array.isArray(b.details)) data.details = b.details.slice(0, 20)
+    .filter((d): d is { field: string; message: string } => record(d) && safeText(d.field) && safeText(d.message))
+    .map(({ field, message }) => ({ field, message }));
+  const code = typeof b.code === 'string' && /^[a-z][a-z0-9-]{0,63}$/.test(b.code)
+    ? b.code : codes[status] || (status >= 500 ? 'internal-error' : 'request-failed');
+  const error = new ApiError(safeText(b.error) ? b.error : fallbackMessage(status), status, code, data);
+  error.legacy = b.code === undefined && safeText(b.error);
+  return error;
+}
+
+const ERROR_BYTES = 64 * 1024;
+export function decodeJsonText<T = any>(text: string, status: number): T {
+  const ok = status >= 200 && status < 300;
+  let body: unknown;
+  try { body = JSON.parse(!ok && text.length > ERROR_BYTES ? '' : text); }
+  catch {
+    if (!ok) throw httpError(status, null);
+    if (!text.trim()) return undefined as T; // 204/205 and existing empty successes
+    throw new ApiError('The server returned an unreadable response. Check the result before trying again.', status, 'unreadable-response');
+  }
+  if (!ok) throw httpError(status, body);
+  return body as T; // ok:false is domain data, not an HTTP failure
+}
+
+async function errorText(response: Response): Promise<string> {
+  if (!response.body) return '';
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let size = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > ERROR_BYTES) { void reader.cancel().catch(() => {}); return ''; }
+      chunks.push(value);
+    }
+  } finally { reader.releaseLock(); }
+  const bytes = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.length; }
+  return new TextDecoder().decode(bytes);
+}
+
+export function connectionError(error: unknown, status: number | null = null): Error {
+  if (error instanceof ApiError) return error;
+  // Reader owns its aborts and deadlines; preserve AbortError identity.
+  if (error instanceof Error && error.name === 'AbortError') return error;
+  if (error instanceof Error && error.name === 'TimeoutError') return new ApiError('The request timed out. Check the result before trying again.', status, 'timeout');
+  const offline = typeof navigator !== 'undefined' && navigator.onLine === false;
+  return new ApiError(offline ? 'This device is offline.' : 'The connection was interrupted before the result was confirmed.', status, offline ? 'offline' : 'network-error');
+}
+
+export async function decodeResponse<T = any>(response: Response, format: 'json' | 'text' = 'json'): Promise<T> {
+  let text: string;
+  try { text = response.ok ? await response.text() : await errorText(response); }
+  catch (error) { throw connectionError(error, response.status); }
+  if (response.ok && format === 'text') return text as T;
+  return decodeJsonText<T>(text, response.status);
+}

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -654,7 +654,7 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
       // A refused save must NOT drop the text — put it back so the next attempt
       // (or an overwrite) still has it.
       pending.current = job;
-      setConflict(/changed on disk/.test(msg));
+      setConflict((e instanceof api.ApiError && e.code === 'file-changed') || /changed on disk/.test(msg));
       setSaveErr(msg);
       setStatus('error');
       return false;

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -54,7 +54,7 @@ export default function Sidebar({
   onOpenSession: (sessionId: string, groupId?: string) => void;
   onOpenSettings: () => void;
   onNewSession: (name: string, cli: string, path: string, groupId?: string) => void;
-  onNewGroup: (name: string, cart?: { cli: string; count: number }[], path?: string) => void;
+  onNewGroup: (name: string, cart?: { cli: string; count: number }[], path?: string) => void | Promise<void>;
   onRenameGroup: (id: string, name: string) => void;
   onRenameSession: (id: string, name: string) => void;
   onDeleteGroup: (id: string) => void;
@@ -427,10 +427,16 @@ export default function Sidebar({
       setQuickError(error instanceof Error ? error.message : 'could not quickstart the agent');
     } finally { setQuickSending(false); }
   };
-  const submitGroup = () => {
+  const submitGroup = async () => {
+    if (quickSending) return;
     const items = Object.entries(cart).filter(([, n]) => n > 0).map(([cli, count]) => ({ cli, count }));
-    onNewGroup(groupName.trim() || 'Group', items, groupLoc);
-    setGroupName(''); setCart({}); closePanel();
+    setQuickSending(true); setQuickError(null);
+    try {
+      await onNewGroup(groupName.trim() || 'Group', items, groupLoc);
+      setGroupName(''); setCart({}); closePanel();
+    } catch (error) {
+      setQuickError(error instanceof Error ? error.message : 'Could not create the group.');
+    } finally { setQuickSending(false); }
   };
   const startEdit = (ref: string, name: string) => { setEditRef(ref); setEditName(name); };
   const commitEdit = () => {
@@ -839,9 +845,10 @@ export default function Sidebar({
                   })}
                 </div>
                 <div className="widget-actions">
-                  <button className="btn-primary" onClick={submitGroup}>Create group</button>
-                  <button className="btn-ghost" onClick={() => { setCart({}); closePanel(); }}>Cancel</button>
+                  <button className="btn-primary" onClick={submitGroup} disabled={quickSending}>{quickSending ? 'Creating…' : 'Create group'}</button>
+                  <button className="btn-ghost" onClick={() => { setCart({}); closePanel(); }} disabled={quickSending}>Cancel</button>
                 </div>
+                {quickError && <div className="open-trace-err" role="alert">{quickError}</div>}
               </>
             )}
           </div>

--- a/web/test/apiErrors.render.test.mjs
+++ b/web/test/apiErrors.render.test.mjs
@@ -83,6 +83,14 @@ try {
   await page.getByRole('button', { name: 'Create group', exact: true }).click();
   await page.getByRole('alert').filter({ hasText: 'choose a different group name' }).waitFor();
   assert.equal(await page.getByPlaceholder('Group name').inputValue(), 'group draft');
+  await page.locator('.quick-clis .quick-cli').first().click();
+  const quickPrompt = page.locator('.quick textarea').first();
+  await quickPrompt.fill('session prompt draft');
+  await page.locator('input.quick-name').fill('session name draft');
+  await page.getByRole('button', { name: 'Create & send', exact: true }).click();
+  await page.getByRole('alert').filter({ hasText: 'choose a different session name' }).waitFor();
+  assert.equal(await quickPrompt.inputValue(), 'session prompt draft');
+  assert.equal(await page.locator('input.quick-name').inputValue(), 'session name draft');
   await page.evaluate(() => window.mount('share'));
   await page.getByPlaceholder('alice, bob').fill('fixture-recipient');
   await page.getByRole('button', { name: 'Public', exact: true }).click();

--- a/web/test/apiErrors.render.test.mjs
+++ b/web/test/apiErrors.render.test.mjs
@@ -1,0 +1,133 @@
+// Real controls and real fetch/XHR over local HTTP; all backend data is synthetic.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import http from 'node:http';
+import { once } from 'node:events';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-api-controls-'));
+const bundle = path.join(root, 'fixture.js');
+await build({ stdin: { resolveDir: process.cwd(), loader: 'tsx', contents: `
+  import React from 'react'; import {createRoot} from 'react-dom/client'; import {flushSync} from 'react-dom';
+  import Sidebar from './src/components/Sidebar'; import ShareDialog from './src/components/ShareDialog';
+  import TerminalPane from './src/components/TerminalPane'; import FilesPane from './src/components/FilesPane';
+  import * as api from './src/api';
+  const cli={id:'claude',label:'Fixture',available:true,ready:true,color:'#777'};
+  const session={id:'one',cli:'claude',name:'Fixture',state:'stopped',running:false,everStarted:false,path:'.',createdAt:new Date().toISOString()};
+  class FakeSocket { static OPEN=1; readyState=1; send(){} close(){this.readyState=3;} } window.WebSocket=FakeSocket;
+  const noop=()=>{}; window.api=api; let root;
+  window.mount=(mode)=>{
+    if(root)flushSync(()=>root.unmount()); root=createRoot(document.getElementById('root'));
+    flushSync(()=>root.render(mode==='share'?<ShareDialog session={session} onClose={noop}/>
+      :mode==='reader'?<div style={{height:650,display:'flex'}}><TerminalPane session={session} cli={cli} mode="reader" theme="light" zoom={100} focused active visible onClose={noop}/></div>
+      :mode==='file'?<FilesPane session={session} zoom={100} focused onClose={noop}/>
+      :<Sidebar clis={[cli]} tree={{sessions:[],groups:[],order:[]}} activeRef={null} focusedId={null} defaultPath="."
+        onActivate={noop} onOpenSession={noop} onOpenSettings={noop} onNewSession={noop}
+        onNewGroup={async(name)=>{await api.createGroup(name);}} onRenameGroup={noop} onRenameSession={noop} onDeleteGroup={noop}
+        onArchiveSession={noop} onUnarchiveSession={noop} onSetRemotePaused={noop} onDeleteSession={noop}
+        onTraceHandover={async()=>({path:'.'})} handoverFor={null} onHandoverHandled={noop} onMove={noop}
+        theme="light" onToggleTheme={noop} onQuickStart={async(cli,prompt,name)=>{await api.quickStart(cli,prompt,name);}}
+        onPrepareQuickStart={async()=>session} onAbandonQuickStart={async()=>{}}
+        archived={new Set()} retired={new Set()} showArchived={false} onToggleArchived={noop} overviewHidden={new Set()} onToggleOverviewHidden={noop}/>));
+  };
+` }, outfile: bundle, bundle: true, platform: 'browser', format: 'iife', define: { 'process.env.NODE_ENV': '"production"' }, logLevel: 'silent' });
+let mutations = 0;
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, 'http://fixture');
+  const send = (status, body) => { if (res.destroyed) return; res.writeHead(status, { 'content-type': 'application/json' }); res.end(JSON.stringify(body)); };
+  if (!url.pathname.startsWith('/api/')) {
+    if (url.pathname === '/fixture.js') { res.setHeader('content-type', 'text/javascript'); res.end(fs.readFileSync(bundle)); }
+    else if (url.pathname === '/style.css') { res.setHeader('content-type', 'text/css'); res.end(fs.readFileSync('src/styles.css')); }
+    else res.end('<!doctype html><html><head><link rel="stylesheet" href="/style.css"></head><body><div id="root"></div><script src="/fixture.js"></script></body></html>');
+    return;
+  }
+  if (req.method !== 'GET') mutations++;
+  if (url.pathname.endsWith('/attachments')) {
+    req.resume();
+    req.once('end', () => {
+      if (url.pathname.includes('/large/')) send(413, { error: 'File is too large.', code: 'payload-too-large' });
+      else if (url.pathname.includes('/bad/')) { res.writeHead(502, { 'content-type': 'text/html' }); res.end('<html>private proxy details</html>'); }
+      else if (url.pathname.includes('/slow/')) { const timer = setTimeout(() => send(201, { id: 'attachment' }), 3000); res.once('close', () => clearTimeout(timer)); }
+      else send(201, { id: 'attachment', name: 'fixture.txt', bytes: 10, kind: 'file', mime: 'text/plain', insertText: 'fixture' });
+    }); return;
+  }
+  req.resume();
+  if (req.method === 'POST' && url.pathname === '/api/groups') return send(400, { error: 'name: choose a different group name', code: 'invalid-input' });
+  if (req.method === 'POST' && url.pathname === '/api/sessions') return send(400, { error: 'name: choose a different session name', code: 'invalid-input' });
+  if (url.pathname.endsWith('/share')) return req.method === 'GET'
+    ? send(200, { canShare: true, namespace: 'fixture', reason: null, lastShare: null })
+    : send(409, { error: 'Refused by redaction', code: 'redaction-blocked', hits: { fixture_rule: 2 } });
+  if (url.pathname.endsWith('/input')) return send(429, { error: 'Wait a moment before sending again.', code: 'rate-limited', retryAfter: 60 });
+  if (url.pathname.endsWith('/preview')) return send(200, { kind: 'text', name: 'fixture.txt', mime: 'text/plain', size: 8, mtime: 1, tag: 'old', text: 'original' });
+  if (url.pathname === '/api/files/one') return send(200, { root: 'fixture', path: '', entries: [{ name: 'fixture.txt', dir: false, size: 8, mtime: 1, kind: 'text' }] });
+  if (url.pathname.endsWith('/write')) return send(409, { error: 'changed on disk since you opened it', code: 'file-changed', mtime: 2, tag: 'new' });
+  if (url.pathname.startsWith('/api/trace/')) return send(404, { error: 'No trace yet', code: 'no-trace' });
+  if (url.pathname.endsWith('/subagents')) return send(200, { agents: [], supported: true });
+  if (url.pathname === '/api/next-name') return send(200, { name: 'fixture' });
+  if (url.pathname === '/api/folders') return send(200, { path: '', folders: [] });
+  send(200, {});
+});
+server.listen(0, '127.0.0.1'); await once(server, 'listening');
+const browser = await chromium.launch(chromiumLaunchOptions());
+try {
+  const page = await browser.newPage({ viewport: { width: 1000, height: 800 } });
+  const errors = []; page.on('pageerror', (error) => errors.push(error.message));
+  await page.goto(`http://127.0.0.1:${server.address().port}`);
+  await page.evaluate(() => window.mount('sidebar'));
+  await page.getByTitle('New agent or group').click();
+  await page.getByTitle('Group — several agents created together, sharing a folder').click();
+  await page.getByPlaceholder('Group name').fill('group draft');
+  await page.getByRole('button', { name: 'Create group', exact: true }).click();
+  await page.getByRole('alert').filter({ hasText: 'choose a different group name' }).waitFor();
+  assert.equal(await page.getByPlaceholder('Group name').inputValue(), 'group draft');
+  await page.evaluate(() => window.mount('share'));
+  await page.getByPlaceholder('alice, bob').fill('fixture-recipient');
+  await page.getByRole('button', { name: 'Public', exact: true }).click();
+  await page.getByRole('button', { name: 'Publish', exact: true }).click();
+  await page.getByText('Not published.', { exact: true }).waitFor();
+  assert.match(await page.locator('.share-blocked').innerText(), /fixture_rule × 2/);
+  await page.getByRole('button', { name: 'Private', exact: true }).click();
+  assert.equal(await page.getByPlaceholder('alice, bob').inputValue(), 'fixture-recipient');
+  await page.getByRole('link', { name: 'Download transcript' }).waitFor();
+  await page.evaluate(() => window.mount('reader'));
+  const composer = page.locator('.cxv-composer textarea').first();
+  await composer.fill('reader draft');
+  await composer.press('Enter');
+  await page.getByText('Wait a moment before sending again.', { exact: true }).waitFor();
+  assert.equal(await composer.inputValue(), 'reader draft');
+  await page.evaluate(() => window.mount('file'));
+  await page.getByText('fixture.txt', { exact: true }).click();
+  const editor = page.locator('.cm-content');
+  await editor.click(); await page.keyboard.press('ControlOrMeta+A'); await page.keyboard.type('unsaved file draft');
+  await page.keyboard.press('ControlOrMeta+S');
+  await page.getByRole('button', { name: 'Reload', exact: true }).waitFor();
+  await page.getByRole('button', { name: 'Overwrite', exact: true }).waitFor();
+  assert.equal(await editor.innerText(), 'unsaved file draft');
+  const before = mutations;
+  const upload = await page.evaluate(async () => {
+    const file = new File(['x'.repeat(2 * 1024 * 1024)], 'fixture.txt', { type: 'text/plain' });
+    const progress = [];
+    const success = await window.api.uploadAttachment('one', file, { onProgress: (p) => progress.push(p.loaded) });
+    const failures = [];
+    for (const id of ['large', 'bad']) {
+      try { await window.api.uploadAttachment(id, file); }
+      catch (e) { failures.push({ status: e.status, code: e.code, message: e.message }); }
+    }
+    const ac = new AbortController();
+    const canceled = window.api.uploadAttachment('slow', file, { signal: ac.signal }); setTimeout(() => ac.abort(), 30);
+    try { await canceled; } catch (e) { failures.push({ code: e.code }); }
+    try { await window.api.uploadAttachment('slow', file, { timeoutMs: 30 }); } catch (e) { failures.push({ code: e.code }); }
+    const early = new AbortController();
+    try { await window.api.uploadAttachment('one', file, { signal: early.signal, onProgress: () => early.abort() }); } catch (e) { failures.push({ code: e.code }); }
+    return { success, progress, failures };
+  });
+  assert.equal(upload.success.id, 'attachment'); assert.ok(upload.progress.some((n) => n > 0));
+  assert.equal(upload.failures[0].status, 413); assert.equal(upload.failures[1].status, 502); assert.ok(!upload.failures[1].message.includes('private'));
+  assert.deepEqual(upload.failures.slice(2).map((e) => e.code), ['canceled', 'timeout', 'canceled']);
+  assert.equal(mutations - before, 5, 'no mutation replay; canceled-before-send upload never starts');
+  assert.deepEqual(errors, []);
+  console.log('Actual controls retain drafts, show domain errors, keep reader composer and XHR progress/cancel/timeout');
+} finally { await browser.close(); server.closeAllConnections(); await new Promise((r) => server.close(r)); fs.rmSync(root, { recursive: true, force: true }); }

--- a/web/test/apiResponse.test.mjs
+++ b/web/test/apiResponse.test.mjs
@@ -53,6 +53,15 @@ try {
   }
   globalThis.fetch = async () => new Response(new ReadableStream({ start(controller) { controller.error(new Error('private stream data')); } }), { status: 503 });
   await assert.rejects(api.getTree(), (e) => e.code === 'network-error' && e.status === 503 && !e.message.includes('private'));
+  const navigatorDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'navigator');
+  Object.defineProperty(globalThis, 'navigator', { configurable: true, value: { onLine: false } });
+  try {
+    globalThis.fetch = async () => { throw new Error('private network detail'); };
+    await assert.rejects(api.getTree(), (e) => e.code === 'offline' && e.status === null);
+  } finally {
+    if (navigatorDescriptor) Object.defineProperty(globalThis, 'navigator', navigatorDescriptor);
+    else delete globalThis.navigator;
+  }
   let canceled = false;
   globalThis.fetch = async () => new Response(new ReadableStream({ start(c) { c.enqueue(new Uint8Array(70_000)); }, cancel() { canceled = true; } }), { status: 502 });
   await assert.rejects(api.getTree(), (e) => e.status === 502);

--- a/web/test/apiResponse.test.mjs
+++ b/web/test/apiResponse.test.mjs
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+const root = fs.mkdtempSync(path.join(os.tmpdir(), 'am-api-decoder-'));
+const output = path.join(root, 'api.mjs');
+await build({ entryPoints: ['src/api.ts'], outfile: output, bundle: true, format: 'esm', platform: 'node', logLevel: 'silent' });
+const api = await import(pathToFileURL(output));
+const original = globalThis.fetch;
+let calls = 0;
+const respond = (body, status = 200, headers = { 'content-type': 'application/json' }) => {
+  globalThis.fetch = async () => { calls++; return new Response(body, { status, headers }); };
+};
+const json = (body, status) => respond(JSON.stringify(body), status);
+try {
+  for (const status of [400, 403, 404, 409, 413, 429, 500, 502, 503, 504]) {
+    json({ error: 'Useful refusal', code: 'fixture-refused', reason: 'fixture', tag: 'revision', retryAfter: 5, raw: 'must-not-retain' }, status);
+    await assert.rejects(api.renameSession('one', 'draft'), (e) => e instanceof api.ApiError && e.status === status && e.code === 'fixture-refused' && e.message === 'Useful refusal' && e.data.tag === 'revision' && !('raw' in e.data));
+  }
+  json({ error: 'Legacy message' }, 400);
+  await assert.rejects(api.createGroup('draft'), (e) => e.code === 'bad-request' && e.message === 'Legacy message');
+  for (const body of ['', '<html>proxy diagnostics</html>', 'broken JSON {', JSON.stringify({ error: '<script>unsafe</script>' }), 'x'.repeat(70_000)]) {
+    respond(body, 502);
+    await assert.rejects(api.getTree(), (e) => e.status === 502 && !/proxy|script|diagnostics|SyntaxError/.test(e.message));
+  }
+  json({ error: 'No trace yet', code: 'no-trace', reason: 'new-session' }, 404);
+  await assert.rejects(api.getTracePage('one'), (e) => e instanceof api.TraceUnavailable && e.status === 404 && e.data.reason === 'new-session');
+  json({ error: 'Legacy no trace' }, 404);
+  await assert.rejects(api.getTracePage('one'), (e) => e instanceof api.TraceUnavailable && e.code === 'no-trace');
+  json({ error: 'API route not found', code: 'api-not-found' }, 404);
+  await assert.rejects(api.getTracePage('one'), (e) => e instanceof api.ApiError && !(e instanceof api.TraceUnavailable));
+  respond('<html>proxy not found</html>', 404);
+  await assert.rejects(api.getTracePage('one'), (e) => e.status === 404 && !(e instanceof api.TraceUnavailable));
+  json({ error: 'Server failed', code: 'internal-error' }, 500);
+  await assert.rejects(api.getFileTracePage('one', 'fixture'), (e) => e.status === 500 && !(e instanceof api.TraceUnavailable));
+  json({ error: 'Refused by redaction', code: 'redaction-blocked', hits: { fixture: 2 } }, 409);
+  await assert.rejects(api.shareSession('one', { visibility: 'public' }), (e) => e instanceof api.RedactionBlocked && e.hits.fixture === 2 && e.status === 409);
+  json({ error: 'changed on disk', code: 'file-changed', mtime: 123, tag: 'new' }, 409);
+  await assert.rejects(api.writeFile('one', 'fixture', 'draft', 'old'), (e) => e.code === 'file-changed' && e.data.mtime === 123 && e.data.tag === 'new');
+  json({ ok: false, reason: 'no-space' }); assert.deepEqual(await api.relaunchSpace(), { ok: false, reason: 'no-space' });
+  respond(null, 204); assert.equal(await api.renameSession('one', 'draft'), undefined);
+  respond('', 200); assert.equal(await api.renameSession('one', 'draft'), undefined);
+  respond('{invalid', 200); await assert.rejects(api.getTree(), (e) => e.code === 'unreadable-response' && e.status === 200);
+  respond('plain instructions', 200, { 'content-type': 'text/plain' }); assert.equal(await api.getRemotePrompt('one'), 'plain instructions');
+  for (const [name, code] of [['AbortError', null], ['TimeoutError', 'timeout'], ['Error', 'network-error']]) {
+    const originalError = new DOMException('synthetic private detail', name);
+    globalThis.fetch = async () => { calls++; throw originalError; };
+    const before = calls;
+    await assert.rejects(api.renameSession('one', 'draft'), (e) => name === 'AbortError' ? e === originalError : e.code === code && !e.message.includes('private'));
+    assert.equal(calls, before + 1, 'mutations are never replayed');
+  }
+  globalThis.fetch = async () => new Response(new ReadableStream({ start(controller) { controller.error(new Error('private stream data')); } }), { status: 503 });
+  await assert.rejects(api.getTree(), (e) => e.code === 'network-error' && e.status === 503 && !e.message.includes('private'));
+  let canceled = false;
+  globalThis.fetch = async () => new Response(new ReadableStream({ start(c) { c.enqueue(new Uint8Array(70_000)); }, cancel() { canceled = true; } }), { status: 502 });
+  await assert.rejects(api.getTree(), (e) => e.status === 502);
+  assert.equal(canceled, true, 'oversized failure bodies are canceled');
+  let reads = 0;
+  globalThis.fetch = async () => { const r = new Response('{"error":"once"}', { status: 400 }); const reader = r.body.getReader.bind(r.body); r.body.getReader = () => { reads++; return reader(); }; return r; };
+  await assert.rejects(api.getTree(), /once/); assert.equal(reads, 1);
+  console.log('API decoder: statuses, legacy/domain data, bounded single read, parsing and cancellation passed');
+} finally { globalThis.fetch = original; fs.rmSync(root, { recursive: true, force: true }); }


### PR DESCRIPTION
Closes #134

## Implemented

- A shared Express 4 route wrapper catches synchronous and asynchronous request failures. API not-found/parser errors use JSON; committed streams terminate without a second response. Remote poll and file-upload callbacks have explicit cleanup.
- Runtime validation before route actions: JSON types, required fields, enums, queries, target references, settings, text prompts and raw uploads. Existing replacement/patch semantics and native text/query aliases remain supported; existing history-size clamps remain compatible.
- Additive `{ error: string, code }` failures, safe unexpected errors, preserved domain fields, and truthful incomplete audit outcomes. Request-body logging/filtering is unchanged.
- One typed browser decoder for fetch and XHR, retaining HTTP status and safe domain data. Legacy error strings, empty successes, trace availability, sharing refusals, file conflicts, rate limits, cancellation and upload progress remain supported. Existing controls show useful errors and retain drafts.
- [Route/response inventory, status table, validator conventions and examples](https://github.com/huggingface/agent-manager/blob/fix/api-errors-validation-134/docs/api-errors.md).

## Deliberately left alone

No Express/framework migration, domain-service rewrite, safe trace re-import transaction work, scheduled-target identity changes, store durability/recovery, automatic mutation retries, delivery receipts, process supervision, authentication, WebSocket framing, deployment or general UI redesign. Optional-subsystem fallbacks and meaningful successful partial/capability results remain intact. The file overwrite policy and settings durability work remain with their separate issues; origin protection and audit content filtering are not reimplemented here.

The audit's additive `incomplete` flag describes an unfinished HTTP response, not a rolled-back operation or permission to retry. The only direct persistence changes here stop request handlers from acknowledging failed writes; there is no new persistence protocol.

## Verification

All tests used isolated local state, fake agents and mocked external services. No live agent work, notifications or deployments.

- `cd server && npm test`: new tests pass; stops at the already-known main failure in `test/crons.test.mjs` #4. The 21 suites after that point were also run individually and pass (29 passing discovered server suites overall, excluding the known-red suite).
- `cd server && node ../scripts/run-suites.mjs api-boundary api-http attachments backup cron-api operations reader-protocol trace`: 12 suites pass.
- `cd server && node ../scripts/run-suites.mjs terminal-ui screenshot-input reader-info --manual`: all 3 desktop integration suites pass.
- `cd server && node ../scripts/run-suites.mjs api-boundary api-http operations`: all 3 pass after the final audit change.
- `cd web && npm test`: all 25 discovered suites pass, including real control/fetch/XHR tests.
- `cd web && npm run build`: typecheck and production build pass.
- Ten deliberate mutations are caught: promise forwarding, validation, safe failure bodies, committed-stream handling, poll cleanup, HTTP status retention, trace error classification, bounded failure reads, the production attachment route wrapper, and incomplete audit outcomes. Mutations were made only in a separate disposable checkout and restored.

<details>
<summary>Individual server commands run after the aggregate stopped</summary>

```sh
node test/first-run.test.mjs
node test/hidden.test.mjs
node test/input-required.test.mjs
node test/next-name.test.mjs
node test/opencode-resume.test.mjs
node test/operations.test.mjs
node test/queued-prompts.test.mjs
node test/reader-protocol.test.mjs
node test/repin.test.mjs
node test/revive.test.mjs
node test/slowfs.test.mjs
node test/spawn-group.test.mjs
node test/subagent-traces.test.mjs
node test/terminal-modes.test.mjs
node test/trace-download.test.mjs
node test/trace-tail.test.mjs
node test/trace-window.test.mjs
node test/usage.test.mjs
node migration.test.mjs
node resize.test.mjs
node state-checkpoint.test.mjs
```

</details>
