### PR TITLE
Files: browse and act on files from the keyboard

### DIFF
--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { recall, remember, readWrap, writeWrap } from './filesMemory';
 import type { Session } from '../types';
 import * as api from '../api';
 import { Rails, railPad } from './Rails';
+import { keyIntent, keepInView, survivingFocus, type TreeRow } from '../lib/treeNav';
 import type { FileEntry, FileKind, FilePreview } from '../api';
 import Logo from './Logo';
 import { renderMarkdown } from '../lib/markdown';
@@ -100,16 +101,24 @@ const padFor = railPad;
 // One directory listing, fetched once. Used by the pane for the current folder
 // and by every expanded FolderNode, so each level is loaded exactly once.
 function useDir(sessionId: string, path: string, reloadKey: number) {
-  const [state, setState] = useState<{ entries: FileEntry[] | null; err: boolean }>({ entries: null, err: false });
+  const [state, setState] = useState<{ for: string | null; entries: FileEntry[] | null; err: boolean }>(
+    { for: null, entries: null, err: false });
   useEffect(() => {
     let alive = true;
-    setState({ entries: null, err: false });
+    setState({ for: null, entries: null, err: false });
     api.listFiles(sessionId, path)
-      .then((r) => { if (alive) setState({ entries: r.entries, err: false }); })
-      .catch(() => { if (alive) setState({ entries: null, err: true }); });
+      .then((r) => { if (alive) setState({ for: path, entries: r.entries, err: false }); })
+      .catch(() => { if (alive) setState({ for: path, entries: null, err: true }); });
     return () => { alive = false; };
   }, [sessionId, path, reloadKey]);
-  return state;
+  // WHICH FOLDER THESE ENTRIES ARE FROM. The state update above lands in an
+  // effect, one render after `path` changed, so for that one render the previous
+  // folder's entries would be drawn against the new folder's path — rows called
+  // `docs/alpha.txt` for a file that is `alpha.txt` at the root. Nobody saw it
+  // (it lasts a frame) but it is a real wrong path: a click landing in that frame
+  // would act on it, and anything keyed by path — the keyboard focus — follows it
+  // into a row that then disappears.
+  return state.for === path ? state : { entries: null, err: false };
 }
 
 type RowProps = {
@@ -126,7 +135,33 @@ type RowProps = {
   /** The folder new entries and uploads land in. */
   target: string;
   setTarget: (dir: string) => void;
+  /** Expanded folders, by path — held by the pane so a key and a click agree. */
+  open: ReadonlySet<string>;
+  setOpen: (path: string, on?: boolean) => void;
+  /** The one row that is in the tab order. Focus, not selection: see treeNav. */
+  focusPath: string | null;
+  /** A row took the focus (Tab, a click, a key) — remember which. */
+  onRowFocus: (path: string) => void;
+  /** Ask for the focus to be MOVED to a row, once it is drawn. */
+  requestFocus: (path: string) => void;
 };
+
+// Everything a row needs to be one item of the tree widget: which of the
+// listing's rows carries the tab stop, where it sits in the hierarchy, and a
+// path the pane can find it by again after a re-render reorders everything.
+const rowProps = (
+  path: string, dir: boolean, level: number, pos: number, size: number,
+  focusPath: string | null, onRowFocus: (p: string) => void,
+) => ({
+  role: 'treeitem' as const,
+  'aria-level': level,
+  'aria-posinset': pos,
+  'aria-setsize': size,
+  'data-path': path,
+  'data-dir': dir ? '1' : undefined,
+  tabIndex: focusPath === path ? 0 : -1,
+  onFocus: (e: React.FocusEvent) => { if (e.target === e.currentTarget) onRowFocus(path); },
+});
 
 export interface Moving { path: string; name: string; dir: boolean }
 
@@ -161,6 +196,9 @@ function RenameInput({ init, onCommit, onCancel }: {
       onChange={(e) => setV(e.target.value)}
       onKeyDown={(e) => {
         e.stopPropagation();
+        // An IME sends Enter to accept the candidate it is showing. Committing
+        // the rename on that key would rename the file to half a word.
+        if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
         if (e.key === 'Enter') { e.preventDefault(); finish(true); }
         if (e.key === 'Escape') { e.preventDefault(); done.current = true; onCancel(); }
       }}
@@ -220,13 +258,13 @@ function ConfirmDelete({ name, dir, busy, onYes, onNo }: {
         {dir ? `Delete "${name}" and everything in it?` : `Delete "${name}"?`}
       </span>
       <button className="mini-btn danger" disabled={busy} onClick={onYes}>{busy ? 'Deleting…' : 'Delete'}</button>
-      <button className="mini-btn" disabled={busy} onClick={onNo}>Cancel</button>
+      <button className="mini-btn" data-confirm="cancel" disabled={busy} onClick={onNo}>Cancel</button>
     </span>
   );
 }
 
 // Rows for one already-loaded listing; folders recurse through FolderNode.
-function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving, target, setTarget }: RowProps & {
+function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, onPreview, selected, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving, target, setTarget, open, setOpen, focusPath, onRowFocus, requestFocus }: RowProps & {
   entries: FileEntry[]; path: string;
 }) {
   const arr = sortEntries(entries, sort);
@@ -243,13 +281,21 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
               onOpen={onOpen} onPreview={onPreview} selected={selected} onDelete={onDelete}
               onRename={onRename} renaming={renaming} setRenaming={setRenaming}
               onMove={onMove} moving={moving} setMoving={setMoving} target={target} setTarget={setTarget}
+              open={open} setOpen={setOpen} focusPath={focusPath} onRowFocus={onRowFocus}
+              requestFocus={requestFocus} pos={i + 1} setSize={arr.length}
             />
           );
         }
         const kindNote = e.kind && e.kind !== 'binary' ? `${KIND_LABEL[e.kind]} · ` : '';
+        // Only the focused row's actions are Tab stops. Every row's would mean
+        // four stops per row between the listing and whatever follows it, all of
+        // them invisible until their row is hovered.
+        const act = focusPath === p ? 0 : -1;
         return (
           <div
             key={e.name}
+            {...rowProps(p, false, prefix.length + 1, i + 1, arr.length, focusPath, onRowFocus)}
+            aria-selected={selected === p ? true : undefined}
             className={`tree-row file${selected === p ? ' selected' : ''}${moving?.path === p ? ' moving' : ''}`}
             style={padFor(prefix)}
             draggable={renaming !== p}
@@ -268,32 +314,33 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
               <RenameInput
                 init={e.name}
                 onCommit={(name) => onRename(p, name)}
-                onCancel={() => setRenaming(null)}
+                onCancel={() => { setRenaming(null); requestFocus(p); }}
               />
             ) : <span className="tw-name">{e.name}</span>}
             <span className="tw-size">{fmtSize(e.size)}</span>
             <span className="tw-time">{fmtWhen(e.mtime)}</span>
             <span className="tw-acts">
               <button
-                className="tw-act" title="Download"
+                className="tw-act" tabIndex={act} title="Download" aria-label={`Download ${e.name}`}
                 onClick={(ev) => { ev.stopPropagation(); triggerDownload(api.downloadUrl(sessionId, p), e.name); }}
               >
                 <DownloadGlyph />
               </button>
               <button
-                className="tw-act" title={`Rename ${e.name}`}
+                className="tw-act" tabIndex={act} title={`Rename ${e.name}`} aria-label={`Rename ${e.name}`}
                 onClick={(ev) => { ev.stopPropagation(); setRenaming(p); }}
               >
                 <PencilGlyph />
               </button>
               <button
-                className="tw-act" title={`Move ${e.name} — then pick a folder`}
-                onClick={(ev) => { ev.stopPropagation(); setMoving({ path: p, name: e.name, dir: false }); }}
+                className="tw-act" tabIndex={act} title={`Move ${e.name} — then pick a folder`}
+                aria-label={`Move ${e.name} — then pick a destination folder`}
+                onClick={(ev) => { ev.stopPropagation(); setMoving({ path: p, name: e.name, dir: false }); requestFocus(p); }}
               >
                 <MoveGlyph />
               </button>
               <button
-                className="tw-act danger" title={`Delete ${e.name}`}
+                className="tw-act danger" tabIndex={act} title={`Delete ${e.name}`} aria-label={`Delete ${e.name}`}
                 onClick={(ev) => { ev.stopPropagation(); onDelete(p, e.name, false); }}
               >
                 <TrashGlyph />
@@ -309,21 +356,33 @@ function DirRows({ entries, path, sessionId, prefix, sort, reloadKey, onOpen, on
 // Lazily-loaded contents of one expanded directory.
 function DirContents({ path, sessionId, prefix, ...rest }: RowProps & { path: string }) {
   const { entries, err } = useDir(sessionId, path, rest.reloadKey);
-  if (err) return <div className="tree-msg" style={padFor(prefix)}>can't read folder</div>;
-  if (!entries) return <div className="tree-msg" style={padFor(prefix)}>…</div>;
-  if (entries.length === 0) return <div className="tree-msg" style={padFor(prefix)}>empty</div>;
+  // Not rows: a folder that is loading, empty or unreadable has nothing to focus,
+  // and offering an empty destination would be a keyboard dead end. They are
+  // announced instead, so the state is readable rather than silent.
+  const here = path.split('/').pop() || path;
+  const msg = (text: string, label?: string) => (
+    <div className="tree-msg" style={padFor(prefix)} role="status" aria-label={label}>{text}</div>
+  );
+  if (err) return msg("can't read folder", `${here} could not be read`);
+  // The visible ellipsis is the listing's own idiom; a reader gets a sentence.
+  if (!entries) return msg('…', `Loading ${here}`);
+  if (entries.length === 0) return msg('empty', `${here} is empty`);
   return <DirRows entries={entries} path={path} sessionId={sessionId} prefix={prefix} {...rest} />;
 }
 
 // A folder row: single click toggles inline expand, double click opens it as the
 // new tree root. A short timer disambiguates the two.
-function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
-  path: string; name: string; mtime: number; isLast: boolean;
+function FolderNode({ path, name, mtime, isLast, pos, setSize, ...rest }: RowProps & {
+  path: string; name: string; mtime: number; isLast: boolean; pos: number; setSize: number;
 }) {
-  const { prefix, onOpen, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving, target, setTarget } = rest;
-  const [open, setOpen] = useState(false);
+  const {
+    prefix, onOpen, onDelete, onRename, renaming, setRenaming, onMove, moving, setMoving,
+    target, setTarget, open: openSet, setOpen: setOpenPath, focusPath, onRowFocus, requestFocus,
+  } = rest;
+  const open = openSet.has(path);
   const [over, setOver] = useState(false);
   const takes = !!moving && canMoveTo(moving, path);   // would a drop here do anything?
+  const act = focusPath === path ? 0 : -1;            // see the file row
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => () => { if (timer.current) clearTimeout(timer.current); }, []);
   const onClick = () => {
@@ -335,7 +394,7 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
     }
     setTarget(path);                 // new folders, new files and uploads land here
     if (timer.current) return;
-    timer.current = setTimeout(() => { timer.current = null; setOpen((o) => !o); }, 200);
+    timer.current = setTimeout(() => { timer.current = null; setOpenPath(path); }, 200);
   };
   const onDoubleClick = () => {
     if (timer.current) { clearTimeout(timer.current); timer.current = null; }
@@ -344,6 +403,8 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
   return (
     <>
       <div
+        {...rowProps(path, true, prefix.length + 1, pos, setSize, focusPath, onRowFocus)}
+        aria-expanded={open}
         className={`tree-row folder${target === path ? ' target' : ''}${over && takes ? ' drop' : ''}${moving?.path === path ? ' moving' : ''}`}
         style={padFor(prefix)}
         draggable={renaming !== path}
@@ -370,7 +431,7 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
           <RenameInput
             init={name}
             onCommit={(next) => onRename(path, next)}
-            onCancel={() => setRenaming(null)}
+            onCancel={() => { setRenaming(null); requestFocus(path); }}
           />
         ) : <span className="tw-name">{name}</span>}
         <span className="tw-size" />
@@ -380,19 +441,21 @@ function FolderNode({ path, name, mtime, isLast, ...rest }: RowProps & {
               sit in the same place on every row */}
           <span className="tw-act ghost" aria-hidden />
           <button
-            className="tw-act" title={`Rename ${name}`}
+            className="tw-act" tabIndex={act} title={`Rename ${name}`} aria-label={`Rename folder ${name}`}
             onClick={(ev) => { ev.stopPropagation(); setRenaming(path); }}
           >
             <PencilGlyph />
           </button>
           <button
-            className="tw-act" title={`Move ${name} — then pick a folder`}
-            onClick={(ev) => { ev.stopPropagation(); setMoving({ path, name, dir: true }); }}
+            className="tw-act" tabIndex={act} title={`Move ${name} — then pick a folder`}
+            aria-label={`Move folder ${name} — then pick a destination folder`}
+            onClick={(ev) => { ev.stopPropagation(); setMoving({ path, name, dir: true }); requestFocus(path); }}
           >
             <MoveGlyph />
           </button>
           <button
-            className="tw-act danger" title={`Delete ${name}`}
+            className="tw-act danger" tabIndex={act} title={`Delete ${name}`}
+            aria-label={`Delete folder ${name} and everything in it`}
             onClick={(ev) => { ev.stopPropagation(); onDelete(path, name, true); }}
           >
             <TrashGlyph />
@@ -909,8 +972,53 @@ export default function FilesPane({
   const [acting, setActing] = useState(false);
   const [actErr, setActErr] = useState<string | null>(null);
   const paneRef = useRef<HTMLDivElement | null>(null);
+  // Expanded folders live here rather than in each row, so the keyboard's
+  // expand/collapse and the pointer's click-to-expand are the same fact, and
+  // `aria-expanded` can be read off it.
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() => new Set());
+  // WHICH ROW OWNS THE KEYBOARD — by path, never by index: a sort or a refresh
+  // reorders the listing under you, and an index would silently mean a different
+  // file. It is the tree's single tab stop and nothing more; opening, moving and
+  // deleting are separate acts, so arrowing over a row changes nothing on disk.
+  const [focusPath, setFocusPath] = useState<string | null>(null);
+  const bodyRef = useRef<HTMLDivElement | null>(null);
+  // A pending request to MOVE the browser's focus, which is a different question
+  // from which row is the tab stop: only a user action sets one, it expires, and
+  // it is dropped if the operator has since gone to another pane. That is what
+  // keeps a slow directory response from stealing the keyboard.
+  const wantFocus = useRef<{ path: string; until: number } | null>(null);
+  // Set by an operation that is about to remove the focused row, so the repair
+  // below knows the focus was ours to place and not someone else's to keep. A
+  // deadline rather than a flag: opening a folder empties the listing until the
+  // read comes back, so the claim has to outlive a render or two — and then
+  // lapse, rather than waiting to pounce on whatever is drawn next.
+  const claim = useRef(0);
+  const drawn = useRef<string[]>([]);
 
   const dir = useDir(session.id, root, reloadKey);
+
+  const rowEls = () => Array.from(bodyRef.current?.querySelectorAll<HTMLElement>('[role="treeitem"]') || []);
+  const rowEl = (path: string) => rowEls().find((el) => el.dataset.path === path) || null;
+  const rows = (): TreeRow[] => rowEls().map((el) => ({
+    path: el.dataset.path || '', dir: el.dataset.dir === '1', open: el.getAttribute('aria-expanded') === 'true',
+  }));
+  const requestFocus = useCallback((path: string) => {
+    setFocusPath(path);
+    wantFocus.current = { path, until: Date.now() + 2000 };
+  }, []);
+  const setOpenPath = useCallback((path: string, on?: boolean) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (on ?? !next.has(path)) next.add(path); else next.delete(path);
+      return next;
+    });
+  }, []);
+  // True when the focus is somewhere in this pane right now — asked BEFORE an
+  // operation removes the row that had it, since by the time React has taken the
+  // row away the browser has already parked the focus on <body>.
+  const claimFocus = () => {
+    if (paneRef.current?.contains(document.activeElement)) claim.current = Date.now() + 2000;
+  };
 
   // Coming back to a pane should put you where you left it, not at the top of
   // the workspace — the folder you were in, the file you were reading, and the
@@ -931,6 +1039,43 @@ export default function FilesPane({
     if (viewing) paneRef.current?.focus({ preventScroll: true });
   }, [viewing]);
 
+  // KEEP THE TAB STOP ON A ROW THAT EXISTS. Runs after every render because
+  // every render is a chance the listing changed underneath the focus: renamed,
+  // deleted, moved away, re-sorted, or replaced when the root changed. Only the
+  // tab stop is repaired here; the browser's focus moves only when this pane was
+  // the one holding it.
+  useLayoutEffect(() => {
+    if (viewing || !bodyRef.current) return;
+    const paths = rowEls().map((el) => el.dataset.path || '');
+    const before = drawn.current;
+    drawn.current = paths;
+    if (!paths.length) return;                 // still reading: a claim keeps waiting
+    if (focusPath && paths.includes(focusPath)) return;   // the claim, if any, keeps until it lapses
+    const mine = Date.now() < claim.current || bodyRef.current.contains(document.activeElement);
+    claim.current = 0;
+    const next = focusPath ? survivingFocus(before, paths, focusPath) : paths[0];
+    if (!next) return;
+    if (mine) requestFocus(next); else setFocusPath(next);
+  });
+
+  // Move the focus to a row that was asked for. Split from the repair above
+  // because the row is often not drawn yet — a rename or a move only lands after
+  // the listing has been read again — so this waits for the render that draws it,
+  // and gives up rather than pouncing on a row that arrives much later.
+  useLayoutEffect(() => {
+    const req = wantFocus.current;
+    const box = bodyRef.current;
+    if (!req || !box || viewing) return;
+    const active = document.activeElement as HTMLElement | null;
+    const elsewhere = active && active !== document.body && !paneRef.current?.contains(active);
+    if (elsewhere || Date.now() > req.until) { wantFocus.current = null; return; }
+    const el = rowEl(req.path);
+    if (!el) return;
+    wantFocus.current = null;
+    el.focus({ preventScroll: true });
+    keepInView(el, box);
+  });
+
   const upload = async (files: FileList | File[]) => {
     setBusy(true);
     for (const f of Array.from(files)) {
@@ -947,6 +1092,10 @@ export default function FilesPane({
   const leaveView = () => {
     if (unsaved) { setConfirmClose(true); return; }
     setConfirmClose(false);
+    // Back to the row the file was opened from — the listing was only hidden, so
+    // its expansion and scroll are still there and this is the last piece of
+    // where you were.
+    if (viewing) requestFocus(viewing);
     setViewing(null);
   };
   useEffect(() => { if (!unsaved) setConfirmClose(false); }, [unsaved]);
@@ -966,7 +1115,7 @@ export default function FilesPane({
   const saveAndClose = async () => {
     if (!edit) return;
     const ok = await edit.saveNow(!!edit.conflict);
-    if (ok) { setConfirmClose(false); setViewing(null); }
+    if (ok) { setConfirmClose(false); if (viewing) requestFocus(viewing); setViewing(null); }
   };
 
   // Create lands in the folder you are looking at, which is the one the
@@ -990,9 +1139,10 @@ export default function FilesPane({
   useEffect(() => { setTarget(null); setMoving(null); }, [root]);
 
   const doMove = async (from: string, toDir: string) => {
-    setMoving(null); setActErr(null);
+    setMoving(null); setActErr(null); claimFocus();
     try {
       const { path: next } = await api.moveEntry(session.id, from, toDir);
+      requestFocus(next);          // follow the entry to where it went
       if (viewing === from) setViewing(next);
       else if (viewing && viewing.startsWith(`${from}/`)) setViewing(`${next}${viewing.slice(from.length)}`);
       setReloadKey((k) => k + 1);
@@ -1002,9 +1152,10 @@ export default function FilesPane({
   };
 
   const doRename = async (p: string, name: string) => {
-    setRenaming(null); setActErr(null);
+    setRenaming(null); setActErr(null); claimFocus();
     try {
       const { path: next } = await api.renameEntry(session.id, p, name);
+      requestFocus(next);          // same row, new name
       // Keep the viewer pointed at the same bytes: renaming the open file, or a
       // folder above it, should not close what you were reading.
       if (viewing === p) setViewing(next);
@@ -1017,7 +1168,7 @@ export default function FilesPane({
 
   const doDelete = async () => {
     if (!pendingDel) return;
-    setActing(true); setActErr(null);
+    setActing(true); setActErr(null); claimFocus();
     try {
       await api.deleteEntry(session.id, pendingDel.path);
       // If the open file was the one deleted, leave the viewer rather than
@@ -1032,9 +1183,68 @@ export default function FilesPane({
     }
   };
 
+  // THE LISTING'S KEYS. One handler for every row, on the box they sit in: rows
+  // come and go, and a listener per row would be a listener per row to get wrong.
+  // What each key means is in lib/treeNav.ts; what is here is everything that
+  // depends on what the pane is doing — an armed move, an open confirmation — and
+  // the rule that a key belongs to whatever is focused before it belongs to us.
+  const onTreeKey = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    const el = e.target as HTMLElement;
+    // Composition first: an IME sends Enter to finish a word, and that Enter is
+    // the input's, not ours. Then anything being typed into.
+    if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;
+    if (el.closest('input, textarea, select, [contenteditable="true"]')) return;
+    if (e.altKey || e.metaKey || e.ctrlKey) return;   // ⌘S and friends belong to the pane
+
+    if (e.key === 'Escape') {
+      // One Escape undoes one pending thing, and closes nothing else. The row it
+      // was about gets the focus back, because that is where the eye is.
+      if (moving) { e.preventDefault(); e.stopPropagation(); const { path } = moving; setMoving(null); requestFocus(path); return; }
+      if (pendingDel && !acting) { e.preventDefault(); e.stopPropagation(); const { path } = pendingDel; setPendingDel(null); requestFocus(path); return; }
+      return;
+    }
+    // A focused action button owns its own Enter and Space; the row must not act
+    // on the same press as well.
+    if (el.closest('button')) return;
+
+    const here = el.closest<HTMLElement>('[role="treeitem"]')?.dataset.path ?? focusPath;
+    const intent = keyIntent(rows(), here ?? null, e.key);
+    if (!intent) return;                     // Tab, typing, anything else: not ours
+    e.preventDefault();
+    e.stopPropagation();                     // and not the other panes' either
+    if (intent.kind === 'focus') { requestFocus(intent.path); return; }
+    if (intent.kind === 'expand' || intent.kind === 'collapse') {
+      setOpenPath(intent.path, intent.kind === 'expand');
+      requestFocus(intent.path);             // expanding does not leave the folder
+      return;
+    }
+    // Enter. While a move is armed the tree is a destination picker, exactly as
+    // it is for the pointer: a folder that can take the entry takes it, a folder
+    // that cannot cancels, and a file is not a destination at all.
+    if (moving) {
+      if (!intent.dir) return;
+      if (canMoveTo(moving, intent.path)) doMove(moving.path, intent.path);
+      else { const { path } = moving; setMoving(null); requestFocus(path); }
+      return;
+    }
+    // Opening a folder replaces every row, so say the focus is ours to place —
+    // asked here, while the row that has it is still on screen.
+    if (intent.dir) { claimFocus(); openDir(intent.path); } else setViewing(intent.path);
+  };
+
   const up = () => setRoot(root.includes('/') ? root.slice(0, root.lastIndexOf('/')) : '');
   const openDir = (p: string) => { setViewing(null); setRoot(p); };
   const crumbs = ['', ...root.split('/').filter(Boolean).map((_, i, arr) => arr.slice(0, i + 1).join('/'))];
+
+  // A confirmation that nobody's keyboard can reach is not a confirmation. It
+  // opens on Cancel, never on Delete: the key that opened it is still going up,
+  // and a Space release landing on a freshly focused Delete would delete the file
+  // with one press. One Tab away is close enough for the answer that is meant to
+  // cost something.
+  useEffect(() => {
+    if (!pendingDel || !paneRef.current?.contains(document.activeElement)) return;
+    paneRef.current.querySelector<HTMLElement>('[data-confirm="cancel"]')?.focus({ preventScroll: true });
+  }, [pendingDel]);
 
   // Folder summary: the numbers that used to be nowhere on screen.
   const stats = useMemo(() => {
@@ -1055,6 +1265,11 @@ export default function FilesPane({
     <div
       className={`slot${focused ? ' focused' : ''}`} ref={paneRef} tabIndex={-1}
       onMouseDown={onFocus}
+      // …and the same for the keyboard: tabbing into the listing has to make
+      // this the pane the app considers current, or the row you are standing on
+      // is in one pane while the app's shortcuts are pointed at another. React's
+      // onFocus is focusin, so it fires for anything inside the pane.
+      onFocus={onFocus}
       // Esc anywhere in the pane leaves the preview — the handler sits on the
       // pane, not on the viewer, so it still fires after a click on a toggle in
       // the info strip moved focus out of the body.
@@ -1077,7 +1292,7 @@ export default function FilesPane({
         <Logo cli="files" size={16} tint="#d99a2b" />
         {viewing ? (
           <>
-            <button className="mini-btn" title="Back to files (Esc)" onClick={leaveView}><BackGlyph /></button>
+            <button className="mini-btn" title="Back to files (Esc)" aria-label="Back to files" onClick={leaveView}><BackGlyph /></button>
             <span className="fv-title" title={viewing}>
               <KindGlyph name={name} kind={meta?.kind} className="tw-ico" />
               <span className="fv-name">{name}</span>
@@ -1086,13 +1301,16 @@ export default function FilesPane({
               )}
             </span>
             <span className="spacer" />
-            <button className="mini-btn" title="Download" onClick={() => triggerDownload(api.downloadUrl(session.id, viewing), name)}>
+            <button
+              className="mini-btn" title="Download" aria-label={`Download ${name}`}
+              onClick={() => triggerDownload(api.downloadUrl(session.id, viewing), name)}
+            >
               <DownloadGlyph />
             </button>
           </>
         ) : (
           <>
-            <button className="mini-btn" title="Up" disabled={!root} onClick={up}><UpGlyph /></button>
+            <button className="mini-btn" title="Up" aria-label="Up one folder" disabled={!root} onClick={up}><UpGlyph /></button>
             <div className="crumbs">
               {crumbs.map((c, i) => (
                 <span key={c || 'root'}>
@@ -1103,21 +1321,39 @@ export default function FilesPane({
             </div>
             <span className="spacer" />
             <button
-              className="mini-btn" title="New folder here"
+              className="mini-btn" title="New folder here" aria-label={`New folder in ${dest || rootLabel}`}
               onClick={() => { setCreating('folder'); setNewName(''); setActErr(null); }}
             ><FolderPlusGlyph /></button>
             <button
-              className="mini-btn" title="New empty file here"
+              className="mini-btn" title="New empty file here" aria-label={`New file in ${dest || rootLabel}`}
               onClick={() => { setCreating('file'); setNewName(''); setActErr(null); }}
             ><FilePlusGlyph /></button>
-            <button className="mini-btn" title="Refresh" onClick={() => setReloadKey((k) => k + 1)}><RefreshGlyph /></button>
-            <label className="mini-btn upload-btn" title="Upload files">
+            <button
+              className="mini-btn" title="Refresh" aria-label="Refresh the listing"
+              onClick={() => setReloadKey((k) => k + 1)}
+            ><RefreshGlyph /></button>
+            {/* A <label> around a hidden <input type=file> is clickable and
+                nothing else: the input cannot be tabbed to (it is hidden) and a
+                label is not a control, so the picker had no keyboard at all.
+                Made a button in its own right, opening the same picker. */}
+            <label
+              className="mini-btn upload-btn" title="Upload files"
+              role="button" tabIndex={0} aria-label="Upload files"
+              onKeyDown={(e) => {
+                if (e.key !== 'Enter' && e.key !== ' ') return;
+                e.preventDefault();
+                e.currentTarget.querySelector<HTMLInputElement>('input[type=file]')?.click();
+              }}
+            >
               <UploadGlyph /> Upload
               <input type="file" multiple hidden onChange={(e) => { if (e.target.files) upload(e.target.files); e.target.value = ''; }} />
             </label>
           </>
         )}
-        <button className="mini-btn ph-close" title="Close" onClick={(e) => { e.stopPropagation(); onClose(); }}><CloseGlyph /></button>
+        <button
+          className="mini-btn ph-close" title="Close" aria-label="Close the files pane"
+          onClick={(e) => { e.stopPropagation(); onClose(); }}
+        ><CloseGlyph /></button>
       </div>
 
       {/* Info strip: where you are, or what you're looking at. */}
@@ -1236,6 +1472,7 @@ export default function FilesPane({
               value={newName}
               onChange={(e) => { setNewName(e.target.value); setActErr(null); }}
               onKeyDown={(e) => {
+                if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) return;   // see RenameInput
                 if (e.key === 'Enter') { e.preventDefault(); create(); }
                 if (e.key === 'Escape') { e.preventDefault(); setCreating(null); setActErr(null); }
               }}
@@ -1264,7 +1501,8 @@ export default function FilesPane({
             <TrashGlyph className="tw-ico" />
             <ConfirmDelete
               name={pendingDel.name} dir={pendingDel.dir} busy={acting}
-              onYes={doDelete} onNo={() => { setPendingDel(null); setActErr(null); }}
+              onYes={doDelete}
+              onNo={() => { setPendingDel(null); setActErr(null); requestFocus(pendingDel.path); }}
             />
           </div>
         )}
@@ -1274,14 +1512,22 @@ export default function FilesPane({
           onSort={(k) => setSort((s) => (s.key === k ? { key: k, desc: !s.desc } : { key: k, desc: k !== 'name' }))}
         />
         <div
+          ref={bodyRef}
           className={`files-body tree${dragOver ? ' drag' : ''}`}
+          role="tree"
+          aria-label={`Files in ${root ? `${rootLabel}/${root}` : rootLabel}`}
+          // With rows on screen the tab stop is one of them; with none — loading,
+          // empty, unreadable — it is the box itself, so Tab still finds the
+          // listing and lands on something that says what it is.
+          tabIndex={dir.entries?.length ? -1 : 0}
+          onKeyDown={onTreeKey}
           onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
           onDragLeave={() => setDragOver(false)}
           onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) upload(e.dataTransfer.files); }}
         >
-          {dir.err && <div className="tree-msg">can't read folder</div>}
-          {!dir.err && !dir.entries && <div className="tree-msg">…</div>}
-          {dir.entries?.length === 0 && <div className="tree-msg">empty</div>}
+          {dir.err && <div className="tree-msg" role="status">can't read folder</div>}
+          {!dir.err && !dir.entries && <div className="tree-msg" role="status" aria-label="Loading files">…</div>}
+          {dir.entries?.length === 0 && <div className="tree-msg" role="status">empty folder</div>}
           {dir.entries && dir.entries.length > 0 && (
             <DirRows
               entries={dir.entries} path={root} sessionId={session.id} prefix={[]} sort={sort}
@@ -1290,6 +1536,8 @@ export default function FilesPane({
               onRename={doRename} renaming={renaming} setRenaming={(p) => { setActErr(null); setRenaming(p); }}
               onMove={doMove} moving={moving} setMoving={(m) => { setActErr(null); setMoving(m); }}
               target={dest} setTarget={setTarget}
+              open={expanded} setOpen={setOpenPath} focusPath={focusPath}
+              onRowFocus={setFocusPath} requestFocus={requestFocus}
             />
           )}
           {busy && <div className="tree-msg">Uploading…</div>}
@@ -1302,7 +1550,7 @@ export default function FilesPane({
           conflict={!!edit.conflict}
           busy={edit.status === 'saving'}
           onSave={saveAndClose}
-          onDiscard={() => { edit.discard(); setConfirmClose(false); setViewing(null); }}
+          onDiscard={() => { edit.discard(); setConfirmClose(false); requestFocus(viewing); setViewing(null); }}
           onCancel={backToEditing}
         />
       )}
@@ -1318,7 +1566,7 @@ export default function FilesPane({
 
       <div className="files-hint">
         {!viewing
-          ? 'Click a file to preview · click a folder to expand · double-click a folder to open it'
+          ? 'Click a file to preview · double-click a folder to open it · ↑↓ move, → expand, ← collapse, Enter opens, Tab reaches the row\u2019s actions'
           : edit?.status === 'dirty'
               ? 'Unsaved changes — ⌘S or Save'
               : edit?.can

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -101,24 +101,33 @@ const padFor = railPad;
 // One directory listing, fetched once. Used by the pane for the current folder
 // and by every expanded FolderNode, so each level is loaded exactly once.
 function useDir(sessionId: string, path: string, reloadKey: number) {
+  const stamp = `${sessionId}\u0000${path}\u0000${reloadKey}`;
   const [state, setState] = useState<{ for: string | null; entries: FileEntry[] | null; err: boolean }>(
     { for: null, entries: null, err: false });
   useEffect(() => {
     let alive = true;
     setState({ for: null, entries: null, err: false });
     api.listFiles(sessionId, path)
-      .then((r) => { if (alive) setState({ for: path, entries: r.entries, err: false }); })
-      .catch(() => { if (alive) setState({ for: path, entries: null, err: true }); });
+      .then((r) => { if (alive) setState({ for: stamp, entries: r.entries, err: false }); })
+      .catch(() => { if (alive) setState({ for: stamp, entries: null, err: true }); });
     return () => { alive = false; };
   }, [sessionId, path, reloadKey]);
-  // WHICH FOLDER THESE ENTRIES ARE FROM. The state update above lands in an
-  // effect, one render after `path` changed, so for that one render the previous
-  // folder's entries would be drawn against the new folder's path — rows called
-  // `docs/alpha.txt` for a file that is `alpha.txt` at the root. Nobody saw it
-  // (it lasts a frame) but it is a real wrong path: a click landing in that frame
-  // would act on it, and anything keyed by path — the keyboard focus — follows it
-  // into a row that then disappears.
-  return state.for === path ? state : { entries: null, err: false };
+  // WHICH READ THESE ENTRIES CAME FROM — the folder AND the reload that asked
+  // for them. The state update above lands in an effect, one render after its
+  // inputs changed, so for that one render the previous answer would be drawn as
+  // if it were this one. Two ways that bites, both real:
+  //
+  //   · a new FOLDER draws the old folder's entries against the new path — rows
+  //     called `docs/alpha.txt` for a file that is `alpha.txt` at the root;
+  //   · a RELOAD after a rename or a move draws the listing from before it, so
+  //     the row the operation just created is briefly absent and the row it
+  //     replaced is briefly still there.
+  //
+  // The second one is what put the keyboard on the wrong file: the focus is
+  // asked to follow the renamed entry, that stale frame does not contain it, and
+  // the repair below reasonably concludes the row is gone. A listing that is not
+  // this read's is not a listing yet.
+  return state.for === stamp ? state : { entries: null, err: false };
 }
 
 type RowProps = {
@@ -1047,9 +1056,15 @@ export default function FilesPane({
   useLayoutEffect(() => {
     if (viewing || !bodyRef.current) return;
     const paths = rowEls().map((el) => el.dataset.path || '');
+    // NOTHING DRAWN YET. The folder is still being read, so this is not an answer
+    // about anything: a claim keeps waiting, a pending focus request keeps
+    // waiting, and — the part that bit — the last listing the operator actually
+    // saw stays recorded. Overwriting it with the empty one made the repair
+    // afterwards forget where the missing row had been, and send the focus to
+    // the top of the listing instead of to its neighbour.
+    if (!paths.length) return;
     const before = drawn.current;
     drawn.current = paths;
-    if (!paths.length) return;                 // still reading: a claim keeps waiting
     if (focusPath && paths.includes(focusPath)) return;   // the claim, if any, keeps until it lapses
     const mine = Date.now() < claim.current || bodyRef.current.contains(document.activeElement);
     claim.current = 0;
@@ -1461,7 +1476,15 @@ export default function FilesPane({
 
       {/* The tree stays mounted while a preview is open, so going back lands on
           the same expanded folders and the same scroll position. */}
-      <div className="files-stack" hidden={!!viewing} style={{ fontSize: `${(13 * zoom) / 100}px` }}>
+      {/* The key handler sits on the STACK, not on the listing: the create field,
+          the move bar and the delete confirmation are drawn above the rows, not
+          inside them, and Escape has to reach them from whichever of their
+          buttons has the focus. Everything it does is still about the listing —
+          see onTreeKey, which hands every key back that is not its business. */}
+      <div
+        className="files-stack" hidden={!!viewing} onKeyDown={onTreeKey}
+        style={{ fontSize: `${(13 * zoom) / 100}px` }}
+      >
         {creating && (
           <div className="files-new">
             {creating === 'folder' ? <FolderPlusGlyph className="tw-ico" /> : <FilePlusGlyph className="tw-ico" />}
@@ -1493,7 +1516,10 @@ export default function FilesPane({
                 Move here ({root ? root.split('/').pop() : rootLabel})
               </button>
             )}
-            <button className="mini-btn" onClick={() => setMoving(null)}>Cancel</button>
+            <button
+              className="mini-btn"
+              onClick={() => { const { path } = moving; setMoving(null); requestFocus(path); }}
+            >Cancel</button>
           </div>
         )}
         {pendingDel && (
@@ -1520,7 +1546,6 @@ export default function FilesPane({
           // empty, unreadable — it is the box itself, so Tab still finds the
           // listing and lands on something that says what it is.
           tabIndex={dir.entries?.length ? -1 : 0}
-          onKeyDown={onTreeKey}
           onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
           onDragLeave={() => setDragOver(false)}
           onDrop={(e) => { e.preventDefault(); setDragOver(false); if (e.dataTransfer.files.length) upload(e.dataTransfer.files); }}

--- a/web/src/lib/treeNav.ts
+++ b/web/src/lib/treeNav.ts
@@ -1,0 +1,123 @@
+// Keyboard navigation for the Files listing.
+//
+// The listing is a tree drawn as a flat run of rows: an expanded folder's
+// children are siblings in the DOM, indented by rails rather than nested in it.
+// So "the row above" is a question about the rendered order, not about the
+// component tree, and every answer here is computed from the rows that are
+// actually on screen — collapsed children are not in that list at all, which is
+// what keeps a hidden row from being a keyboard destination.
+//
+// THE KEY CONTRACT (W3C tree-view pattern, trimmed to what this listing has):
+//
+//   ↑ / ↓        previous / next visible row
+//   →            collapsed folder: expand · expanded folder: first child · file: nothing
+//   ←            expanded folder: collapse · otherwise: the parent row
+//   Home / End   first / last visible row
+//   Enter        file: preview it · folder: open it as the listing root
+//
+// Enter is the only key here that acts on a file, and none of them commits a
+// file operation: moving the focus is not choosing anything. The pane adds two
+// state-dependent keys of its own (Enter picks a destination while a move is
+// armed, Escape cancels), because those depend on what the pane is doing.
+
+/** One row as it is drawn: what the pane knows about it after rendering. */
+export interface TreeRow {
+  path: string;
+  dir: boolean;
+  /** Folders only: is it showing its children right now? */
+  open: boolean;
+}
+
+export type TreeIntent =
+  | { kind: 'focus'; path: string }
+  | { kind: 'expand'; path: string }
+  | { kind: 'collapse'; path: string }
+  | { kind: 'activate'; path: string; dir: boolean };
+
+const parentOf = (p: string) => (p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '');
+
+/**
+ * What a key means, given the rows on screen and which one has the focus.
+ *
+ * Returns null for a key this tree does not claim, so the caller can leave it
+ * alone — Tab has to keep working, and a key that does nothing here must not be
+ * swallowed on the way to something that would have used it.
+ */
+export function keyIntent(rows: TreeRow[], current: string | null, key: string): TreeIntent | null {
+  if (!rows.length) return null;
+  const i = rows.findIndex((r) => r.path === current);
+  const row = i >= 0 ? rows[i] : null;
+  const at = (n: number) => ({ kind: 'focus', path: rows[Math.max(0, Math.min(rows.length - 1, n))].path } as const);
+
+  switch (key) {
+    case 'ArrowDown': return i < 0 ? at(0) : at(i + 1);
+    case 'ArrowUp': return i < 0 ? at(rows.length - 1) : at(i - 1);
+    case 'Home': return at(0);
+    case 'End': return at(rows.length - 1);
+    case 'ArrowRight': {
+      if (!row?.dir) return null;
+      if (!row.open) return { kind: 'expand', path: row.path };
+      // An expanded folder's first child is the row after it — it cannot be
+      // anything else, since children are drawn immediately below their folder.
+      const child = rows[i + 1];
+      return child && child.path.startsWith(`${row.path}/`) ? { kind: 'focus', path: child.path } : null;
+    }
+    case 'ArrowLeft': {
+      if (!row) return null;
+      if (row.dir && row.open) return { kind: 'collapse', path: row.path };
+      const parent = parentOf(row.path);
+      const up = rows.find((r) => r.path === parent);
+      return up ? { kind: 'focus', path: up.path } : null;
+    }
+    case 'Enter': return row ? { kind: 'activate', path: row.path, dir: row.dir } : null;
+    default: return null;
+  }
+}
+
+/**
+ * Where the focus goes when the row that had it is no longer drawn — renamed,
+ * deleted, moved away, collapsed out of sight, or dropped by a refresh.
+ *
+ * In order: the next thing in the same folder, then the previous one, then the
+ * folder itself, then whatever else was nearby, then the top of the listing.
+ * Same folder first because that is what "it was here a second ago" means to the
+ * person looking; the folder next because when a whole folder's worth of rows
+ * goes at once — someone collapsed it — the folder is what is left of where you
+ * were. Everything is decided from PATHS, never an index into the new list: a
+ * re-sort renumbers every row and would silently hand the focus to a stranger.
+ */
+export function survivingFocus(before: string[], after: string[], gone: string): string | null {
+  if (after.includes(gone)) return gone;
+  const alive = new Set(after);
+  const i = before.indexOf(gone);
+  const home = parentOf(gone);
+  const scan = (test: (p: string) => boolean) => {
+    for (let n = i + 1; n < before.length; n++) if (alive.has(before[n]) && test(before[n])) return before[n];
+    for (let n = i - 1; n >= 0; n--) if (alive.has(before[n]) && test(before[n])) return before[n];
+    return null;
+  };
+  if (i >= 0) {
+    const sibling = scan((p) => parentOf(p) === home);
+    if (sibling) return sibling;
+  }
+  for (let p = home; p; p = parentOf(p)) if (alive.has(p)) return p;
+  if (i >= 0) {
+    const near = scan(() => true);
+    if (near) return near;
+  }
+  return after[0] ?? null;
+}
+
+/**
+ * Scroll the focused row into view inside the listing, and nowhere else.
+ *
+ * `scrollIntoView` walks up and scrolls every scrollable ancestor it finds,
+ * which in a tiled app means the pane can drag the page around under the other
+ * panes. This moves one box's scrollTop by the amount the row overhangs it.
+ */
+export function keepInView(row: HTMLElement, box: HTMLElement) {
+  const r = row.getBoundingClientRect();
+  const b = box.getBoundingClientRect();
+  if (r.top < b.top) box.scrollTop -= b.top - r.top;
+  else if (r.bottom > b.bottom) box.scrollTop += r.bottom - b.bottom;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1063,6 +1063,13 @@ body {
 .tw-act { flex: none; width: 1.6em; height: 1.3em; padding: 0; display: inline-flex; align-items: center; justify-content: center; background: none; border: none; color: var(--muted); cursor: pointer; opacity: 0; transition: opacity 0.1s ease-out; }
 .tw-act svg { width: 1em; height: 1em; }
 .tree-row:hover .tw-act { opacity: 1; }
+/* …and for the keyboard, which has no hover: a row with the focus, or one of its
+   buttons with the focus, shows its actions. Same rule the sidebar rows use.
+   Without it the buttons were tab stops at opacity 0 — focus you cannot see. */
+.tree-row:focus-within .tw-act { opacity: 1; }
+/* The row's own focus ring is the app-wide one ([tabindex]:focus-visible), drawn
+   inside the scroller so it is not clipped at the first and last row. */
+.tree-row:focus-visible { outline-offset: -1px; }
 .tw-act:hover { color: var(--accent); }
 .tw-act.danger:hover { color: var(--danger); }
 .tw-act.ghost { pointer-events: none; }

--- a/web/test/filesKeyboard.test.mjs
+++ b/web/test/filesKeyboard.test.mjs
@@ -51,13 +51,18 @@ fs.writeFileSync(stub, `
     count(op) { return this.calls.filter((c) => c.op === op).length; },
   };
   window.__api = api;
+  // Fresh objects every time, exactly as parsing a JSON response gives you. The
+  // fixture used to hand back its own live array, so a rename that edited an
+  // entry in place also edited the listing the pane was already showing — which
+  // hid a real bug: in production that stale listing still holds the OLD name.
+  const snapshot = (entries) => (entries || []).map((entry) => ({ ...entry }));
   export const listFiles = (id, p = '') => {
     api.calls.push({ op: 'list', id, p });
     if (p === 'broken') return Promise.reject(new Error('EACCES'));
     if (p === 'slow' && api.holdSlow) {
-      return new Promise((resolve) => api.slowWaiters.push(() => resolve({ root: 'workspace', entries: api.tree.slow })));
+      return new Promise((resolve) => api.slowWaiters.push(() => resolve({ root: 'workspace', entries: snapshot(api.tree.slow) })));
     }
-    return Promise.resolve({ root: 'workspace', entries: api.tree[p] || [] });
+    return Promise.resolve({ root: 'workspace', entries: snapshot(api.tree[p]) });
   };
   export const previewFile = (id, p) => {
     api.calls.push({ op: 'preview', id, p });
@@ -529,6 +534,12 @@ await mount('kb-move');
   await settle(250);
   await check('Enter on the folder performs exactly one move, to that folder', async () =>
     assert.deepEqual(await calls('move'), [{ op: 'move', id: 'kb-move', p: 'alpha.txt', to: 'docs' }]));
+  // `docs` is closed, so the moved file has no row to stand on. The folder it
+  // went into is the nearest thing that is on screen, and it is where the file
+  // now is — better than the top of the listing, and better than expanding a
+  // folder the operator did not ask to open.
+  await check('…and the focus lands on the folder it went into', async () =>
+    assert.equal(await active(), 'row:docs'));
   await check('…and the move bar is gone', async () =>
     assert.equal(await page.evaluate(() => !!document.querySelector('.files-new .tw-warn')), false));
 }
@@ -561,6 +572,8 @@ await mount('kb-move-root');
   await settle(250);
   await check('“Move here” puts it in the folder the breadcrumb names', async () =>
     assert.deepEqual(await calls('move'), [{ op: 'move', id: 'kb-move-root', p: 'docs/guide.md', to: '' }]));
+  await check('…and the focus is on the file that moved, not on whatever row took its place', async () =>
+    assert.equal(await active(), 'row:guide.md'));
 }
 await mount('kb-move-cancel');
 {
@@ -576,6 +589,21 @@ await mount('kb-move-cancel');
     assert.equal(await active(), 'row:alpha.txt');
   });
 }
+await mount('kb-move-bar-cancel');
+{
+  await enterTree();
+  await tabTo('Move alpha.txt — then pick a destination folder');
+  await press('Enter');
+  await tabTo('Cancel');
+  await press('Enter');
+  await settle(150);
+  await check('the move bar’s own Cancel button cancels the move', async () => {
+    assert.deepEqual(await calls('move'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-new .tw-warn')), false);
+  });
+  await check('…and gives the keyboard back to the row instead of dropping it', async () =>
+    assert.equal(await active(), 'row:alpha.txt'));
+}
 await mount('kb-delete');
 {
   await toRow('beta.md');
@@ -589,6 +617,18 @@ await mount('kb-delete');
   });
   await check('…and the confirmation opens on Cancel, not on Delete', async () =>
     assert.equal(await active(), 'Cancel'));
+  // Escape is promised to cancel an open confirmation, and the focus is on the
+  // confirmation bar at that moment — which is not inside the tree.
+  await press('Escape');
+  await settle(150);
+  await check('Escape from the confirmation closes it and deletes nothing', async () => {
+    assert.deepEqual(await calls('delete'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.tw-confirm')), false);
+  });
+  await check('…and hands the row back', async () => assert.equal(await active(), 'row:beta.md'));
+  await tabTo('Delete beta.md');
+  await press('Enter');
+  await settle(150);
   await press('Enter');
   await settle(200);
   await check('Cancel deletes nothing and returns to the row', async () => {

--- a/web/test/filesKeyboard.test.mjs
+++ b/web/test/filesKeyboard.test.mjs
@@ -1,0 +1,975 @@
+// The Files listing, driven by the keyboard only — the real FilesPane, real
+// stylesheet, real React, in Chromium. Nothing here clicks or hovers a row to
+// prepare it: every row it acts on was reached by Tab and the arrow keys, which
+// is the whole point. The file APIs are a fixture, so no test can touch a real
+// workspace, and every mutation is counted.
+//
+// What it is pinning, in one line each:
+//   · the listing is one widget with one tab stop, not N rows × 4 invisible ones
+//   · moving the focus is not an action — nothing opens, nothing is written
+//   · every existing row action (download, rename, Move, Delete) has a key path
+//   · the focus survives renames, deletes, sorts, previews and slow folders,
+//     and a late directory response never takes the keyboard off another pane
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const WEB = path.join(HERE, '..');
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'files-keyboard-'));
+const bundle = path.join(tmp, 'app.js');
+const stub = path.join(tmp, 'api-stub.ts');
+
+// The fixture workspace. Sorted by name (the default), the root reads:
+//   alpha.txt · beta.md · broken · docs · images · slow
+// `broken` fails to list, `slow` answers only when the test says so, `images`
+// is empty, and `docs` has a folder of its own — the four states a listing has
+// to keep navigable.
+fs.writeFileSync(stub, `
+  export class TraceUnavailable extends Error {}
+  const f = (name, extra = {}) => ({ name, dir: false, size: 10, mtime: 1, kind: 'text', ...extra });
+  const d = (name) => ({ name, dir: true, size: 0, mtime: 2 });
+  const FRESH = () => ({
+    '': [f('alpha.txt'), f('beta.md', { kind: 'markdown' }), d('broken'), d('docs'), d('images'), d('slow')],
+    'docs': [d('docs/deep'), f('guide.md', { kind: 'markdown' })].map((e) => ({ ...e, name: e.name.split('/').pop() })),
+    'docs/deep': [f('note.txt')],
+    'images': [],
+    'slow': [f('later.txt')],
+  });
+  const api = {
+    tree: FRESH(),
+    calls: [],
+    holdSlow: true,
+    slowWaiters: [],
+    reset() { this.tree = FRESH(); this.calls = []; this.holdSlow = true; this.slowWaiters = []; },
+    settleSlow() { const w = this.slowWaiters; this.slowWaiters = []; this.holdSlow = false; w.forEach((r) => r()); },
+    count(op) { return this.calls.filter((c) => c.op === op).length; },
+  };
+  window.__api = api;
+  export const listFiles = (id, p = '') => {
+    api.calls.push({ op: 'list', id, p });
+    if (p === 'broken') return Promise.reject(new Error('EACCES'));
+    if (p === 'slow' && api.holdSlow) {
+      return new Promise((resolve) => api.slowWaiters.push(() => resolve({ root: 'workspace', entries: api.tree.slow })));
+    }
+    return Promise.resolve({ root: 'workspace', entries: api.tree[p] || [] });
+  };
+  export const previewFile = (id, p) => {
+    api.calls.push({ op: 'preview', id, p });
+    return Promise.resolve({ kind: 'text', name: p.split('/').pop(), mime: 'text/plain', size: 4, mtime: 1, tag: 't1', text: 'body' });
+  };
+  export const rawUrl = (_id, p) => 'data:text/plain,' + encodeURIComponent(p);
+  export const downloadUrl = (_id, p) => 'blob:download/' + p;
+  export const uploadFile = (id, p, file) => { api.calls.push({ op: 'upload', id, p, name: file.name }); return Promise.resolve({}); };
+  export const createFolder = (id, parent, name) => { api.calls.push({ op: 'mkdir', id, parent, name }); return Promise.resolve({}); };
+  export const createFile = (id, parent, name) => { api.calls.push({ op: 'touch', id, parent, name }); return Promise.resolve({}); };
+  export const renameEntry = (id, p, name) => {
+    api.calls.push({ op: 'rename', id, p, name });
+    const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+    const next = dir ? dir + '/' + name : name;
+    const list = api.tree[dir] || [];
+    const hit = list.find((e) => e.name === p.split('/').pop());
+    if (hit) hit.name = name;
+    return Promise.resolve({ path: next });
+  };
+  export const moveEntry = (id, p, to) => {
+    api.calls.push({ op: 'move', id, p, to });
+    const from = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+    const name = p.split('/').pop();
+    api.tree[from] = (api.tree[from] || []).filter((e) => e.name !== name);
+    const moved = { name, dir: false, size: 10, mtime: 1, kind: 'text' };
+    api.tree[to] = [...(api.tree[to] || []), moved];
+    return Promise.resolve({ path: to ? to + '/' + name : name });
+  };
+  export const deleteEntry = (id, p) => {
+    api.calls.push({ op: 'delete', id, p });
+    const dir = p.includes('/') ? p.slice(0, p.lastIndexOf('/')) : '';
+    const name = p.split('/').pop();
+    api.tree[dir] = (api.tree[dir] || []).filter((e) => e.name !== name);
+    return Promise.resolve({});
+  };
+  export const writeFile = () => Promise.resolve({ size: 4, mtime: 2, tag: 't2' });
+  export const getFileTraceWindow = () => new Promise(() => {});
+  export const getFileTraceSummary = () => new Promise(() => {});
+`);
+
+await build({
+  stdin: { resolveDir: WEB, loader: 'tsx', contents: `
+    import React from 'react';
+    import { createRoot } from 'react-dom/client';
+    import FilesPane from './src/components/FilesPane.tsx';
+
+    const root = createRoot(document.getElementById('root'));
+    // Every case mounts a pane with its OWN session id: the pane remembers where
+    // it was (filesMemory) per session, and a shared id would carry one case's
+    // open file into the next.
+    window.__mount = (id) => {
+      window.__api.reset();
+      const session = { id, name: id, cli: 'files', path: '', createdAt: '', everStarted: false, running: false, state: 'idle' };
+      // The key prop matters here: without it React keeps the same FilesPane
+      // instance and the next case inherits the last one's folder and open file.
+      root.render(<div className="tile">
+        <button id="outside">another pane</button>
+        <FilesPane
+          key={id} session={session} focused
+          onFocus={() => { window.__paneFocused = (window.__paneFocused || 0) + 1; }}
+          onClose={() => { window.__closed = true; }}
+        />
+      </div>);
+    };
+    window.__closed = false;
+    // Downloads leave the page in a real browser; record the click instead.
+    window.__downloads = [];
+    const realClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function click() {
+      if (this.download) { window.__downloads.push({ href: this.href, name: this.download }); return; }
+      return realClick.call(this);
+    };
+  ` },
+  outfile: bundle, bundle: true, format: 'iife', platform: 'browser', logLevel: 'error',
+  plugins: [{ name: 'stub-api', setup(b) { b.onResolve({ filter: /(^|\/)\.\.?\/api$/ }, () => ({ path: stub })); } }],
+});
+
+const css = fs.readFileSync(path.join(WEB, 'src/styles.css'), 'utf8');
+const browser = await chromium.launch(chromiumLaunchOptions());
+const page = await browser.newPage({ viewport: { width: 900, height: 620 } });
+let failed = 0;
+page.on('pageerror', (e) => { console.log('  PAGE ERROR', String(e).slice(0, 200)); failed++; });
+// Async on purpose: nearly every assertion here has to ask the page something,
+// and a `check` that did not await would report ok and then blow up as an
+// unhandled rejection somewhere else entirely.
+const check = async (what, fn) => {
+  try { await fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    const why = String(e.message).split('\n').filter(Boolean).slice(0, 6).join('\n       ');
+    console.log(`  FAIL ${what}\n       ${why}`);
+  }
+};
+
+// ── driving the page ────────────────────────────────────────────────────────
+const settle = (ms = 90) => page.waitForTimeout(ms);
+const press = async (key, times = 1) => { for (let i = 0; i < times; i++) await page.keyboard.press(key); await settle(); };
+/** What has the focus, described the way a person would: row path, or button name. */
+const active = () => page.evaluate(() => {
+  const a = document.activeElement;
+  if (!a || a === document.body) return 'body';
+  const row = a.getAttribute?.('data-path');
+  if (row !== null && row !== undefined) return `row:${row}`;
+  return `${a.getAttribute?.('aria-label') || a.textContent?.trim().slice(0, 24) || a.getAttribute?.('title') || a.tagName}`;
+});
+/** Tab until something matches, so no test ever hand-focuses a row. */
+const tabTo = async (want, { shift = false, max = 24 } = {}) => {
+  for (let i = 0; i < max; i++) {
+    await page.keyboard.press(shift ? 'Shift+Tab' : 'Tab');
+    await settle(40);
+    const now = await active();
+    if (now === want || (want instanceof RegExp && want.test(now))) return now;
+  }
+  throw new Error(`Tab never reached ${want} (stopped at ${await active()})`);
+};
+const rows = () => page.evaluate(() => Array.from(document.querySelectorAll('[role="treeitem"]')).map((el) => ({
+  path: el.dataset.path, level: Number(el.getAttribute('aria-level')), open: el.getAttribute('aria-expanded'),
+  tab: el.tabIndex, pos: el.getAttribute('aria-posinset'), size: el.getAttribute('aria-setsize'),
+})));
+const calls = (op) => page.evaluate((o) => window.__api.calls.filter((c) => c.op === o), op);
+const mount = async (id) => {
+  await page.evaluate((sid) => window.__mount(sid), id);
+  await page.waitForFunction(() => document.querySelectorAll('.tree-row').length > 0);
+  await settle(120);
+  await page.evaluate(() => document.getElementById('outside').focus());
+};
+/** Into the listing the way a person gets there: Tab until a row has the focus. */
+const enterTree = async () => tabTo(/^row:/);
+/** …and to a particular row with the arrow keys, never by focusing it directly. */
+const toRow = async (want) => {
+  if (!/^row:/.test(await active())) await enterTree();
+  await press('Home');
+  for (let i = 0; i < 30; i++) {
+    if (await active() === `row:${want}`) return;
+    await press('ArrowDown');
+  }
+  throw new Error(`the arrows never reached ${want} (stopped at ${await active()})`);
+};
+
+await page.setContent(`<style>${css}
+  html, body, #root { margin: 0; height: 100%; }
+  .tile { height: 600px; display: flex; flex-direction: column; }
+  .slot { flex: 1; display: flex; flex-direction: column; min-height: 0; }
+  #outside { flex: none; }
+</style><div id="root"></div>`);
+await page.addScriptTag({ path: bundle });
+await page.waitForFunction(() => !!window.__mount);
+
+// ── 1 · basic navigation ────────────────────────────────────────────────────
+console.log('the listing is one widget with one way in');
+await mount('kb-nav');
+{
+  const shape = await rows();
+  await check('every row is a treeitem, with its place in the hierarchy on it', () => {
+    assert.deepEqual(shape.map((r) => r.path), ['alpha.txt', 'beta.md', 'broken', 'docs', 'images', 'slow']);
+    assert.deepEqual(shape.map((r) => r.level), [1, 1, 1, 1, 1, 1]);
+    assert.deepEqual(shape.map((r) => r.pos), ['1', '2', '3', '4', '5', '6']);
+    assert.equal(shape[0].size, '6');
+    assert.deepEqual(shape.map((r) => r.open), [null, null, 'false', 'false', 'false', 'false']);
+  });
+  const role = await page.evaluate(() => {
+    const t = document.querySelector('[role="tree"]');
+    return { role: t?.getAttribute('role'), label: t?.getAttribute('aria-label'), tab: t?.tabIndex };
+  });
+  await check('…a labelled tree, and not itself a tab stop while it has rows', () => {
+    assert.equal(role.role, 'tree');
+    assert.match(role.label, /^Files in workspace/);
+    assert.equal(role.tab, -1);
+  });
+  await check('exactly one row is in the tab order', () => assert.equal(shape.filter((r) => r.tab === 0).length, 1));
+
+  await page.evaluate(() => { window.__paneFocused = 0; });
+  const landed = await enterTree();
+  await check('Tab from outside lands on a row', () => assert.equal(landed, 'row:alpha.txt'));
+  await check('…and the app now treats this pane as the focused one', async () =>
+    assert.ok(await page.evaluate(() => window.__paneFocused > 0), 'the pane never reported focus'));
+  await press('ArrowDown');
+  await check('down moves one row', async () => assert.equal(await active(), 'row:beta.md'));
+  await press('End');
+  await check('End reaches the last row', async () => assert.equal(await active(), 'row:slow'));
+  await press('Home');
+  await check('Home reaches the first', async () => assert.equal(await active(), 'row:alpha.txt'));
+
+  // expansion: right opens, right again steps in, left collapses
+  await press('ArrowDown', 3);            // alpha → beta → broken → docs
+  await check('down four times is the first folder', async () => assert.equal(await active(), 'row:docs'));
+  await press('ArrowRight');
+  await page.waitForFunction(() => document.querySelectorAll('.tree-row').length > 6);
+  const opened = await rows();
+  await check('right expands a folder in place and stays on it', async () => {
+    assert.equal(await active(), 'row:docs');
+    assert.equal(opened.find((r) => r.path === 'docs').open, 'true');
+    assert.deepEqual(opened.filter((r) => r.level === 2).map((r) => r.path), ['docs/deep', 'docs/guide.md']);
+  });
+  await press('ArrowRight');
+  await check('right again steps into the first child', async () => assert.equal(await active(), 'row:docs/deep'));
+  await press('ArrowLeft');
+  await check('left from a child goes back to the folder', async () => assert.equal(await active(), 'row:docs'));
+  await press('ArrowLeft');
+  await check('left again collapses it, and its children stop being destinations', async () => {
+    assert.equal(await active(), 'row:docs');
+    const now = await rows();
+    assert.equal(now.find((r) => r.path === 'docs').open, 'false');
+    assert.deepEqual(now.filter((r) => r.path.startsWith('docs/')), []);
+  });
+  await press('ArrowDown');
+  await check('…and down from the collapsed folder is the next sibling, not a hidden child', async () =>
+    assert.equal(await active(), 'row:images'));
+
+  // Enter opens — once
+  await press('Home');
+  await press('Enter');
+  await page.waitForFunction(() => !!document.querySelector('.files-view'));
+  const previews = await calls('preview');
+  await check('Enter on a file opens the preview, exactly once', () => {
+    assert.equal(previews.length, 1);
+    assert.equal(previews[0].p, 'alpha.txt');
+  });
+  await press('Escape');
+  await page.waitForFunction(() => !document.querySelector('.files-view'));
+  await press('ArrowDown', 3);
+  await check('Escape from the preview put the focus back, so the arrows resume from it',
+    async () => assert.equal(await active(), 'row:docs'));
+  await press('Enter');
+  await settle(150);
+  await check('Enter on a folder opens it as the listing root', async () => {
+    const where = await page.evaluate(() => document.querySelector('.fi-where').textContent);
+    assert.equal(where, 'workspace/docs');
+    assert.deepEqual((await rows()).map((r) => r.path), ['docs/deep', 'docs/guide.md']);
+  });
+  await check('…and the focus enters the new listing rather than falling on the floor', async () =>
+    assert.equal(await active(), 'row:docs/deep'));
+}
+
+// ── 1b · what a screen reader is handed ─────────────────────────────────────
+console.log('\nand the accessibility tree says the same thing the DOM does');
+await mount('kb-a11y');
+{
+  await enterTree();
+  await press('ArrowDown', 3);
+  await press('ArrowRight');                 // docs, expanded
+  await settle(200);
+  // Read the browser's own accessibility tree, not our attributes back: this is
+  // what a screen reader is actually handed. (Chromium's CDP — Playwright's
+  // page.accessibility was removed in 1.60.)
+  const cdp = await page.context().newCDPSession(page);
+  await cdp.send('Accessibility.enable');
+  const { nodes } = await cdp.send('Accessibility.getFullAXTree');
+  const prop = (n, want) => n.properties?.find((x) => x.name === want)?.value?.value;
+  const flat = nodes
+    .filter((n) => !n.ignored)
+    .map((n) => ({ role: n.role?.value, name: (n.name?.value || '').trim(), expanded: prop(n, 'expanded'), level: prop(n, 'level') }));
+  const items = flat.filter((n) => n.role === 'treeitem');
+  await check('the widget is announced as a tree, by name', () => {
+    const trees = flat.filter((n) => n.role === 'tree');
+    assert.equal(trees.length, 1);
+    assert.match(trees[0].name, /^Files in workspace/);
+  });
+  await check('its rows are treeitems, named after the file, at the right level', () => {
+    assert.equal(items.length, 8);
+    assert.match(items[0].name, /alpha\.txt/);
+    assert.equal(items[0].level, 1);
+    const child = items.find((i) => /guide\.md/.test(i.name));
+    assert.equal(child.level, 2, `guide.md announced at level ${child.level}`);
+  });
+  await check('a folder announces whether it is open, and a file has no such state', () => {
+    const docs = items.find((i) => /^docs/.test(i.name));
+    const images = items.find((i) => /^images/.test(i.name));
+    assert.equal(docs.expanded, true);
+    assert.equal(images.expanded, false);
+    assert.equal(items[0].expanded, undefined);
+  });
+  await check('and the row’s actions are named buttons inside it', () => {
+    const names = flat.filter((n) => n.role === 'button').map((n) => n.name);
+    for (const want of ['Download alpha.txt', 'Rename alpha.txt', 'Delete alpha.txt'])
+      assert.ok(names.includes(want), `${want} not in the accessibility tree`);
+  });
+}
+
+// ── 2 · focus is not an action ──────────────────────────────────────────────
+console.log('\nmoving the focus does not do anything to anything');
+await mount('kb-focus');
+{
+  await enterTree();
+  await press('ArrowDown', 5);
+  await press('ArrowUp', 2);
+  const after = await page.evaluate(() => ({
+    calls: window.__api.calls.filter((c) => c.op !== 'list'),
+    preview: !!document.querySelector('.files-view'),
+    target: document.querySelector('.tree-row.target')?.textContent || null,
+    moving: !!document.querySelector('.files-new .tw-warn'),
+  }));
+  await check('nothing was previewed, written, moved or deleted', () => {
+    assert.deepEqual(after.calls, []);
+    assert.equal(after.preview, false);
+    assert.equal(after.moving, false);
+  });
+  await check('and the folder new files land in did not move under the focus', () =>
+    assert.equal(after.target, null));
+
+  await settle(250);   // the reveal is a CSS fade; read it once it has finished
+  await check('the focused row shows its actions, named, without any hover', async () => {
+    const acts = await page.evaluate(() => {
+      const row = document.querySelector('[role="treeitem"][tabindex="0"]');
+      return Array.from(row.querySelectorAll('button.tw-act')).map((b) => ({
+        name: b.getAttribute('aria-label'), opacity: getComputedStyle(b).opacity, tab: b.tabIndex,
+      }));
+    });
+    assert.deepEqual(acts.map((a) => a.name), [
+      'Rename folder docs',
+      'Move folder docs — then pick a destination folder',
+      'Delete folder docs and everything in it',
+    ]);
+    assert.ok(acts.every((a) => a.opacity === '1'), `hidden while focused: ${JSON.stringify(acts)}`);
+    assert.ok(acts.every((a) => a.tab === 0));
+  });
+  await check('…and an unfocused row keeps its buttons out of the tab order', async () => {
+    const others = await page.evaluate(() => Array.from(document.querySelectorAll('[role="treeitem"]:not([tabindex="0"]) .tw-act'))
+      .map((b) => b.tabIndex));
+    assert.ok(others.length >= 12, `only ${others.length} buttons on the other rows`);
+    assert.ok(others.every((t) => t === -1));
+  });
+
+  const seen = [];
+  for (let i = 0; i < 4; i++) { await page.keyboard.press('Tab'); await settle(40); seen.push(await active()); }
+  await check('Tab leaves through this row’s actions and then out of the pane', () => {
+    assert.deepEqual(seen.slice(0, 3), [
+      'Rename folder docs',
+      'Move folder docs — then pick a destination folder',
+      'Delete folder docs and everything in it',
+    ]);
+    assert.equal(seen[3], 'body');
+  });
+  await tabTo('row:docs', { shift: true, max: 8 });
+  await page.keyboard.press('Shift+Tab'); await settle(40);
+  await check('Shift+Tab comes back through them and out the top, without trapping', async () =>
+    assert.match(await active(), /Modified|Size|Name|Sort by/i));
+}
+
+// ── 3 · lazy, empty and unreadable folders ──────────────────────────────────
+console.log('\nfolders that are slow, empty or unreadable stay navigable');
+await mount('kb-lazy');
+{
+  await enterTree();
+  await press('ArrowDown', 4);                    // alpha, beta, broken, docs → images
+  await check('at the empty folder', async () => assert.equal(await active(), 'row:images'));
+  await press('ArrowRight');
+  await check('an empty folder says so and adds no destinations', async () => {
+    const msg = await page.evaluate(() => Array.from(document.querySelectorAll('.tree-msg')).map((m) => m.textContent));
+    assert.ok(msg.includes('empty'), msg.join('|'));
+    assert.deepEqual((await rows()).map((r) => r.path), ['alpha.txt', 'beta.md', 'broken', 'docs', 'images', 'slow']);
+  });
+  await press('ArrowDown');
+  await check('…so down goes to the next row, not into the message', async () => assert.equal(await active(), 'row:slow'));
+
+  await press('ArrowRight');                      // slow: the listing has not answered yet
+  await check('a slow folder shows that it is loading and stays the focused row', async () => {
+    const msg = await page.evaluate(() => Array.from(document.querySelectorAll('.tree-msg[role="status"]')).map((m) => m.textContent));
+    assert.ok(msg.includes('…'), msg.join('|'));
+    assert.equal(await active(), 'row:slow');
+  });
+  await press('ArrowLeft');                       // collapse before the answer arrives
+  await page.evaluate(() => document.getElementById('outside').focus());
+  await page.evaluate(() => window.__api.settleSlow());
+  await settle(200);
+  await check('collapsing before the answer is fine, and the answer does not take the keyboard', async () => {
+    assert.equal(await active(), 'another pane');
+    assert.deepEqual((await rows()).filter((r) => r.path.startsWith('slow/')), []);
+  });
+}
+await mount('kb-broken');
+{
+  await enterTree();
+  await press('ArrowDown', 2);
+  await press('ArrowRight');
+  await settle(150);
+  await check('an unreadable folder says so and keeps the focus on itself', async () => {
+    const msg = await page.evaluate(() => Array.from(document.querySelectorAll('.tree-msg')).map((m) => m.textContent));
+    assert.ok(msg.some((m) => /can't read folder/.test(m)), msg.join('|'));
+    assert.equal(await active(), 'row:broken');
+  });
+  await press('ArrowDown');
+  await check('…and the row after it is the next entry', async () => assert.equal(await active(), 'row:docs'));
+}
+
+// ── 4 · sorting under the focus ─────────────────────────────────────────────
+console.log('\nthe focus is a path, so re-sorting cannot hand it to another file');
+await mount('kb-sort');
+{
+  await enterTree();
+  await press('ArrowDown');                       // beta.md
+  await page.evaluate(() => document.querySelector('.fc-btn.tw-name').click());
+  await settle(200);
+  await check('the same file still owns the tab stop after the order flips', async () => {
+    const now = await rows();
+    assert.deepEqual(now.map((r) => r.path), ['slow', 'images', 'docs', 'broken', 'beta.md', 'alpha.txt']);
+    assert.equal(now.find((r) => r.tab === 0)?.path, 'beta.md');
+  });
+  await tabTo('row:beta.md');
+  await press('ArrowDown');
+  await check('…and the arrows follow the order on screen', async () => assert.equal(await active(), 'row:alpha.txt'));
+}
+
+// ── 5 · the existing row actions, from the keyboard ─────────────────────────
+console.log('\nevery action a mouse can reach, a keyboard can reach');
+await mount('kb-download');
+{
+  await enterTree();
+  await tabTo('Download alpha.txt');
+  await press('Enter');
+  await check('Download saves the focused file, once', async () => {
+    const got = await page.evaluate(() => window.__downloads.splice(0));
+    assert.deepEqual(got, [{ href: 'blob:download/alpha.txt', name: 'alpha.txt' }]);
+  });
+}
+await mount('kb-rename');
+{
+  await enterTree();
+  await tabTo('Rename alpha.txt');
+  await press('Enter');
+  await check('Rename opens the field on the row itself, with the stem selected', async () => {
+    const state = await page.evaluate(() => {
+      const i = document.querySelector('.tw-rename');
+      return i ? { focused: document.activeElement === i, value: i.value, sel: [i.selectionStart, i.selectionEnd] } : null;
+    });
+    assert.deepEqual(state, { focused: true, value: 'alpha.txt', sel: [0, 5] });
+  });
+  await page.keyboard.type('renamed');
+  await press('ArrowLeft');            // a cursor key inside the field is the field's
+  await check('typing and cursor keys stay in the field', async () => {
+    assert.ok(await page.evaluate(() => document.activeElement.classList.contains('tw-rename')));
+    assert.deepEqual((await rows()).map((r) => r.path)[0], 'alpha.txt');   // nothing moved
+  });
+  await press('Enter');
+  await settle(200);
+  await check('Enter commits it once — the typing replaced the stem, not the suffix', async () => {
+    assert.deepEqual(await calls('rename'), [{ op: 'rename', id: 'kb-rename', p: 'alpha.txt', name: 'renamed.txt' }]);
+  });
+  await check('…and the focus follows the file to its new name', async () =>
+    assert.equal(await active(), 'row:renamed.txt'));
+
+  await toRow('beta.md');
+  await tabTo('Rename beta.md');
+  await press('Enter');
+  await page.keyboard.type('zzz');
+  await press('Escape');
+  await settle(150);
+  await check('Escape abandons a rename, writes nothing, and hands the row back', async () => {
+    assert.equal((await calls('rename')).length, 1);
+    assert.equal(await active(), 'row:beta.md');
+  });
+}
+await mount('kb-move');
+{
+  await enterTree();
+  await tabTo('Move alpha.txt — then pick a destination folder');
+  await press('Enter');
+  await check('Move arms the existing move flow and gives the row back to the arrows', async () => {
+    const bar = await page.evaluate(() => document.querySelector('.files-new .tw-warn')?.textContent || '');
+    assert.match(bar, /Moving\s+alpha\.txt/);
+    assert.equal(await active(), 'row:alpha.txt');
+    assert.equal((await calls('move')).length, 0);       // arming is not moving
+  });
+  await press('ArrowDown', 3);                            // → docs
+  await check('arrowing over a destination does not commit anything', async () => {
+    assert.equal(await active(), 'row:docs');
+    assert.equal((await calls('move')).length, 0);
+  });
+  await press('Enter');
+  await settle(250);
+  await check('Enter on the folder performs exactly one move, to that folder', async () =>
+    assert.deepEqual(await calls('move'), [{ op: 'move', id: 'kb-move', p: 'alpha.txt', to: 'docs' }]));
+  await check('…and the move bar is gone', async () =>
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-new .tw-warn')), false));
+}
+await mount('kb-move-invalid');
+{
+  await enterTree();
+  await press('ArrowDown', 3);                            // docs
+  await tabTo('Move folder docs — then pick a destination folder');
+  await press('Enter');
+  await press('Enter');                                   // docs into itself: not a destination
+  await settle(200);
+  await check('a destination that would eat itself moves nothing and cancels', async () => {
+    assert.deepEqual(await calls('move'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-new .tw-warn')), false);
+    assert.equal(await active(), 'row:docs');
+  });
+}
+await mount('kb-move-root');
+{
+  await enterTree();
+  await press('ArrowDown', 3);
+  await press('ArrowRight');                              // open docs
+  await settle(150);
+  await press('ArrowRight');                              // docs/deep
+  await press('ArrowDown');                               // docs/guide.md
+  await tabTo('Move guide.md — then pick a destination folder');
+  await press('Enter');
+  await tabTo(/^Move here/);
+  await press('Enter');
+  await settle(250);
+  await check('“Move here” puts it in the folder the breadcrumb names', async () =>
+    assert.deepEqual(await calls('move'), [{ op: 'move', id: 'kb-move-root', p: 'docs/guide.md', to: '' }]));
+}
+await mount('kb-move-cancel');
+{
+  await enterTree();
+  await tabTo('Move alpha.txt — then pick a destination folder');
+  await press('Enter');
+  await press('Escape');
+  await settle(150);
+  await check('Escape cancels an armed move and nothing else', async () => {
+    assert.deepEqual(await calls('move'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-new .tw-warn')), false);
+    assert.equal(await page.evaluate(() => window.__closed), false);
+    assert.equal(await active(), 'row:alpha.txt');
+  });
+}
+await mount('kb-delete');
+{
+  await toRow('beta.md');
+  await tabTo('Delete beta.md');
+  await page.keyboard.press('Space');                     // the trap: Space fires on the way UP
+  await settle(200);
+  await check('the key that opens the confirmation does not also answer it', async () => {
+    assert.deepEqual(await calls('delete'), []);
+    const warn = await page.evaluate(() => document.querySelector('.tw-warn')?.textContent || '');
+    assert.match(warn, /Delete "beta\.md"\?/);
+  });
+  await check('…and the confirmation opens on Cancel, not on Delete', async () =>
+    assert.equal(await active(), 'Cancel'));
+  await press('Enter');
+  await settle(200);
+  await check('Cancel deletes nothing and returns to the row', async () => {
+    assert.deepEqual(await calls('delete'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.tw-confirm')), false);
+    assert.equal(await active(), 'row:beta.md');
+  });
+  await toRow('beta.md');
+  await tabTo('Delete beta.md');
+  await press('Enter');
+  await tabTo('Delete', { shift: true, max: 4 });
+  await press('Enter');
+  await settle(300);
+  await check('confirming deletes that one path, exactly once', async () =>
+    assert.deepEqual(await calls('delete'), [{ op: 'delete', id: 'kb-delete', p: 'beta.md' }]));
+  await check('…and the focus lands on a row that survived', async () => {
+    assert.equal(await active(), 'row:broken');
+    assert.deepEqual((await rows()).map((r) => r.path), ['alpha.txt', 'broken', 'docs', 'images', 'slow']);
+  });
+  await press('Escape');
+  await check('a stray Escape afterwards closes nothing', async () =>
+    assert.equal(await page.evaluate(() => window.__closed), false));
+}
+
+// ── 6 · preview and back ────────────────────────────────────────────────────
+console.log('\nopening a file and coming back lands where you left');
+await mount('kb-preview');
+{
+  await enterTree();
+  await press('ArrowDown', 3);
+  await press('ArrowRight');                        // expand docs, so there is expansion to lose
+  await settle(150);
+  await press('ArrowDown', 2);                      // docs/guide.md
+  await check('at the nested file', async () => assert.equal(await active(), 'row:docs/guide.md'));
+  await press('Enter');
+  await page.waitForFunction(() => !!document.querySelector('.files-view'));
+  await check('it opens, and the listing is only hidden', async () => {
+    const state = await page.evaluate(() => ({
+      viewing: !!document.querySelector('.files-view'),
+      stackHidden: document.querySelector('.files-stack').hasAttribute('hidden'),
+      rowsStillMounted: document.querySelectorAll('[role="treeitem"]').length,
+    }));
+    assert.equal(state.viewing, true);
+    assert.equal(state.stackHidden, true);
+    assert.ok(state.rowsStillMounted >= 7, `rows unmounted: ${state.rowsStillMounted}`);
+  });
+  await press('Escape');
+  await page.waitForFunction(() => !document.querySelector('.files-view'));
+  await settle(150);
+  await check('Escape comes back to the row it was opened from', async () =>
+    assert.equal(await active(), 'row:docs/guide.md'));
+  await check('…with the folder still expanded', async () =>
+    assert.equal((await rows()).find((r) => r.path === 'docs')?.open, 'true'));
+}
+
+// ── 6b · scrolling: the listing moves, the app does not ─────────────────────
+console.log('\nthe focused row is kept in view by scrolling the listing alone');
+await mount('kb-scroll');
+{
+  // A pane shorter than its listing — the tile owns its height, so shrink that
+  // rather than the window, which is also what a tiled layout does.
+  await page.evaluate(() => { document.querySelector('.tile').style.height = '150px'; });
+  await settle(150);
+  await enterTree();
+  await press('ArrowDown', 3);
+  await press('ArrowRight');                                  // docs, expanded
+  await settle(150);
+  const scrolled = await page.evaluate(() => ({
+    body: document.querySelector('.files-body').scrollTop,
+    win: window.scrollY,
+    docTop: document.documentElement.scrollTop,
+  }));
+  await press('End');
+  const atEnd = await page.evaluate(() => ({
+    body: document.querySelector('.files-body').scrollTop,
+    win: window.scrollY,
+    docTop: document.documentElement.scrollTop,
+    visible: (() => {
+      const row = document.activeElement.getBoundingClientRect();
+      const box = document.querySelector('.files-body').getBoundingClientRect();
+      return row.top >= box.top - 1 && row.bottom <= box.bottom + 1;
+    })(),
+  }));
+  await check('End scrolls the listing to show the last row', () => {
+    assert.ok(atEnd.body > scrolled.body, `listing did not scroll (${scrolled.body} → ${atEnd.body})`);
+    assert.equal(atEnd.visible, true);
+  });
+  await check('…and nothing else on the page moved', () => {
+    assert.equal(atEnd.win, scrolled.win);
+    assert.equal(atEnd.docTop, scrolled.docTop);
+  });
+  await press('ArrowUp', 2);            // back up to a file, without leaving the bottom
+  const before = await page.evaluate(() => document.querySelector('.files-body').scrollTop);
+  await check('the row the preview is opened from is a file down here', async () =>
+    assert.equal(await active(), 'row:docs/guide.md'));
+  await press('Enter');
+  await page.waitForFunction(() => !!document.querySelector('.files-view'));
+  await press('Escape');
+  await page.waitForFunction(() => !document.querySelector('.files-view'));
+  await settle(150);
+  await check('and a preview gives the listing back at the same scroll position', async () => {
+    const now = await page.evaluate(() => document.querySelector('.files-body').scrollTop);
+    assert.equal(now, before);
+  });
+  await page.evaluate(() => { document.querySelector('.tile').style.height = ''; });
+}
+
+// ── 7 · identity changes and late answers ───────────────────────────────────
+console.log('\nthe listing changing underneath does not lose or steal the keyboard');
+await mount('kb-identity');
+{
+  await enterTree();
+  await press('ArrowDown');                          // beta.md
+  await page.evaluate(() => { window.__api.tree[''] = window.__api.tree[''].filter((e) => e.name !== 'beta.md'); });
+  await tabTo('Refresh the listing');
+  await press('Enter');
+  await settle(300);
+  await check('a refresh that drops the focused row moves the tab stop to a neighbour', async () => {
+    const now = await rows();
+    assert.deepEqual(now.map((r) => r.path), ['alpha.txt', 'broken', 'docs', 'images', 'slow']);
+    assert.equal(now.find((r) => r.tab === 0)?.path, 'broken');
+  });
+  await check('…and the keyboard stays on the button that was pressed, not yanked into the list', async () =>
+    assert.equal(await active(), 'Refresh the listing'));
+  await tabTo(/^row:/, { max: 10 });
+  await check('…so tabbing on into the listing lands on the repaired row', async () =>
+    assert.equal(await active(), 'row:broken'));
+}
+await mount('kb-late');
+{
+  await enterTree();
+  await press('ArrowDown', 5);
+  await press('ArrowRight');                         // slow, still loading
+  await page.evaluate(() => document.getElementById('outside').focus());
+  await page.evaluate(() => window.__api.settleSlow());
+  await settle(250);
+  await check('a directory that answers while another pane has the focus keeps its hands off', async () => {
+    assert.equal(await active(), 'another pane');
+    assert.ok((await rows()).some((r) => r.path === 'slow/later.txt'), 'the folder did open');
+  });
+  await tabTo(/^row:/);
+  await check('…and the listing is still enterable, at the row it left off on', async () =>
+    assert.equal(await active(), 'row:slow'));
+}
+await mount('kb-session-a');
+{
+  await enterTree();
+  await press('ArrowDown', 2);
+  await page.evaluate(() => document.getElementById('outside').focus());
+  await mount('kb-session-b');
+  await check('switching sessions does not pull the focus into the new listing', async () =>
+    assert.equal(await active(), 'another pane'));
+  await check('…and the new listing is at its own root', async () =>
+    assert.deepEqual((await rows()).map((r) => r.path).slice(0, 2), ['alpha.txt', 'beta.md']));
+}
+
+// ── 7b · inputs, nested controls and the pane's own shortcuts ───────────────
+console.log('\nwhat is typed into a field stays in the field');
+await mount('kb-inputs');
+{
+  await enterTree();
+  await tabTo('Rename alpha.txt');
+  await press('Enter');
+  await page.keyboard.type('draft');
+  // An IME's Enter accepts a candidate. It must not commit the rename, and it
+  // must not reach the row underneath either.
+  await page.evaluate(() => document.querySelector('.tw-rename')
+    .dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', isComposing: true, bubbles: true })));
+  await settle(120);
+  await check('Enter while an IME is composing commits nothing', async () => {
+    assert.deepEqual(await calls('rename'), []);
+    assert.ok(await page.evaluate(() => !!document.querySelector('.tw-rename')), 'the field closed');
+  });
+  await press('Enter');
+  await settle(200);
+  await check('…and the next Enter, outside composition, commits once', async () =>
+    assert.deepEqual(await calls('rename'), [{ op: 'rename', id: 'kb-inputs', p: 'alpha.txt', name: 'draft.txt' }]));
+
+  // The create field: its own Enter and Escape, and nothing else's.
+  await tabTo('New file in workspace');
+  await press('Enter');
+  await page.keyboard.type('made.txt');
+  await press('ArrowDown');
+  await check('arrows in the create field do not walk the listing', async () =>
+    assert.ok(await page.evaluate(() => document.activeElement.classList.contains('files-new-input'))));
+  await press('Escape');
+  await settle(120);
+  await check('Escape closes the create field only — nothing is created, nothing is deleted', async () => {
+    assert.deepEqual(await calls('touch'), []);
+    assert.deepEqual(await calls('delete'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-new-input')), false);
+    assert.equal(await page.evaluate(() => window.__closed), false);
+  });
+
+  // A focused action button owns its keys: the row must not act on them too.
+  await toRow('beta.md');
+  await tabTo('Download beta.md');
+  await press('ArrowDown');
+  await check('an arrow key on a focused action does not move the row focus', async () =>
+    assert.equal(await active(), 'Download beta.md'));
+  await press('Enter');
+  await settle(150);
+  await check('…and Enter on it downloads without ALSO opening the preview', async () => {
+    assert.deepEqual(await page.evaluate(() => window.__downloads.splice(0)),
+      [{ href: 'blob:download/beta.md', name: 'beta.md' }]);
+    assert.deepEqual(await calls('preview'), []);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-view')), false);
+  });
+
+  await toRow('beta.md');
+  await page.keyboard.press('Control+s');
+  await settle(120);
+  await check('the save shortcut in the listing writes nothing and breaks nothing', async () => {
+    assert.deepEqual(await calls('write'), []);
+    assert.equal(await active(), 'row:beta.md');
+  });
+}
+
+// ── 7c · leaving a preview with an unsaved edit ─────────────────────────────
+console.log('\nthe unsaved-changes guard still guards, and still gives the row back');
+await mount('kb-unsaved');
+{
+  await enterTree();
+  await press('Enter');                                    // alpha.txt
+  await page.waitForFunction(() => !!document.querySelector('.fv-cm .cm-content'));
+  await page.click('.fv-cm .cm-content');
+  await page.keyboard.type('edited');
+  await page.waitForFunction(() => !!document.querySelector('.fv-dirty'));
+  await press('Escape');
+  await check('Escape with an unsaved buffer asks instead of leaving', async () => {
+    assert.equal(await page.evaluate(() => !!document.querySelector('[role="dialog"]')), true);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-view')), true);
+  });
+  await press('Escape');
+  await check('…and Escape again goes back to editing rather than discarding', async () => {
+    assert.equal(await page.evaluate(() => !!document.querySelector('[role="dialog"]')), false);
+    assert.equal(await page.evaluate(() => !!document.querySelector('.files-view')), true);
+    assert.deepEqual(await calls('write'), []);
+  });
+  await press('Escape');
+  await page.waitForFunction(() => !!document.querySelector('[role="dialog"]'));
+  await page.click('.fv-modal-acts .mini-btn.danger');     // Discard
+  await page.waitForFunction(() => !document.querySelector('.files-view'));
+  await settle(150);
+  await check('discarding closes the file, writes nothing and returns to its row', async () => {
+    assert.deepEqual(await calls('write'), []);
+    assert.equal(await active(), 'row:alpha.txt');
+  });
+}
+
+// ── 7d · the listing's other controls ───────────────────────────────────────
+console.log('\nthe controls around the listing are reachable too');
+await mount('kb-controls');
+{
+  await page.evaluate(() => {
+    window.__picker = 0;
+    const real = HTMLInputElement.prototype.click;
+    HTMLInputElement.prototype.click = function click() { if (this.type === 'file') { window.__picker++; return; } return real.call(this); };
+  });
+  const stops = [];
+  for (let i = 0; i < 10; i++) { await page.keyboard.press('Tab'); await settle(35); stops.push(await active()); }
+  await check('breadcrumb, create, refresh, upload and the sort headings are all tab stops', () => {
+    for (const want of ['workspace', 'New folder in workspace', 'New file in workspace', 'Refresh the listing', 'Upload files'])
+      assert.ok(stops.includes(want), `${want} is not reachable: ${stops.join(' → ')}`);
+    assert.ok(stops.some((s) => /Name/.test(s)) && stops.some((s) => /Size/.test(s)), stops.join(' → '));
+  });
+  await tabTo('Upload files', { shift: true, max: 12 });
+  await press('Enter');
+  await check('and Enter on Upload opens the file picker', async () =>
+    assert.equal(await page.evaluate(() => window.__picker), 1));
+}
+
+// ── 8 · the pointer, the layout and the themes ──────────────────────────────
+console.log('\nnothing the mouse could do stopped working');
+await mount('kb-pointer');
+{
+  await page.click('.tree-row.file');                 // a file: preview
+  await page.waitForFunction(() => !!document.querySelector('.files-view'));
+  await check('clicking a file still previews it', async () =>
+    assert.equal((await calls('preview'))[0].p, 'alpha.txt'));
+  await page.click('.mini-btn[title="Back to files (Esc)"]');
+  await settle(150);
+  await page.click('[data-path="docs"]');
+  await settle(400);                                   // the click/double-click timer
+  await check('a single click on a folder still expands it in place', async () =>
+    assert.equal((await rows()).find((r) => r.path === 'docs')?.open, 'true'));
+  await page.dblclick('[data-path="docs"]');
+  await settle(300);
+  await check('a double click still opens it as the listing root', async () =>
+    assert.equal(await page.evaluate(() => document.querySelector('.fi-where').textContent), 'workspace/docs'));
+}
+await mount('kb-drag');
+{
+  await check('drag and drop still moves a file into a folder', async () => {
+    await page.evaluate(() => {
+      window.__dt = new DataTransfer();
+      document.querySelector('[data-path="alpha.txt"]')
+        .dispatchEvent(new DragEvent('dragstart', { dataTransfer: window.__dt, bubbles: true }));
+    });
+    await settle(80);
+    await page.evaluate(() => {
+      const to = document.querySelector('[data-path="docs"]');
+      to.dispatchEvent(new DragEvent('dragover', { dataTransfer: window.__dt, bubbles: true, cancelable: true }));
+      to.dispatchEvent(new DragEvent('drop', { dataTransfer: window.__dt, bubbles: true, cancelable: true }));
+    });
+    await settle(250);
+    assert.deepEqual(await calls('move'), [{ op: 'move', id: 'kb-drag', p: 'alpha.txt', to: 'docs' }]);
+  });
+}
+await mount('kb-layout');
+{
+  await enterTree();
+  await press('ArrowDown', 3);
+  for (const [w, label] of [[900, 'a wide pane'], [320, 'a narrow pane']]) {
+    await page.setViewportSize({ width: w, height: 620 });
+    await settle(120);
+    await check(`${label} shows the focused row's actions without overflowing`, async () => {
+      const m = await page.evaluate(() => {
+        const row = document.querySelector('[role="treeitem"][tabindex="0"]');
+        const body = document.querySelector('.files-body');
+        const act = row.querySelector('.tw-act:last-child');
+        return {
+          overflow: body.scrollWidth - body.clientWidth,
+          actOpacity: getComputedStyle(act).opacity,
+          actRight: Math.round(act.getBoundingClientRect().right),
+          bodyRight: Math.round(body.getBoundingClientRect().right),
+        };
+      });
+      assert.ok(m.overflow <= 1, `listing scrolls sideways by ${m.overflow}px`);
+      assert.equal(m.actOpacity, '1');
+      assert.ok(m.actRight <= m.bodyRight + 1, `actions spill past the pane by ${m.actRight - m.bodyRight}px`);
+    });
+  }
+  await page.setViewportSize({ width: 900, height: 620 });
+  for (const theme of ['light', 'dark']) {
+    await page.evaluate((t) => document.documentElement.setAttribute('data-theme', t), theme);
+    await settle(80);
+    await check(`the focus ring is drawn in the ${theme} theme`, async () => {
+      const ring = await page.evaluate(() => {
+        const row = document.querySelector('[role="treeitem"][tabindex="0"]');
+        row.focus();
+        const cs = getComputedStyle(row);
+        return { width: cs.outlineWidth, style: cs.outlineStyle, colour: cs.outlineColor };
+      });
+      assert.equal(ring.style, 'solid');
+      assert.ok(parseFloat(ring.width) >= 2, `ring is ${ring.width}`);
+      assert.notEqual(ring.colour, 'rgba(0, 0, 0, 0)');
+    });
+  }
+  await page.evaluate(() => document.documentElement.removeAttribute('data-theme'));
+  // Zoom: the pane's own font-size knob, which the rows are sized from.
+  await page.evaluate(() => { document.querySelector('.files-stack').style.fontSize = '20px'; });
+  await settle(80);
+  await check('and at a larger reading size the rows still fit their pane', async () => {
+    const m = await page.evaluate(() => {
+      const body = document.querySelector('.files-body');
+      return body.scrollWidth - body.clientWidth;
+    });
+    assert.ok(m <= 1, `listing scrolls sideways by ${m}px at 20px rows`);
+  });
+}
+
+if (process.env.FILES_KEYBOARD_SHOTS) {
+  const dir = process.env.FILES_KEYBOARD_SHOTS;
+  fs.mkdirSync(dir, { recursive: true });
+  await mount('kb-shot');
+  await enterTree();
+  await press('ArrowDown', 3);
+  await press('ArrowRight');
+  await settle(200);
+  await page.screenshot({ path: path.join(dir, 'focused-row.png') });
+  await tabTo('Rename folder docs');
+  await page.screenshot({ path: path.join(dir, 'focused-action.png') });
+  await press('Escape');
+  await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+  await settle(120);
+  await page.screenshot({ path: path.join(dir, 'focused-action-dark.png') });
+  await page.evaluate(() => document.documentElement.removeAttribute('data-theme'));
+  console.log(`  (screenshots in ${dir})`);
+}
+
+await browser.close();
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/treeNav.test.mjs
+++ b/web/test/treeNav.test.mjs
@@ -1,0 +1,119 @@
+// What a key means in the Files listing, and where the focus goes when the row
+// that had it is gone. Both are pure functions over the rows on screen, so they
+// are checked here in milliseconds; the browser suite (filesKeyboard) then
+// checks that the listing really produces those rows and really obeys them.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const outDir = path.join(HERE, '../node_modules/.test-build');
+fs.mkdirSync(outDir, { recursive: true });
+const out = path.join(outDir, 'treeNav.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/treeNav.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const { keyIntent, survivingFocus } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++; console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`);
+  }
+};
+
+// The listing of the fixture used throughout: two files, a folder expanded to
+// show a file and a folder of its own, and a folder that is still closed.
+//   alpha.txt
+//   docs            (open)
+//     docs/deep     (closed)
+//     docs/guide.md
+//   images          (closed)
+const ROWS = [
+  { path: 'alpha.txt', dir: false, open: false },
+  { path: 'docs', dir: true, open: true },
+  { path: 'docs/deep', dir: true, open: false },
+  { path: 'docs/guide.md', dir: false, open: false },
+  { path: 'images', dir: true, open: false },
+];
+const at = (current, key) => keyIntent(ROWS, current, key);
+
+console.log('up and down walk the rows that are on screen');
+{
+  check('down goes to the next one', () => assert.deepEqual(at('alpha.txt', 'ArrowDown'), { kind: 'focus', path: 'docs' }));
+  check('…including into an open folder', () => assert.deepEqual(at('docs', 'ArrowDown'), { kind: 'focus', path: 'docs/deep' }));
+  check('up goes back', () => assert.deepEqual(at('docs/deep', 'ArrowUp'), { kind: 'focus', path: 'docs' }));
+  check('the ends hold still', () => {
+    assert.deepEqual(at('alpha.txt', 'ArrowUp'), { kind: 'focus', path: 'alpha.txt' });
+    assert.deepEqual(at('images', 'ArrowDown'), { kind: 'focus', path: 'images' });
+  });
+  check('Home and End reach them', () => {
+    assert.deepEqual(at('docs', 'Home'), { kind: 'focus', path: 'alpha.txt' });
+    assert.deepEqual(at('docs', 'End'), { kind: 'focus', path: 'images' });
+  });
+  check('with nothing focused, down enters at the top and up at the bottom', () => {
+    assert.deepEqual(at(null, 'ArrowDown'), { kind: 'focus', path: 'alpha.txt' });
+    assert.deepEqual(at(null, 'ArrowUp'), { kind: 'focus', path: 'images' });
+  });
+  check('a focus that is no longer drawn does not wedge the keys', () =>
+    assert.deepEqual(at('deleted.txt', 'ArrowDown'), { kind: 'focus', path: 'alpha.txt' }));
+}
+
+console.log('\nright and left are the hierarchy');
+{
+  check('right opens a closed folder', () => assert.deepEqual(at('images', 'ArrowRight'), { kind: 'expand', path: 'images' }));
+  check('right on an open one steps into its first child', () =>
+    assert.deepEqual(at('docs', 'ArrowRight'), { kind: 'focus', path: 'docs/deep' }));
+  check('right on an open but EMPTY folder stays put — the next row is not its child', () => {
+    const rows = [{ path: 'images', dir: true, open: true }, { path: 'zeta.txt', dir: false, open: false }];
+    assert.equal(keyIntent(rows, 'images', 'ArrowRight'), null);
+  });
+  check('right does nothing on a file', () => assert.equal(at('alpha.txt', 'ArrowRight'), null));
+  check('left closes an open folder', () => assert.deepEqual(at('docs', 'ArrowLeft'), { kind: 'collapse', path: 'docs' }));
+  check('left on a child goes up to its folder', () =>
+    assert.deepEqual(at('docs/guide.md', 'ArrowLeft'), { kind: 'focus', path: 'docs' }));
+  check('left at the top level has nowhere to go', () => assert.equal(at('alpha.txt', 'ArrowLeft'), null));
+}
+
+console.log('\nEnter is the only key that acts, and only on the focused row');
+{
+  check('a file is a preview', () => assert.deepEqual(at('alpha.txt', 'Enter'), { kind: 'activate', path: 'alpha.txt', dir: false }));
+  check('a folder is a folder', () => assert.deepEqual(at('docs', 'Enter'), { kind: 'activate', path: 'docs', dir: true }));
+  check('with nothing focused it activates nothing', () => assert.equal(at(null, 'Enter'), null));
+}
+
+console.log('\nkeys this tree does not claim are left alone');
+{
+  for (const key of ['Tab', ' ', 'a', 'Delete', 'Backspace', 'PageDown', 'Escape'])
+    check(`${JSON.stringify(key)} is not ours`, () => assert.equal(at('alpha.txt', key), null));
+  check('and an empty listing claims nothing at all', () => assert.equal(keyIntent([], null, 'ArrowDown'), null));
+}
+
+console.log('\nwhen the focused row disappears, the focus lands nearby');
+{
+  const before = ['alpha.txt', 'docs', 'docs/deep', 'docs/guide.md', 'images'];
+  check('the next row in the same folder', () =>
+    assert.equal(survivingFocus(before, ['alpha.txt', 'docs', 'docs/guide.md', 'images'], 'docs/deep'), 'docs/guide.md'));
+  check('…else the previous one in the same folder', () =>
+    assert.equal(survivingFocus(before, ['alpha.txt', 'docs', 'docs/deep', 'docs/guide.md'], 'images'), 'docs'));
+  check('…else the folder it was in — the case where a collapse took every sibling', () =>
+    assert.equal(survivingFocus(before, ['alpha.txt', 'docs', 'images'], 'docs/guide.md'), 'docs'));
+  check('…else any row that is still nearby', () =>
+    assert.equal(survivingFocus(['a/one.txt', 'b.txt'], ['b.txt'], 'a/one.txt'), 'b.txt'));
+  check('…else the top of the listing', () =>
+    assert.equal(survivingFocus(before, ['zeta.txt'], 'docs/guide.md'), 'zeta.txt'));
+  check('and nothing at all when the listing is empty', () =>
+    assert.equal(survivingFocus(before, [], 'alpha.txt'), null));
+  check('a row that is still there keeps the focus', () =>
+    assert.equal(survivingFocus(before, before, 'docs'), 'docs'));
+  check('a neighbour is a PATH, not a position — a re-sort must not move the focus', () => {
+    const sorted = ['images', 'docs', 'docs/guide.md', 'alpha.txt'];
+    assert.equal(survivingFocus(before, sorted, 'docs/guide.md'), 'docs/guide.md');
+  });
+}
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Closes #125

Review item U06: keyboard navigation and keyboard access to the file operations that already exist. No file-browser or dialog redesign; mouse, touch and the compact layout are unchanged.

## What was there before (measured on `ef08e84`, by tabbing through a mounted pane)

- Rows had pointer handlers only — no role, not focusable, arrow keys did nothing.
- The only things Tab could reach inside the listing were each row's four action buttons, all at `opacity: 0`. Six files = 24 invisible tab stops between the header and whatever follows the pane.
- Those buttons were named by `title` alone.
- The upload picker (a `<label>` around a hidden `<input type=file>`) was not in the tab order at all — a hidden input cannot be focused and a label is not a control.

## Implemented

**One navigation model.** `role="tree"` with a name; rows are `treeitem` with `aria-level`/`aria-posinset`/`aria-setsize`, folders with `aria-expanded`. One roving tab stop.

| key | |
| --- | --- |
| `↑` `↓` | previous / next **visible** row (a collapsed folder's children are not destinations) |
| `→` | collapsed folder: expand · open folder: first child · file: nothing |
| `←` | open folder: collapse · otherwise the parent row |
| `Home` `End` | first / last visible row |
| `Enter` | file: preview · folder: open as the listing root · while a move is armed: this folder is the destination, as a click is |
| `Esc` | cancel an armed move or an open delete confirmation, and hand the row back |
| `Tab` | from the focused row: that row's actions, then out of the pane |

The contract is documented in `web/src/lib/treeNav.ts` and on the pane's hint line. Keyboard expand/collapse does not touch the pointer's click/double-click timer.

**Focus is not an action.** Arrowing opens nothing, writes nothing, and changes neither the folder new files land in nor a pending move's destination. Only the focused row's actions are tab stops, so leaving the listing is 3–4 stops, not 4 × rows.

**Visible and announced.** Row actions are revealed by `:focus-within` — the same rule the sidebar rows already use — and every icon button has an `aria-label` naming the action and the file or folder. The header's icon buttons and the upload control got names too; the upload label is now a real keyboard control. Loading / empty / unreadable folders announce themselves and are not focus destinations, so navigation skips them cleanly. With no rows at all, the tree itself is the tab stop.

**Existing operations, unchanged semantics.** Download, rename (commit and cancel), Move (nested folder, "Move here", invalid destination, cancel) and Delete are all reachable and use the existing flows, `canMoveTo` checks and confirmation. Focusing a destination never commits; activation does. The delete confirmation opens on **Cancel**, not Delete — the key that opened it is still going up, and a `Space` release landing on a freshly focused Delete would delete the file in one press. No Delete/Backspace shortcut was added.

**Predictable focus lifetime.** Keyed by session and path, never by row index (a sort renumbers every row). Restored to the originating row on preview return, on rename/move commit, and on cancel; when the row is gone, to the next thing in the same folder, else the previous, else the folder. A late directory read repairs which row is the tab stop but never moves the browser's focus unless this pane was holding it.

**Inputs are left alone.** Typing, cursor keys, `Enter`/`Escape` and IME composition in the rename and create fields never reach the row underneath; a focused action button owns its own keys, and one press produces one action (Enter on Download does not also open the preview).

## Four things fixed because the above needed them

- `useDir` returned the previous folder's entries for one render after the root changed, so rows were drawn with paths that never existed (`docs/alpha.txt` for a root-level `alpha.txt`). One frame, but a click landing in it would have acted on that path. It now reports entries only for the folder it read.
- Folder expansion moved from each row's local state to the pane, so a key and a click cannot disagree and `aria-expanded` has something true to read.
- Rename and create committed on `Enter` mid-IME-composition.
- Tabbing into the pane did not make it the app's focused pane (`onFocus` was on `onMouseDown` only).

## Deliberately left out

- **No type-ahead** (the APG tree pattern's optional letter navigation): it would consume typing in a pane that has two text fields in it. Say the word if you want it.
- **No `role="group"` wrappers.** Children are DOM siblings indented by rails; nesting them inside the row would mean putting a block inside a flex row and reworking the row CSS. Hierarchy is carried by `aria-level`/`posinset`/`setsize`, which ARIA supports for exactly this case.
- The creation target still follows a folder **click** only; from the keyboard, new files land in the folder the breadcrumb names (open a folder with `Enter` to create inside it). Changing that would mean focus deciding a destination, which requirement 2 rules out.
- No multi-selection, global shortcut system, command palette, dialog migration, upload redesign, new persistence, eager recursive loading or backend change.
- Nothing from #122 (upload/replacement safeguards) or #123 (editor save state); the only overlap with #120 is that both touch `FilesPane.tsx`, in different regions (it changes `FileView`/markdown links, this changes the listing rows).

## Tests

- `web/test/treeNav.test.mjs` — the key contract and the focus fallback as pure functions (35 checks, milliseconds).
- `web/test/filesKeyboard.test.mjs` — the real `FilesPane` in Chromium with fixture file APIs, **driven only by the keyboard**: nothing clicks or hovers a row to prepare it, and every mutation is counted by session and path. 90 checks across all eight areas the issue lists, including the browser's own accessibility tree read over CDP (one named `tree`, eight `treeitem`s, children at level 2, `expanded` on folders only), slow/empty/failed folders, collapse-before-response, sort under the focus, preview return with expansion **and scroll** preserved, and the pointer/drag/narrow-pane/both-theme regressions.

Both run through normal discovery.

```
web/ npm test           25 suites passed  (adds ~40s: the new browser suite)
web/ npm run build      typecheck + production build clean
```

Thirteen deliberate mutations (remove the key handler, the roles, the roving tabindex, the button guard, the IME guard, the confirmation's focus, the focus restore, the scroll-into-view, the focus-within CSS, the upload's keyboard, and three focus-repair rules) each break the suite, on the check that names the rule.

No server change, so no server suite applies. `server/test/crons.test.mjs` #4 is red on clean main and untouched here.

Screens and the full write-up: https://lvwerra-agent-artifacts.static.hf.space/files-keyboard-125.html

Chromium only — no screen reader is installed in this container, so the announcements above are what the browser's accessibility tree contains, not an NVDA/VoiceOver transcript.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
