### PR TITLE
Extract the idle-window verdict so its pinning exemption is testable

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -21,6 +21,7 @@ import OverviewSearchBox from './components/OverviewSearchBox';
 import Welcome from './components/Welcome';
 import * as api from './api';
 import { pinnedSessionIds } from './lib/pinned';
+import { quietSessionIds } from './lib/idleWindow';
 import { applyAck, furtherMark, retireLocal, type ReadMark } from './lib/unread';
 // Matches the server's per-request cap; the client splits rather than being cut.
 const ACK_CHUNK = 100;
@@ -627,33 +628,18 @@ export default function App() {
     () => new Set(tree.sessions.filter((s) => s.archivedAt).map((s) => s.id)),
     [tree.sessions],
   );
-  // Road two: quiet for longer than the window. Unchanged, and still derived —
-  // it is a statement about the clock, so it has to be recomputed against the
-  // clock rather than written down once.
   // Pinned, counting membership — see lib/pinned.ts for why a group's members
   // inherit the exemption.
   const pinnedIds = useMemo(
     () => pinnedSessionIds(tree.sessions, tree.groups),
     [tree.sessions, tree.groups],
   );
-  const quietIds = useMemo(() => {
-    const out = new Set<string>();
-    if (archiveAfter === 'never') return out;
-    const cut = Date.now() - (archiveAfter === 'week' ? 7 : 30) * 864e5;
-    for (const s of tree.sessions) {
-      // Shells and passive panels have no trace clock — never archive them.
-      if (s.cli === 'shell' || isPassive(s.cli) || s.state === 'working') continue;
-      if (s.archivedAt) continue;                       // already on road one
-      // Pinning suppresses THIS road and only this one. It is a statement about
-      // the clock, and pinning says the clock is not the point for this session;
-      // road one is the operator saying they are finished, which pinning has no
-      // business overriding (and which clears the pin server-side).
-      if (pinnedIds.has(s.id)) continue;
-      const last = ages[s.id] || Date.parse(s.createdAt) || 0;
-      if (last && last < cut) out.add(s.id);
-    }
-    return out;
-  }, [tree.sessions, ages, archiveAfter, pinnedIds]);
+  // Road two: quiet for longer than the window — see lib/idleWindow.ts, where
+  // the rule and pinning's exemption from it live together.
+  const quietIds = useMemo(
+    () => quietSessionIds(tree.sessions, ages, archiveAfter, pinnedIds),
+    [tree.sessions, ages, archiveAfter, pinnedIds],
+  );
   // What the sidebar and overview leave out of the working list.
   const archivedIds = useMemo(
     () => new Set([...retiredIds, ...quietIds]),

--- a/web/src/lib/idleWindow.ts
+++ b/web/src/lib/idleWindow.ts
@@ -1,0 +1,51 @@
+import type { Session } from '../types';
+import { isPassive } from '../types';
+
+// Road two of the two that take a session out of the working list.
+//
+// Road one is the operator saying "I am finished with this one" — stored on the
+// server as `archivedAt`, and it means the same thing on every device. Road two
+// is this: quiet for longer than the window. It is a statement about the clock,
+// so it stays DERIVED — recomputed against the clock rather than written down
+// once — which is why it expires the moment the setting changes and why nothing
+// persists it.
+//
+// It lives here rather than inline in App because pinning's exemption is part of
+// the verdict, and a rule that only exists inside a `useMemo` cannot be tested
+// apart from the component that happens to hold it.
+
+export type ArchiveAfter = 'week' | 'month' | 'never';
+
+/**
+ * Which sessions the idle window judges quiet.
+ *
+ * `pinned` is the exemption, and it suppresses THIS road and only this one.
+ * Pinning says the clock is not the point for this session; road one is the
+ * operator saying they are finished, which pinning has no business overriding
+ * (and which clears the pin server-side anyway). Pass the set from
+ * `pinnedSessionIds` in lib/pinned.ts — it counts group membership, so a pinned
+ * group's members are exempt without being pinned in their own right.
+ *
+ * `now` is a parameter so the verdict can be asked about a moment other than
+ * this one; callers in the app leave it alone.
+ */
+export function quietSessionIds(
+  sessions: Session[],
+  ages: Record<string, number>,
+  archiveAfter: ArchiveAfter,
+  pinned: Set<string>,
+  now = Date.now(),
+): Set<string> {
+  const out = new Set<string>();
+  if (archiveAfter === 'never') return out;
+  const cut = now - (archiveAfter === 'week' ? 7 : 30) * 864e5;
+  for (const s of sessions) {
+    // Shells and passive panels have no trace clock — never archive them.
+    if (s.cli === 'shell' || isPassive(s.cli) || s.state === 'working') continue;
+    if (s.archivedAt) continue;                       // already on road one
+    if (pinned.has(s.id)) continue;
+    const last = ages[s.id] || Date.parse(s.createdAt) || 0;
+    if (last && last < cut) out.add(s.id);
+  }
+  return out;
+}

--- a/web/test/idleWindow.test.mjs
+++ b/web/test/idleWindow.test.mjs
@@ -1,0 +1,114 @@
+// The idle window's verdict — road two out of the working list.
+//
+// This is the rule review found untested: `pinnedSessionIds` had good unit
+// coverage, but nothing showed the archive verdict CONSUMED it. The skip could
+// be deleted and every suite plus the typechecked build stayed green, while
+// pinned sessions quietly started ageing out again — the one thing pinning
+// promises not to let happen.
+//
+// Run with:  node test/idleWindow.test.mjs
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { build } from 'esbuild';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const out = path.join(fs.mkdtempSync(path.join(os.tmpdir(), 'idle-window-')), 'idleWindow.mjs');
+await build({
+  entryPoints: [path.join(HERE, '../src/lib/idleWindow.ts')],
+  outfile: out, format: 'esm', bundle: true, logLevel: 'error',
+});
+const { quietSessionIds } = await import(pathToFileURL(out).href);
+
+let failed = 0;
+const check = (what, fn) => {
+  try { fn(); console.log(`  ok  ${what}`); } catch (e) {
+    failed += 1; console.log(`  FAIL ${what}\n       ${e.message}`);
+  }
+};
+
+const NOW = Date.parse('2026-09-11T12:00:00Z');
+const DAY = 864e5;
+const session = (id, extra = {}) => ({
+  id, name: id, cli: 'claude', path: null, state: 'idle',
+  createdAt: new Date(NOW - 90 * DAY).toISOString(),
+  everStarted: true, running: false, ...extra,
+});
+// Old enough that every window has passed it by.
+const ancient = { };
+const ages = (ids, daysAgo) => Object.fromEntries(ids.map((id) => [id, NOW - daysAgo * DAY]));
+
+console.log('the window itself');
+check('a session quiet past the window is quiet', () => {
+  const quiet = quietSessionIds([session('a')], ages(['a'], 40), 'month', new Set(), NOW);
+  assert.deepEqual([...quiet], ['a']);
+});
+check('one inside the window is not', () => {
+  const quiet = quietSessionIds([session('a')], ages(['a'], 3), 'month', new Set(), NOW);
+  assert.deepEqual([...quiet], []);
+});
+check("'week' is a shorter window than 'month'", () => {
+  const at = ages(['a'], 10);
+  assert.deepEqual([...quietSessionIds([session('a')], at, 'week', new Set(), NOW)], ['a']);
+  assert.deepEqual([...quietSessionIds([session('a')], at, 'month', new Set(), NOW)], []);
+});
+check("'never' archives nothing, however old", () => {
+  const quiet = quietSessionIds([session('a')], ages(['a'], 4000), 'never', new Set(), NOW);
+  assert.deepEqual([...quiet], []);
+});
+
+console.log('\nwhat the window is not allowed to touch');
+check('a shell has no trace clock, so it never ages out', () => {
+  const quiet = quietSessionIds([session('a', { cli: 'shell' })], ages(['a'], 400), 'month', new Set(), NOW);
+  assert.deepEqual([...quiet], []);
+});
+check('nor does one that is working right now', () => {
+  const quiet = quietSessionIds([session('a', { state: 'working' })], ages(['a'], 400), 'month', new Set(), NOW);
+  assert.deepEqual([...quiet], []);
+});
+check('an already-archived session is road one, not road two', () => {
+  const s = session('a', { archivedAt: new Date(NOW - DAY).toISOString() });
+  assert.deepEqual([...quietSessionIds([s], ages(['a'], 400), 'month', new Set(), NOW)], []);
+});
+
+console.log('\nthe exemption — the wiring review found untested');
+check('a pinned session does not age out', () => {
+  const quiet = quietSessionIds([session('a')], ages(['a'], 400), 'month', new Set(['a']), NOW);
+  assert.deepEqual([...quiet], [],
+    'pinning exists to keep a session in front of the operator; ageing it out is the one thing it forbids');
+});
+check('and the exemption is per-session, not a blanket off-switch', () => {
+  const quiet = quietSessionIds(
+    [session('pinned'), session('loose')],
+    ages(['pinned', 'loose'], 400), 'month', new Set(['pinned']), NOW,
+  );
+  assert.deepEqual([...quiet], ['loose']);
+});
+check('a member of a pinned GROUP is exempt too — the set carries membership', () => {
+  // pinnedSessionIds() puts every member of a pinned group in this set; the
+  // verdict never looks at groups itself. See lib/pinned.ts for why: a pinned
+  // group whose agents aged out one by one would empty and vanish.
+  const members = [session('m1'), session('m2')];
+  const quiet = quietSessionIds(members, ages(['m1', 'm2'], 400), 'month', new Set(['m1', 'm2']), NOW);
+  assert.deepEqual([...quiet], []);
+});
+check('pinning does not rescue a session the operator archived', () => {
+  // Road one outranks the exemption: pinning suppresses the clock's verdict,
+  // not the operator's own.
+  const s = session('a', { archivedAt: new Date(NOW - DAY).toISOString() });
+  assert.deepEqual([...quietSessionIds([s], ages(['a'], 400), 'month', new Set(['a']), NOW)], []);
+});
+
+console.log('\nodds and ends');
+check('a session with no recorded age falls back to when it was created', () => {
+  const quiet = quietSessionIds([session('a')], ancient, 'month', new Set(), NOW);
+  assert.deepEqual([...quiet], ['a'], 'createdAt 90 days ago is past the month window');
+});
+check('no sessions is an empty verdict, not a throw', () => {
+  assert.deepEqual([...quietSessionIds([], {}, 'month', new Set(), NOW)], []);
+});
+
+console.log(failed ? `\n${failed} failed` : '\nall checks passed');
+process.exit(failed ? 1 : 0);


### PR DESCRIPTION
Follow-up to the second review finding on #118, deferred at the time because #139 was mid-merge over these exact lines. Both have landed, so the target has stopped moving.

### What the finding was

`lib/pinned.ts` had good unit coverage, but nothing showed the **archive verdict consumed it**. The reviewer disabled the `pinnedIds` skip in `App.tsx` and `node test/pinned.test.mjs` plus the typechecked production build both stayed green — while pinned sessions quietly began ageing out again, which is the one thing pinning promises not to allow.

The rule was untestable because it lived inside a `useMemo` in a 1282-line component. Mounting `App` to reach it would need a stub surface larger than the test.

### What changed

`web/src/lib/idleWindow.ts` — `quietSessionIds(sessions, ages, archiveAfter, pinned, now?)`. Same computation, same dependencies; `now` is a parameter so the verdict can be asked about a fixed moment instead of the wall clock. App's `useMemo` becomes a one-line call. **No behaviour change** — this is the extraction only.

The explanatory comments moved with the logic rather than staying behind, since what they explain is now there.

### Tests

`web/test/idleWindow.test.mjs`, 14 checks in three groups: the window itself (`week` vs `month` vs `never`), the three kinds of session it may never touch (shells and passive panels have no trace clock, one that is working, one already archived on road one), and the exemption itself — that it applies, that it is per-session rather than a blanket off-switch, that a pinned group's members inherit it through the set, and that it does **not** override an archive the operator asked for.

Mutation-checked, including the reviewer's own mutation:

| reverted | checks that fail |
|---|---|
| the pinned skip (the finding) | 3 |
| the archived skip | 1 |
| shells/passive/working exemption | 2 |
| `never` meaning never | 1 |
| the week window | 1 |

### Also confirmed while in here

The pin suite's integration fix on `main` is the right shape, not a minimal patch for green: it imports the shared `native-client.mjs` that ten other suites use, and that helper takes its headers from `src/request-admission.js` itself rather than hardcoding them, so #130's real guard still runs and attribution stays with each test.

### Status

`web`: 50/50 suites and the typechecked production build. `server`: 43 suites pass run individually; `crons.test.mjs` #4 fails identically on `main`. One web suite (`lazyPanels`) first failed on `EADDRINUSE` for a port another agent held on this shared box, and passes in isolation and on re-run.
