### PR TITLE
Load Files, Trace and Settings panels on demand, measured (#133)

### DIFF
--- a/scripts/startup-bench.mjs
+++ b/scripts/startup-bench.mjs
@@ -30,6 +30,7 @@ import os from 'node:os';
 import { chromium } from '../web/node_modules/playwright/index.mjs';
 import { chromiumLaunchOptions } from './test-chromium.mjs';
 import { startFixtureServer } from '../web/test/helpers/fixture-server.mjs';
+import { MARK } from '../web/test/helpers/markers.mjs';
 
 const arg = (k, d) => { const i = process.argv.indexOf(`--${k}`); return i > 0 ? process.argv[i + 1] : d; };
 const DIST = path.resolve(arg('dist'));
@@ -48,17 +49,7 @@ const server = await startFixtureServer({ port: PORT, publicDir: DIST, tag: 'am-
 const { ids } = server;
 const browser = await chromium.launch(chromiumLaunchOptions());
 
-// The markers: a view is "usable" when its first interactive content is in the DOM.
-const MARK = {
-  nav: '.sidebar .row.session',
-  overview: '.ov-tile, .ov-card',
-  reader: '.pane-reader .cx-prompt',
-  composer: '.pane-reader .ov-composer textarea:not([disabled])',
-  files: '.files-body.tree .tree-row',
-  trace: '.trace-body .cx-prompt, .trace-body .tv-md',
-  settings: '.settings-page .setting-row',
-  usage: '.usage', apilog: '.al-tbl, .al-head', skills: '.skills', cron: '.cron-form',
-};
+// A view is usable at its first USEFUL content — see web/test/helpers/markers.mjs.
 const SCENARIOS = [
   { id: 'overview', restore: 'overview', view: ['overview'] },
   { id: 'reader', restore: `s:${ids.cadence}`, view: ['reader', 'composer'] },

--- a/scripts/startup-bench.mjs
+++ b/scripts/startup-bench.mjs
@@ -155,11 +155,18 @@ async function panelOpens(page, mobile) {
 }
 
 const gz = (f) => zlib.gzipSync(fs.readFileSync(f), { level: 6 }).length;
-const results = { label: LABEL, dist: DIST, at: new Date().toISOString(), runs: RUNS, node: process.version, chromium: browser.version(), mobile: MOBILE, profiles: {} };
+// Resumable: a partial file from an interrupted run of the same build is
+// continued, cell by cell, rather than started over.
+const prior = fs.existsSync(OUT) ? JSON.parse(fs.readFileSync(OUT, 'utf8')) : null;
+const results = prior && prior.dist === DIST && prior.runs === RUNS
+  ? { ...prior, resumedAt: new Date().toISOString() }
+  : { label: LABEL, dist: DIST, at: new Date().toISOString(), runs: RUNS, node: process.version, chromium: browser.version(), mobile: MOBILE, profiles: {} };
+const save = () => fs.writeFileSync(OUT, JSON.stringify(results, null, 1));
 try {
   for (const profile of PROFILES) {
-    const P = (results.profiles[profile] = { scenarios: {}, panels: null });
+    const P = (results.profiles[profile] ||= { scenarios: {}, panels: null });
     for (const sc of SCENARIOS) {
+      if (P.scenarios[sc.id]) continue;
       const samples = [];
       for (let i = 0; i < RUNS; i++) {
         const v = await visit(profile, sc);
@@ -173,7 +180,9 @@ try {
         script: stat(samples.map((s) => s.script)), compile: stat(samples.map((s) => s.compile)), task: stat(samples.map((s) => s.task)),
         js: { count: samples[0].js.count, bytes: samples[0].js.bytes, gzip: files.reduce((n, f) => n + gz(path.join(DIST, 'assets', f)), 0), files },
       };
+      save();
     }
+    if (P.panels) continue;
     console.log();
     const opens = [];
     for (let i = 0; i < RUNS; i++) {
@@ -188,14 +197,14 @@ try {
       P.panels[pass] = {};
       for (const k of Object.keys(opens[0][pass])) P.panels[pass][k] = stat(opens.map((o) => o[pass][k]));
     }
-    fs.writeFileSync(OUT, JSON.stringify(results, null, 1)); // a later crash keeps this profile
+    save();
   }
   results.chunks = Object.fromEntries(fs.readdirSync(path.join(DIST, 'assets')).filter((f) => f.endsWith('.js')).map((f) => [f, { bytes: fs.statSync(path.join(DIST, 'assets', f)).size, gzip: gz(path.join(DIST, 'assets', f)) }]));
 } finally {
   await browser.close();
   await server.stop();
 }
-fs.writeFileSync(OUT, JSON.stringify(results, null, 1));
+save();
 
 const kb = (n) => `${(n / 1024).toFixed(0)}k`;
 const ms = (s) => `${s.median.toFixed(0)}ms`;

--- a/scripts/startup-bench.mjs
+++ b/scripts/startup-bench.mjs
@@ -1,0 +1,192 @@
+// Startup cost of a production build, measured in a real Chromium against the
+// fixture fleet (web/test/helpers/fixture-server.mjs), before and after a change
+// to how the app loads. Every number here is a measurement of THIS machine under
+// the stated conditions — compare two runs of this script, never a run to a
+// figure from somewhere else.
+//
+// For each profile × scenario, `--runs` cold visits (fresh browser profile,
+// HTTP cache disabled, nothing preloaded) record:
+//   js.bytes / js.count   script bytes and requests until the view was usable
+//   script / compile      V8 ScriptDuration and V8CompileDuration (ms) at that point
+//   nav                   ms from navigation start until the sidebar lists sessions
+//   view                  ms until the selected view's first useful interaction:
+//                         Overview cards, the Reader's first exchange + composer,
+//                         the Files listing, the Trace's first turn, both group tiles
+// then, from a warm Overview, the cost of opening each deferred panel the first
+// time (its chunk on the wire) and again (from the module cache): Settings and
+// each subpage, Files, Trace.
+//
+// Profiles: desktop (1280×800, no throttling) and mobile-like (390×844, 4× CPU
+// slowdown, 1.6 Mbps down / 750 kbps up / 150 ms RTT — Chrome's "Slow 4G").
+// The server does not compress; gzip sizes are computed from the files.
+//
+//   node scripts/startup-bench.mjs --dist <web/dist> --label before --runs 5 --out before.json
+//
+// am-test: manual — a benchmark, not a pass/fail suite.
+import fs from 'node:fs';
+import path from 'node:path';
+import zlib from 'node:zlib';
+import { chromium } from '../web/node_modules/playwright/index.mjs';
+import { chromiumLaunchOptions } from './test-chromium.mjs';
+import { startFixtureServer } from '../web/test/helpers/fixture-server.mjs';
+
+const arg = (k, d) => { const i = process.argv.indexOf(`--${k}`); return i > 0 ? process.argv[i + 1] : d; };
+const DIST = path.resolve(arg('dist'));
+const LABEL = arg('label', path.basename(DIST));
+const RUNS = Number(arg('runs', 5));
+const OUT = arg('out', `startup-${LABEL}.json`);
+const PORT = Number(arg('port', 7905));
+const PROFILES = arg('profiles', 'desktop,mobile').split(',');
+
+const MOBILE = { cpu: 4, latency: 150, down: 1.6e6 / 8, up: 750e3 / 8 };
+const med = (a) => { const s = [...a].sort((x, y) => x - y); return s.length ? (s.length % 2 ? s[(s.length - 1) / 2] : (s[s.length / 2 - 1] + s[s.length / 2]) / 2) : NaN; };
+const stat = (a) => ({ median: med(a), min: Math.min(...a), max: Math.max(...a), n: a.length });
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const server = await startFixtureServer({ port: PORT, publicDir: DIST, tag: 'am-bench-' });
+const { ids } = server;
+const browser = await chromium.launch(chromiumLaunchOptions());
+
+// The markers: a view is "usable" when its first interactive content is in the DOM.
+const MARK = {
+  nav: '.sidebar .row.session',
+  overview: '.ov-tile, .ov-card',
+  reader: '.pane-reader .cx-prompt',
+  composer: '.pane-reader .ov-composer textarea:not([disabled])',
+  files: '.files-body.tree .tree-row',
+  trace: '.trace-body .cx-prompt, .trace-body .tv-md',
+  settings: '.settings-page .setting-row',
+  usage: '.usage', apilog: '.al-tbl, .al-head', skills: '.skills', cron: '.cron-form',
+};
+const SCENARIOS = [
+  { id: 'overview', restore: 'overview', view: ['overview'] },
+  { id: 'reader', restore: `s:${ids.cadence}`, view: ['reader', 'composer'] },
+  { id: 'reader-empty', restore: `s:${ids.fresh}`, view: ['composer'] },
+  { id: 'files', restore: `s:${ids.files}`, view: ['files'] },
+  { id: 'trace', restore: `s:${ids.trace}`, view: ['trace'] },
+  { id: 'group', restore: `g:${ids.group}`, focused: ids.groupFiles, view: ['files', 'trace'] },
+];
+
+async function visit(profile, scenario) {
+  const mobile = profile === 'mobile';
+  const ctx = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  const cdp = await ctx.newCDPSession(page);
+  await cdp.send('Network.enable');
+  await cdp.send('Network.setCacheDisabled', { cacheDisabled: true });
+  await cdp.send('Performance.enable');
+  if (mobile) {
+    await cdp.send('Emulation.setCPUThrottlingRate', { rate: MOBILE.cpu });
+    await cdp.send('Network.emulateNetworkConditions', { offline: false, latency: MOBILE.latency, downloadThroughput: MOBILE.down, uploadThroughput: MOBILE.up });
+  }
+  const js = new Map(); // requestId -> {url, bytes}
+  cdp.on('Network.requestWillBeSent', (e) => { if (e.type === 'Script') js.set(e.requestId, { url: e.request.url, bytes: 0, t: null }); });
+  cdp.on('Network.loadingFinished', (e) => { const r = js.get(e.requestId); if (r) { r.bytes = e.encodedDataLength; r.t = e.timestamp; } });
+  await page.addInitScript(({ restore, focused, mobile, marks }) => {
+    localStorage.setItem('am-active-ref', restore);
+    if (focused) localStorage.setItem('am-focused-id', focused);
+    localStorage.setItem('am-pane-mode', 'reader');
+    if (mobile) localStorage.setItem('am-mobile-stage', '1');
+    // First appearance of each marker, stamped by a MutationObserver rather than
+    // by polling from outside, so the numbers are the DOM's, not the harness's.
+    const seen = (window.__marks = {});
+    const look = () => { for (const [k, sel] of Object.entries(marks)) if (!(k in seen) && document.querySelector(sel)) seen[k] = performance.now(); };
+    // `document` itself: init scripts run before <html> exists.
+    new MutationObserver(look).observe(document, { childList: true, subtree: true, attributes: true });
+    look();
+  }, { restore: scenario.restore, focused: scenario.focused || null, mobile, marks: MARK });
+
+  await page.goto(server.origin + '/');
+  const want = ['nav', ...scenario.view];
+  await page.waitForFunction((want) => want.every((k) => k in window.__marks), want, { timeout: 60_000 });
+  const marks = await page.evaluate(() => window.__marks);
+  const perf = Object.fromEntries((await cdp.send('Performance.getMetrics')).metrics.map((m) => [m.name, m.value]));
+  const startup = {
+    nav: marks.nav,
+    view: Math.max(...scenario.view.map((k) => marks[k])),
+    js: { count: js.size, bytes: [...js.values()].reduce((n, r) => n + r.bytes, 0), files: [...js.values()].map((r) => path.basename(new URL(r.url).pathname)) },
+    script: perf.ScriptDuration * 1000, compile: perf.V8CompileDuration * 1000, task: perf.TaskDuration * 1000,
+  };
+  return { ctx, page, cdp, js, startup };
+}
+
+// From a warm Overview: open each deferred panel cold (chunk on the wire) and
+// again warm (module cached), timing click → first useful content.
+async function panelOpens(page) {
+  const timeIt = async (act, marker) => {
+    const t0 = Date.now();
+    await act();
+    await page.locator(marker).first().waitFor({ timeout: 30_000 });
+    return Date.now() - t0;
+  };
+  const back = () => page.locator('.brand .icon-btn[title="Back"]').click();
+  const tab = (l) => page.locator('.settings-navitem', { hasText: l }).click();
+  const rowOf = (name) => page.locator('.sidebar .row.session:not(.nested)').filter({ has: page.locator('.name', { hasText: new RegExp(`^${name}$`) }) });
+  const settingsBtn = page.locator('.icon-btn[title="Settings"]').first();
+  const out = {};
+  for (const pass of ['cold', 'warm']) {
+    const r = (out[pass] = {});
+    r.settings = await timeIt(() => settingsBtn.click(), MARK.settings);
+    for (const [k, label] of [['usage', 'Usage'], ['apilog', 'API log'], ['skills', 'Skills'], ['cron', 'Cron']]) r[k] = await timeIt(() => tab(label), MARK[k]);
+    await back();
+    await page.locator('.app:not(.settings)').waitFor();
+    r.files = await timeIt(() => rowOf('files').click(), MARK.files);
+    r.trace = await timeIt(() => rowOf('trace').click(), MARK.trace);
+    await page.locator('.sidebar .row.ov-row').first().click();
+    await page.locator(MARK.overview).first().waitFor({ timeout: 10_000 }).catch(() => {});
+  }
+  return out;
+}
+
+const gz = (f) => zlib.gzipSync(fs.readFileSync(f), { level: 6 }).length;
+const results = { label: LABEL, dist: DIST, at: new Date().toISOString(), runs: RUNS, node: process.version, chromium: browser.version(), mobile: MOBILE, profiles: {} };
+try {
+  for (const profile of PROFILES) {
+    const P = (results.profiles[profile] = { scenarios: {}, panels: null });
+    for (const sc of SCENARIOS) {
+      const samples = [];
+      for (let i = 0; i < RUNS; i++) {
+        const v = await visit(profile, sc);
+        samples.push(v.startup);
+        await v.ctx.close();
+        process.stdout.write(`\r${LABEL} ${profile} ${sc.id} ${i + 1}/${RUNS}   `);
+      }
+      const files = samples[0].js.files;
+      P.scenarios[sc.id] = {
+        nav: stat(samples.map((s) => s.nav)), view: stat(samples.map((s) => s.view)),
+        script: stat(samples.map((s) => s.script)), compile: stat(samples.map((s) => s.compile)), task: stat(samples.map((s) => s.task)),
+        js: { count: samples[0].js.count, bytes: samples[0].js.bytes, gzip: files.reduce((n, f) => n + gz(path.join(DIST, 'assets', f)), 0), files },
+      };
+    }
+    console.log();
+    const opens = [];
+    for (let i = 0; i < RUNS; i++) {
+      const v = await visit(profile, SCENARIOS[0]);
+      opens.push(await panelOpens(v.page));
+      await v.ctx.close();
+      process.stdout.write(`\r${LABEL} ${profile} panel opens ${i + 1}/${RUNS}   `);
+    }
+    console.log();
+    P.panels = {};
+    for (const pass of ['cold', 'warm']) {
+      P.panels[pass] = {};
+      for (const k of Object.keys(opens[0][pass])) P.panels[pass][k] = stat(opens.map((o) => o[pass][k]));
+    }
+  }
+  results.chunks = Object.fromEntries(fs.readdirSync(path.join(DIST, 'assets')).filter((f) => f.endsWith('.js')).map((f) => [f, { bytes: fs.statSync(path.join(DIST, 'assets', f)).size, gzip: gz(path.join(DIST, 'assets', f)) }]));
+} finally {
+  await browser.close();
+  await server.stop();
+}
+fs.writeFileSync(OUT, JSON.stringify(results, null, 1));
+
+const kb = (n) => `${(n / 1024).toFixed(0)}k`;
+const ms = (s) => `${s.median.toFixed(0)}ms`;
+for (const [profile, P] of Object.entries(results.profiles)) {
+  console.log(`\n${LABEL} · ${profile} · medians of ${RUNS}`);
+  console.log('scenario      js req  js bytes  gzip   script   compile  nav      view');
+  for (const [id, s] of Object.entries(P.scenarios)) console.log(`${id.padEnd(13)} ${String(s.js.count).padStart(6)}  ${kb(s.js.bytes).padStart(8)}  ${kb(s.js.gzip).padStart(5)}  ${ms(s.script).padStart(7)}  ${ms(s.compile).padStart(7)}  ${ms(s.nav).padStart(7)}  ${ms(s.view).padStart(7)}`);
+  console.log('panel open    cold     warm');
+  for (const k of Object.keys(P.panels.cold)) console.log(`${k.padEnd(13)} ${ms(P.panels.cold[k]).padStart(7)}  ${ms(P.panels.warm[k]).padStart(7)}`);
+}
+console.log(`\nwritten ${OUT}`);

--- a/scripts/startup-bench.mjs
+++ b/scripts/startup-bench.mjs
@@ -26,6 +26,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import zlib from 'node:zlib';
+import os from 'node:os';
 import { chromium } from '../web/node_modules/playwright/index.mjs';
 import { chromiumLaunchOptions } from './test-chromium.mjs';
 import { startFixtureServer } from '../web/test/helpers/fixture-server.mjs';
@@ -160,7 +161,11 @@ const gz = (f) => zlib.gzipSync(fs.readFileSync(f), { level: 6 }).length;
 const prior = fs.existsSync(OUT) ? JSON.parse(fs.readFileSync(OUT, 'utf8')) : null;
 const results = prior && prior.dist === DIST && prior.runs === RUNS
   ? { ...prior, resumedAt: new Date().toISOString() }
-  : { label: LABEL, dist: DIST, at: new Date().toISOString(), runs: RUNS, node: process.version, chromium: browser.version(), mobile: MOBILE, profiles: {} };
+  : { label: LABEL, dist: DIST, at: new Date().toISOString(), runs: RUNS, node: process.version, chromium: browser.version(), mobile: MOBILE, cpus: os.cpus().length, load: [], profiles: {} };
+// The box is shared: a run taken under load is not a measurement. Record the
+// 1-minute load average at the start and after every profile.
+const noteLoad = (when) => { results.load.push({ when, at: new Date().toISOString(), load1: +os.loadavg()[0].toFixed(2) }); console.log(`load ${when}: ${os.loadavg().map((x) => x.toFixed(1)).join(' ')}`); };
+noteLoad('start');
 const save = () => fs.writeFileSync(OUT, JSON.stringify(results, null, 1));
 try {
   for (const profile of PROFILES) {
@@ -197,6 +202,7 @@ try {
       P.panels[pass] = {};
       for (const k of Object.keys(opens[0][pass])) P.panels[pass][k] = stat(opens.map((o) => o[pass][k]));
     }
+    noteLoad(`after ${profile}`);
     save();
   }
   results.chunks = Object.fromEntries(fs.readdirSync(path.join(DIST, 'assets')).filter((f) => f.endsWith('.js')).map((f) => [f, { bytes: fs.statSync(path.join(DIST, 'assets', f)).size, gzip: gz(path.join(DIST, 'assets', f)) }]));

--- a/scripts/startup-bench.mjs
+++ b/scripts/startup-bench.mjs
@@ -64,10 +64,13 @@ const SCENARIOS = [
   { id: 'reader-empty', restore: `s:${ids.fresh}`, view: ['composer'] },
   { id: 'files', restore: `s:${ids.files}`, view: ['files'] },
   { id: 'trace', restore: `s:${ids.trace}`, view: ['trace'] },
-  { id: 'group', restore: `g:${ids.group}`, focused: ids.groupFiles, view: ['files', 'trace'] },
+  // A phone shows one pane of a group at a time, so only the focused one can land.
+  { id: 'group', restore: `g:${ids.group}`, focused: ids.groupFiles, view: ['files', 'trace'], mobileView: ['files'] },
 ];
 
-async function visit(profile, scenario) {
+// `stage`: on a phone, start on the selected view (true) or on the sidebar list
+// (false) — the Settings button lives in the sidebar.
+async function visit(profile, scenario, { stage = true, want: wantOnly = null } = {}) {
   const mobile = profile === 'mobile';
   const ctx = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1280, height: 800 } });
   const page = await ctx.newPage();
@@ -94,16 +97,17 @@ async function visit(profile, scenario) {
     // `document` itself: init scripts run before <html> exists.
     new MutationObserver(look).observe(document, { childList: true, subtree: true, attributes: true });
     look();
-  }, { restore: scenario.restore, focused: scenario.focused || null, mobile, marks: MARK });
+  }, { restore: scenario.restore, focused: scenario.focused || null, mobile: mobile && stage, marks: MARK });
 
   await page.goto(server.origin + '/');
-  const want = ['nav', ...scenario.view];
+  const views = mobile && scenario.mobileView ? scenario.mobileView : scenario.view;
+  const want = wantOnly || ['nav', ...views];
   await page.waitForFunction((want) => want.every((k) => k in window.__marks), want, { timeout: 60_000 });
   const marks = await page.evaluate(() => window.__marks);
   const perf = Object.fromEntries((await cdp.send('Performance.getMetrics')).metrics.map((m) => [m.name, m.value]));
   const startup = {
     nav: marks.nav,
-    view: Math.max(...scenario.view.map((k) => marks[k])),
+    view: wantOnly ? NaN : Math.max(...views.map((k) => marks[k])),
     js: { count: js.size, bytes: [...js.values()].reduce((n, r) => n + r.bytes, 0), files: [...js.values()].map((r) => path.basename(new URL(r.url).pathname)) },
     script: perf.ScriptDuration * 1000, compile: perf.V8CompileDuration * 1000, task: perf.TaskDuration * 1000,
   };
@@ -112,11 +116,19 @@ async function visit(profile, scenario) {
 
 // From a warm Overview: open each deferred panel cold (chunk on the wire) and
 // again warm (module cached), timing click → first useful content.
-async function panelOpens(page) {
+// On a phone only the Settings pages are opened this way: Files and Trace are
+// reached through the stage, whose cold cost the scenarios above already hold.
+async function panelOpens(page, mobile) {
   const timeIt = async (act, marker) => {
     const t0 = Date.now();
     await act();
-    await page.locator(marker).first().waitFor({ timeout: 30_000 });
+    try {
+      await page.locator(marker).first().waitFor({ timeout: 30_000 });
+    } catch (e) {
+      // Say what the page showed instead — a bare timeout hides the cause.
+      const seen = await page.evaluate(() => [...document.querySelectorAll('.app')].map((el) => el.className).join(' | ') + ' ; main: ' + [...document.querySelectorAll('.main > *, .settings-main > *')].map((el) => el.className).join(' | ')).catch(() => '?');
+      throw new Error(`${e.message.split('\n')[0]} — page showed: ${seen}`);
+    }
     return Date.now() - t0;
   };
   const back = () => page.locator('.brand .icon-btn[title="Back"]').click();
@@ -128,8 +140,12 @@ async function panelOpens(page) {
     const r = (out[pass] = {});
     r.settings = await timeIt(() => settingsBtn.click(), MARK.settings);
     for (const [k, label] of [['usage', 'Usage'], ['apilog', 'API log'], ['skills', 'Skills'], ['cron', 'Cron']]) r[k] = await timeIt(() => tab(label), MARK[k]);
+    // Settings reopens on the page it was left on; leave it on General so the
+    // warm pass measures the same open as the cold one.
+    await timeIt(() => tab('General'), MARK.settings);
     await back();
     await page.locator('.app:not(.settings)').waitFor();
+    if (mobile) continue;
     r.files = await timeIt(() => rowOf('files').click(), MARK.files);
     r.trace = await timeIt(() => rowOf('trace').click(), MARK.trace);
     await page.locator('.sidebar .row.ov-row').first().click();
@@ -161,8 +177,8 @@ try {
     console.log();
     const opens = [];
     for (let i = 0; i < RUNS; i++) {
-      const v = await visit(profile, SCENARIOS[0]);
-      opens.push(await panelOpens(v.page));
+      const v = await visit(profile, SCENARIOS[0], { stage: false, want: ['nav'] });
+      opens.push(await panelOpens(v.page, profile === 'mobile'));
       await v.ctx.close();
       process.stdout.write(`\r${LABEL} ${profile} panel opens ${i + 1}/${RUNS}   `);
     }
@@ -172,6 +188,7 @@ try {
       P.panels[pass] = {};
       for (const k of Object.keys(opens[0][pass])) P.panels[pass][k] = stat(opens.map((o) => o[pass][k]));
     }
+    fs.writeFileSync(OUT, JSON.stringify(results, null, 1)); // a later crash keeps this profile
   }
   results.chunks = Object.fromEntries(fs.readdirSync(path.join(DIST, 'assets')).filter((f) => f.endsWith('.js')).map((f) => [f, { bytes: fs.statSync(path.join(DIST, 'assets', f)).size, gzip: gz(path.join(DIST, 'assets', f)) }]));
 } finally {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,10 +2,9 @@ import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } fro
 import Sidebar from './components/Sidebar';
 import type { QuickStartAttachmentOptions } from './components/Sidebar';
 import TerminalPane from './components/TerminalPane';
-import FilesPane from './components/FilesPane';
-import TracePane from './components/TracePane';
 import RemotePane from './components/RemotePane';
-import SettingsView from './components/SettingsView';
+import SettingsShell, { type SettingsPage } from './components/SettingsShell';
+import LazyPanel from './components/LazyPanel';
 import NewSession from './components/NewSession';
 import LayoutPicker from './components/LayoutPicker';
 import ShareDialog from './components/ShareDialog';
@@ -29,6 +28,15 @@ import { EyeGlyph, EyeOffGlyph, GridGlyph, ListGlyph, SortGlyph } from './compon
 const VV_DEBUG = new URLSearchParams(location.search).has('vvdebug');
 const ViewportDebug = lazy(() => import('./components/ViewportDebug'));
 
+// Panels a visit may never open ship as their own chunks and are fetched when
+// first shown (LazyPanel). The terminal/reader pane is the app's reason to
+// exist and stays in the entry. These loaders are module-level on purpose: the
+// module cache is keyed by the function, and a stable component type is what
+// keeps a mounted panel's state through re-renders.
+const loadFilesPane = () => import('./components/FilesPane');
+const loadTracePane = () => import('./components/TracePane');
+const loadSettingsView = () => import('./components/SettingsView');
+
 // Phone-sized viewport: the app becomes two full-screen views (list ⇄ pane).
 function useIsMobile() {
   const [m, setM] = useState(() => window.matchMedia('(max-width: 720px)').matches);
@@ -50,7 +58,6 @@ function autoGrid(n: number): GridSpec {
   return { cols: 3, rows: 3 };
 }
 
-type SettingsPage = 'general' | 'usage' | 'skills' | 'cron' | 'apilog';
 const ROOT_PATH = '.';
 const WARM_TERMINAL_LIMIT = 12;
 const normalizePath = (p?: string | null) => (p && p.trim() ? p : ROOT_PATH);
@@ -953,15 +960,17 @@ export default function App() {
             {...(activeGroup ? tileDnd(i, !!s) : {})}
           >
             {s && (s.cli === 'files' ? (
-              <FilesPane
-                session={s}
-                zoom={zoom}
-                focused={visibleSessions.length > 1 && s.id === focusedId}
-                dragId={canDrag ? `p:${s.id}` : undefined}
-                onDragActive={setPaneDrag}
-                onFocus={() => setFocusedId(s.id)}
-                onClose={() => closePane(s.id)}
-              />
+              <LazyPanel load={loadFilesPane} what="the file browser" onClose={() => closePane(s.id)} render={(m) => (
+                <m.default
+                  session={s}
+                  zoom={zoom}
+                  focused={visibleSessions.length > 1 && s.id === focusedId}
+                  dragId={canDrag ? `p:${s.id}` : undefined}
+                  onDragActive={setPaneDrag}
+                  onFocus={() => setFocusedId(s.id)}
+                  onClose={() => closePane(s.id)}
+                />
+              )} />
             ) : s.cli === 'remote' ? (
               <RemotePane
                 session={s}
@@ -976,25 +985,27 @@ export default function App() {
                 onClose={() => closePane(s.id)}
               />
             ) : (
-              <TracePane
-                session={s}
-                // A trace pane follows its SOURCE session: whether that agent is
-                // still writing decides how hard this pane looks for new turns.
-                sourceLive={(() => {
-                  const ref = s.traceSource?.kind === 'session' ? s.traceSource.ref : null;
-                  return ref ? sessById[ref]?.state === 'working' : false;
-                })()}
-                zoom={zoom}
-                focused={visibleSessions.length > 1 && s.id === focusedId}
-                dragId={canDrag ? `p:${s.id}` : undefined}
-                onDragActive={setPaneDrag}
-                onFocus={() => setFocusedId(s.id)}
-                onShare={() => shareTrace(s.id)}
-                // The prefilled create panel lives in the sidebar, so the
-                // request travels there rather than the panel moving here.
-                onHandover={() => setHandoverFor(s.id)}
-                onClose={() => closePane(s.id)}
-              />
+              <LazyPanel load={loadTracePane} what="the trace viewer" onClose={() => closePane(s.id)} render={(m) => (
+                <m.default
+                  session={s}
+                  // A trace pane follows its SOURCE session: whether that agent is
+                  // still writing decides how hard this pane looks for new turns.
+                  sourceLive={(() => {
+                    const ref = s.traceSource?.kind === 'session' ? s.traceSource.ref : null;
+                    return ref ? sessById[ref]?.state === 'working' : false;
+                  })()}
+                  zoom={zoom}
+                  focused={visibleSessions.length > 1 && s.id === focusedId}
+                  dragId={canDrag ? `p:${s.id}` : undefined}
+                  onDragActive={setPaneDrag}
+                  onFocus={() => setFocusedId(s.id)}
+                  onShare={() => shareTrace(s.id)}
+                  // The prefilled create panel lives in the sidebar, so the
+                  // request travels there rather than the panel moving here.
+                  onHandover={() => setHandoverFor(s.id)}
+                  onClose={() => closePane(s.id)}
+                />
+              )} />
             ))}
           </div>
         )))}
@@ -1015,19 +1026,23 @@ export default function App() {
   return (
     <>
       {settingsOpen && (
-      <SettingsView
-        page={settingsPage}
-        onPage={setSettingsPage}
-        onClose={() => setSettingsOpen(false)}
-        theme={theme}
-        onToggleTheme={toggleTheme}
-        clis={clis}
-        info={info}
-        onShowWelcome={openWelcome}
-        onOpenSharedTrace={openSharedTrace}
-        demoMode={!!info?.demoMode}
-        onToggleDemo={toggleDemo}
-      />
+      <SettingsShell page={settingsPage} onPage={setSettingsPage} onClose={() => setSettingsOpen(false)}>
+        <LazyPanel load={loadSettingsView} what="settings" onClose={() => setSettingsOpen(false)} render={(m) => (
+          <m.default
+            page={settingsPage}
+            onPage={setSettingsPage}
+            onClose={() => setSettingsOpen(false)}
+            theme={theme}
+            onToggleTheme={toggleTheme}
+            clis={clis}
+            info={info}
+            onShowWelcome={openWelcome}
+            onOpenSharedTrace={openSharedTrace}
+            demoMode={!!info?.demoMode}
+            onToggleDemo={toggleDemo}
+          />
+        )} />
+      </SettingsShell>
       )}
     {/* Outside .app: it reports where .app was put. That does not make it
         immune — it is fixed too, so a displaced fixed subtree would carry it

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1030,7 +1030,6 @@ export default function App() {
         <LazyPanel load={loadSettingsView} what="settings" onClose={() => setSettingsOpen(false)} render={(m) => (
           <m.default
             page={settingsPage}
-            onPage={setSettingsPage}
             onClose={() => setSettingsOpen(false)}
             theme={theme}
             onToggleTheme={toggleTheme}

--- a/web/src/components/FilesPane.tsx
+++ b/web/src/components/FilesPane.tsx
@@ -9,12 +9,17 @@ import { renderMarkdown } from '../lib/markdown';
 import CodeView from './CodeView';
 import FileWrapToggle from './FileWrapToggle';
 import PdfView from './PdfView';
-import { TraceView, type TraceHeadInfo, type TraceSource } from './TracePane';
+import type { TraceHeadInfo, TraceSource } from '../lib/traceWindows';
+import LazyPanel from './LazyPanel';
 import {
   FolderGlyph, FileGlyph, CloseGlyph, UpGlyph, UploadGlyph, BackGlyph, DownloadGlyph,
   RefreshGlyph, ImageGlyph, CodeGlyph, DocGlyph, GlobeGlyph,
   FolderPlusGlyph, FilePlusGlyph, TrashGlyph, PencilGlyph, MoveGlyph,
 } from './icons';
+
+// The rendered-conversation view of a .jsonl file is the trace pane's code,
+// fetched only when such a file is opened (most Files sessions never do).
+const loadTraceView = () => import('./TracePane');
 
 const fmtSize = (n: number) => {
   if (n < 1024) return `${n} B`;
@@ -795,10 +800,12 @@ export function FileView({ sessionId, path, zoom, raw, scripts, onInfo, onSaved 
       // Same two faces as markdown: the rendered conversation, or the JSONL
       // underneath it.
       return raw ? code(shown) : (
-        <TraceView
-          src={traceSrc} srcKey={`file:${sessionId}:${path}`} zoom={zoom} query={traceQuery}
-          onHead={setTraceHead} onNav={(go) => { traceNav.current = go; }}
-        />
+        <LazyPanel load={loadTraceView} what="the trace viewer" render={(m) => (
+          <m.TraceView
+            src={traceSrc} srcKey={`file:${sessionId}:${path}`} zoom={zoom} query={traceQuery}
+            onHead={setTraceHead} onNav={(go) => { traceNav.current = go; }}
+          />
+        )} />
       );
     }
     if (meta.kind === 'text') return code(shown);

--- a/web/src/components/LazyPanel.tsx
+++ b/web/src/components/LazyPanel.tsx
@@ -1,0 +1,59 @@
+// The boundary a deferred panel mounts behind. It reserves the panel's place
+// while the code is on its way, shows the panel once it lands, and — when it
+// does not — says so where the panel would be, with a way onwards that is true:
+// Try again when a retry can work, Reload when a newer build made this tab's
+// chunk URLs stale, and always the panel's own Close. The page around it stays
+// interactive, and nothing here can reopen a panel that was closed meanwhile:
+// open/closed is the parent's state and module completion never touches it.
+import { useSyncExternalStore, type ReactNode } from 'react';
+import { readModule, retryModule, subscribeModule, type Loader, type ModuleState } from '../lib/lazyModule';
+
+export function useLazyModule<T>(load: Loader<T>): ModuleState<T> {
+  return useSyncExternalStore(
+    (cb) => subscribeModule(load, cb),
+    () => readModule(load),
+    () => readModule(load),
+  );
+}
+
+export default function LazyPanel<T>({ load, render, what, onClose, closeLabel = 'Close', className }: {
+  /** A stable, module-level `() => import('…')` — the cache is keyed by it. */
+  load: Loader<T>;
+  render: (m: T) => ReactNode;
+  /** Named in the loading and failure copy: "the file browser". */
+  what: string;
+  onClose?: () => void;
+  closeLabel?: string;
+  className?: string;
+}) {
+  const st = useLazyModule(load);
+  const cls = `lazy-panel${className ? ` ${className}` : ''}`;
+  if (st.kind === 'ready') return <>{render(st.module)}</>;
+  if (st.kind === 'loading') {
+    return (
+      <div className={cls} aria-busy="true" aria-live="polite">
+        <div className="lazy-msg">Loading {what}…</div>
+      </div>
+    );
+  }
+  const stale = st.stale === true;
+  return (
+    <div className={`${cls} lazy-failed`} role="alert">
+      <div className="lazy-card">
+        <div className="lazy-title">{stale ? 'Agent Manager was updated' : `Couldn’t load ${what}`}</div>
+        <div className="lazy-msg">
+          {stale
+            ? 'A newer version was deployed since this page loaded, so this tab can’t fetch that part any more. Reload to get the new version — finish or copy anything unsent first.'
+            : st.retryable
+              ? 'The request didn’t get through — you may be offline.'
+              : 'The request didn’t get through. Reloading the page usually fixes it — finish or copy anything unsent first.'}
+        </div>
+        <div className="lazy-actions">
+          {st.retryable && <button className="btn-primary" onClick={() => retryModule(load)}>Try again</button>}
+          {(stale || !st.retryable) && <button className="btn-primary" onClick={() => location.reload()}>Reload</button>}
+          {onClose && <button className="btn-ghost" onClick={onClose}>{closeLabel}</button>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsShell.tsx
+++ b/web/src/components/SettingsShell.tsx
@@ -1,0 +1,42 @@
+// The part of Settings that is always there: the Back button, the title and the
+// page tabs. Settings replaces the whole app while it is open (`.app-suspended`
+// hides the fleet), so this shell has to stand on its own — the page bodies
+// behind it are loaded on demand, and until they land the operator still sees
+// where they are, can pick a page and can leave.
+import type { ReactNode } from 'react';
+
+export type SettingsPage = 'general' | 'usage' | 'skills' | 'cron' | 'apilog';
+export const SETTINGS_PAGES: { id: SettingsPage; label: string }[] = [
+  { id: 'general', label: 'General' },
+  { id: 'usage', label: 'Usage' },
+  { id: 'skills', label: 'Skills' },
+  { id: 'cron', label: 'Cron' },
+  { id: 'apilog', label: 'API log' },
+];
+
+export default function SettingsShell({ page, onPage, onClose, children }: {
+  page: SettingsPage;
+  onPage: (p: SettingsPage) => void;
+  onClose: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="app settings">
+      <aside className="sidebar">
+        <div className="brand">
+          <button className="icon-btn" onClick={onClose} title="Back">←</button>
+          <h1 style={{ flex: 1, marginLeft: 4 }}>Settings</h1>
+        </div>
+        <div className="settings-nav">
+          {SETTINGS_PAGES.map((p) => (
+            <button key={p.id} className={`settings-navitem${page === p.id ? ' active' : ''}`} onClick={() => onPage(p.id)}>
+              {p.label}
+            </button>
+          ))}
+        </div>
+      </aside>
+
+      <div className="main settings-main">{children}</div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -1,21 +1,17 @@
 import { useEffect, useState } from 'react';
 import { isPassive, isRemote, type Cli } from '../types';
 import * as api from '../api';
-import SkillsEditor from './SkillsEditor';
-import ApiLog from './ApiLog';
-import UsagePanel from './UsagePanel';
-import CronSettings from './CronSettings';
 import { SunGlyph, MoonGlyph, RefreshGlyph, InfoGlyph } from './icons';
 import Logo from './Logo';
+import LazyPanel from './LazyPanel';
+import type { SettingsPage as Page } from './SettingsShell';
 
-type Page = 'general' | 'usage' | 'skills' | 'cron' | 'apilog';
-const PAGES: { id: Page; label: string }[] = [
-  { id: 'general', label: 'General' },
-  { id: 'usage', label: 'Usage' },
-  { id: 'skills', label: 'Skills' },
-  { id: 'cron', label: 'Cron' },
-  { id: 'apilog', label: 'API log' },
-];
+// Each subpage is its own chunk, fetched the first time its tab is opened; the
+// General page is this module. Module-level so the loader cache keys on them.
+const loadUsage = () => import('./UsagePanel');
+const loadApiLog = () => import('./ApiLog');
+const loadSkills = () => import('./SkillsEditor');
+const loadCron = () => import('./CronSettings');
 
 interface Info { dataDir?: string; home?: string; spaceId?: string | null; spaceHost?: string | null; engine?: string; ghostty?: boolean; canRelaunch?: boolean; secrets?: string[]; bucketUnverified?: boolean; }
 
@@ -270,23 +266,10 @@ export default function SettingsView({
       else setRelaunch({ msg: `Couldn't relaunch (${r.reason}).` });
     } catch { setRelaunch({ msg: 'Request failed.' }); }
   };
+  // The shell around these pages (Back, title, tabs) is SettingsShell, rendered
+  // by App so it is there before this module is.
   return (
-    <div className="app settings">
-      <aside className="sidebar">
-        <div className="brand">
-          <button className="icon-btn" onClick={onClose} title="Back">←</button>
-          <h1 style={{ flex: 1, marginLeft: 4 }}>Settings</h1>
-        </div>
-        <div className="settings-nav">
-          {PAGES.map((p) => (
-            <button key={p.id} className={`settings-navitem${page === p.id ? ' active' : ''}`} onClick={() => onPage(p.id)}>
-              {p.label}
-            </button>
-          ))}
-        </div>
-      </aside>
-
-      <div className="main settings-main">
+    <>
         {page === 'general' && (
           <div className="settings-page">
             <h2>General</h2>
@@ -775,7 +758,7 @@ export default function SettingsView({
         {page === 'usage' && (
           <div className="settings-page wide">
             <h2>Usage</h2>
-            <UsagePanel />
+            <LazyPanel load={loadUsage} what="the usage page" render={(m) => <m.default />} />
           </div>
         )}
 
@@ -787,7 +770,7 @@ export default function SettingsView({
               what, when, and in their own words: each entry keeps the call whole, body included.
               Credentials are the exception and are never written here.
             </p>
-            <ApiLog />
+            <LazyPanel load={loadApiLog} what="the API log" render={(m) => <m.default />} />
           </div>
         )}
 
@@ -795,7 +778,7 @@ export default function SettingsView({
           <div className="settings-page wide">
             <h2>Skills</h2>
             <p className="s-help">Reusable markdown/text skills. Saved skills are published as <span className="mono">SKILL.md</span> to every agent (Claude, Codex, Gemini, opencode, Hermes) and available in all new sessions. View renders markdown; Edit is plain text.</p>
-            <SkillsEditor />
+            <LazyPanel load={loadSkills} what="the skills editor" render={(m) => <m.default />} />
           </div>
         )}
 
@@ -803,10 +786,9 @@ export default function SettingsView({
           <div className="settings-page wide cron-page">
             <h2>Cron</h2>
             <p className="s-help cron-intro">Send a prompt to an agent on a schedule. Jobs persist across Space restarts; if the named agent does not exist when a job fires, it is created first.</p>
-            <CronSettings clis={clis} />
+            <LazyPanel load={loadCron} what="the cron page" render={(m) => <m.default clis={clis} />} />
           </div>
         )}
-      </div>
-    </div>
+    </>
   );
 }

--- a/web/src/components/SettingsView.tsx
+++ b/web/src/components/SettingsView.tsx
@@ -118,11 +118,11 @@ function PushRow() {
 }
 
 export default function SettingsView({
-  page, onPage, onClose, theme, onToggleTheme, clis, info, onShowWelcome, demoMode, onToggleDemo,
+  page, onClose, theme, onToggleTheme, clis, info, onShowWelcome, demoMode, onToggleDemo,
   onOpenSharedTrace,
 }: {
   page: Page;
-  onPage: (p: Page) => void;
+  /** Closing from inside a page (a shared trace opened). The shell owns the tabs. */
   onClose: () => void;
   theme: 'light' | 'dark';
   onToggleTheme: () => void;

--- a/web/src/lib/lazyModule.ts
+++ b/web/src/lib/lazyModule.ts
@@ -111,8 +111,9 @@ async function attempt<T>(loader: Loader<T>, e: Entry<T>): Promise<void> {
     const mod = e.url ? await lazyModuleInternals.importUrl(bustUrl(e.url, e.tries)) as T : await loader();
     setState(e, { kind: 'ready', module: mod });
   } catch (err) {
-    const url = failedModuleUrl(err);
-    if (url) e.url = url;
+    // Remember the chunk the FIRST failure named: a retry's error names the
+    // busted URL, and busting that again would only pile up query strings.
+    if (!e.url) e.url = failedModuleUrl(err);
     if (e.url && e.auto < MAX_AUTO_RETRIES) {
       e.auto++;
       await lazyModuleInternals.delay(RETRY_DELAY_MS);

--- a/web/src/lib/lazyModule.ts
+++ b/web/src/lib/lazyModule.ts
@@ -1,0 +1,150 @@
+// Code for the panels an operator may never open — Files, Trace, Settings and
+// its subpages — is fetched the first time such a panel is shown, not at
+// startup. A loader is a stable, module-level `() => import('…')`; each loader
+// gets one entry here holding the module once it landed (every later mount
+// reuses it without a request) or the failure, so the panel can say what
+// happened and what the operator can do about it.
+//
+// Why not React.lazy: React caches a rejected lazy promise for good, so the only
+// "retry" it can offer is a reload. Chromium caches a FAILED module fetch too —
+// verified: after one aborted fetch, a second import() of the same URL fails
+// without touching the network. A retry that can succeed has to ask for the
+// same file under a new URL, and the browser only tells us that URL in its error
+// message (Chromium and Firefox do, WebKit does not) — so "Try again" is offered
+// exactly when it can work. One automatic retry covers a dropped request; after
+// that the operator decides.
+//
+// A chunk that is gone because a newer build replaced the hashed files is a
+// different situation: nothing this tab can do will load it. Rather than a
+// reload loop, the page's own HTML is re-read once and, when its entry script
+// changed, the panel says so and offers a reload. It never reloads on its own.
+
+export type Loader<T> = () => Promise<T>;
+
+export type ModuleState<T> =
+  | { kind: 'loading' }
+  | { kind: 'ready'; module: T }
+  /** `stale`: a newer deployment replaced this build's files (null = could not tell). */
+  | { kind: 'failed'; error: unknown; stale: boolean | null; retryable: boolean };
+
+type Entry<T> = {
+  state: ModuleState<T>;
+  auto: number;                 // automatic retries spent
+  tries: number;                // every attempt, for a unique cache-busting URL
+  url: string | null;           // the chunk the browser named in its last failure
+  listeners: Set<() => void>;
+};
+
+const MAX_AUTO_RETRIES = 1;
+const RETRY_DELAY_MS = 400;
+
+// Seams the unit test replaces; the browser build never touches them.
+export const lazyModuleInternals = {
+  delay: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+  importUrl: (url: string): Promise<unknown> => import(/* @vite-ignore */ url),
+  fetchPageHtml: async (): Promise<string | null> => {
+    try {
+      const r = await fetch(`${location.pathname}${location.search}`, { cache: 'no-store', headers: { accept: 'text/html' } });
+      return r.ok ? await r.text() : null;
+    } catch { return null; }
+  },
+  currentEntryScript: (): string | null =>
+    document.querySelector('script[type="module"][src]')?.getAttribute('src') ?? null,
+  baseHref: () => location.href,
+};
+
+const entries = new Map<Loader<unknown>, Entry<unknown>>();
+const LOADING: ModuleState<never> = { kind: 'loading' };
+
+const entryFor = <T>(loader: Loader<T>): Entry<T> => {
+  let e = entries.get(loader as Loader<unknown>) as Entry<T> | undefined;
+  if (!e) {
+    e = { state: LOADING, auto: 0, tries: 0, url: null, listeners: new Set() };
+    entries.set(loader as Loader<unknown>, e as Entry<unknown>);
+    void attempt(loader, e);
+  }
+  return e;
+};
+
+const setState = <T>(e: Entry<T>, s: ModuleState<T>) => {
+  e.state = s;
+  for (const l of e.listeners) l();
+};
+
+/** The chunk URL a failed dynamic import names, when the browser says (same origin only). */
+export function failedModuleUrl(err: unknown, base = lazyModuleInternals.baseHref()): string | null {
+  const msg = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+  const m = /(?:module|script)[^:]*:\s*(\S+)/i.exec(msg) || /(https?:\/\/\S+)/.exec(msg);
+  if (!m) return null;
+  try {
+    const u = new URL(m[1].replace(/[.,;)]+$/, ''), base);
+    return u.origin === new URL(base).origin ? u.href : null;
+  } catch { return null; }
+}
+
+/** Same file, a URL the module map has not seen: `?am-retry=<n>` (kept apart from any query it has). */
+export const bustUrl = (url: string, n: number) => `${url}${url.includes('?') ? '&' : '?'}am-retry=${n}`;
+
+/** The `<script type="module" src>` a page's HTML would load, or null. */
+export function entryScriptOf(html: string): string | null {
+  const m = /<script\b[^>]*\btype=["']module["'][^>]*\bsrc=["']([^"']+)["']/i.exec(html)
+    || /<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*\btype=["']module["']/i.exec(html);
+  return m ? m[1] : null;
+}
+
+/** true = the server now hands out a different build than this page runs; null = could not tell. */
+export async function deploymentChanged(): Promise<boolean | null> {
+  const mine = lazyModuleInternals.currentEntryScript();
+  const html = await lazyModuleInternals.fetchPageHtml();
+  if (!mine || html === null) return null;
+  const theirs = entryScriptOf(html);
+  if (!theirs) return null;
+  const base = lazyModuleInternals.baseHref();
+  try { return new URL(theirs, base).href !== new URL(mine, base).href; } catch { return null; }
+}
+
+async function attempt<T>(loader: Loader<T>, e: Entry<T>): Promise<void> {
+  e.tries++;
+  try {
+    // A retry asks for the chunk the browser named, under a fresh URL; the first
+    // attempt is the plain import the bundler wrote.
+    const mod = e.url ? await lazyModuleInternals.importUrl(bustUrl(e.url, e.tries)) as T : await loader();
+    setState(e, { kind: 'ready', module: mod });
+  } catch (err) {
+    const url = failedModuleUrl(err);
+    if (url) e.url = url;
+    if (e.url && e.auto < MAX_AUTO_RETRIES) {
+      e.auto++;
+      await lazyModuleInternals.delay(RETRY_DELAY_MS);
+      return attempt(loader, e);
+    }
+    setState(e, { kind: 'failed', error: err, stale: null, retryable: !!e.url });
+    const stale = await deploymentChanged();
+    // Only annotate the failure it belongs to: a manual retry may have moved on.
+    if (e.state.kind === 'failed' && e.state.error === err) {
+      setState(e, { ...e.state, stale, retryable: !!e.url && !stale });
+    }
+  }
+}
+
+/** Start loading (once) and read the current state. Idempotent, so safe during render. */
+export function readModule<T>(loader: Loader<T>): ModuleState<T> {
+  return entryFor(loader).state;
+}
+
+export function subscribeModule<T>(loader: Loader<T>, listener: () => void): () => void {
+  const e = entryFor(loader);
+  e.listeners.add(listener);
+  return () => { e.listeners.delete(listener); };
+}
+
+/** Operator-driven: one more attempt for a failure that can still succeed. */
+export function retryModule<T>(loader: Loader<T>): void {
+  const e = entryFor(loader);
+  if (e.state.kind !== 'failed' || !e.state.retryable) return;
+  setState(e, LOADING);
+  void attempt(loader, e);
+}
+
+/** Tests only: forget every entry. */
+export function resetLazyModules(): void { entries.clear(); }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1240,6 +1240,19 @@ body {
 .fv-sub { color: var(--muted); font-size: 11.5px; font-family: var(--font-mono); opacity: 0.85; }
 .fv-empty .mini-btn { border: 1px solid var(--border); }
 
+/* A deferred panel's place while its code loads, and where it says so when it
+   cannot. Fills the slot it stands in (tile, settings page, file viewer) so the
+   layout does not jump when the real panel lands. */
+.lazy-panel { flex: 1; min-width: 0; min-height: 0; display: flex; align-items: center; justify-content: center; padding: 24px; color: var(--muted); font-size: 13px; text-align: center; }
+.tile > .lazy-panel { background: var(--panel); border-radius: var(--r-xl); border: 1px solid var(--border); }
+.settings-page > .lazy-panel { min-height: 120px; }
+.lazy-panel.lazy-failed { color: var(--text); }
+.lazy-card { max-width: 380px; display: flex; flex-direction: column; align-items: center; gap: 10px; }
+.lazy-title { font-weight: 600; font-size: 14px; }
+.lazy-msg { line-height: 1.45; }
+.lazy-failed .lazy-msg { color: var(--muted); }
+.lazy-actions { display: flex; flex-wrap: wrap; justify-content: center; gap: 8px; margin-top: 4px; }
+
 .fv-toggles { flex: none; display: inline-flex; align-items: center; gap: 8px; }
 .fv-toggles .seg button { padding: 1px 8px; font-size: 10.5px; }
 .fv-check { display: inline-flex; align-items: center; gap: 3px; cursor: pointer; font-size: 10.5px; }

--- a/web/test/cronSettings.test.mjs
+++ b/web/test/cronSettings.test.mjs
@@ -41,6 +41,7 @@ await build({
       import React from 'react';
       import { createRoot } from 'react-dom/client';
       import SettingsView from './src/components/SettingsView.tsx';
+      import SettingsShell from './src/components/SettingsShell.tsx';
       const clis = [
         { id: 'shell', label: 'Shell', color: '#888', available: true },
         { id: 'files', label: 'Files', color: '#888', available: true },
@@ -49,9 +50,13 @@ await build({
         { id: 'claude', label: 'Claude Code', color: '#d97757', available: true },
         { id: 'codex', label: 'Codex', color: '#5eb6a6', available: false },
       ];
+      // Shell (Back, tabs, the .settings-main scroller) and page are two
+      // components, as in App; the Cron page's code arrives on demand.
       createRoot(document.getElementById('root')).render(
-        <SettingsView page="cron" onPage={() => {}} onClose={() => {}} theme="light"
-          onToggleTheme={() => {}} clis={clis} info={{ dataDir: '/data' }} />,
+        <SettingsShell page="cron" onPage={() => {}} onClose={() => {}}>
+          <SettingsView page="cron" onClose={() => {}} theme="light"
+            onToggleTheme={() => {}} clis={clis} info={{ dataDir: '/data' }} />
+        </SettingsShell>,
       );
     `,
   },

--- a/web/test/fixtureServer.test.mjs
+++ b/web/test/fixtureServer.test.mjs
@@ -1,0 +1,35 @@
+// The fixture server must own its port before it seeds anything. With the port
+// already taken, the spawned child dies of EADDRINUSE while the OTHER listener
+// answers every probe — so a helper that trusts /api/health would write its
+// fixture fleet into someone else's instance and measure someone else's build.
+// This holds a stub on the port, asks the helper to start there, and requires
+// a rejection with zero writes to the stub. Run with:  node test/fixtureServer.test.mjs
+import assert from 'node:assert/strict';
+import http from 'node:http';
+import { startFixtureServer } from './helpers/fixture-server.mjs';
+
+const PORT = 7909;
+const hits = [];
+const stub = http.createServer((req, res) => {
+  hits.push(`${req.method} ${req.url}`);
+  res.setHeader('content-type', 'application/json');
+  // Answers like a healthy server that belongs to somebody else.
+  res.end(JSON.stringify({ ok: true, dataDir: '/somebody/elses/data', id: 'x' }));
+});
+await new Promise((r) => stub.listen(PORT, '127.0.0.1', r));
+
+let failed = 0;
+const check = (what, ok, detail = '') => { console.log(`  ${ok ? 'ok ' : 'FAIL'} ${what}${detail ? `  ${detail}` : ''}`); if (!ok) failed++; };
+try {
+  const outcome = await startFixtureServer({ port: PORT, publicDir: '/nonexistent', tag: 'am-occupied-' })
+    .then((s) => ({ started: s }), (e) => ({ error: e }));
+  check('starting on an occupied port is rejected', !!outcome.error, outcome.error ? outcome.error.message.split('\n')[0] : 'resolved');
+  if (outcome.started) await outcome.started.stop();
+  const writes = hits.filter((h) => !h.startsWith('GET '));
+  check('the other listener received no fixture writes', writes.length === 0, writes.slice(0, 3).join(', '));
+  check('…and was not even probed for readiness', hits.length === 0, hits.slice(0, 3).join(', '));
+} finally {
+  stub.close();
+}
+console.log(failed ? `\n${failed} failed` : '\nfixture-server: ok');
+process.exit(failed ? 1 : 0);

--- a/web/test/helpers/fixture-server.mjs
+++ b/web/test/helpers/fixture-server.mjs
@@ -1,0 +1,158 @@
+// A real backend over a throwaway DATA_DIR, holding a small fleet the browser
+// suites and the startup benchmark both drive: two Claude sessions (one with a
+// transcript the Reader can show, one empty so the composer is the whole view),
+// a Files pane, a Trace pane over the first session, and a group with a Files
+// and a Trace pane side by side. Nothing here is live — the Claude sessions are
+// never attached (reader mode reads transcripts), and `claude` on PATH is a stub
+// that would only sleep if something did spawn it.
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+export const ROOT = path.resolve(HERE, '..', '..', '..');
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+export async function startFixtureServer({ port, publicDir, tag = 'am-fixture-' }) {
+  const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), tag));
+  const cfgDir = path.join(dataDir, 'claude-config');
+  const binDir = path.join(dataDir, 'bin');
+  fs.mkdirSync(binDir, { recursive: true });
+  fs.writeFileSync(path.join(binDir, 'claude'), '#!/bin/sh\necho "fixture claude stub — nothing to see"; sleep 3600\n', { mode: 0o755 });
+
+  // No skill publishing from a test server (SPACE_ID would fan this checkout's
+  // templates into every live agent's skills dir), no production hostname.
+  const { SPACE_ID, AM_DISTRIBUTE_SKILLS, ...base } = process.env;
+  const child = spawn('node', ['src/index.js'], {
+    cwd: path.join(ROOT, 'server'),
+    env: {
+      ...base,
+      PORT: String(port), DATA_DIR: dataDir, PUBLIC_DIR: publicDir,
+      CLAUDE_CONFIG_DIR: cfgDir, PATH: `${binDir}:${base.PATH || ''}`,
+      AM_BASHRC: '/nonexistent', SPACE_HOST: '', AM_ALLOW_MISSING_ORIGIN: '1', USE_TMUX: '0',
+    },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let logs = '';
+  child.stdout.on('data', (d) => { logs += d; });
+  child.stderr.on('data', (d) => { logs += d; });
+
+  const origin = `http://127.0.0.1:${port}`;
+  const api = async (p, method = 'GET', body) => {
+    const r = await fetch(origin + p, {
+      method, headers: body ? { 'content-type': 'application/json' } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!r.ok) throw new Error(`${method} ${p} → ${r.status} ${await r.text()}`);
+    return r.status === 204 ? null : r.json();
+  };
+  const until = Date.now() + 60_000;
+  let up = false;
+  while (Date.now() < until && !up) {
+    up = await fetch(`${origin}/api/health`).then((r) => r.ok).catch(() => false);
+    if (!up) await sleep(100);
+  }
+  if (!up) { child.kill('SIGKILL'); throw new Error(`fixture server did not come up on ${port}\n${logs}`); }
+
+  await api('/api/welcome/seen', 'POST');
+  const cadence = await api('/api/sessions', 'POST', { name: 'cadence', cli: 'claude', path: 'cadence' });
+  const fresh = await api('/api/sessions', 'POST', { name: 'fresh', cli: 'claude', path: 'fresh' });
+  const files = await api('/api/sessions', 'POST', { name: 'files', cli: 'files' });
+  const trace = await api('/api/sessions', 'POST', { name: 'trace', cli: 'trace' });
+  await api(`/api/trace/${trace.id}/source`, 'PUT', { kind: 'session', ref: cadence.id });
+  const group = await api('/api/groups', 'POST', { name: 'mixed' });
+  const groupFiles = await api('/api/sessions', 'POST', { name: 'g-files', cli: 'files', groupId: group.id });
+  const groupTrace = await api('/api/sessions', 'POST', { name: 'g-trace', cli: 'trace', groupId: group.id });
+  await api(`/api/trace/${groupTrace.id}/source`, 'PUT', { kind: 'session', ref: cadence.id });
+  writeTranscript(cfgDir, path.join(dataDir, 'workspaces', cadence.path || cadence.id));
+  // Something for the Files pane to list.
+  const ws = path.join(dataDir, 'workspaces');
+  fs.mkdirSync(path.join(ws, 'notes'), { recursive: true });
+  fs.writeFileSync(path.join(ws, 'notes', 'README.md'), '# notes\n\nA fixture file.\n');
+  fs.writeFileSync(path.join(ws, 'notes', 'plan.txt'), 'one\ntwo\n');
+
+  return {
+    origin, api, dataDir, cfgDir,
+    ids: { cadence: cadence.id, fresh: fresh.id, files: files.id, trace: trace.id, group: group.id, groupFiles: groupFiles.id, groupTrace: groupTrace.id },
+    logs: () => logs,
+    stop: async () => {
+      child.kill('SIGTERM');
+      await Promise.race([new Promise((r) => child.once('exit', r)), sleep(3000)]);
+      if (child.exitCode === null) child.kill('SIGKILL');
+      fs.rmSync(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+// A Claude transcript of the shape the reader renders (tool calls, a table,
+// several turns) — enough history to scroll, small enough to be the same size
+// every run. Matched to the session by cwd, so the folder is exactly the one
+// the server gave the session.
+function writeTranscript(cfgDir, cwd) {
+  const UUID = 'f1c7a0de-0000-4000-8000-00000000cade';
+  const t0 = Date.parse('2026-08-06T21:14:00Z');
+  const at = (min) => new Date(t0 + min * 60_000).toISOString();
+  const msg = (i, content, usage) => ({
+    type: 'assistant', uuid: `a${i}`, timestamp: at(i), cwd, sessionId: UUID,
+    message: { id: `msg_${i}`, role: 'assistant', content, usage },
+  });
+  const user = (i, text) => ({
+    type: 'user', uuid: `u${i}`, timestamp: at(i), cwd, sessionId: UUID,
+    message: { role: 'user', content: [{ type: 'text', text }] },
+  });
+  const result = (i, id, out) => ({
+    type: 'user', uuid: `r${i}`, timestamp: at(i), cwd, sessionId: UUID, toolUseResult: { stdout: out },
+    message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: out }] },
+  });
+  const U = (i, o) => ({ input_tokens: i, output_tokens: o, cache_read_input_tokens: 0, cache_creation_input_tokens: 0 });
+  const EARLIER = [
+    ['is the nightly export still green?', 'Green — last run 03:12, 41s, no retries.'],
+    ['how big is the bucket now?', '2.4 TB, up 60 GB this week. The trace archive is most of the growth.'],
+    ['anything stuck in the queue?', 'Nothing stuck. Two jobs waiting on the same lock, both under a minute old.'],
+    ['did the cert renewal go through?', 'Yes, renewed Tuesday, expires 2026-11-04.'],
+    ['why did CI take 22 minutes yesterday?', 'A cold npm cache on the runner. Warm again since the last build: 6m 40s.'],
+    ['is anyone else on this box?', 'One other session, idle for three hours.'],
+    ['what changed in the deploy config?', 'Only the health-check path, from /healthz to /api/health.'],
+    ['do we still need the nightly vacuum?', 'Not really — autovacuum keeps up now. It costs 90s a night and reclaims ~12 MB.'],
+  ];
+  const lines = [
+    ...EARLIER.flatMap(([q, a], k) => [
+      user(-200 + k * 20, q),
+      msg(-199 + k * 20, [{ type: 'tool_use', id: `e${k}`, name: 'Bash', input: { command: 'systemctl status export.service' } }], U(2000, 40)),
+      result(-198 + k * 20, `e${k}`, 'active (exited) since Tue 2026-08-06 03:12:44 UTC'),
+      msg(-197 + k * 20, [{ type: 'text', text: a }], U(900, 50)),
+    ]),
+    user(0, 'can you check whether the backup job still runs hourly?'),
+    msg(1, [
+      { type: 'text', text: 'Checking the timer.' },
+      { type: 'tool_use', id: 'tu1', name: 'Bash', input: { command: 'systemctl list-timers backup.timer' } },
+    ], U(8900, 120)),
+    result(2, 'tu1', 'NEXT                        LEFT     LAST                        UNIT\nTue 2026-08-06 22:00:00 UTC 42min    Tue 2026-08-06 20:56:00 UTC backup.timer'),
+    msg(3, [{ type: 'text', text: 'Hourly, and the last run was 18 minutes ago — nothing to fix.' }], U(1200, 60)),
+    user(10, 'the terminal freezes for about a second every 20s. why?'),
+    msg(11, [
+      { type: 'text', text: 'Let me look at what runs on a 20s cadence.' },
+      { type: 'tool_use', id: 'tu2', name: 'Grep', input: { pattern: 'setInterval', path: 'server/src' } },
+    ], U(12000, 210)),
+    result(12, 'tu2', 'server/src/runner.js:184:  setInterval(tick, 20_000);'),
+    msg(15, [{
+      type: 'text',
+      text: 'Found it — the repin watcher, not the terminal.\n\n**What happens:** `tick()` walks every candidate transcript with a *synchronous* `statSync` every 20s. On the bucket mount those stats are bimodal: **3ms warm, ~1.2s cold**.\n\n| backstop | blocked share |\n| --- | --- |\n| 20s (today) | ~6% |\n| 1 min | ~2% |\n| 10 min | ~0.2% |\n\n**The fix is not blocking:** `fsp.stat` hands the same I/O to the threadpool.',
+    }], U(83300, 1900)),
+  ];
+  const dir = path.join(cfgDir, 'projects', cwd.replace(/[/.]/g, '-'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, `${UUID}.jsonl`), lines.map((l) => JSON.stringify(l)).join('\n') + '\n');
+}
+
+/** `vite build` into a fresh directory; returns it. Reuses $AM_TEST_DIST if set. */
+export function buildWeb(spawnSync, tag = 'am-dist-') {
+  if (process.env.AM_TEST_DIST) return process.env.AM_TEST_DIST;
+  const out = fs.mkdtempSync(path.join(os.tmpdir(), tag));
+  const r = spawnSync('npx', ['vite', 'build', '--outDir', out], { cwd: path.join(ROOT, 'web'), encoding: 'utf8' });
+  if (r.status !== 0) throw new Error(`web build failed:\n${r.stdout}\n${r.stderr}`);
+  return out;
+}

--- a/web/test/helpers/fixture-server.mjs
+++ b/web/test/helpers/fixture-server.mjs
@@ -6,6 +6,7 @@
 // never attached (reader mode reads transcripts), and `claude` on PATH is a stub
 // that would only sleep if something did spawn it.
 import fs from 'node:fs';
+import net from 'node:net';
 import os from 'node:os';
 import path from 'node:path';
 import { spawn } from 'node:child_process';
@@ -16,7 +17,19 @@ export const ROOT = path.resolve(HERE, '..', '..', '..');
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
+/** Resolves when nothing listens on the port; rejects otherwise. */
+const assertPortFree = (port) => new Promise((resolve, reject) => {
+  const probe = net.createServer();
+  probe.once('error', (e) => reject(new Error(`port ${port} is not free (${e.code}): another server is there, and seeding it would write fixtures into someone else's instance`)));
+  probe.listen(port, '127.0.0.1', () => probe.close(() => resolve()));
+});
+
 export async function startFixtureServer({ port, publicDir, tag = 'am-fixture-' }) {
+  // Never seed a listener this helper did not start: with the port taken, the
+  // child dies of EADDRINUSE while /api/health from the OTHER server answers
+  // 200, and every fixture write below would land in that instance — and the
+  // measurement would be of whatever build it serves.
+  await assertPortFree(port);
   const dataDir = fs.mkdtempSync(path.join(os.tmpdir(), tag));
   const cfgDir = path.join(dataDir, 'claude-config');
   const binDir = path.join(dataDir, 'bin');
@@ -49,13 +62,21 @@ export async function startFixtureServer({ port, publicDir, tag = 'am-fixture-' 
     if (!r.ok) throw new Error(`${method} ${p} → ${r.status} ${await r.text()}`);
     return r.status === 204 ? null : r.json();
   };
+  // Ready means THIS child answers: /api/info names the DATA_DIR it was given,
+  // which no other instance shares. A child that exited is a failure at once.
+  let exited = null;
+  child.once('exit', (code, signal) => { exited = { code, signal }; });
   const until = Date.now() + 60_000;
   let up = false;
-  while (Date.now() < until && !up) {
-    up = await fetch(`${origin}/api/health`).then((r) => r.ok).catch(() => false);
+  while (Date.now() < until && !up && !exited) {
+    up = await fetch(`${origin}/api/info`).then((r) => (r.ok ? r.json() : null)).then((i) => i?.dataDir === dataDir).catch(() => false);
     if (!up) await sleep(100);
   }
-  if (!up) { child.kill('SIGKILL'); throw new Error(`fixture server did not come up on ${port}\n${logs}`); }
+  if (!up) {
+    child.kill('SIGKILL');
+    fs.rmSync(dataDir, { recursive: true, force: true });
+    throw new Error(`fixture server did not come up on ${port}${exited ? ` (child exited: ${JSON.stringify(exited)})` : ''}\n${logs}`);
+  }
 
   await api('/api/welcome/seen', 'POST');
   const cadence = await api('/api/sessions', 'POST', { name: 'cadence', cli: 'claude', path: 'cadence' });

--- a/web/test/helpers/markers.mjs
+++ b/web/test/helpers/markers.mjs
@@ -1,0 +1,24 @@
+// When a view counts as usable — shared by the startup benchmark and the
+// browser suite so a timing and its regression test agree on the definition.
+//
+// A marker names the first USEFUL content, not the first paint: for the Usage
+// page that is a populated trace row, because the page's frame and its skeleton
+// rows exist long before any of its seven requests answered (review of #133).
+// The API log likewise counts its first real row, not the "loading…" header.
+// General/Skills/Cron mark their forms and controls, which are real interaction
+// (a job can be created before the job list has loaded).
+export const MARK = {
+  nav: '.sidebar .row.session',
+  overview: '.ov-tile, .ov-card',
+  reader: '.pane-reader .cx-prompt',
+  composer: '.pane-reader .ov-composer textarea:not([disabled])',
+  files: '.files-body.tree .tree-row',
+  trace: '.trace-body .cx-prompt, .trace-body .tv-md',
+  settings: '.settings-page .setting-row',
+  usage: '.usage .traces-table td.tr-agent',
+  apilog: '.al-tbl tbody tr, .al-empty',
+  skills: '.skills',
+  cron: '.cron-form',
+};
+// The page's frame, as distinct from its data — what a chunk test waits for.
+export const FRAME = { usage: '.usage', apilog: '.al-tbl, .al-head' };

--- a/web/test/lazyModule.test.mjs
+++ b/web/test/lazyModule.test.mjs
@@ -36,6 +36,8 @@ const settle = async () => { for (let i = 0; i < 20; i++) await tick(); };
 let html = `<!doctype html><html><body><script type="module" crossorigin src="${ENTRY}"></script></body></html>`;
 const imports = [];
 let importResult = () => Promise.resolve({ default: 'retried' });
+// The browser's error for a busted URL names THAT URL — the way Chromium does.
+const errorFor = (url) => new TypeError(`Failed to fetch dynamically imported module: ${url}`);
 Object.assign(lazyModuleInternals, {
   delay: () => Promise.resolve(),
   importUrl: (url) => { imports.push(url); return importResult(url); },
@@ -102,7 +104,7 @@ await check('a named chunk gets exactly one automatic retry, under a new URL', a
 await check('when the retry fails too it settles as failed, retryable, and not stale', async () => {
   fresh();
   const loader = () => Promise.reject(chromeError());
-  importResult = () => Promise.reject(chromeError());
+  importResult = (url) => Promise.reject(errorFor(url));
   readModule(loader);
   await settle();
   const st = readModule(loader);
@@ -116,7 +118,7 @@ await check('a manual retry is one more attempt, and success is kept', async () 
   fresh();
   const loader = () => Promise.reject(chromeError());
   let n = 0;
-  importResult = () => (++n < 2 ? Promise.reject(chromeError()) : Promise.resolve({ default: 'third' }));
+  importResult = (url) => (++n < 2 ? Promise.reject(errorFor(url)) : Promise.resolve({ default: 'third' }));
   readModule(loader);
   await settle();
   assert.equal(readModule(loader).kind, 'failed');

--- a/web/test/lazyModule.test.mjs
+++ b/web/test/lazyModule.test.mjs
@@ -1,0 +1,189 @@
+// What the on-demand module cache promises, without a browser: one request per
+// loader however many panels mount, a bounded automatic retry that asks for the
+// chunk under a new URL (a plain re-import never reaches the network — Chromium
+// remembers the failure), a manual retry only where one can work, and a stale
+// deployment recognised from the page's own HTML rather than guessed.
+//
+// No test runner: esbuild transpiles the module and it is imported directly.
+// Run with:  node test/lazyModule.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'lazy-module-')), 'lazyModule.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/lazyModule.ts')],
+  outfile: out, format: 'esm', bundle: false, logLevel: 'error',
+});
+const m = await import(pathToFileURL(out).href);
+const {
+  readModule, subscribeModule, retryModule, resetLazyModules, lazyModuleInternals,
+  failedModuleUrl, bustUrl, entryScriptOf, deploymentChanged,
+} = m;
+
+const PAGE = 'http://app.test/some/path?x=1';
+const ENTRY = '/assets/index-AAA.js';
+const CHUNK = 'http://app.test/assets/FilesPane-BBB.js';
+const chromeError = () => new TypeError(`Failed to fetch dynamically imported module: ${CHUNK}`);
+const tick = () => new Promise((r) => setTimeout(r, 0));
+const settle = async () => { for (let i = 0; i < 20; i++) await tick(); };
+
+// The seams: no timers, no network, no DOM.
+let html = `<!doctype html><html><body><script type="module" crossorigin src="${ENTRY}"></script></body></html>`;
+const imports = [];
+let importResult = () => Promise.resolve({ default: 'retried' });
+Object.assign(lazyModuleInternals, {
+  delay: () => Promise.resolve(),
+  importUrl: (url) => { imports.push(url); return importResult(url); },
+  fetchPageHtml: () => Promise.resolve(html),
+  currentEntryScript: () => ENTRY,
+  baseHref: () => PAGE,
+});
+
+let failed = 0;
+const check = (what, fn) => fn().then(
+  () => console.log(`  ok  ${what}`),
+  (e) => { failed++; console.log(`  FAIL ${what}\n       ${e.message.split('\n')[0]}`); },
+);
+const fresh = () => { resetLazyModules(); imports.length = 0; };
+
+await check('pure helpers: the URL a browser names, a busted URL, the entry script of a page', async () => {
+  assert.equal(failedModuleUrl(chromeError(), PAGE), CHUNK);
+  assert.equal(failedModuleUrl(new Error(`error loading dynamically imported module: ${CHUNK}`), PAGE), CHUNK, 'Firefox wording');
+  assert.equal(failedModuleUrl(new Error('Importing a module script failed.'), PAGE), null, 'WebKit names nothing');
+  assert.equal(failedModuleUrl(new Error('Failed to fetch dynamically imported module: https://evil.test/x.js'), PAGE), null, 'never another origin');
+  assert.equal(failedModuleUrl(undefined, PAGE), null);
+  assert.equal(bustUrl(CHUNK, 2), `${CHUNK}?am-retry=2`);
+  assert.equal(bustUrl(`${CHUNK}?v=1`, 3), `${CHUNK}?v=1&am-retry=3`);
+  assert.equal(entryScriptOf(html), ENTRY);
+  assert.equal(entryScriptOf('<script src="/assets/a.js" type="module"></script>'), '/assets/a.js', 'attribute order');
+  assert.equal(entryScriptOf('<script src="/sw.js"></script>'), null, 'a classic script is not the entry');
+  assert.equal(await deploymentChanged(), false);
+  html = html.replace(ENTRY, '/assets/index-ZZZ.js');
+  assert.equal(await deploymentChanged(), true);
+  html = html.replace('/assets/index-ZZZ.js', ENTRY);
+});
+
+await check('one loader call serves every reader; the module is kept', async () => {
+  fresh();
+  let calls = 0;
+  let resolve;
+  const loader = () => { calls++; return new Promise((r) => { resolve = r; }); };
+  const seen = [];
+  const un = subscribeModule(loader, () => seen.push(readModule(loader).kind));
+  assert.equal(readModule(loader).kind, 'loading');
+  assert.equal(readModule(loader).kind, 'loading', 'a second reader does not start a second load');
+  subscribeModule(loader, () => {});
+  assert.equal(calls, 1);
+  resolve({ default: 'Panel' });
+  await settle();
+  assert.deepEqual(seen, ['ready']);
+  assert.deepEqual(readModule(loader), { kind: 'ready', module: { default: 'Panel' } });
+  un();
+  assert.equal(calls, 1, 'nothing re-fetches on later reads');
+});
+
+await check('a named chunk gets exactly one automatic retry, under a new URL', async () => {
+  fresh();
+  let calls = 0;
+  const loader = () => { calls++; return Promise.reject(chromeError()); };
+  importResult = () => Promise.resolve({ default: 'second try' });
+  readModule(loader);
+  await settle();
+  assert.equal(calls, 1, 'the plain import is not repeated — the module map would answer from memory');
+  assert.deepEqual(imports, [`${CHUNK}?am-retry=2`]);
+  assert.deepEqual(readModule(loader), { kind: 'ready', module: { default: 'second try' } });
+});
+
+await check('when the retry fails too it settles as failed, retryable, and not stale', async () => {
+  fresh();
+  const loader = () => Promise.reject(chromeError());
+  importResult = () => Promise.reject(chromeError());
+  readModule(loader);
+  await settle();
+  const st = readModule(loader);
+  assert.equal(st.kind, 'failed');
+  assert.equal(st.retryable, true);
+  assert.equal(st.stale, false, 'the page HTML still names this build');
+  assert.equal(imports.length, 1, 'automatic retries are bounded');
+});
+
+await check('a manual retry is one more attempt, and success is kept', async () => {
+  fresh();
+  const loader = () => Promise.reject(chromeError());
+  let n = 0;
+  importResult = () => (++n < 2 ? Promise.reject(chromeError()) : Promise.resolve({ default: 'third' }));
+  readModule(loader);
+  await settle();
+  assert.equal(readModule(loader).kind, 'failed');
+  retryModule(loader);
+  assert.equal(readModule(loader).kind, 'loading');
+  await settle();
+  assert.deepEqual(readModule(loader), { kind: 'ready', module: { default: 'third' } });
+  assert.deepEqual(imports, [`${CHUNK}?am-retry=2`, `${CHUNK}?am-retry=3`], 'every attempt uses a URL the module map has not seen');
+  retryModule(loader);
+  assert.equal(readModule(loader).kind, 'ready', 'retry is a no-op unless the load failed');
+});
+
+await check('a stale deployment is reported as such and is not offered a retry', async () => {
+  fresh();
+  const loader = () => Promise.reject(chromeError());
+  importResult = () => Promise.reject(chromeError());
+  html = html.replace(ENTRY, '/assets/index-NEW.js');
+  readModule(loader);
+  await settle();
+  const st = readModule(loader);
+  assert.equal(st.kind, 'failed');
+  assert.equal(st.stale, true);
+  assert.equal(st.retryable, false);
+  retryModule(loader);
+  assert.equal(readModule(loader).kind, 'failed', 'nothing this tab can fetch would succeed');
+  html = html.replace('/assets/index-NEW.js', ENTRY);
+});
+
+await check('a failure the browser does not name is not retryable and asks nothing of the network', async () => {
+  fresh();
+  const loader = () => Promise.reject(new Error('Importing a module script failed.'));
+  readModule(loader);
+  await settle();
+  const st = readModule(loader);
+  assert.equal(st.kind, 'failed');
+  assert.equal(st.retryable, false);
+  assert.equal(imports.length, 0);
+  retryModule(loader);
+  assert.equal(readModule(loader).kind, 'failed');
+});
+
+await check('when the page HTML cannot be read, staleness is unknown rather than asserted', async () => {
+  fresh();
+  const loader = () => Promise.reject(chromeError());
+  importResult = () => Promise.reject(chromeError());
+  const saved = lazyModuleInternals.fetchPageHtml;
+  lazyModuleInternals.fetchPageHtml = () => Promise.resolve(null);
+  readModule(loader);
+  await settle();
+  const st = readModule(loader);
+  assert.equal(st.stale, null);
+  assert.equal(st.retryable, true, 'offline is exactly when a retry is worth offering');
+  lazyModuleInternals.fetchPageHtml = saved;
+});
+
+await check('a listener that unsubscribed hears nothing more', async () => {
+  fresh();
+  let resolve;
+  const loader = () => new Promise((r) => { resolve = r; });
+  let heard = 0;
+  const un = subscribeModule(loader, () => heard++);
+  un();
+  resolve({ default: 'x' });
+  await settle();
+  assert.equal(heard, 0);
+  assert.equal(readModule(loader).kind, 'ready');
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall passed');
+process.exit(failed ? 1 : 0);

--- a/web/test/lazyPanels.test.mjs
+++ b/web/test/lazyPanels.test.mjs
@@ -17,6 +17,7 @@ import { spawnSync } from 'node:child_process';
 import { chromium } from 'playwright';
 import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
 import { startFixtureServer, buildWeb } from './helpers/fixture-server.mjs';
+import { MARK, FRAME } from './helpers/markers.mjs';
 
 const PORT = 7904;
 const PANEL_CHUNK = /\/assets\/(FilesPane|TracePane|SettingsView|ApiLog|CronSettings|UsagePanel|SkillsEditor)-[^/]+\.js/;
@@ -76,6 +77,10 @@ try {
     await sleep(1500); // the polls settle; nothing further may arrive
     assert.deepEqual(requests(PANEL_CHUNK), [], 'panel chunks requested at startup');
     const entry = await fetch(server.origin + entrySrc).then((r) => r.text());
+    // The budget from the #133 measurements (697 kB measured, headroom to 720).
+    // Reaching it again means a panel grew back into the entry or a new eager
+    // import landed there; read the chunk stats before raising it.
+    assert.ok(entry.length <= 720 * 1024, `entry chunk is ${(entry.length / 1024).toFixed(0)} kB, over the 720 kB budget`);
     // One literal only that panel's module contains — a dynamic import that
     // merely wraps an unchanged graph would leave these in the entry.
     for (const [panel, marker] of [
@@ -97,7 +102,7 @@ try {
     await page.locator('.settings-page .setting-row').first().waitFor({ timeout: 10_000 });
     assert.equal(requests(chunkOf('SettingsView')).length, 1);
     assert.equal(requests(/UsagePanel|ApiLog|CronSettings|SkillsEditor/).length, 0, 'subpages came with the General page');
-    for (const [label, marker, chunk] of [['Usage', '.usage', 'UsagePanel'], ['API log', '.al-tbl, .al-head', 'ApiLog'], ['Skills', '.skills', 'SkillsEditor'], ['Cron', '.cron-form', 'CronSettings']]) {
+    for (const [label, marker, chunk] of [['Usage', FRAME.usage, 'UsagePanel'], ['API log', FRAME.apilog, 'ApiLog'], ['Skills', MARK.skills, 'SkillsEditor'], ['Cron', MARK.cron, 'CronSettings']]) {
       await tab(page, label);
       await page.locator(marker).first().waitFor({ timeout: 10_000 });
       assert.equal(requests(chunkOf(chunk)).length, 1, `${chunk} fetched once`);
@@ -264,6 +269,24 @@ try {
     await page.locator('.al-tbl, .al-head').first().waitFor({ timeout: 10_000 });
     assert.equal(await page.locator('.usage').count(), 0, 'the earlier page showed up late');
     assert.equal(await page.locator('.lazy-panel').count(), 0);
+    await ctx.close();
+  });
+
+  await check('the Usage readiness marker cannot fire on skeletons: with its data held back, the frame is there and the marker is not', async () => {
+    const { ctx, page } = await open();
+    let release;
+    const held = new Promise((r) => { release = r; });
+    await page.route(/\/api\/(usage|traces)(\?|$)/, async (r) => { await held; await r.continue(); });
+    await page.locator(CARD).first().waitFor({ timeout: 15_000 });
+    await openSettings(page);
+    await page.locator(MARK.settings).first().waitFor({ timeout: 10_000 });
+    await tab(page, 'Usage');
+    await page.locator(FRAME.usage).waitFor({ timeout: 10_000 });
+    await sleep(1000);
+    assert.ok((await page.locator('.usage .skel').count()) > 0, 'the page shows skeletons while its data is on the way');
+    assert.equal(await page.locator(MARK.usage).count(), 0, 'the usable-content marker fired on skeletons');
+    release();
+    await page.locator(MARK.usage).first().waitFor({ timeout: 10_000 });
     await ctx.close();
   });
 

--- a/web/test/lazyPanels.test.mjs
+++ b/web/test/lazyPanels.test.mjs
@@ -1,0 +1,303 @@
+// The on-demand panels, in the production build, against a real backend.
+//
+// What the build promises (issue #133): a cold visit does not fetch or run the
+// Files, Trace or Settings code; the first time a panel is shown its chunk is
+// fetched and later shows reuse it; a chunk that does not load fails where the
+// panel would be — with a way out, a retry that really retries, and an honest
+// "reload" when a newer deployment replaced this build — while the rest of the
+// app keeps working; and a panel closed while its code was still on the way
+// stays closed. Assertions are on actual network entries and rendered DOM, not
+// on mocked imports.
+//
+// Builds the web app into a temp dir (or uses $AM_TEST_DIST), boots the server
+// on 7904 with the fixture fleet from helpers/fixture-server.mjs.
+// Run with:  node test/lazyPanels.test.mjs
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+import { startFixtureServer, buildWeb } from './helpers/fixture-server.mjs';
+
+const PORT = 7904;
+const PANEL_CHUNK = /\/assets\/(FilesPane|TracePane|SettingsView|ApiLog|CronSettings|UsagePanel|SkillsEditor)-[^/]+\.js/;
+const chunkOf = (name) => new RegExp(`/assets/${name}-[^/]+\\.js`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failed = 0;
+const check = async (what, fn) => {
+  try { await fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed++;
+    console.log(`  FAIL ${what}\n       ${String(e && e.message || e).split('\n').slice(0, 3).join('\n       ')}`);
+  }
+};
+
+const dist = buildWeb(spawnSync, 'am-lazy-dist-');
+const server = await startFixtureServer({ port: PORT, publicDir: dist, tag: 'am-lazy-' });
+const browser = await chromium.launch(chromiumLaunchOptions());
+
+// A fresh browser profile with the remembered selection already in place, and
+// every script request on the wire recorded — the assertions read that log.
+async function open({ restore = 'overview', focused = null, mobile = false, stage = false, storage = true, offline = false } = {}) {
+  const ctx = await browser.newContext({ viewport: mobile ? { width: 390, height: 844 } : { width: 1280, height: 800 }, offline });
+  const page = await ctx.newPage();
+  const scripts = [];
+  page.on('request', (r) => { if (r.resourceType() === 'script') scripts.push(r.url()); });
+  await page.addInitScript(({ restore, focused, storage, stage }) => {
+    if (!storage) {
+      Object.defineProperty(window, 'localStorage', { get() { throw new DOMException('denied', 'SecurityError'); } });
+      return;
+    }
+    localStorage.setItem('am-active-ref', restore);
+    if (focused) localStorage.setItem('am-focused-id', focused);
+    localStorage.setItem('am-pane-mode', 'reader');
+    if (stage) localStorage.setItem('am-mobile-stage', '1');
+  }, { restore, focused, storage, stage });
+  const cdp = await ctx.newCDPSession(page);
+  await cdp.send('Network.setCacheDisabled', { cacheDisabled: true });
+  await page.goto(server.origin + '/');
+  return { ctx, page, scripts, requests: (re) => scripts.filter((u) => re.test(u)) };
+}
+// A top-level row by its exact name: `files` must not match the group's `g-files`.
+const row = (page, name) => page.locator('.sidebar .row.session:not(.nested)').filter({ has: page.locator('.name', { hasText: new RegExp(`^${name}$`) }) });
+const CARD = '.ov-tile, .ov-card';
+const openSettings = (page) => page.locator('.icon-btn[title="Settings"]').first().click();
+const tab = (page, label) => page.locator('.settings-navitem', { hasText: label }).click();
+const failure = (page) => page.locator('.lazy-failed');
+
+const entryHtml = await fetch(server.origin + '/').then((r) => r.text());
+const entrySrc = /<script[^>]*type="module"[^>]*src="([^"]+)"/.exec(entryHtml)[1];
+
+try {
+  console.log('the production dependency graph');
+  await check('a cold Overview visit fetches no panel-specific chunk, and the entry carries no panel code', async () => {
+    const { ctx, page, requests } = await open();
+    await page.locator(CARD).first().waitFor({ timeout: 15_000 });
+    await page.locator('.sidebar .row.session').first().waitFor();
+    await sleep(1500); // the polls settle; nothing further may arrive
+    assert.deepEqual(requests(PANEL_CHUNK), [], 'panel chunks requested at startup');
+    const entry = await fetch(server.origin + entrySrc).then((r) => r.text());
+    // One literal only that panel's module contains — a dynamic import that
+    // merely wraps an unchanged graph would leave these in the entry.
+    for (const [panel, marker] of [
+      ['FilesPane', 'files-body'], ['TracePane', 'trace-body'], ['SettingsView', 'Defaults to your system setting.'],
+      ['ApiLog', 'al-tbl'], ['CronSettings', 'cron-form'], ['UsagePanel', 'usage-card'], ['SkillsEditor', 'skills-list'],
+    ]) assert.ok(!entry.includes(marker), `${panel} code is still in the entry chunk ("${marker}")`);
+    // And the deferred panels do no background work while unopened.
+    const api = [];
+    page.on('request', (r) => { if (/\/api\/(usage|operations|crons|skills)\b/.test(r.url())) api.push(r.url()); });
+    await sleep(2500);
+    assert.deepEqual(api, [], 'unopened panels polled their APIs');
+    await ctx.close();
+  });
+
+  await check('first Settings open fetches its chunk; each subpage fetches its own, once; a second visit reuses them', async () => {
+    const { ctx, page, requests } = await open();
+    await page.locator(CARD).first().waitFor({ timeout: 15_000 });
+    await openSettings(page);
+    await page.locator('.settings-page .setting-row').first().waitFor({ timeout: 10_000 });
+    assert.equal(requests(chunkOf('SettingsView')).length, 1);
+    assert.equal(requests(/UsagePanel|ApiLog|CronSettings|SkillsEditor/).length, 0, 'subpages came with the General page');
+    for (const [label, marker, chunk] of [['Usage', '.usage', 'UsagePanel'], ['API log', '.al-tbl, .al-head', 'ApiLog'], ['Skills', '.skills', 'SkillsEditor'], ['Cron', '.cron-form', 'CronSettings']]) {
+      await tab(page, label);
+      await page.locator(marker).first().waitFor({ timeout: 10_000 });
+      assert.equal(requests(chunkOf(chunk)).length, 1, `${chunk} fetched once`);
+    }
+    await tab(page, 'General');
+    await tab(page, 'Usage');
+    await page.locator('.usage').waitFor();
+    await page.locator('.brand .icon-btn[title="Back"]').click();
+    await page.locator('.app:not(.settings)').waitFor();
+    assert.equal(await page.locator('.app.settings').count(), 0);
+    await openSettings(page);
+    await tab(page, 'Cron');
+    await page.locator('.cron-form').waitFor();
+    assert.equal(requests(chunkOf('SettingsView')).length, 1, 'Settings reopened without a second fetch');
+    assert.equal(requests(chunkOf('UsagePanel')).length, 1);
+    assert.equal(requests(chunkOf('CronSettings')).length, 1);
+    // Closing Settings ends its subpages' polling too.
+    await page.locator('.brand .icon-btn[title="Back"]').click();
+    await page.locator('.app:not(.settings)').waitFor();
+    const api = [];
+    page.on('request', (r) => { if (/\/api\/(usage|crons)\b/.test(r.url())) api.push(r.url()); });
+    await sleep(2500);
+    assert.deepEqual(api, [], 'closed subpages kept polling');
+    await ctx.close();
+  });
+
+  await check('opening Files fetches the Files chunk and not the Trace one; the Trace pane fetches its own', async () => {
+    const { ctx, page, requests } = await open();
+    await row(page, 'files').waitFor({ timeout: 15_000 });
+    await row(page, 'files').click();
+    await page.locator('.files-body.tree .tree-row').first().waitFor({ timeout: 10_000 });
+    assert.equal(requests(chunkOf('FilesPane')).length, 1);
+    assert.equal(requests(chunkOf('TracePane')).length, 0, 'the trace renderer rode along with Files');
+    await row(page, 'trace').click();
+    await page.locator('.trace-body .cx-prompt, .trace-body .tv-md').first().waitFor({ timeout: 10_000 });
+    assert.equal(requests(chunkOf('TracePane')).length, 1);
+    await row(page, 'files').click();
+    await page.locator('.files-body.tree .tree-row').first().waitFor();
+    assert.equal(requests(chunkOf('FilesPane')).length, 1, 'Files reopened from the cached module');
+    await ctx.close();
+  });
+
+  console.log('restored selections');
+  await check('a restored Files selection starts its chunk as soon as the tree names it, without waiting on anything else', async () => {
+    const { ctx, page, requests } = await open({ restore: `s:${server.ids.files}` });
+    await page.locator('.files-body.tree .tree-row').first().waitFor({ timeout: 15_000 });
+    assert.equal(requests(chunkOf('FilesPane')).length, 1);
+    assert.equal(requests(/SettingsView|TracePane|ApiLog|CronSettings|UsagePanel|SkillsEditor/).length, 0);
+    await ctx.close();
+  });
+  await check('a restored Reader session needs no panel chunk at all, and its composer is usable', async () => {
+    const { ctx, page, requests } = await open({ restore: `s:${server.ids.cadence}` });
+    await page.locator('.pane-reader .cx-prompt').first().waitFor({ timeout: 15_000 });
+    await page.locator('.pane-reader .ov-composer textarea:not([disabled])').waitFor();
+    await sleep(1000);
+    assert.deepEqual(requests(PANEL_CHUNK), []);
+    await ctx.close();
+  });
+  await check('a restored group shows its Files and Trace panes, each from its own chunk', async () => {
+    const { ctx, page, requests } = await open({ restore: `g:${server.ids.group}`, focused: server.ids.groupFiles });
+    await page.locator('.tile .files-body.tree .tree-row').first().waitFor({ timeout: 15_000 });
+    await page.locator('.tile .trace-body .cx-prompt, .tile .trace-body .tv-md').first().waitFor({ timeout: 15_000 });
+    assert.equal(requests(chunkOf('FilesPane')).length, 1);
+    assert.equal(requests(chunkOf('TracePane')).length, 1);
+    await ctx.close();
+  });
+
+  console.log('when a chunk does not load');
+  await check('a failed Files chunk fails in its own tile: the Trace tile, the sidebar and Close still work; Try again then really loads it', async () => {
+    const { ctx, page, requests } = await open({ restore: `g:${server.ids.group}`, focused: server.ids.groupFiles });
+    let block = true;
+    await page.route(chunkOf('FilesPane'), (r) => (block ? r.abort('failed') : r.continue()));
+    await page.locator('.tile .trace-body .cx-prompt, .tile .trace-body .tv-md').first().waitFor({ timeout: 15_000 });
+    await failure(page).waitFor({ timeout: 10_000 });
+    assert.equal(await failure(page).count(), 1, 'one tile failed, not both');
+    assert.match(await failure(page).innerText(), /Couldn’t load the file browser/);
+    assert.equal(await failure(page).locator('button', { hasText: 'Try again' }).count(), 1);
+    assert.equal(await failure(page).locator('button', { hasText: 'Close' }).count(), 1);
+    assert.ok(await page.locator('.sidebar .row.session').first().isVisible(), 'the sidebar is gone');
+    // The automatic retry asked for the chunk under a new URL and was blocked too.
+    const urls = requests(chunkOf('FilesPane'));
+    assert.equal(urls.length, 2, `attempts: ${urls.join(' ')}`);
+    assert.match(urls[1], /\?am-retry=2$/);
+    block = false;
+    await failure(page).locator('button', { hasText: 'Try again' }).click();
+    await page.locator('.tile .files-body.tree .tree-row').first().waitFor({ timeout: 10_000 });
+    assert.equal(await failure(page).count(), 0);
+    assert.match(requests(chunkOf('FilesPane')).at(-1), /\?am-retry=3$/, 'the manual retry used a fresh URL');
+    await ctx.close();
+  });
+
+  await check('a chunk a newer deployment removed: says so, offers Reload, offers no retry, and never reloads by itself', async () => {
+    const { ctx, page } = await open();
+    await page.route(chunkOf('FilesPane'), (r) => r.fulfill({ status: 404, body: 'gone' }));
+    // The page's own HTML, re-read by the panel: now naming another build.
+    await page.route(`${server.origin}/`, (r) => (r.request().resourceType() === 'fetch'
+      ? r.fulfill({ status: 200, contentType: 'text/html', body: entryHtml.replace(entrySrc, '/assets/index-NEWBUILD.js') })
+      : r.continue()));
+    let navigations = 0;
+    page.on('framenavigated', (f) => { if (f === page.mainFrame()) navigations++; });
+    await row(page, 'files').waitFor({ timeout: 15_000 });
+    await row(page, 'files').click();
+    await failure(page).waitFor({ timeout: 10_000 });
+    await failure(page).locator('button', { hasText: 'Reload' }).waitFor({ timeout: 5000 });
+    assert.match(await failure(page).innerText(), /Agent Manager was updated/);
+    assert.equal(await failure(page).locator('button', { hasText: 'Try again' }).count(), 0);
+    await sleep(1500);
+    assert.equal(navigations, 0, 'the page reloaded on its own');
+    assert.equal(await page.locator('.sidebar').count(), 1);
+    await ctx.close();
+  });
+
+  await check('offline first open settles as a failure with Try again; back online, Try again loads the panel', async () => {
+    const { ctx, page } = await open();
+    await row(page, 'files').waitFor({ timeout: 15_000 });
+    await ctx.setOffline(true);
+    await row(page, 'files').click();
+    await failure(page).waitFor({ timeout: 10_000 });
+    assert.match(await failure(page).innerText(), /offline/);
+    await ctx.setOffline(false);
+    await failure(page).locator('button', { hasText: 'Try again' }).click();
+    await page.locator('.files-body.tree .tree-row').first().waitFor({ timeout: 10_000 });
+    await ctx.close();
+  });
+
+  await check('Settings closed while its code was still loading stays closed when the code lands; the shell was usable meanwhile', async () => {
+    const { ctx, page, requests } = await open();
+    let release;
+    const held = new Promise((r) => { release = r; });
+    await page.route(chunkOf('SettingsView'), async (r) => { await held; await r.continue(); });
+    await page.locator(CARD).first().waitFor({ timeout: 15_000 });
+    await openSettings(page);
+    await page.locator('.app.settings .settings-nav .settings-navitem').first().waitFor();
+    assert.equal(await page.locator('.app.settings .lazy-panel[aria-busy="true"]').count(), 1, 'the page body reserved its place');
+    assert.equal(await page.locator('.app.app-suspended').count(), 1);
+    await tab(page, 'Cron');
+    assert.ok(await page.locator('.settings-navitem.active', { hasText: 'Cron' }).isVisible(), 'tabs work before the code is here');
+    await page.locator('.brand .icon-btn[title="Back"]').click();
+    await page.locator('.app:not(.settings)').waitFor();
+    release();
+    await sleep(800);
+    assert.equal(await page.locator('.app.settings').count(), 0, 'module completion reopened Settings');
+    await openSettings(page);
+    await page.locator('.cron-form').waitFor({ timeout: 10_000 });
+    assert.equal(requests(chunkOf('SettingsView')).length, 1, 'the landed module was reused');
+    await ctx.close();
+  });
+
+  await check('two subpage switches while both chunks are in flight: the last choice wins, whatever order the code arrives in', async () => {
+    const { ctx, page } = await open();
+    const gates = {};
+    for (const name of ['UsagePanel', 'ApiLog']) {
+      gates[name] = new Promise((r) => { gates[`${name}Go`] = r; });
+      await page.route(chunkOf(name), async (r) => { await gates[name]; await r.continue(); });
+    }
+    await page.locator(CARD).first().waitFor({ timeout: 15_000 });
+    await openSettings(page);
+    await page.locator('.settings-page .setting-row').first().waitFor({ timeout: 10_000 });
+    await tab(page, 'Usage');
+    await tab(page, 'API log');
+    gates.UsagePanelGo();
+    await sleep(500);
+    gates.ApiLogGo();
+    await page.locator('.al-tbl, .al-head').first().waitFor({ timeout: 10_000 });
+    assert.equal(await page.locator('.usage').count(), 0, 'the earlier page showed up late');
+    assert.equal(await page.locator('.lazy-panel').count(), 0);
+    await ctx.close();
+  });
+
+  console.log('layout, storage, viewport');
+  await check('at phone width the Settings shell has its Back button while the page loads, and the loaded page lands under it', async () => {
+    const { ctx, page } = await open({ mobile: true });
+    let release;
+    const held = new Promise((r) => { release = r; });
+    await page.route(chunkOf('SettingsView'), async (r) => { await held; await r.continue(); });
+    await page.locator('.sidebar .row.session').first().waitFor({ timeout: 15_000 });
+    await openSettings(page);
+    const back = page.locator('.app.settings .brand .icon-btn[title="Back"]');
+    await back.waitFor();
+    assert.ok(await back.isVisible());
+    const busy = page.locator('.app.settings .lazy-panel[aria-busy="true"]');
+    assert.ok(await busy.isVisible(), 'the loading placeholder is on screen');
+    release();
+    await page.locator('.settings-page .setting-row').first().waitFor({ timeout: 10_000 });
+    assert.equal(await page.locator('.lazy-panel').count(), 0);
+    await ctx.close();
+  });
+
+  await check('with browser storage denied the app still starts and Files still opens on demand', async () => {
+    const { ctx, page, requests } = await open({ storage: false });
+    await row(page, 'files').waitFor({ timeout: 15_000 });
+    await row(page, 'files').click();
+    await page.locator('.files-body.tree .tree-row').first().waitFor({ timeout: 10_000 });
+    assert.equal(requests(chunkOf('FilesPane')).length, 1);
+    await ctx.close();
+  });
+} finally {
+  await browser.close();
+  await server.stop();
+}
+
+console.log(failed ? `\n${failed} failed` : '\nlazy-panels: ok');
+process.exit(failed ? 1 : 0);

--- a/web/test/settingsMobile.test.mjs
+++ b/web/test/settingsMobile.test.mjs
@@ -78,16 +78,21 @@ await build({
       import React from 'react';
       import { createRoot } from 'react-dom/client';
       import SettingsView from './src/components/SettingsView.tsx';
+      import SettingsShell from './src/components/SettingsShell.tsx';
 
       const clis = [
         { id: 'claude', label: 'Claude Code', color: '#d97757', available: true, ready: true, version: '2.1.232' },
         { id: 'gemini', label: 'Gemini CLI', color: '#4796e3', available: true, ready: false, version: '0.55.1', setup: 'Sign in once.' },
       ];
       const info = { dataDir: '/data', home: '/data/home', spaceId: 'me/space', ghostty: true, canRelaunch: true };
+      // The shell (Back, title, tabs) and the page are two components in the
+      // app too: App mounts the shell at once and the page's code on demand.
       createRoot(document.getElementById('root')).render(
-        <SettingsView page="general" onPage={() => {}} onClose={() => {}}
-          theme="light" onToggleTheme={() => {}} clis={clis} info={info}
-          onShowWelcome={() => {}} demoMode={false} onToggleDemo={() => {}} />,
+        <SettingsShell page="general" onPage={() => {}} onClose={() => {}}>
+          <SettingsView page="general" onPage={() => {}} onClose={() => {}}
+            theme="light" onToggleTheme={() => {}} clis={clis} info={info}
+            onShowWelcome={() => {}} demoMode={false} onToggleDemo={() => {}} />
+        </SettingsShell>,
       );
     `,
   },

--- a/web/test/settingsMobile.test.mjs
+++ b/web/test/settingsMobile.test.mjs
@@ -89,7 +89,7 @@ await build({
       // app too: App mounts the shell at once and the page's code on demand.
       createRoot(document.getElementById('root')).render(
         <SettingsShell page="general" onPage={() => {}} onClose={() => {}}>
-          <SettingsView page="general" onPage={() => {}} onClose={() => {}}
+          <SettingsView page="general" onClose={() => {}}
             theme="light" onToggleTheme={() => {}} clis={clis} info={info}
             onShowWelcome={() => {}} demoMode={false} onToggleDemo={() => {}} />
         </SettingsShell>,


### PR DESCRIPTION
Closes #133

## What this does

A cold visit no longer parses the code of panels most visits never open. `FilesPane`, `TracePane` and `SettingsView` are fetched the first time they are shown, and each Settings subpage (`UsagePanel`, `ApiLog`, `SkillsEditor`, `CronSettings`) is its own chunk behind its tab. The terminal/Reader pane, the sidebar, the Overview and the lock screen stay in the entry.

**Boundaries** (`web/src/lib/lazyModule.ts` + `web/src/components/LazyPanel.tsx`)
- One module-level loader per panel keyed into a small cache: one request however many tiles show the panel, and every later show reuses the module. No hidden mounting, no prefetch: nothing is fetched until a panel is actually rendered, and fetching never mounts a view or starts its polling.
- The boundary reserves the panel's geometry (tile / settings page / file viewer), keeps the panel's own Close reachable, and settles visibly on failure. Open/closed stays the parent's state, so a chunk landing after Close cannot reopen anything.
- **Honest retry.** Chromium caches a *failed* module fetch in its module map — verified here: after one aborted fetch, a second `import()` of the same URL rejects without touching the network. So a plain re-import is not a retry. The loader takes the chunk URL from the browser's error (Chromium/Firefox name it; WebKit does not), makes one automatic attempt under `?am-retry=N` (400 ms later), and offers **Try again** only when that mechanism is available. When the page's own HTML, re-read with `cache: no-store`, names a different entry script, the panel says a newer version was deployed and offers an explicit **Reload** — it never reloads by itself and never offers a retry that cannot work.
- Settings' Back/title/tabs move into an eager `SettingsShell`, so the operator is never behind an invisible overlay while the page body loads (`.app-suspended` hides the fleet as before) and can already pick a tab.
- `FilesPane` now takes its trace types from `lib/traceWindows` and loads `TraceView` on demand only when a `.jsonl` file is opened, so opening Files no longer pulls the trace renderer and a failure in one does not take the other.

**Kept as-is:** the CodeMirror and PDF dynamic imports; `RemotePane`, `Locked`, `TraceInfo` (the Reader's info popover) stay in the entry — the first two are small and the last is part of the active pane. xterm/react-dom/marked/dompurify remain in the entry because the terminal and the Reader need them.

## Measurements (production build, this machine)

Evidence page with all cells, ranges and conditions: https://lvwerra-agent-artifacts.static.hf.space/issue-133-startup.html

Harness: `node scripts/startup-bench.mjs --dist <dist> --label before|after --runs 5` — a real backend over a fixture fleet (`web/test/helpers/fixture-server.mjs`: two Claude sessions, one with a 14-turn transcript, a Files pane, a Trace pane, a group with both), Reader mode only, no PTY ever attached. Fresh browser context per visit, HTTP cache disabled; markers stamped in-page by a MutationObserver. Desktop 1280×800 unthrottled; mobile-like 390×844 with 4× CPU slowdown and Chrome's "Slow 4G" (1.6 Mbps / 150 ms). Medians of 5.


**Desktop, unthrottled** — cold visit, medians of 5 (range)

| scenario | JS on the wire | gzip | V8 script ms | sidebar usable ms | view usable ms |
|---|---|---|---|---|---|
| Overview (cold) | 795 kB → 697 kB | 234 kB → 206 kB | 83 → 57 | 167 → 128 | 167 (126–205) → 128 (113–153) |
| Restored Reader | 795 kB → 697 kB | 234 kB → 206 kB | 110 → 109 | 94 → 84 | 209 (195–277) → 200 (196–354) |
| Restored empty session | 795 kB → 697 kB | 234 kB → 206 kB | 97 → 66 | 110 → 80 | 224 (194–274) → 154 (151–163) |
| Restored Files | 795 kB → 729 kB | 234 kB → 216 kB | 94 → 76 | 105 → 81 | 225 (186–274) → 164 (159–176) |
| Restored Trace | 795 kB → 709 kB | 234 kB → 210 kB | 188 → 108 | 146 → 79 | 387 (277–443) → 188 (181–291) |
| Restored group (Files+Trace) | 795 kB → 741 kB | 234 kB → 221 kB | 178 → 136 | 146 → 96 | 336 (214–486) → 235 (215–308) |

desktop: first open of a deferred panel from a warm Overview, before → after (ms), at first *useful* content (Usage: a populated trace row; API log: a real row)

| panel | first open | reopen |
|---|---|---|
| settings | 108 → 116 | 35 → 35 |
| usage | 68 → 75 | 73 → 74 |
| apilog | 62 → 70 | 67 → 64 |
| skills | 41 → 58 | 41 → 42 |
| cron | 49 → 67 | 38 → 38 |
| files | 68 → 57 | 56 → 54 |
| trace | 99 → 119 | 63 → 62 |

**Mobile-like (4× CPU, 1.6 Mbps / 150 ms)** — cold visit, medians of 5 (range)

| scenario | JS on the wire | gzip | V8 script ms | sidebar usable ms | view usable ms |
|---|---|---|---|---|---|
| Overview (cold) | 795 kB → 697 kB | 234 kB → 206 kB | 249 → 257 | 5250 → 4760 | 5250 (5240–5260) → 4760 (4728–4760) |
| Restored Reader | 795 kB → 697 kB | 234 kB → 206 kB | 482 → 492 | 5244 → 4733 | 6029 (6014–6060) → 5515 (5500–5573) |
| Restored empty session | 795 kB → 697 kB | 234 kB → 206 kB | 324 → 304 | 5244 → 4732 | 5646 (5623–5671) → 5121 (5103–5161) |
| Restored Files | 795 kB → 729 kB | 234 kB → 216 kB | 365 → 356 | 5250 → 4736 | 5905 (5889–5917) → 5739 (5736–5774) |
| Restored Trace | 795 kB → 709 kB | 234 kB → 210 kB | 690 → 622 | 5257 → 4734 | 6014 (6006–6037) → 5667 (5663–5692) |
| Restored group (Files+Trace) | 795 kB → 729 kB | 234 kB → 216 kB | 355 → 354 | 5254 → 4741 | 5907 (5876–5947) → 5750 (5723–5781) |

mobile: first open of a deferred panel from a warm Overview, before → after (ms), at first *useful* content (Usage: a populated trace row; API log: a real row)

| panel | first open | reopen |
|---|---|---|
| settings | 262 → 948 | 84 → 83 |
| usage | 916 → 875 | 865 → 865 |
| apilog | 314 → 838 | 332 → 332 |
| skills | 53 → 224 | 46 → 46 |
| cron | 127 → 327 | 92 → 94 |

Entry chunk 795 kB → 697 kB minified (gzip 234 kB → 206 kB), −12 %. New on-demand chunks (minified): FilesPane 31 kB, SettingsView 24 kB, ApiLog 15 kB, CronSettings 12 kB, TracePane 12 kB, UsagePanel 5.6 kB, SkillsEditor 3.6 kB.

Reading it: on the throttled profile every view that needs no panel is usable ~0.5 s sooner (−9 to −10 %), and the restored Files/Trace/group views 0.15–0.35 s sooner even though their chunk now follows the entry (ranges are 20–60 ms wide, so these are real). Desktop cells are noise around zero — see the reviewer's reproduction below. The cost moved to first open is visible on the throttled profile where the panel's own data is quick: Settings 262 → 948 ms, API log 314 → 838 ms, Skills 53 → 224, Cron 127 → 327 (the chunk shares the slow link with the Overview's polls). Usage is ~0.9 s cold on **both** builds (916 → 875) because its first useful row waits on its own seven usage/trace requests — the chunk is not what the operator waits for there. Desktop first opens are 0–20 ms slower. Reopen is unchanged everywhere (module cached).

Conditions: shared box, 8 cores available to the container; the harness records the 1-minute load average at the start and after each profile and a run is kept only if it stayed under ~10. Cold-visit cells: before 6.3 → 6.8 → 9.5, after desktop 7.5 → 8.2 and mobile 6.4 → 6.35 (a first mobile pass that ended at load 18.1 was discarded, as was an earlier full pair taken at load 11–20). Panel-open cells (re-measured after the review's marker fix): before 5.1 → 6.6, after 6.5 → 6.4.

Regression budgets from these runs: entry chunk ≤ 720 kB minified and free of the seven panel modules (both asserted by `web/test/lazyPanels.test.mjs` on the built chunks); zero panel chunks on a cold Overview or restored Reader visit (asserted); first open of a deferred panel within ~1.2× the **after** medians above (mobile-like: Settings ≲ 1.15 s, API log ≲ 1.05 s, other subpages ≲ 0.45 s; desktop ≲ 150 ms) — that first-open cost is the accepted trade, and if it must come down the boundary needs tuning (intent prefetch on the Settings button, or one chunk for Settings + API log), not a bigger entry; warm reopen equal to before (cache intact).

**Read the gain as less to download and wait for at startup, not a CPU speedup.** The reviewer's independent rerun reproduced the mobile-like numbers (Overview 5246 → 4752 ms, Reader 6028 → 5535) and the first-open trade, and found desktop flat (Overview 88 → 81 ms, Reader 195 → 195, mixed group 195 → 220) — so the desktop cells in my run are noise around zero, and V8 script time is broadly flat for Overview/Reader in both runs.

## Tests

- `web/test/lazyModule.test.mjs` (node, no browser): dedupe, bounded automatic retry under a busted URL, manual retry only where it can work, stale deployment read from the page HTML, unknown when offline. Mutation-checked: reintroducing the retry-URL bug this caught (`?am-retry=2&am-retry=3`) fails it.
- `web/test/lazyPanels.test.mjs` (Chromium, production build, real server, port 7904): cold Overview requests no panel chunk and the entry contains no panel-only literal; unopened panels do no API polling; first Settings open + each subpage fetch once and reopen from cache, closing stops their polling; Files fetches Files only, Trace its own; restored Files / Reader / group; a failed Files chunk fails in its tile while the Trace tile, sidebar and Close work and Try again really loads it (asserting the `?am-retry=` URLs on the wire); a chunk removed by a newer deployment shows Reload, no Try again, and no self-navigation; offline first open then Try again online; Settings closed while loading stays closed when the code lands and the shell's tabs work meanwhile; two in-flight subpage switches — the last choice wins; phone width shell with Back during load; denied `localStorage`.
- `web/test/fixtureServer.test.mjs` (review fix): the fixture server refuses a port that is not free and only calls itself ready when `/api/info` names its own `DATA_DIR`; the test holds a stub on the port and requires a rejection with zero requests to it.
- `web/test/helpers/markers.mjs` (review fix): one definition of "usable" shared by the benchmark and the browser suite. Usage counts a populated trace row and the API log a real row, not the frame or its skeletons; the suite holds the Usage data back and requires the marker to stay silent while skeletons show. The Usage/API-log first-open cells below were re-measured with that marker.
- `web/test/settingsMobile.test.mjs` and `cronSettings.test.mjs` adapted: they mount `SettingsShell` around `SettingsView`, as App does.

Commands run and results: 
- `cd web && npx tsc --noEmit` — ok
- `cd web && npx vite build` — ok (chunk list above)
- `cd web && npm test` — 25 suites passed (3 render suites skipped as manual by the runner); includes the two new suites
- `cd server && npm test` — stops at `test/crons.test.mjs` (#4, known-red on main); every other `server/test/*.test.mjs` suite run individually via `node ../scripts/run-suites.mjs test/<name>.test.mjs` — all pass
- `node scripts/startup-bench.mjs` on both builds as described above

## Deliberately left out
- No intent-driven prefetch (hover/pointerdown): measurements did not justify it — see the first-open table; the restored Files/Trace case starts its chunk as soon as the tree names the pane, without a timer.
- No change to what the Reader/terminal pane imports (xterm stays in the entry), no Reader/composer changes, no router, service worker or Vite config changes, no CI.
- `RemotePane` not deferred (small; not named in the issue).
- Locked/setup mode: unchanged code path (`Locked` is in the entry); not separately benchmarked.

Known-red on main, not touched: `server/test/crons.test.mjs` #4.
