### PR TITLE
Refresh cron fixture clock before scheduler test

### DIFF
--- a/server/test/crons.test.mjs
+++ b/server/test/crons.test.mjs
@@ -49,6 +49,9 @@ test('jobs persist, stop without deletion, resume from now, and never replay sta
 });
 
 test('run on restart fires once for enabled running jobs, not stopped ones', async () => {
+  // The previous case used a historical clock. Reload at the real startup
+  // time before arming real timers, otherwise its overdue job also fires.
+  crons.init();
   const running = crons.get(crons.list()[0].id);
   assert.equal(running.runOnRestart, true);
   const stopped = crons.create({


### PR DESCRIPTION
## Diagnosis

This is a stale test fixture, not a scheduler defect.

The preceding persistence test initializes cron state at `2026-08-25T10:00:00Z` and leaves the running job's next occurrence at `2026-08-26T09:00:00Z`. Test #4 then starts real timers without performing the real boot-time reload. On today's clock that occurrence is overdue, so `armExisting()` correctly fires it immediately and the test observes one `schedule` fire plus one `restart` fire.

Production does not take that path: `server/src/index.js` calls `crons.init()` with the current boot time before `startScheduler()`, which recalculates persisted occurrences into the future and deliberately does not replay missed work.

## Change

Reload the persisted fixture with the real startup clock before test #4 arms real timers. No scheduler code changes; the separate deterministic test for restart/schedule coalescing remains unchanged and still covers the genuine double-fire boundary.

## Verification

- Reproduced on clean `main` (`39b04bb`): test #4 received `schedule`, then `restart`.
- Removing the added `crons.init()` reproduces that failure; restoring it passes all six cron unit tests.
- `cd server && npm test`: the queued-prompt precheck and all 47 default-discovered server suites pass. The five explicitly manual Chromium suites remain skipped by the runner as designed.
- `git diff --check`
