### PR TITLE
Enable mobile writing assistance and a terminal draft buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,22 @@ scrollback comes back from the terminal history checkpoint, so a reopened pane
 reads as you left it. Settings → General → *Restart sessions after a reboot*
 sets the window (1 / 3 / 7 days, or off).
 
+## Mobile writing assistance
+
+On phones, Reader and Overview reply boxes allow the OS keyboard's writing
+assistance (autocorrection, sentence capitalization and spelling suggestions).
+The **Writing assistance** checkbox turns it off for literal code or commands;
+the choice is shared between composers and remembered in this browser.
+The OS still controls whether predictive suggestions appear: on iPhone enable
+Settings → General → Keyboard → Predictive Text.
+
+In terminal mode, tap **write** to compose in a normal text box, then **Paste draft
+into terminal**. Nothing is streamed while typing and no Enter is appended. You
+must have terminal control to paste. Multiple lines still follow the running
+program's paste behavior and may execute shell commands. Closing the buffer
+keeps its text while the pane remains mounted; reloading the page does not.
+The raw terminal keyboard and desktop reply behavior remain unchanged.
+
 ## Configuration (env)
 
 | Var | Default | Purpose |

--- a/web/src/components/MobileTerminalDraft.tsx
+++ b/web/src/components/MobileTerminalDraft.tsx
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+import Composer from './conversation/Composer';
+
+/** A real text field lets the OS replace whole words before any bytes reach the PTY. */
+export default function MobileTerminalDraft({ draft, onChange, onInsert, onClose, canInsert }: {
+  draft: string;
+  onChange: (value: string) => void;
+  onInsert: () => void;
+  onClose: () => void;
+  canInsert: boolean;
+}) {
+  const input = useRef<HTMLTextAreaElement>(null);
+  return <div className="term-draft" onPointerDown={(e) => e.stopPropagation()}>
+    <div className="term-draft-caption">
+      <span>Write here, then paste at the terminal cursor. No Enter is added.</span>
+      <button type="button" onClick={onClose} aria-label="Close terminal draft">close</button>
+    </div>
+    <Composer draft={draft} onChange={onChange} onSend={() => { if (canInsert) onInsert(); }}
+      isMobile inputRef={input} placeholder="write a prompt…" sendLabel="Paste draft into terminal"
+      canSend={!!draft} sendDisabled={!canInsert} />
+    {!canInsert && <small>Reconnect and tap the terminal to take control before pasting.</small>}
+    {/[\r\n]/.test(draft) && <small>Multiple lines follow the terminal’s paste behavior and may run commands in a shell.</small>}
+  </div>;
+}

--- a/web/src/components/TerminalPane.tsx
+++ b/web/src/components/TerminalPane.tsx
@@ -12,6 +12,7 @@ import { STATE_LABEL, isRemote } from '../types';
 import StateLogo from './StateLogo';
 import TraceInfo from './TraceInfo';
 import ConversationView from './conversation/ConversationView';
+import MobileTerminalDraft from './MobileTerminalDraft';
 import type { ConversationSeen } from './conversation/ConversationView';
 import { isPassive } from '../types';
 import type { PaneMode } from '../lib/paneMode';
@@ -268,6 +269,8 @@ export default function TerminalPane({
   const [draft, setDraft] = useState(session.name);
   // Fallback paste sheet: shown only when we can't read the clipboard directly.
   const [pasteOpen, setPasteOpen] = useState(false);
+  const [writeOpen, setWriteOpen] = useState(false);
+  const [terminalDraft, setTerminalDraft] = useState('');
   const [imageDrop, setImageDrop] = useState(false);
   const [imageStatus, setImageStatus] = useState<{ kind: 'uploading' | 'success' | 'error'; text: string } | null>(null);
   const [imageUploadBusy, setImageUploadBusy] = useState(false);
@@ -1285,6 +1288,9 @@ export default function TerminalPane({
         // pickers, etc.). preventDefault keeps terminal focus so the keyboard
         // stays up; the send also refocuses the terminal.
         <div className="term-keybar mono" onPointerDown={(e) => e.preventDefault()}>
+          <button type="button" className="tk-btn tk-paste" aria-expanded={writeOpen}
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={() => { setWriteOpen((open) => !open); setPasteOpen(false); }}>write</button>
           {([
             ['esc', '\x1b'], ['tab', '\t'],
             ['←', '\x1b[D'], ['↑', '\x1b[A'], ['↓', '\x1b[B'], ['→', '\x1b[C'],
@@ -1305,6 +1311,17 @@ export default function TerminalPane({
             onClick={(e) => { e.stopPropagation(); requestPaste(); }}
           >paste</button>
         </div>
+      )}
+      {isMobile && writeOpen && !reading && (
+        <MobileTerminalDraft draft={terminalDraft} onChange={setTerminalDraft}
+          onClose={() => setWriteOpen(false)} canInsert={conn === 'connected' && hasInputControl}
+          onInsert={() => {
+            if (conn !== 'connected' || !controllerRef.current || !termRef.current || !terminalDraft) return;
+            termRef.current.paste(terminalDraft);
+            setTerminalDraft('');
+            setWriteOpen(false);
+            focusTerm();
+          }} />
       )}
       {!reading && pasteOpen && (
         // Reached when the clipboard read was blocked (cross-origin iframe) or

--- a/web/src/components/conversation/Composer.tsx
+++ b/web/src/components/conversation/Composer.tsx
@@ -11,10 +11,11 @@ import { useState } from 'react';
 import type { ClipboardEvent, DragEvent, KeyboardEvent, ReactNode, RefObject } from 'react';
 import { filesFromTransfer, transferMayContainFile } from '../../lib/attachments';
 import { SendGlyph } from '../icons';
+import { useWritingAssistance } from '../../lib/writingAssistance';
 
 export default function Composer({
   draft, sending, isMobile, inputRef, className = '', containerClassName = '', above, canSend,
-  onChange, onSend, onCancel, onPasteFiles,
+  onChange, onSend, onCancel, onPasteFiles, sendLabel = 'Send', placeholder = 'reply…', sendDisabled,
 }: {
   draft: string;
   sending?: boolean;
@@ -26,6 +27,9 @@ export default function Composer({
   above?: ReactNode;
   /** Overrides the send-button condition, for example when files are attached without text. */
   canSend?: boolean;
+  sendLabel?: string;
+  sendDisabled?: boolean;
+  placeholder?: string;
   onChange: (v: string) => void;
   onSend: () => void;
   onCancel?: () => void;
@@ -37,6 +41,8 @@ export default function Composer({
   onPasteFiles?: (files: File[]) => void;
 }) {
   const [dropActive, setDropActive] = useState(false);
+  const [writingAssistance, setWritingAssistance] = useWritingAssistance();
+  const assisted = !!isMobile && writingAssistance;
   const filesEnabled = !!onPasteFiles && !sending;
   const grow = (el: HTMLTextAreaElement) => {
     el.style.height = 'auto';
@@ -52,6 +58,9 @@ export default function Composer({
   const acceptsDrop = (e: DragEvent<HTMLDivElement>) =>
     filesEnabled && transferMayContainFile(e.dataTransfer);
   const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    // Enter/Escape may accept or dismiss an IME/predictive composition rather
+    // than send/cancel the draft. Safari can report only the legacy 229 marker.
+    if (e.nativeEvent.isComposing || e.keyCode === 229) return;
     // Desktop: Enter sends, Shift+Enter newlines. Mobile keyboards cannot do
     // Shift+Enter, so there Enter newlines and the button sends.
     if (e.key === 'Enter' && !e.shiftKey && !isMobile) { e.preventDefault(); onSend(); }
@@ -79,8 +88,9 @@ export default function Composer({
         rows={1}
         value={draft}
         disabled={sending}
-        placeholder={sending ? 'sending…' : 'reply…'}
-        autoComplete="off" autoCorrect="off" autoCapitalize="off" spellCheck={false}
+        placeholder={sending ? 'sending…' : placeholder}
+        autoComplete="off" autoCorrect={assisted ? 'on' : 'off'}
+        autoCapitalize={assisted ? 'sentences' : 'off'} spellCheck={assisted}
         onChange={(e) => { onChange(e.target.value); grow(e.currentTarget); }}
         onPaste={onPaste}
         // iOS does not resize the layout for the keyboard — scroll the input
@@ -89,9 +99,15 @@ export default function Composer({
         onKeyDown={onKeyDown}
       />
         {(canSend ?? !!draft.trim()) && (
-          <button className="ov-send" title="Send" onClick={onSend} disabled={sending}><SendGlyph /></button>
+          <button type="button" className="ov-send" title={sendLabel} aria-label={sendLabel} onClick={onSend} disabled={sending || sendDisabled}><SendGlyph /></button>
         )}
       </div>
+      {isMobile && (
+        <label className="writing-assistance">
+          <input type="checkbox" checked={writingAssistance} onChange={(e) => setWritingAssistance(e.target.checked)} />
+          Writing assistance
+        </label>
+      )}
     </div>
   );
 }

--- a/web/src/lib/writingAssistance.ts
+++ b/web/src/lib/writingAssistance.ts
@@ -1,0 +1,29 @@
+import { useSyncExternalStore } from 'react';
+
+const KEY = 'am:writing-assistance';
+const CHANGE = 'am:writing-assistance-change';
+let volatilePreference: boolean | undefined;
+const snapshot = () => {
+  if (volatilePreference !== undefined) return volatilePreference;
+  try { return localStorage.getItem(KEY) !== 'off'; } catch { return true; }
+};
+const subscribe = (notify: () => void) => {
+  const onStorage = (event: StorageEvent) => { if (!event.key || event.key === KEY) notify(); };
+  window.addEventListener(CHANGE, notify);
+  window.addEventListener('storage', onStorage);
+  return () => {
+    window.removeEventListener(CHANGE, notify);
+    window.removeEventListener('storage', onStorage);
+  };
+};
+
+/** Browser-local preference shared by every composer; raw terminal input never uses it. */
+export function useWritingAssistance() {
+  const enabled = useSyncExternalStore(subscribe, snapshot, () => true);
+  const setEnabled = (value: boolean) => {
+    try { localStorage.setItem(KEY, value ? 'on' : 'off'); volatilePreference = undefined; }
+    catch { volatilePreference = value; }
+    window.dispatchEvent(new Event(CHANGE));
+  };
+  return [enabled, setEnabled] as const;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1022,6 +1022,13 @@ body {
 .term-paste .tp-input { width: 100%; box-sizing: border-box; resize: none; padding: 6px 8px; border: 1px solid var(--border-strong); border-radius: var(--r-md);
   background: var(--panel-2); color: var(--text); font-size: 13px; line-height: 1.35; }
 .term-paste .tp-input:focus { outline: none; border-color: var(--accent); }
+.writing-assistance { grid-column: 1 / -1; display: flex; align-items: center; gap: 6px; font-size: 12px; color: var(--muted); }
+.writing-assistance input { margin: 0; accent-color: var(--accent); }
+.term-draft { flex: none; position: relative; z-index: 6; padding: 8px; background: var(--panel); border-top: 1px solid var(--border); touch-action: auto; }
+.term-draft-caption { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--muted); }
+.term-draft-caption span { flex: 1; }
+.term-draft-caption button { background: none; border: none; color: var(--accent); cursor: pointer; padding: 6px; }
+.term-draft small { display: block; margin-top: 6px; color: var(--muted); }
 .term-host .xterm { width: 100%; height: 100%; padding: 10px 8px 8px 12px; }
 .xterm .xterm-viewport { scrollbar-width: none; }
 .xterm .xterm-viewport::-webkit-scrollbar { width: 0; height: 0; display: none; }

--- a/web/test/mobileTerminalDraft.test.mjs
+++ b/web/test/mobileTerminalDraft.test.mjs
@@ -33,7 +33,7 @@ try {
   const css = ['src/styles.css', 'src/conversation.css', 'node_modules/@xterm/xterm/css/xterm.css']
     .map((file) => fs.readFileSync(path.join(web, file), 'utf8')).join('\n');
   await page.route('http://keyboard.test/**', (route) => route.fulfill({ contentType: 'text/html',
-    body: `<style>${css}\n#root{height:100vh}.slot{height:100%}</style><div id="root"></div>` }));
+    body: `<meta name="viewport" content="width=device-width,initial-scale=1"><style>${css}\n#root{height:100vh}.slot{height:100%}</style><div id="root"></div>` }));
   await page.goto('http://keyboard.test/');
   await page.addScriptTag({ content: result.outputFiles[0].text });
   await page.getByRole('button', { name: 'write', exact: true }).click();

--- a/web/test/mobileTerminalDraft.test.mjs
+++ b/web/test/mobileTerminalDraft.test.mjs
@@ -39,6 +39,7 @@ try {
   await page.getByRole('button', { name: 'write', exact: true }).click();
   const input = page.getByPlaceholder('write a prompt…');
   await input.fill('a corrected prompt');
+  if (process.env.AM_KEYBOARD_SCREENSHOT) await page.screenshot({ path: process.env.AM_KEYBOARD_SCREENSHOT });
   assert.equal(await input.getAttribute('autocorrect'), 'on');
   assert.equal(await page.locator('.xterm-helper-textarea').getAttribute('autocorrect'), 'off', 'raw input remains literal');
   const inputs = () => page.evaluate(() => window.sent.filter((m) => m.t === 'i').map((m) => m.d));

--- a/web/test/mobileTerminalDraft.test.mjs
+++ b/web/test/mobileTerminalDraft.test.mjs
@@ -1,0 +1,59 @@
+// Real TerminalPane + xterm; only the websocket transport is fake. No agents start.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const result = await build({
+  stdin: { resolveDir: web, loader: 'tsx', contents: `
+    import React from 'react'; import {createRoot} from 'react-dom/client';
+    import TerminalPane from './src/components/TerminalPane';
+    window.sent=[];
+    class Socket {
+      static OPEN=1; readyState=1;
+      constructor(){window.socket=this;setTimeout(()=>{this.onopen?.();this.grid(true);this.onmessage?.({data:'\\x1b[?2004hReady> '});},20);}
+      send(data){window.sent.push(JSON.parse(data));}
+      grid(controller){this.onmessage?.({data:'\\x00\\x00AM:'+JSON.stringify({t:'grid',cols:40,rows:12,controller})});}
+      close(){this.readyState=3;}
+    }
+    window.WebSocket=Socket;
+    createRoot(document.getElementById('root')).render(<TerminalPane
+      session={{id:'keyboard',cli:'shell',name:'Keyboard fixture',state:'idle',running:true,everStarted:true,path:null}}
+      mode="terminal" theme="light" zoom={100} isMobile focused active visible onClose={()=>{}}/>);
+  ` }, bundle: true, write: false, format: 'iife', loader: { '.css': 'empty' },
+  define: { 'process.env.NODE_ENV': '"production"' },
+});
+const browser = await chromium.launch(chromiumLaunchOptions());
+try {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 }, isMobile: true, hasTouch: true });
+  const css = ['src/styles.css', 'src/conversation.css', 'node_modules/@xterm/xterm/css/xterm.css']
+    .map((file) => fs.readFileSync(path.join(web, file), 'utf8')).join('\n');
+  await page.route('http://keyboard.test/**', (route) => route.fulfill({ contentType: 'text/html',
+    body: `<style>${css}\n#root{height:100vh}.slot{height:100%}</style><div id="root"></div>` }));
+  await page.goto('http://keyboard.test/');
+  await page.addScriptTag({ content: result.outputFiles[0].text });
+  await page.getByRole('button', { name: 'write', exact: true }).click();
+  const input = page.getByPlaceholder('write a prompt…');
+  await input.fill('a corrected prompt');
+  assert.equal(await input.getAttribute('autocorrect'), 'on');
+  assert.equal(await page.locator('.xterm-helper-textarea').getAttribute('autocorrect'), 'off', 'raw input remains literal');
+  const inputs = () => page.evaluate(() => window.sent.filter((m) => m.t === 'i').map((m) => m.d));
+  assert.deepEqual(await inputs(), [], 'draft typing does not reach the transport');
+  await page.getByRole('button', { name: 'Paste draft into terminal', exact: true }).click();
+  assert.deepEqual(await inputs(), ['\x1b[200~a corrected prompt\x1b[201~'], 'xterm bracketed paste, no appended Enter');
+  await page.getByRole('button', { name: 'write', exact: true }).click();
+  await input.fill('keep this draft');
+  await page.evaluate(() => window.socket.grid(false));
+  await page.waitForFunction(() => document.querySelector('button[title="Paste draft into terminal"]')?.disabled);
+  assert.equal(await page.getByRole('button', { name: 'Paste draft into terminal', exact: true }).isDisabled(), true);
+  assert.equal(await input.inputValue(), 'keep this draft', 'loss of control preserves text');
+  assert.equal((await inputs()).length, 1);
+  await page.getByRole('button', { name: 'Close terminal draft' }).click();
+  await page.getByRole('button', { name: 'write', exact: true }).click();
+  assert.equal(await input.inputValue(), 'keep this draft', 'closing and reopening preserves text');
+  console.log('mobile-terminal-draft: real xterm paste framing, no keystroke streaming, control guard and draft retention passed');
+} finally { await browser.close(); }

--- a/web/test/writingAssistance.test.mjs
+++ b/web/test/writingAssistance.test.mjs
@@ -1,0 +1,77 @@
+// Real controlled textareas. No model calls or terminal processes.
+import assert from 'node:assert/strict';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium } from 'playwright';
+import { chromiumLaunchOptions } from '../../scripts/test-chromium.mjs';
+
+const web = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const result = await build({
+  stdin: { resolveDir: web, loader: 'tsx', contents: `
+    import React, {useState} from 'react'; import {createRoot} from 'react-dom/client';
+    import Composer from './src/components/conversation/Composer';
+    import MobileTerminalDraft from './src/components/MobileTerminalDraft';
+    window.sent=[]; window.inserted=[];
+    function App(){
+      const [draft,setDraft]=useState(''); const [second,setSecond]=useState('');
+      const [terminal,setTerminal]=useState(''); const [control,setControl]=useState(false);
+      window.control=setControl;
+      return <><section id="mobile"><Composer isMobile draft={draft} onChange={setDraft} onSend={()=>window.sent.push(draft)}/></section>
+        <section id="desktop"><Composer draft={second} onChange={setSecond} onSend={()=>window.sent.push(second)}/></section>
+        <section id="terminal"><MobileTerminalDraft draft={terminal} onChange={setTerminal} canInsert={control}
+          onInsert={()=>{window.inserted.push(terminal);setTerminal('');}} onClose={()=>{}}/></section></>;
+    }
+    createRoot(document.getElementById('root')).render(<App/>);
+  ` }, bundle: true, write: false, format: 'iife', define: { 'process.env.NODE_ENV': '"test"' },
+});
+const browser = await chromium.launch(chromiumLaunchOptions());
+try {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  await page.route('http://composer.test/**', (route) => route.fulfill({ contentType: 'text/html', body: '<div id="root"></div>' }));
+  const mount = async () => { await page.goto('http://composer.test/'); await page.addScriptTag({ content: result.outputFiles[0].text }); await page.locator('#mobile textarea').waitFor(); };
+  await mount();
+  const mobile = page.locator('#mobile textarea'), desktop = page.locator('#desktop textarea');
+  assert.equal(await mobile.getAttribute('autocorrect'), 'on');
+  assert.equal(await mobile.getAttribute('autocapitalize'), 'sentences');
+  assert.equal(await mobile.getAttribute('spellcheck'), 'true');
+  assert.equal(await desktop.getAttribute('autocorrect'), 'off');
+  assert.equal(await page.locator('#desktop input[type=checkbox]').count(), 0);
+  await mobile.fill('some');
+  // A keyboard suggestion replaces the existing word through a normal input event.
+  await mobile.evaluate((el) => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set.call(el, 'something');
+    el.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertReplacementText', data: 'something' }));
+  });
+  await page.locator('#mobile button[title="Send"]').click();
+  assert.deepEqual(await page.evaluate(() => window.sent), ['something']);
+  await mobile.press('Enter');
+  assert.equal((await page.evaluate(() => window.sent)).length, 1, 'mobile Enter cannot submit');
+  await desktop.fill('composition');
+  for (const event of [{key:'Enter',isComposing:true},{key:'Escape',isComposing:true},{key:'Enter',keyCode:229}]) {
+    await desktop.dispatchEvent('keydown', event);
+  }
+  assert.equal(await desktop.inputValue(), 'composition');
+  assert.equal((await page.evaluate(() => window.sent)).length, 1, 'IME confirmation never submits');
+  await desktop.press('Enter');
+  assert.deepEqual(await page.evaluate(() => window.sent), ['something', 'composition']);
+  await page.locator('#mobile input').uncheck();
+  assert.equal(await mobile.getAttribute('autocorrect'), 'off');
+  assert.equal(await page.locator('#terminal textarea').getAttribute('autocorrect'), 'off', 'same-page composers share the preference');
+  assert.equal(await mobile.inputValue(), 'something\n', 'toggling preserves the draft');
+  await mount();
+  assert.equal(await mobile.getAttribute('autocorrect'), 'off', 'preference survives reload');
+  await page.locator('#mobile input').check();
+  const terminal = page.locator('#terminal textarea');
+  await terminal.fill('two\nlines');
+  assert.deepEqual(await page.evaluate(() => window.inserted), [], 'typing sends nothing');
+  assert.equal(await page.locator('#terminal button[title="Paste draft into terminal"]').isDisabled(), true);
+  await page.evaluate(() => window.control(true));
+  await page.locator('#terminal button[title="Paste draft into terminal"]').click();
+  assert.deepEqual(await page.evaluate(() => window.inserted), ['two\nlines'], 'explicit paste preserves text without adding Enter');
+  // A denied storage write must not prevent the preference working in memory.
+  await page.evaluate(() => { Storage.prototype.setItem = () => { throw new Error('storage denied'); }; });
+  await page.locator('#mobile input').uncheck();
+  assert.equal(await mobile.getAttribute('autocorrect'), 'off');
+  console.log('writing-assistance: mobile hints, preference, replacements, IME and buffered terminal draft passed');
+} finally { await browser.close(); }


### PR DESCRIPTION
## Summary

- Enable OS writing assistance in mobile Reader/Overview reply boxes, with a browser-local checkbox shared between composers. Desktop and raw xterm input remain literal.
- Add a mobile terminal **write** buffer: edit with a normal textarea, then explicitly **Paste draft into terminal**. Use xterm's bracketed-paste path; never append Enter or stream draft keystrokes. Require terminal control and retain the buffer when closed or control is lost.
- Ignore Enter/Escape during IME composition, including Safari's legacy keycode 229 path.
- Document the device-level Predictive Text setting and the fact that multiline terminal pastes can execute shell commands depending on the running program.

## Validation

- Browser regression: OS word replacement, mobile hints, desktop preservation, preference synchronization/reload/denied storage, mobile Enter, IME confirmation, and buffered insertion.
- Real TerminalPane + xterm browser regression: bracketed paste bytes, no extra Enter, no keystroke streaming, control guard and buffer retention.
- Web typecheck/build passed. All **52 default frontend suites passed** with Chromium, including the two new keyboard regressions and the Reader scroll tests. The terminal draft was also checked at a 390px device-width touch viewport.

## Device QA still needed

This is a draft pending a real iPhone/Safari check of the predictive suggestion bar (including the Hugging Face iframe). Headless Chromium can verify the attributes and insertion behavior, but cannot prove that iOS displays its native keyboard suggestions. The OS/user settings have the final say.

The terminal buffer is retained only while the pane is mounted, not across a page reload. No production or testing Space was restarted for this PR.
